### PR TITLE
Set default 4bit compression to INT4_ASYM

### DIFF
--- a/llm_bench/python/utils/conversion_utils/helpers.py
+++ b/llm_bench/python/utils/conversion_utils/helpers.py
@@ -199,7 +199,7 @@ def compress_ov_model_weights_helper(ov_model, tok, config, out_path, compress_w
             if model_id in INT4_MODEL_CONFIGURATION:
                 compression_args = INT4_MODEL_CONFIGURATION[model_id]
             else:
-                compression_args = COMPRESSION_OPTIONS["INT4_SYM"]
+                compression_args = COMPRESSION_OPTIONS["INT4_ASYM"]
 
     if compression_args is None:
         compression_args = COMPRESSION_OPTIONS[compress_weights_format]


### PR DESCRIPTION
This PR aligns default 4-bit weight compression parameters between optimum-intel and opengino.genai repositories. The default parameters are: `bits=4, sym=False, ratio=1.0, group_size=128`. This will be applied when there is no custom compression recipe for the given model id.

Corresponding PR to optimum-intel: https://github.com/huggingface/optimum-intel/pull/805