### PR TITLE
added int4 config for qwen

### DIFF
--- a/llm_bench/python/utils/nncf_utils.py
+++ b/llm_bench/python/utils/nncf_utils.py
@@ -33,4 +33,5 @@ INT4_MODEL_CONFIGURATION = {
     "stablelm-3b-4e1t": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.8},
     "stablelm-epoch-3b-preview": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.8},
     "chatglm2-6b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.72},
+    "qwen-7b-chat": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.6},
 }


### PR DESCRIPTION
The “best guess” int4 configuration for qwen-7b-chat - int4_g128_nozp_r60.

Decided to evaluate Chinese models on Ceval-hard (30-40min per configuration):
https://github.com/hkust-nlp/ceval/blob/main/README.md#c-eval-hard-leaderboard

> We select 8 challenging math, physics, and chemistry subjects from C-Eval to form a separate benchmark, C-Eval Hard, which includes advanced mathematics, discrete mathematics, probability and statistics, college chemistry, college physics, high school mathematics, high school chemistry, and high school physics. These subjects often involve with complex LaTeX equations and require non-trivial reasoning abilities to solve.

![image](https://github.com/openvinotoolkit/openvino.genai/assets/4014476/0ded739d-9e03-45e3-bcc3-23fce123c2f2)
