### PR TITLE
Allow multiple compression options

### DIFF
--- a/llm_bench/python/README.md
+++ b/llm_bench/python/README.md
@@ -29,7 +29,7 @@ Paramters:
 * `--output_dir` - output directory for saving OpenVINO model
 * `--precision` - (optional, default FP32), precision for model conversion FP32 or FP16
 * `--save_orig` - flag for saving original pytorch model, model will be located in `<output_dir>/pytorch` subdirectory.
-* `--compress_weights` - The weight compression option, INT8 - INT8 weights, INT4_SYM - for INT4 compressed weights with symmetric quantization, INT4_ASYM - for INT4 compressed weights with assymetric quantization. You can specify multiple options separated by a space.
+* `--compress_weights` - The weight compression option, INT8 - INT8 weights, INT4_SYM - for INT4 compressed weights with symmetric quantization, INT4_ASYM - for INT4 compressed weights with assymetric quantization. You can specify multiple options separated by a space, e.g. "--compress_weights INT8 INT4_SYM".
 * `--compress_weights_backends` - (optional, default openvino) backends for weights compression, this option has an effect only with `--compress_weights`. For `openvino` backend, model will be located in `<output_dir>/pytorch/dldt/INT8_compressed_weights` subdirectory. For `pytorch` backend, model will be located in `<output_dir>/pytorch/dldt/PT_compressed_weights` subdirectory. You can specify multiple backends separated by a space.
 * `--ratio` - Compression ratio between primary and backup precision, e.g. INT4/INT8.
 * `--group_size` - Size of the group of weights that share the same quantization parameters

--- a/llm_bench/python/README.md
+++ b/llm_bench/python/README.md
@@ -29,7 +29,7 @@ Paramters:
 * `--output_dir` - output directory for saving OpenVINO model
 * `--precision` - (optional, default FP32), precision for model conversion FP32 or FP16
 * `--save_orig` - flag for saving original pytorch model, model will be located in `<output_dir>/pytorch` subdirectory.
-* `--compress_weights` - The weight compression option, INT8 - INT8 weights, INT4_SYM - for INT4 compressed weights with symmetric quantization, INT4_ASYM - for INT4 compressed weights with assymetric quantization.
+* `--compress_weights` - The weight compression option, INT8 - INT8 weights, INT4_SYM - for INT4 compressed weights with symmetric quantization, INT4_ASYM - for INT4 compressed weights with assymetric quantization. You can specify multiple options separated by a space.
 * `--compress_weights_backends` - (optional, default openvino) backends for weights compression, this option has an effect only with `--compress_weights`. For `openvino` backend, model will be located in `<output_dir>/pytorch/dldt/INT8_compressed_weights` subdirectory. For `pytorch` backend, model will be located in `<output_dir>/pytorch/dldt/PT_compressed_weights` subdirectory. You can specify multiple backends separated by a space.
 * `--ratio` - Compression ratio between primary and backup precision, e.g. INT4/INT8.
 * `--group_size` - Size of the group of weights that share the same quantization parameters


### PR DESCRIPTION
usage example:
```
 python convert.py --model_id databricks/dolly-v2-3b --precision FP16 --output_dir dolly-v2-3b -c INT8 INT4_SYM
```