### PR TITLE
add submodule update into sd installation instructions

### DIFF
--- a/image_generation/lcm_dreamshaper_v7/cpp/README.md
+++ b/image_generation/lcm_dreamshaper_v7/cpp/README.md
@@ -24,6 +24,7 @@ conda install -c conda-forge openvino c-compiler cxx-compiler make
 1. Install dependencies to import models from HuggingFace:
 
     ```shell
+    git submodule update --init
     conda activate openvino_lcm_cpp
     python -m pip install -r scripts/requirements.txt
     python -m pip install ../../../thirdparty/openvino_tokenizers/[transformers]

--- a/image_generation/stable_diffusion_1_5/cpp/README.md
+++ b/image_generation/stable_diffusion_1_5/cpp/README.md
@@ -23,7 +23,6 @@ conda install openvino c-compiler cxx-compiler make
 
 1. Install dependencies to import models from HuggingFace:
 ```shell
-
 git submodule update --init
 conda activate openvino_sd_cpp
 python -m pip install -r scripts/requirements.txt

--- a/image_generation/stable_diffusion_1_5/cpp/README.md
+++ b/image_generation/stable_diffusion_1_5/cpp/README.md
@@ -23,6 +23,8 @@ conda install openvino c-compiler cxx-compiler make
 
 1. Install dependencies to import models from HuggingFace:
 ```shell
+
+git submodule update --init
 conda activate openvino_sd_cpp
 python -m pip install -r scripts/requirements.txt
 python -m pip install ../../../thirdparty/openvino_tokenizers/[transformers]


### PR DESCRIPTION
installing dependency as 
pip install ../../../thirdparty/openvino_tokenizers[transformers] may be confusing for users and lead to error as there is no any mentions about submodule initialization before it in comparison with text_generation demos https://github.com/openvinotoolkit/openvino.genai/tree/master/text_generation/causal_lm/cpp#install-openvino