### PR TITLE
[Continuous batching] In place logit transformations

### DIFF
--- a/samples/cpp/continuous_batching_benchmark/continuous_batching_benchmark.cpp
+++ b/samples/cpp/continuous_batching_benchmark/continuous_batching_benchmark.cpp
@@ -11,8 +11,6 @@
 #include <mutex>
 #include <atomic>
 
-
-#include <openvino/openvino.hpp>
 #include <nlohmann/json.hpp>
 #include <cxxopts.hpp>
 
@@ -123,6 +121,11 @@ Dataset filtered_dataset(const std::string& models_path, const std::string& data
 
         ov::genai::GenerationConfig greedy_search = ov::genai::greedy();
         greedy_search.max_new_tokens = std::min(max_output_len, output_len);
+        greedy_search.repetition_penalty = 1.0;
+        greedy_search.frequency_penalty = 0.0;
+        greedy_search.presence_penalty = 0.0;
+        greedy_search.diversity_penalty = 0.0;
+        greedy_search.length_penalty = 0.0;
 
         dataset.push_data(human_question, greedy_search);
         dataset.push_lens(input_len, output_len);
@@ -425,7 +428,7 @@ int main(int argc, char* argv[]) try {
     options.add_options()
     ("n,num_prompts", "A number of prompts", cxxopts::value<size_t>()->default_value("1000"))
     ("b,max_batch_size", "A maximum number of batched tokens", cxxopts::value<size_t>()->default_value("256"))
-    ("dynamic_split_fuse", "Whether to use dynamic split-fuse or vLLM scheduling", cxxopts::value<bool>()->default_value("false"))
+    ("dynamic_split_fuse", "Whether to use dynamic split-fuse or vLLM scheduling", cxxopts::value<bool>()->default_value("true"))
     ("m,model", "Path to model and tokenizers base directory", cxxopts::value<std::string>()->default_value("."))
     ("dataset", "Path to dataset .json file", cxxopts::value<std::string>()->default_value("./ShareGPT_V3_unfiltered_cleaned_split.json"))
     ("max_input_len", "Max input length take from dataset", cxxopts::value<size_t>()->default_value("1024"))

--- a/src/cpp/src/sampler.hpp
+++ b/src/cpp/src/sampler.hpp
@@ -288,7 +288,7 @@ SamplerOutput Sampler::sample(std::vector<SequenceGroup::Ptr> & sequence_groups,
                 };
                 for (size_t running_sequence_id = 0; running_sequence_id < num_running_sequences; ++running_sequence_id) {
                     auto logit_vector = _get_logit_vector(sequence_group_logits, running_sequence_id);
-                    logit_vector = logit_processor.apply(logit_vector);
+                    logit_processor.apply(logit_vector);
 
                     Token sampled_token_id;
                     if (sampling_params.is_greedy_decoding()) {

--- a/tests/cpp/logit_filtering.cpp
+++ b/tests/cpp/logit_filtering.cpp
@@ -18,13 +18,14 @@ using TemperatureTransformTest = testing::TestWithParam<TemperatureTransformTest
 
 TEST_P(TemperatureTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = TemperatureLogitTransform(test_struct.temperature);
-    auto test_result = transform.apply(test_struct.input);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    std::sort(test_result.begin(), test_result.end(), [](const Token& lhs, const Token& rhs) {return lhs.m_log_prob > rhs.m_log_prob; });
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    std::sort(logits.begin(), logits.end(), [](const Token& lhs, const Token& rhs) {return lhs.m_log_prob > rhs.m_log_prob; });
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 
@@ -51,12 +52,13 @@ using TopPFilteringTest = testing::TestWithParam<TopPTestStruct>;
 
 TEST_P(TopPFilteringTest, FilterResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = TopPFilter(test_struct.top_p);
-    auto test_result = transform.apply(test_struct.input);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 
@@ -83,12 +85,13 @@ using TopKFilteringTest = testing::TestWithParam<TopKTestStruct>;
 
 TEST_P(TopKFilteringTest, FilterResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = TopKFilter(test_struct.top_k);
-    auto test_result = transform.apply(test_struct.input);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 
@@ -113,12 +116,13 @@ using ProbabilityNormalizeTransformTest = testing::TestWithParam<ProbabilityNorm
 
 TEST_P(ProbabilityNormalizeTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = ProbabilityNormalizeTransform();
-    auto test_result = transform.apply(test_struct.input);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 
@@ -134,7 +138,7 @@ INSTANTIATE_TEST_SUITE_P(VariousInputs,
 
 struct RepetitionPenaltyTransformTestStruct {
     float penalty;
-    std::vector<Token> input_logits;
+    std::vector<Token> input;
     TokenIds input_ids;
     std::vector<Token> expected_output;
 };
@@ -143,12 +147,13 @@ using RepetitionPenaltyTransformTest = testing::TestWithParam<RepetitionPenaltyT
 
 TEST_P(RepetitionPenaltyTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = RepetitionPenaltyTransform(test_struct.penalty);
-    auto test_result = transform.apply(test_struct.input_logits, test_struct.input_ids);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits, test_struct.input_ids);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 
@@ -180,13 +185,15 @@ INSTANTIATE_TEST_SUITE_P(VariousInputs,
 
 TEST(RepetitionPenaltyTransformInitializationTest, ThrowsForInvalidInputIds) {
     auto transform = RepetitionPenaltyTransform(1.5);
-    EXPECT_THROW(transform.apply({{43.0f, 0}}, {1337}), ov::Exception);
-    EXPECT_THROW(transform.apply({{18.0f, 0}}, {0, -1}), ov::Exception);
+    std::vector<Token> input {{43.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {1337}), ov::Exception);
+    input = {{18.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {0, -1}), ov::Exception);
 }
 
 struct FrequencyPenaltyTransformTestStruct {
     float penalty;
-    std::vector<Token> input_logits;
+    std::vector<Token> input;
     TokenIds input_ids;
     std::vector<Token> expected_output;
 };
@@ -195,12 +202,13 @@ using FrequencyPenaltyTransformTest = testing::TestWithParam<FrequencyPenaltyTra
 
 TEST_P(FrequencyPenaltyTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = FrequencyPenaltyTransform(test_struct.penalty);
-    auto test_result = transform.apply(test_struct.input_logits, test_struct.input_ids);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits, test_struct.input_ids);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 };
 
@@ -232,14 +240,16 @@ INSTANTIATE_TEST_SUITE_P(VariousInputs,
 
 TEST(FrequencyPenaltyTransformInitializationTest, ThrowsForInvalidInputIds) {
     auto transform = FrequencyPenaltyTransform(1.5);
-    EXPECT_THROW(transform.apply({{43.0f, 0}}, {1337}), ov::Exception);
-    EXPECT_THROW(transform.apply({{18.0f, 0}}, {0, -1}), ov::Exception);
+    std::vector<Token> input {{43.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {1337}), ov::Exception);
+    input = {{18.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {0, -1}), ov::Exception);
 }
 
 
 struct PresencePenaltyTransformTestStruct {
     float penalty;
-    std::vector<Token> input_logits;
+    std::vector<Token> input;
     TokenIds input_ids;
     std::vector<Token> expected_output;
 };
@@ -248,12 +258,13 @@ using PresencePenaltyTransformTest = testing::TestWithParam<PresencePenaltyTrans
 
 TEST_P(PresencePenaltyTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = PresencePenaltyTransform(test_struct.penalty);
-    auto test_result = transform.apply(test_struct.input_logits, test_struct.input_ids);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits, test_struct.input_ids);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 };
 
@@ -285,13 +296,15 @@ INSTANTIATE_TEST_SUITE_P(VariousInputs,
 
 TEST(PresencePenaltyTransformInitializationTest, ThrowsForInvalidInputIds) {
     auto transform = PresencePenaltyTransform(1.5);
-    EXPECT_THROW(transform.apply({{43.0f, 0}}, {1337}), ov::Exception);
-    EXPECT_THROW(transform.apply({{18.0f, 0}}, {0, -1} ), ov::Exception);
+    std::vector<Token> input {{43.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {1337}), ov::Exception);
+    input = {{18.0f, 0}};
+    EXPECT_THROW(transform.apply(input, {0, -1}), ov::Exception);
 }
 
 struct EOSPenaltyTransformTestStruct {
     size_t eos_token_id;
-    std::vector<Token> input_logits;
+    std::vector<Token> input;
     std::vector<Token> expected_output;
 };
 
@@ -299,12 +312,13 @@ using EOSPenaltyTransformTest = testing::TestWithParam<EOSPenaltyTransformTestSt
 
 TEST_P(EOSPenaltyTransformTest, TransformResultEqualToReference) {
     auto test_struct = GetParam();
+    auto logits = test_struct.input;
     auto transform = EOSPenaltyTransform(test_struct.eos_token_id, std::numeric_limits<size_t>::max());
-    auto test_result = transform.apply(test_struct.input_logits);
-    ASSERT_EQ(test_result.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < test_result.size(); i++) {
-        EXPECT_NEAR(test_result[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(test_result[i].m_index, test_struct.expected_output[i].m_index);
+    transform.apply(logits);
+    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
+        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
     }
 }
 

--- a/tests/cpp/logit_filtering.cpp
+++ b/tests/cpp/logit_filtering.cpp
@@ -106,36 +106,6 @@ INSTANTIATE_TEST_SUITE_P(VariousInputs,
                          TopKFilteringTest,
                          testing::ValuesIn(TOP_K_TRANSFORM_TEST_CASES));
 
-
-struct ProbabilityNormalizeTransformTestStruct {
-    std::vector<Token> input;
-    std::vector<Token> expected_output;
-};
-
-using ProbabilityNormalizeTransformTest = testing::TestWithParam<ProbabilityNormalizeTransformTestStruct>;
-
-TEST_P(ProbabilityNormalizeTransformTest, TransformResultEqualToReference) {
-    auto test_struct = GetParam();
-    auto logits = test_struct.input;
-    auto transform = ProbabilityNormalizeTransform();
-    transform.apply(logits);
-    ASSERT_EQ(logits.size(), test_struct.expected_output.size());
-    for (size_t i = 0; i < logits.size(); i++) {
-        EXPECT_NEAR(logits[i].m_log_prob, test_struct.expected_output[i].m_log_prob, 1e-6);
-        EXPECT_EQ(logits[i].m_index, test_struct.expected_output[i].m_index);
-    }
-}
-
-
-const std::vector<ProbabilityNormalizeTransformTestStruct> NORMALIZE_TRANSFORM_TEST_CASES = {
-    { { {0.090031, 2}, {0.244728, 0}, {0.665241, 1} }, { {0.090031, 2}, {0.244728, 0}, {0.665241, 1}  } },
-    { { {0.05, 0}, {0.03, 1}, {0.02, 2} }, { {0.5, 0}, {0.3, 1}, {0.2, 2}  } },
-};
-
-INSTANTIATE_TEST_SUITE_P(VariousInputs,
-                         ProbabilityNormalizeTransformTest,
-                         testing::ValuesIn(NORMALIZE_TRANSFORM_TEST_CASES));
-
 struct RepetitionPenaltyTransformTestStruct {
     float penalty;
     std::vector<Token> input;

--- a/tests/python_tests/test_preemption.py
+++ b/tests/python_tests/test_preemption.py
@@ -22,7 +22,6 @@ def get_beam_search_seq_len_300() -> GenerationConfig:
     generation_config.num_beam_groups = 3
     generation_config.num_beams = 6
     generation_config.max_new_tokens = 300
-    generation_config.num_return_sequences = 3
     generation_config.num_return_sequences = generation_config.num_beams
     return generation_config
 


### PR DESCRIPTION
Changes:
- Changing apply() methods signature to avoid returning vector copies and run all transformations in place
- Change default benchmark app generation config and use dynamic split fuse by default
- Minor fixes