### PR TITLE
[Continuous Batching] Changes in notify_handle() + simple metrics reporting

### DIFF
--- a/text_generation/causal_lm/cpp/continuous_batching/Dockerfile
+++ b/text_generation/causal_lm/cpp/continuous_batching/Dockerfile
@@ -24,12 +24,16 @@ ENV OpenVINO_DIR=/workspace/openvino_build
 # Download dataset
 RUN wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
 
-# Build continuous batching library
-RUN git clone --branch ct-beam-search https://github.com/ilya-lavrenov/openvino.genai.git && cd /workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching && \
-        git submodule update --remote --init && cmake -DCMAKE_BUILD_TYPE=Release -S ./ -B ./build/ && cmake --build ./build/ -j $JOBS
+# Build GenAI library with dependencies
+RUN git clone https://github.com/openvinotoolkit/openvino.genai.git && \
+        cd /workspace/openvino.genai/thirdparty && git submodule update --remote --init && \
+        mkdir -p openvino_tokenizers/build && cd openvino_tokenizers/build && \
+        cmake -DENABLE_PYTHON=ON -DCMAKE_BUILD_TYPE=Release .. && make -j${JOBS} && \
+        cd /workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching && \
+        cmake -DCMAKE_BUILD_TYPE=Release -S ./ -B ./build/ && cmake --build ./build/ -j $JOBS
 
 # Install test dependencies
 RUN python3 -m pip install --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly/ /workspace/openvino.genai/thirdparty/openvino_tokenizers
 RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install -r /workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching/python/tests/requirements.txt
 ENV PYTHONPATH=/workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching/build/python
-ENV LD_LIBRARY_PATH=/workspace/openvino.genai/build/openvino_genai/
+ENV LD_LIBRARY_PATH=/workspace/openvino.genai/thirdparty/openvino_tokenizers/build/src

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
@@ -11,6 +11,15 @@
 #include "generation_config.hpp"
 #include "generation_handle.hpp"
 
+struct PipelineMetrics { 
+    // All requests as viewed by the pipeline
+    size_t requests = 0;
+    // Requests scheduled for processing
+    size_t scheduled_requests = 0;
+    // Percentage of KV cache usage
+    float cache_usage = 0.0;
+};
+
 class ContinuousBatchingPipeline {
     class Impl;
     std::shared_ptr<Impl> m_impl;
@@ -24,6 +33,8 @@ public:
     std::shared_ptr<Tokenizer> get_tokenizer();
 
     GenerationConfig get_config() const;
+
+    PipelineMetrics get_metrics() const;
 
     GenerationHandle add_request(uint64_t request_id, std::string prompt, GenerationConfig sampling_params);
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/block_manager.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/block_manager.hpp
@@ -130,6 +130,10 @@ public:
         }
     }
 
+    float get_used_percentage() const {
+        return m_allocator.get_used_percentage();
+    }
+
     void fork_sequence(uint64_t parent_id, uint64_t child_id) {
         OPENVINO_ASSERT(m_block_table.count(child_id) == 0);
         m_block_table[child_id].reserve(m_block_table[parent_id].size());

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
@@ -28,6 +28,8 @@ public:
         size_t m_total_num_scheduled_tokens = 0;
         // dedicated prompt phase
         bool is_prompt = false;
+        // current cache usage
+        float m_cache_usage = 0.0;
     };
 
     explicit Scheduler(const SchedulerConfig & config = {}) :
@@ -56,6 +58,7 @@ public:
         }
 
         _clear_waiting_sequences(sequence_groups);
+        scheduler_output.m_cache_usage = m_block_manager.get_used_percentage();
         return scheduler_output;
     }
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
@@ -432,6 +432,13 @@ public:
     }
 
     void notify_handle() {
+
+        if (out_of_memory()) {
+            set_generation_status(GenerationStatus::IGNORED);
+        } else if (has_finished()) {
+            set_generation_status(GenerationStatus::FINISHED);
+        }
+
         GenerationOutputs outputs;
 
         // For beam search streaming is not available, so we notify only upon finishing
@@ -478,12 +485,6 @@ public:
                     m_generation_stream->push(outputs);
                 }
             }
-        }
-
-        if (out_of_memory()) {
-            set_generation_status(GenerationStatus::IGNORED);
-        } else if (has_finished()) {
-            set_generation_status(GenerationStatus::FINISHED);
         }
     } 
 };


### PR DESCRIPTION
Changes:
- switching operation order in notify_handle, so that generation status is set before sending out last token, so user will never get status RUNNING when generation is already done and no new tokens will come
- add simple metrics giving some basic information about pipeline state like number of all requests, number of running request, cache usage etc.