### PR TITLE
Limit transformers to versions smaller than 4.38.0 in releases/2024/0

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -5,7 +5,7 @@ openvino>=2023.3.0
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
-transformers>=4.33
+transformers>=4.33,<4.38.0
 diffusers>=0.22.0
 optimum>=1.14.0,<1.17.0
 git+https://github.com/huggingface/optimum-intel.git@552de65a9c5f7fa1a2f0ce6859ebdeedaeaabe53


### PR DESCRIPTION
Since converting llama to stateful fails in transformers version 4.38.0, limit transformers to versions smaller than 4.38.0.