### PR TITLE
Correctly parse model names for starcoder-2-15b

### DIFF
--- a/llm_bench/python/utils/config_class.py
+++ b/llm_bench/python/utils/config_class.py
@@ -101,7 +101,8 @@ USE_CASES = {
         "deci",
         "internlm",
         "olmo",
-        "phi3"
+        "phi3",
+        "starcoder"
     ],
     'ldm_super_resolution': ['ldm-super-resolution'],
 }


### PR DESCRIPTION
starcoder-2-15b's model name incorrectly parsed as gpt- due to get use_case from model config.