### PR TITLE
[ChatGLM2/3]Simplify the attention_mask to make stateful model correct

### DIFF
--- a/llm_bench/python/utils/conversion_utils/convert_patch.py
+++ b/llm_bench/python/utils/conversion_utils/convert_patch.py
@@ -78,7 +78,17 @@ def _chatglm_transformer_forward(
         if (attention_mask is not None and not attention_mask.all()) or (past_key_values and seq_length != 1):
             full_attention_mask = self.get_masks(input_ids, past_key_values, padding_mask=attention_mask)
         elif past_key_values is not None:
-            full_attention_mask = _get_chatglm_attention_mask(input_ids, past_key_values[0][0])
+            full_attention_mask = torch.ones(batch_size, seq_length, seq_length, 
+                                             device=input_ids.device, 
+                                             dtype=torch.float) * float("-inf")
+            full_attention_mask.triu_(diagonal=1)
+            past_length = 0
+            if past_key_values:
+                past_length = past_key_values[0][0].shape[0]
+            if past_length:
+                full_attention_mask = torch.cat((torch.zeros(batch_size, seq_length, past_length,
+                                                            device=input_ids.device), full_attention_mask), dim=-1)
+            full_attention_mask.unsqueeze_(1)
 
     # Rotary positional embeddings
     rotary_pos_emb = self.rotary_pos_emb(self.seq_length)

--- a/llm_bench/python/utils/conversion_utils/convert_patch.py
+++ b/llm_bench/python/utils/conversion_utils/convert_patch.py
@@ -78,8 +78,8 @@ def _chatglm_transformer_forward(
         if (attention_mask is not None and not attention_mask.all()) or (past_key_values and seq_length != 1):
             full_attention_mask = self.get_masks(input_ids, past_key_values, padding_mask=attention_mask)
         elif past_key_values is not None:
-            full_attention_mask = torch.ones(batch_size, seq_length, seq_length, 
-                                             device=input_ids.device, 
+            full_attention_mask = torch.ones(batch_size, seq_length, seq_length,
+                                             device=input_ids.device,
                                              dtype=torch.float) * float("-inf")
             full_attention_mask.triu_(diagonal=1)
             past_length = 0
@@ -87,7 +87,7 @@ def _chatglm_transformer_forward(
                 past_length = past_key_values[0][0].shape[0]
             if past_length:
                 full_attention_mask = torch.cat((torch.zeros(batch_size, seq_length, past_length,
-                                                            device=input_ids.device), full_attention_mask), dim=-1)
+                                                             device=input_ids.device), full_attention_mask), dim=-1)
             full_attention_mask.unsqueeze_(1)
 
     # Rotary positional embeddings


### PR DESCRIPTION
The original attention mask generation may have an extra connection between past key & attention_mask If node. This connection is not necessary since to generate attention_mask, the only need is the Shape of past-key-value. The past-key-value itself is not needed. 