### PR TITLE
Port Replace ends_with with endswith (#129) to releases/2023/3

### DIFF
--- a/llm_bench/python/utils/model_utils.py
+++ b/llm_bench/python/utils/model_utils.py
@@ -202,7 +202,7 @@ def get_model_type(model_name, use_case, model_framework):
 
 
 def normalize_model_ids(model_ids_list):
-    return [m_id[:-1] if m_id.ends_with('_') else m_id for m_id in model_ids_list]
+    return [m_id[:-1] if m_id.endswith('_') else m_id for m_id in model_ids_list]
 
 
 def get_ir_conversion_frontend(cur_model_name, model_name_list):


### PR DESCRIPTION
Port Replace ends_with with endswith (#129) to releases/2023/3 to fix benchmark.py error
`AttributeError: 'str' object has no attribute 'ends_with'. Did you mean: 'endswith'?`