### PR TITLE
fix infinite generation

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
         // false means continue generation.
         return false;
     };
-    std::cout << pipe.generate("The Sun is yellow bacause", streamer);
+    std::cout << pipe.generate("The Sun is yellow bacause", ov::genai::streamer(streamer));
 }
 ```
 
@@ -192,7 +192,7 @@ int main(int argc, char* argv[]) {
 
     std::string model_path = argv[1];
     ov::genai::LLMPipeline pipe(model_path, "CPU");
-    std::cout << pipe.generate("The Sun is yellow because", custom_streamer);
+    std::cout << pipe.generate("The Sun is yellow because", ov::genai::streamer(custom_streamer));
 }
 ```
 

--- a/src/README.md
+++ b/src/README.md
@@ -50,7 +50,7 @@ Calling generate with custom generation config parameters, e.g. config for group
 import openvino_genai as ov_genai
 pipe = ov_genai.LLMPipeline(model_path, "CPU")
 
-result = pipe.generate("The Sun is yellow because", max_new_tokens=30, num_groups=3, group_size=5, diversity_penalty=1.5)
+result = pipe.generate("The Sun is yellow because", max_new_tokens=30, num_beam_groups=3, num_beams=15, diversity_penalty=1.5)
 print(result)
 ```
 
@@ -64,7 +64,7 @@ A simple chat in Python:
 import openvino_genai as ov_genai
 pipe = ov_genai.LLMPipeline(model_path)
 
-config = {'max_new_tokens': 100, 'num_groups': 3, 'group_size': 5, 'diversity_penalty': 1.5}
+config = {'max_new_tokens': 100, 'num_beam_groups': 3, 'num_beams': 15, 'diversity_penalty': 1.5}
 pipe.set_generation_config(config)
 
 pipe.start_chat()
@@ -104,8 +104,8 @@ int main(int argc, char* argv[]) {
 
     ov::genai::GenerationConfig config;
     config.max_new_tokens = 256;
-    config.num_groups = 3;
-    config.group_size = 5;
+    config.num_beam_groups = 3;
+    config.num_beams = 15;
     config.diversity_penalty = 1.0f;
 
     std::cout << pipe.generate("The Sun is yellow because", config);
@@ -125,8 +125,8 @@ int main(int argc, char* argv[]) {
     
     ov::genai::GenerationConfig config;
     config.max_new_tokens = 100;
-    config.num_groups = 3;
-    config.group_size = 5;
+    config.num_beam_groups = 3;
+    config.num_beams = 15;
     config.diversity_penalty = 1.0f;
     
     pipe.start_chat();

--- a/src/python/py_generate_pipeline.cpp
+++ b/src/python/py_generate_pipeline.cpp
@@ -491,7 +491,7 @@ PYBIND11_MODULE(py_generate_pipeline, m) {
      // Binding for GenerationConfig
     py::class_<GenerationConfig>(m, "GenerationConfig", generation_config_docstring)
         .def(py::init<std::string>(), py::arg("json_path"), "path where generation_config.json is stored")
-        .def(py::init([](py::kwargs kwargs) { return *update_config_from_kwargs({}, kwargs); }))
+        .def(py::init([](py::kwargs kwargs) { return *update_config_from_kwargs(GenerationConfig(), kwargs); }))
         .def_readwrite("max_new_tokens", &GenerationConfig::max_new_tokens)
         .def_readwrite("max_length", &GenerationConfig::max_length)
         .def_readwrite("ignore_eos", &GenerationConfig::ignore_eos)


### PR DESCRIPTION
It turned out that if user didn't specify config in generation then a default `GenerationConfig` is constructed which wipes out config red from `genration_config.json`.

Pass `std::nullopt` if user didn't specify genration config.

Updated docs in openvino repo as well https://github.com/openvinotoolkit/openvino/pull/25283

Tickets: CVS-145154 CVS-145218