### PR TITLE
Fix llama2 conversion issues "Conversion is failed for: aten::mul"

### DIFF
--- a/llm_bench/python/README.md
+++ b/llm_bench/python/README.md
@@ -14,6 +14,8 @@ source python-env/bin/activate
 pip install update --upgrade
 pip install -r requirements.txt
 ```
+> Note: For llama models, ensure to have transformers<4.38.
+
 ### 2. Convert a model to OpenVINO IR
    
 The conversion script for preparing benchmarking models,

--- a/llm_bench/python/README.md
+++ b/llm_bench/python/README.md
@@ -88,6 +88,8 @@ Parameters:
 * `-p` - interactive prompt text
 * `-pf` - path of JSONL file including interactive prompts
 * `-n` - number of benchmarking iterations, if the value greater 0, will exclude the first iteration. (default=0)
+* `-ic` - limit the output token size (default 512) of text_gen and code_gen models.
+
 
 ``` bash
 python ./benchmark.py -h # for more information
@@ -101,7 +103,7 @@ the PyTorch code by compiling it into optimized kernels using a selected backend
 Prerequisites: install benchmarking dependencies using requirements.txt
 
 ``` bash
-pip install -r requirements/requirements.txt
+pip install -r requirements.txt
 ```
 
 In order to run the `torch.compile()` on CUDA GPU, install additionally the nightly PyTorch version:

--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -5,7 +5,7 @@ openvino>=2023.3.0
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
-transformers<4.38
+transformers>=4.33
 diffusers>=0.22.0
 optimum>=1.14.0,<1.17.0
 git+https://github.com/huggingface/optimum-intel.git@552de65a9c5f7fa1a2f0ce6859ebdeedaeaabe53

--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -5,7 +5,7 @@ openvino>=2023.3.0
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
-transformers>=4.33
+transformers<4.38
 diffusers>=0.22.0
 optimum>=1.14.0,<1.17.0
 git+https://github.com/huggingface/optimum-intel.git@552de65a9c5f7fa1a2f0ce6859ebdeedaeaabe53


### PR DESCRIPTION
## Type of Change

- The PR fixes an issue mentioned in #254. There was a fix proposed in #246, but this was only applied the cpp part and not the llm_bench/python. As we speak, with current code version, the llama2 conversion fails with same error when using llm_bench/python.

- This PR introduces same fix as #246 for llm_bench/python too + fixes some missing documentation in README and typos

## Description

- Same as above

## Expected Behavior & Potential Risk

- N/A

## How has this PR been tested?

- N/A

## Dependency Change?

- N/A


