### PR TITLE
fix transformers version & make_stateful

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -4,7 +4,7 @@ openvino>=2023.1.0
 auto-gptq<0.5.0 # int4 gptq
 pillow
 torch
-transformers>=4.33.0
+transformers>=4.34.0
 diffusers>=0.22.0
 optimum>=1.14.0
 git+https://github.com/huggingface/optimum-intel.git@f248835b16ce4ec054d6d4d629dff4213fe94157


### PR DESCRIPTION
 - Detect the correct number of past-kv parameters in `make_stateful` case
 - add empty `__init__.py`  to folder `llm_bench/python/utils/` to fix `import utils` failure.
 - increase transformer version to 4.34.0 in requirement (to include `get_dataloader_samplerhttps` from ://github.com/huggingface/transformers/commit/fb7d246951d5f60aa36a7958841dfea72f51fc6b)