### PR TITLE
Limit transformers to versions smaller than 4.38.0 in releases/2023/3

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -6,7 +6,7 @@ pillow
 torch
 transformers>=4.33.0,<4.38.0
 diffusers>=0.22.0
-optimum>=1.14.0
+optimum>=1.14.0,<1.17.0
 git+https://github.com/huggingface/optimum-intel.git@672c0228f511b6e9db1c690fce46ab5338908193
 nncf~=2.8.0
 packaging

--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -4,7 +4,7 @@ openvino~=2023.3.0
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
-transformers>=4.33.0
+transformers>=4.33.0,<4.38.0
 diffusers>=0.22.0
 optimum>=1.14.0
 git+https://github.com/huggingface/optimum-intel.git@672c0228f511b6e9db1c690fce46ab5338908193


### PR DESCRIPTION
Since converting llama to stateful fails in transformers version 4.38.0, limit transformers to versions smaller than 4.38.0.