### PR TITLE
Fix for pybind11 + python

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,6 +11,11 @@ FetchContent_Declare(
 FetchContent_GetProperties(pybind11)
 if(NOT pybind11_POPULATED)
     FetchContent_Populate(pybind11)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+    else()
+        find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+    endif()
     # search for FindPython3.cmake instead of legacy modules
     set(PYBIND11_FINDPYTHON ON)
     add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})


### PR DESCRIPTION
See https://discourse.cmake.org/t/python3-add-library-should-get-defined-even-if-libpython-not-present/4640