### PR TITLE
[DO_NOT_MERGE] Indirect cache transformation

### DIFF
--- a/llm_bench/python/benchmark.py
+++ b/llm_bench/python/benchmark.py
@@ -430,6 +430,14 @@ def get_argprser():
         help='Fuse ops related to cache reordering to the model, applied only when num_beams > 1',
     )
     parser.add_argument(
+        '--indirect_cache',
+        action='store_true',
+        help='Accumulate 2D beam_table for the indirect kv-cache in the model instead of reordeing past kv-cache values. '
+        'Expose beam_table it as an extra input/output or variable depending on whether --make_stateful is set. '
+        'Gather actual kv-cache values for processing at the current iteration based on beam_table. '
+        'Applicable when --fused_cache_reorder is set.',
+    )
+    parser.add_argument(
         '--torch_compile_backend',
         default='openvino',
         required=False,

--- a/llm_bench/python/utils/model_utils.py
+++ b/llm_bench/python/utils/model_utils.py
@@ -63,6 +63,7 @@ def analyze_args(args):
     model_args['save_prepared_model'] = args.save_prepared_model
     model_args['num_beams'] = args.num_beams
     model_args['fuse_cache_reorder'] = args.fuse_cache_reorder
+    model_args['indirect_cache'] = args.indirect_cache
     model_args['torch_compile_backend'] = args.torch_compile_backend
 
     model_path = args.model

--- a/llm_bench/python/utils/ov_utils.py
+++ b/llm_bench/python/utils/ov_utils.py
@@ -31,6 +31,7 @@ def forward_simplified(
         input_ids = input_ids[:, -1:]
 
     inputs = {}
+    has_beam_table = getattr(self, 'has_beam_table', False)
     if not self.use_cache_as_state:
         if past_key_values is not None:
             if self._pkv_precision == Type.bf16:
@@ -43,6 +44,9 @@ def forward_simplified(
                 past_key_values = tuple(past_key_value for pkv_per_layer in past_key_values for past_key_value in pkv_per_layer)
             # Add the past_key_values to the decoder inputs
             inputs = dict(zip(self.key_value_input_names, past_key_values))
+            if has_beam_table:
+                # beam_table is not stored in past_key_values hence it is not affected by kv_cache external reordering
+                inputs['beam_table_input'] = self.beam_table
 
         # Create empty past_key_values for decoder_with_past first generation step
         elif self.use_cache:
@@ -59,6 +63,11 @@ def forward_simplified(
                 if shape.rank.get_length() == 4 and shape[3].is_dynamic:
                     shape[3] = 0
                 inputs[input_name] = Tensor(model_inputs.get_element_type(), shape.get_shape())
+            if has_beam_table:
+                model_input = self.model.input('beam_table_input')
+                shape = model_input.get_partial_shape()
+                shape = [d.get_length() if not d.is_dynamic else 0 for d in shape]
+                inputs['beam_table_input'] = Tensor(model_input.get_element_type(), shape)
     else:
         # past_key_values are not used explicitly, instead they should be handled inside the model
         if past_key_values is None:
@@ -95,6 +104,10 @@ def forward_simplified(
             past_key_values = tuple(self.request.get_tensor(key).data for key in self.key_value_output_names)
             # Tuple of tuple of length `n_layers`, with each tuple of length equal to 2 (k/v of self-attention)
             past_key_values = tuple(past_key_values[i : i + self.num_pkv] for i in range(0, len(past_key_values), self.num_pkv))
+            if has_beam_table:
+                # beam_table is not a part of potentially externally modified kv_cache, so no need to cast it to numpy
+                # as there is no other code that access it except this function
+                self.beam_table = self.request.get_tensor('beam_table_output')
         else:
             past_key_values = None
 
@@ -158,21 +171,117 @@ def patch_inter_processing(hf_model, **kwargs):
 
     num_beams = kwargs['num_beams'] if 'num_beams' in kwargs and kwargs['num_beams'] > 1 else 1
     batch_size = kwargs['batch_size'] if 'batch_size' in kwargs and kwargs['batch_size'] > 1 else 1
+    batch_dim_size = num_beams * batch_size
+    hf_model.has_beam_idx = False
+    hf_model.has_beam_table = False
+    orig_num_params = len(ov_model.get_parameters())
 
     if kwargs['fuse_cache_reorder'] and num_beams > 1:
-        # Should be run before make_stateful because of adding pre-processing on kv-cashe inputs
+        # Should be run before make_stateful because of adding pre-processing on kv-cache inputs
         # Make a new parameter for beam_idx
         # Adding a new parameter to make _reorder_cache inside the model in the beginning of each iteration
-        beam_idx = opset.parameter(name='beam_idx', dtype=ov.Type.i32, shape=ov.PartialShape([num_beams * batch_size]))
+        beam_idx = opset.parameter(name='beam_idx', dtype=ov.Type.i32, shape=ov.PartialShape([batch_dim_size]))
         beam_idx.output(0).get_tensor().add_names({'beam_idx'})  # why list is not accepted?
+
+        if kwargs['indirect_cache']:
+            # Create one extra input for beam_table with shape [sequence_length, batch_dim_size]
+            # TODO: Provide layout for beam_table compatible with axes of kv_cache inputs/outputs
+            #       for uniform external cache manipulation. For example [B, 1, S, 1], where B - batch/dim, S - sequence.
+            beam_table = opset.parameter(name='beam_table_input', dtype=ov.Type.i32, shape=ov.PartialShape([-1, batch_dim_size]))
+            beam_table.output(0).get_tensor().add_names({'beam_table_input'})  # why list is not accepted?
+            # Adding beam_table parameter before beam_idx because this parameter will potentially
+            # be bound with a corresponding output to keep it as a variable -- need to maintain
+            # all such input/output pairs aligned for more convenient application of make_stateful transformation
+            ov_model.add_parameters([beam_table])
+            hf_model.has_beam_table = True
+
         ov_model.add_parameters([beam_idx])
-        # Go over all cache parameters and fuse _reorder_cache with indices provided by the new parameter beam_idx
-        for i in range(len(ov_model.inputs) - 3):  # 3 == input_ids, attention_mask and new beam_idx
+        hf_model.has_beam_idx = True
+
+        # Detects if op is Concat in the pattern Parameter -> Concat -> Result, and Parameter is among of the state parameters
+        def match_concat(op):
+            # use Node.get_name for nodes to match them to other nodes as just node comparison node1 == node2 gives
+            # different effect due to the syntax sugar implemented in OV Python API: creation of Equal operation Equal(node1, node2)
+            # which is not what we need
+            return (op.get_type_name() == "Concat"
+                    and op.input_value(0).get_node().get_name() in [x.get_name() for x in ov_model.get_parameters()[2:orig_num_params]]
+                    and 'Result' in [consumer.get_node().get_type_name() for consumer in op.output(0).get_target_inputs()])
+
+        if kwargs['indirect_cache']:
+            # Search for the topologically first kv_cache Concat
+            first_concat = next(op for op in ov_model.get_ordered_ops() if match_concat(op))
+            assert first_concat.get_input_size() == 2
+
+            # Build the indirect cache maintainance sub-graph, which
+            #  - takes beam_table_input, beam_idx and an in-model produced input for the found first_concat Concat op,
+            #  - produces updated value for beam_table, and
+            #  - sends it to a newly created Result node beam_table_output.
+
+            beam_table_reordered = opset.gather(beam_table, beam_idx, opset.constant(1))
+            # second input to concat is the current k/v-value, need it to calculate the shape of the addon to beam_table
+            new_kv_cache_part = first_concat.input_value(1)
+            concat_axis = first_concat.get_attributes()['axis']
+            new_kv_cache_size = opset.gather(
+                opset.shape_of(new_kv_cache_part),
+                opset.constant([concat_axis]),
+                opset.constant(0))
+            repeater = opset.concat([new_kv_cache_size, opset.constant([1])], axis=0)
+            # addon to beam_table is repeated slice with 0..(batch_dim_size-1) values
+            new_beam_table_part = opset.tile(
+                opset.range(
+                    opset.constant(0),
+                    opset.constant(batch_dim_size),
+                    opset.constant(1),
+                    output_type='i32'),  # TODO: Why cannot pass ov.Type.i32?
+                repeater)
+            updated_beam_table = opset.concat([beam_table_reordered, new_beam_table_part], axis=0)
+            updated_beam_table.output(0).get_tensor().add_names({'beam_table_output'})
+            ov_model.add_results([opset.result(updated_beam_table, name='beam_table_output')])
+
+        transformed_concat_count = 0
+
+        # Go over all cache parameters and fuse _reorder_cache with indices provided by the new parameter beam_idx/beam_table
+        for i in range(orig_num_params - 2):  # 2 == input_ids, attention_mask
             parameter_output_port = ov_model.inputs[2 + i]
-            consumers = parameter_output_port.get_target_inputs()
-            gather = opset.gather(parameter_output_port, beam_idx, opset.constant(0))
-            for consumer in consumers:
-                consumer.replace_source_output(gather.output(0))
+            consumers = list(parameter_output_port.get_target_inputs())
+            if kwargs['indirect_cache']:
+                matched_concats = tuple(consumer for consumer in consumers if match_concat(consumer.get_node()))
+                unexpected_consumers = tuple(consumer for consumer in consumers if consumer.get_node().get_type_name() not in ('Concat', 'ShapeOf'))
+                if len(matched_concats) == 1 and len(unexpected_consumers) == 0:
+                    # take all consumers of the concat and filter out Results
+                    concat = matched_concats[0].get_node()
+                    concat_consumers = [consumer for consumer in concat.output(0).get_target_inputs() if consumer.get_node().get_type_name() != 'Result']
+                    if len(concat_consumers) == 0:
+                        print(f'[ WARNING ] Too deep pattern match failure, cannot find any kv-cache concat consumer except Result for node {concat}')
+                        continue
+
+                    # Move gather dimensions to the leading positions in the kv-value shape.
+                    # HW plugins are supposed to detect this sequence and replace it with their efficient
+                    # indirect cache implementation.
+                    # TODO: Rework to handle any appropriate rank, now works for rank = 4 only.
+                    # TODO: Propose a new Gather op version with multiple axes to avoid applying Transposes
+                    transposed = opset.transpose(concat, opset.constant([2, 0, 1, 3]))
+                    # restore correct order of kv-cache according to beam_table
+                    reordered = opset.gather(transposed, updated_beam_table, opset.constant(1), batch_dims=1)
+                    # reverse transpose to restore original kv-cache layout
+                    restored = opset.transpose(reordered, opset.constant([1, 2, 0, 3]))
+
+                    # Replace old input for all concat_consumers by a newly created restored tensor
+                    for consumer in concat_consumers:
+                        consumer.replace_source_output(restored.output(0))
+
+                    transformed_concat_count += 1
+            else:
+                gather = opset.gather(parameter_output_port, beam_idx, opset.constant(0))
+                for consumer in consumers:
+                    consumer.replace_source_output(gather.output(0))
+
+        if kwargs['indirect_cache']:
+            assert transformed_concat_count == orig_num_params - 2, (
+                f'Failed to find all places in model to apply indirect cache transformation: '
+                f'appplied to {transformed_concat_count} state tensors among {orig_num_params - 2} in total'
+            )
+
         ov_model.validate_nodes_and_infer_types()
         hf_model.use_cache_as_state = False
 
@@ -184,7 +293,7 @@ def patch_inter_processing(hf_model, **kwargs):
 
         hf_model._reorder_cache = types.MethodType(_reorder_cache_stub, hf_model)
         hf_model.forward = types.MethodType(forward_simplified, hf_model)  # need custom forward to set beam_idx input to OV model
-        hf_model.next_beam_idx = np.zeros([num_beams * batch_size], dtype=int)  # initial value for beam_idx is all zeros
+        hf_model.next_beam_idx = np.zeros([batch_dim_size], dtype=int)  # initial value for beam_idx is all zeros
 
     if kwargs['make_stateful']:
         from openvino._offline_transformations import apply_make_stateful_transformation
@@ -192,9 +301,12 @@ def patch_inter_processing(hf_model, **kwargs):
         input_output_map = {}
         # TODO: Can we derive the dimensions from the model topology?
         num_attention_heads = hf_model.normalized_config.num_attention_heads if hf_model.config.model_type == 'bloom' else 1
-        beam_idx_exist = 'beam_idx' in [port.any_name for port in ov_model.inputs]
-        assert num_beams == 1 or beam_idx_exist, 'Requested to make_stateful with num_beams > 1 but there is no beam_idx parameter for cache reorder fused'
-        left_num_parameters = 2 + int(beam_idx_exist)
+
+        assert num_beams == 1 or hf_model.has_beam_idx, (
+            'Requested to make_stateful with num_beams > 1 but there is no beam_idx parameter for cache reorder fused'
+        )
+
+        left_num_parameters = 2 + int(hf_model.has_beam_idx)
         # Set batch size for input_ids and attention mask to avoid dynamic dimension got propagated from the end of the model back to ReadValue
         for i in range(2):
             input = ov_model.inputs[i]
@@ -206,16 +318,18 @@ def patch_inter_processing(hf_model, **kwargs):
                 print(f'[ WARNING ] Rank of {i} input of the model is not 2, batch size is not set')
 
         for i in range(len(ov_model.inputs) - left_num_parameters):
-            port = ov_model.inputs[2 + i]
+            input = ov_model.inputs[2 + i]
             output = ov_model.outputs[1 + i]
-            input_output_map[port.any_name] = output.any_name
-            shape = port.get_partial_shape()
+            input_output_map[input.any_name] = output.any_name
 
-            # suppose 0-th dimension is a batch
-            # TODO: Deduce from a model via ordinal reshape
-            shape[0] = batch_size * num_attention_heads * num_beams
-
-            port.get_node().set_partial_shape(shape)
+            if not (hf_model.has_beam_table and input.any_name and input.any_name == 'beam_table_input'):
+                # Set batch dimension only for original kv-cache inputs, because beam_table has got already correct shape
+                # and it has a different layout which makes it incompatible with the shape manipulation code below.
+                shape = input.get_partial_shape()
+                # suppose 0-th dimension is a batch
+                # TODO: Deduce from a model via ordinal reshape
+                shape[0] = batch_size * num_attention_heads * num_beams
+                input.get_node().set_partial_shape(shape)
 
         ov_model.validate_nodes_and_infer_types()
 


### PR DESCRIPTION
Transformation of a model to introduce the indirect cache which avoids permutation of the cache tensors when beam search is used. Instead, kv-tensors are permuted just before ScaledDotProductAttention operation, which should be a target for further plugin optimizations. Assumption is that the plugins will apply Gather in a smart way.

Transformation is enabled by new --indirect_cache key and compatible with stateless and stateful models (can be applied in combination with --make_stateful). The key is enabled only when --fuse_cache_reorder is set and --num_beams > 1.

A new input/output pair appears: beam_table_input/beam_table_output that is hidden as a state when --make_stateful is applied. Necessary operations for beam_table update is fused into the model regardless of state-less/full property.