### PR TITLE
Fix INT4 default compression folder naming

### DIFF
--- a/llm_bench/python/utils/conversion_utils/helpers.py
+++ b/llm_bench/python/utils/conversion_utils/helpers.py
@@ -12,7 +12,7 @@ import numpy as np
 from nncf import compress_weights
 from nncf import Dataset
 from openvino import save_model
-from ..nncf_utils import COMPRESSION_OPTIONS, INT4_MODEL_CONFIGURATION
+from ..nncf_utils import COMPRESSION_OPTIONS, INT4_MODEL_CONFIGURATION, is_int4_default_compression
 from optimum.intel.openvino.configuration import _check_default_4bit_configs
 import warnings
 
@@ -187,10 +187,7 @@ def compress_ov_model_weights_helper(ov_model, tok, config, out_path, compress_w
         compression_args = _check_default_4bit_configs(config)
         if compression_args is None:
             model_id = out_path.parents[3].name
-            if model_id in INT4_MODEL_CONFIGURATION:
-                compression_args = INT4_MODEL_CONFIGURATION[model_id]
-            else:
-                compression_args = COMPRESSION_OPTIONS["INT4_SYM"]
+            compression_args = is_int4_default_compression(model_id)
 
     if compression_args is None:
         compression_args = COMPRESSION_OPTIONS[compress_weights_format]

--- a/llm_bench/python/utils/conversion_utils/helpers.py
+++ b/llm_bench/python/utils/conversion_utils/helpers.py
@@ -12,7 +12,7 @@ import numpy as np
 from nncf import compress_weights
 from nncf import Dataset
 from openvino import save_model
-from ..nncf_utils import COMPRESSION_OPTIONS, INT4_MODEL_CONFIGURATION, is_int4_default_compression
+from ..nncf_utils import COMPRESSION_OPTIONS, INT4_MODEL_CONFIGURATION, get_int4_default_compression_args
 from optimum.intel.openvino.configuration import _check_default_4bit_configs
 import warnings
 

--- a/llm_bench/python/utils/nncf_utils.py
+++ b/llm_bench/python/utils/nncf_utils.py
@@ -23,8 +23,20 @@ if "INT8_SYM" in nncf.CompressWeightsMode.__members__:
     COMPRESSION_OPTIONS["INT8_SYM"] = {"mode": nncf.CompressWeightsMode.INT8_SYM}
 
 
-def get_compressed_path(output_dir: str, base_precision, option: str):
-    return Path(output_dir) / "pytorch/dldt/compressed_weights" / f"OV_{base_precision}-{option}"
+def get_int4_default_compression_args(model_id):
+    if model_id in INT4_MODEL_CONFIGURATION:
+        compression_args = INT4_MODEL_CONFIGURATION[model_id]
+    else:
+        compression_args = COMPRESSION_OPTIONS["INT4_SYM"]
+    return compression_args
+
+
+def get_compressed_path(output_dir: str, base_precision: str, option: str):
+    output_dir = Path(output_dir)
+    if option == "4BIT_DEFAULT":
+        model_id = Path(output_dir).parents[3].name
+        option = get_int4_default_compression_args(model_id)["mode"].split(".")[-1].upper()    
+    return output_dir / "pytorch" / "dldt" / "compressed_weights" / f"OV_{base_precision}-{option}"
 
 
 INT4_MODEL_CONFIGURATION = {

--- a/llm_bench/python/utils/nncf_utils.py
+++ b/llm_bench/python/utils/nncf_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging as log
 
 import nncf
 
@@ -28,6 +29,7 @@ def get_int4_default_compression_args(model_id):
         compression_args = INT4_MODEL_CONFIGURATION[model_id]
     else:
         compression_args = COMPRESSION_OPTIONS["INT4_SYM"]
+        log.info(f"Model is not supported with 4BIT_DEFAULT. Compress weights configuration was switched to INT4_SYM.")
     return compression_args
 
 
@@ -35,7 +37,7 @@ def get_compressed_path(output_dir: str, base_precision: str, option: str):
     output_dir = Path(output_dir)
     if option == "4BIT_DEFAULT":
         model_id = Path(output_dir).parents[3].name
-        option = get_int4_default_compression_args(model_id)["mode"].split(".")[-1].upper()    
+        option = get_int4_default_compression_args(model_id)["mode"].split(".")[-1].upper()
     return output_dir / "pytorch" / "dldt" / "compressed_weights" / f"OV_{base_precision}-{option}"
 
 


### PR DESCRIPTION
Previously while running compression with the `4BIT_DEFAULT` parameter there was a misleading folder name when the model wasn't listed in `INT4_MODEL_CONFIGURATION`. Now we are able to locate the model under the actual compression option that was switched to.