### PR TITLE
Fix args sequence in mpt models conversion

### DIFF
--- a/llm_bench/python/convert.py
+++ b/llm_bench/python/convert.py
@@ -1026,7 +1026,7 @@ def convert_mpt(args):
                 log.info(f"Compress model weights to {compress_option}")
                 ov_model = Core().read_model(ov_dir / 'openvino_model.xml')
                 ov_compressed_path = get_compressed_path(args.output_dir, args.precision, compress_option)
-                compress_ov_model_weights_helper(ov_model, tok, pt_model.config, ov_compressed_path, compress_to_fp16, compress_option, args)
+                compress_ov_model_weights_helper(ov_model, tok, pt_model.config, ov_compressed_path, compress_option, compress_to_fp16, args)
 
 
 def convert_stablelm(args):


### PR DESCRIPTION
A fix for the mpt model issue related to https://github.com/openvinotoolkit/openvino.genai/pull/20
```
Traceback (most recent call last):
  File "convert.py", line 1774, in <module>
    main()
  File "convert.py", line 1771, in main
    converter(args)
  File "convert.py", line 1029, in convert_mpt
    compress_ov_model_weights_helper(ov_model, tok, pt_model.config, ov_compressed_path, compress_to_fp16, compress_option, args)
  File "convert.py", line 67, in compress_ov_model_weights_helper
    if "4BIT_DEFAULT" in compress_weights_format:
TypeError: argument of type 'bool' is not iterable
```