### PR TITLE
Added int4 configs when num channels non divisible by default group size

### DIFF
--- a/llm_bench/python/utils/nncf_utils.py
+++ b/llm_bench/python/utils/nncf_utils.py
@@ -44,4 +44,7 @@ INT4_MODEL_CONFIGURATION = {
     "rocket-3b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.8},
     "chatglm2-6b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.72},
     "qwen-7b-chat": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 128, "ratio": 0.6},
+    "open_llama_3b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 64, "all_layers": True},
+    "falcon-7b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 64, "all_layers": True},
+    "orca_mini_3b": {"mode": nncf.CompressWeightsMode.INT4_SYM, "group_size": 64, "all_layers": True},
 }


### PR DESCRIPTION
3 models has the number of channels non-divisible by default group size=128 and weight compression fails with error:
`nncf.errors.ValidationError: Channel size 8640 should be divisible by size of group 128 `
Found int4 configs within 0.2 similarity drop on WWB.

ref ticket: 132035