### PR TITLE
Relax get model type check based on model name

### DIFF
--- a/llm_bench/python/utils/model_utils.py
+++ b/llm_bench/python/utils/model_utils.py
@@ -117,11 +117,11 @@ def get_model_type(model_name, use_case, model_framework):
     default_model_type = DEFAULT_MODEL_CLASSES.get(use_case)
     if model_framework == 'ov':
         for cls in OV_MODEL_CLASSES_MAPPING:
-            if cls in model_name:
+            if cls in model_name.lower():
                 return cls
     elif model_framework == 'pt':
         for cls in PT_MODEL_CLASSES_MAPPING:
-            if cls in model_name:
+            if cls in model_name.lower():
                 return cls
     return default_model_type
 


### PR DESCRIPTION
Recently I met following issue with chatglm3 model with get_model_type() function based on model directory name.
- For model directory with `chatglm3-6b` -> `chatglm3` -> `OVChatGLM2Model` -> Run inference successful
- For model directory with `ChatGLM3-6B` -> `decoder` -> `OVModelForCausalLM` -> Failed with following error
` File "C:\Users\S590\anaconda3\envs\openvino.genai\lib\site-packages\optimum\intel\openvino\modeling_decoder.py", line 361, in forward
    inputs[input_name] = Tensor(model_inputs.get_element_type(), shape.get_shape())
RuntimeError: Check 'min_val == max_val' failed at src\core\src\partial_shape.cpp:131:
get_shape() must be called on a static shape
`

In this PR, I would like to relax to get_model_type() check to be not case sensitives for model directory name to improve UX.
