### PR TITLE
Image generation fixes

### DIFF
--- a/image_generation/lcm_dreamshaper_v7/cpp/README.md
+++ b/image_generation/lcm_dreamshaper_v7/cpp/README.md
@@ -15,7 +15,7 @@ Prepare a python environment and install dependencies:
 ```shell
 conda create -n openvino_lcm_cpp python==3.10
 conda activate openvino_lcm_cpp
-conda install openvino eigen c-compiler cxx-compiler make
+conda install -c conda-forge openvino eigen c-compiler cxx-compiler make
 ```
 
 ## Step 2: Latent Consistency Model and Tokenizer models
@@ -52,7 +52,7 @@ Download and put safetensors and model IR into the models folder.
 ## Step 3: Build the LCM application
 
 ```shell
-conda activate LCM-CPP
+conda activate openvino_lcm_cpp
 cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
 cmake --build build --config Release --parallel
 ```
@@ -66,7 +66,7 @@ Usage:
 ```
 
 * `-p, --posPrompt arg` Initial positive prompt for SD  (default: cyberpunk cityscape like Tokyo New York  with tall buildings at dusk golden hour cinematic lighting)
-* `-d, --device arg`    AUTO, CPU, or GPU (default: CPU)
+* `-d, --device arg`    AUTO, CPU, or GPU. Doesn't apply to Tokenizer model, OpenVINO Tokenizers can be inferred on a CPU device only (default: CPU)
 * `--step arg`          Number of diffusion step ( default: 20)
 * `-s, --seed arg`      Number of random seed to generate latent (default: 42)
 * `--num arg`           Number of image output(default: 1)
@@ -79,6 +79,9 @@ Usage:
 * `-l, --loraPath arg`  Specify path of lora file. (*.safetensors). (default: )
 * `-a, --alpha arg`     alpha for lora (default: 0.75)
 * `-h, --help`          Print usage
+
+> [!NOTE]
+> The tokenizer model will always be loaded to CPU: [OpenVINO tokenizers](https://github.com/openvinotoolkit/openvino_contrib/tree/master/modules/custom_operations/user_ie_extensions/tokenizer/python#readme) can be inferred on a CPU device only.
 
 Example:
 

--- a/image_generation/stable_diffusion_1_5/cpp/README.md
+++ b/image_generation/stable_diffusion_1_5/cpp/README.md
@@ -78,7 +78,7 @@ Usage:
 
 * `-p, --posPrompt arg` Initial positive prompt for SD  (default: cyberpunk cityscape like Tokyo New York  with tall buildings at dusk golden hour cinematic lighting)
 * `-n, --negPrompt arg` Default is empty with space (default: )
-* `-d, --device arg`    AUTO, CPU, or GPU (default: CPU)
+* `-d, --device arg`    AUTO, CPU, or GPU. Doesn't apply to Tokenizer model, OpenVINO Tokenizers can be inferred on a CPU device only (default: CPU)
 * `--step arg`          Number of diffusion step ( default: 20)
 * `-s, --seed arg`      Number of random seed to generate latent (default: 42)
 * `--num arg`           Number of image output(default: 1)
@@ -91,6 +91,9 @@ Usage:
 * `-l, --loraPath arg`  Specify path of lora file. (*.safetensors). (default: )
 * `-a, --alpha arg`     alpha for lora (default: 0.75)
 * `-h, --help`          Print usage
+
+> [!NOTE]
+> The tokenizer model will always be loaded to CPU: [OpenVINO tokenizers](https://github.com/openvinotoolkit/openvino_contrib/tree/master/modules/custom_operations/user_ie_extensions/tokenizer/python#readme) can be inferred on a CPU device only.
 
 #### Examples
 

--- a/image_generation/stable_diffusion_1_5/cpp/src/main.cpp
+++ b/image_generation/stable_diffusion_1_5/cpp/src/main.cpp
@@ -115,7 +115,8 @@ StableDiffusionModels compile_models(const std::string& model_path, const std::s
     // Tokenizer
     {
         Timer t("Loading and compiling tokenizer");
-        models.tokenizer = core.compile_model(model_path + "/tokenizer/openvino_tokenizer.xml", device);
+        // Tokenizer model wil be loaded to CPU: OpenVINO Tokenizers can be inferred on a CPU device only.
+        models.tokenizer = core.compile_model(model_path + "/tokenizer/openvino_tokenizer.xml", "CPU");
     }
 
     return models;
@@ -208,14 +209,14 @@ int32_t main(int32_t argc, char* argv[]) try {
     options.add_options()
     ("p,posPrompt", "Initial positive prompt for SD ", cxxopts::value<std::string>()->default_value("cyberpunk cityscape like Tokyo New York  with tall buildings at dusk golden hour cinematic lighting"))
     ("n,negPrompt","Defaut is empty with space", cxxopts::value<std::string>()->default_value(" "))
-    ("d,device", "AUTO, CPU, or GPU", cxxopts::value<std::string>()->default_value("CPU"))
+    ("d,device", "AUTO, CPU, or GPU.\nDoesn't apply to Tokenizer model, OpenVINO Tokenizers can be inferred on a CPU device only", cxxopts::value<std::string>()->default_value("CPU"))
     ("step", "Number of diffusion steps", cxxopts::value<size_t>()->default_value("20"))
     ("s,seed", "Number of random seed to generate latent for one image output", cxxopts::value<size_t>()->default_value("42"))
     ("num", "Number of image output", cxxopts::value<size_t>()->default_value("1"))
-    ("height", "destination image height", cxxopts::value<size_t>()->default_value("512"))
-    ("width", "destination image width", cxxopts::value<size_t>()->default_value("512"))
-    ("c,useCache", "use model caching", cxxopts::value<bool>()->default_value("false"))
-    ("r,readNPLatent", "read numpy generated latents from file", cxxopts::value<bool>()->default_value("false"))
+    ("height", "Destination image height", cxxopts::value<size_t>()->default_value("512"))
+    ("width", "Destination image width", cxxopts::value<size_t>()->default_value("512"))
+    ("c,useCache", "Use model caching", cxxopts::value<bool>()->default_value("false"))
+    ("r,readNPLatent", "Read numpy generated latents from file", cxxopts::value<bool>()->default_value("false"))
     ("m,modelPath", "Specify path of SD model IRs", cxxopts::value<std::string>()->default_value("../models/dreamlike-anime-1.0"))
     ("t,type", "Specify the type of SD model IRs (e.g., FP16_static or FP16_dyn)", cxxopts::value<std::string>()->default_value("FP16_static"))
     ("l,loraPath", "Specify path of LoRA file. (*.safetensors).", cxxopts::value<std::string>()->default_value(""))
@@ -250,6 +251,9 @@ int32_t main(int32_t argc, char* argv[]) try {
     const std::string lora_path = result["loraPath"].as<std::string>();
     const float alpha = result["alpha"].as<float>();
 
+    OPENVINO_ASSERT(!read_np_latent || (read_np_latent && (num_images == 1)),
+        "\"readNPLatent\" option is only supported for one output image. Number of image output was set to " + std::to_string(num_images));
+
     const std::string folder_name = "images";
     try {
         std::filesystem::create_directory(folder_name);
@@ -277,7 +281,7 @@ int32_t main(int32_t argc, char* argv[]) try {
     std::vector<std::int64_t> timesteps = scheduler->get_timesteps();
 
     for (uint32_t n = 0; n < num_images; n++) {
-        std::uint32_t seed = num_images == 1 ? user_seed: n;
+        std::uint32_t seed = num_images == 1 ? user_seed: user_seed + n;
         ov::Tensor noise = randn_tensor(height, width, read_np_latent, seed);
 
         // latents are multiplied by 'init_noise_sigma'


### PR DESCRIPTION
Fixed:
- `-d` sets device for all models including tokenizer. But tokenizers are known to work on CPU only
- lcm_dreamshaper_v7 --seed is ignored for --num 4
- lcm_dreamshaper_v7 with -r outputs 4 identical images