### PR TITLE
[WWB] not include Nan on parsing ground-truth data

### DIFF
--- a/llm_bench/python/who_what_benchmark/whowhatbench/evaluator.py
+++ b/llm_bench/python/who_what_benchmark/whowhatbench/evaluator.py
@@ -61,7 +61,7 @@ class Evaluator:
         if base_model:
             self.gt_data = self._generate_data(base_model)
         else:
-            self.gt_data = pd.read_csv(gt_data)
+            self.gt_data = pd.read_csv(gt_data, keep_default_na=False)
 
         self.similarity = None
         self.divergency = None


### PR DESCRIPTION
Fixed corner case in the who-what-benchmark.
Sometimes, the ground-truth output is empty for some questions, for example on `psmathur/orca_mini_3b`, it's parsed as NaN, and it leads to error.
```
    gold="nan"
    prediction=""
...
    embeddings = model.encode([gold, prediction])
  File "...lib/python3.8/site-packages/sentence_transformers/SentenceTransformer.py", line 280, in encode
    features = self.tokenize(sentences_batch)
  File ".../lib/python3.8/site-packages/sentence_transformers/SentenceTransformer.py", line 461, in tokenize
    return self._first_module().tokenize(texts)
  File ".../lib/python3.8/site-packages/sentence_transformers/models/Transformer.py", line 134, in tokenize
    batch1.append(text_tuple[0])
TypeError: 'float' object is not subscriptable
```
Added flag to read without NaN.
    
