### PR TITLE
Clear beam search info when generate() is finished.

### DIFF
--- a/samples/cpp/continuous_batching_accuracy/continuous_batching_accuracy.cpp
+++ b/samples/cpp/continuous_batching_accuracy/continuous_batching_accuracy.cpp
@@ -39,16 +39,13 @@ int main(int argc, char* argv[]) try {
 
     const size_t num_prompts = result["num_prompts"].as<size_t>();
     const bool dynamic_split_fuse = result["dynamic_split_fuse"].as<bool>();
-    const std::string models_path = result["model"].as<std::string>();
+    const std::string models_path = "/home/panas/llm/models/TinyLlama-1.1B-Chat-v1.0/";
 
     // create dataset
 
     std::vector<std::string> prompt_examples = {
-        "What is OpenVINO?",
-        "How are you?",
-        "What is your name?",
-        "Tell me something about Canada",
-        "What is OpenVINO?",
+        "hello",
+        "Here is the longest novel ever: "
     };
 
     std::vector<ov::genai::GenerationConfig> sampling_params_examples {
@@ -57,7 +54,7 @@ int main(int argc, char* argv[]) try {
         ov::genai::multinomial(),
     };
 
-    std::vector<std::string> prompts(num_prompts);
+    std::vector<std::string> prompts(2);
     std::vector<ov::genai::GenerationConfig> sampling_params(num_prompts);
 
     for (size_t request_id = 0; request_id < num_prompts; ++request_id) {
@@ -79,7 +76,49 @@ int main(int argc, char* argv[]) try {
     scheduler_config.max_num_seqs = 2;
 
     ov::genai::ContinuousBatchingPipeline pipe(models_path, scheduler_config);
-    std::vector<ov::genai::GenerationResult> generation_results = pipe.generate(prompts, sampling_params);
+    ov::genai::GenerationConfig prototype;
+    prototype.max_new_tokens = 20;
+    prototype.num_beam_groups = 3;
+    prototype.num_beams = 15;
+    prototype.diversity_penalty = 1.0;
+    std::vector<ov::genai::GenerationResult> generation_results = pipe.generate({
+        "hello",
+        "Here is the longest novel ever: "
+    }, std::vector(2, prototype));
+
+
+    for (size_t request_id = 0; request_id < generation_results.size(); ++request_id) {
+        const ov::genai::GenerationResult & generation_result = generation_results[request_id];
+        std::cout << "Question: " << prompts[request_id] << std::endl;
+        switch (generation_result.m_status)
+        {
+        case ov::genai::GenerationStatus::FINISHED:
+            print_generation_result(generation_result);
+            break;
+        case ov::genai::GenerationStatus::IGNORED:
+            std::cout << "Request was ignored due to lack of memory." <<std::endl;
+            if (generation_result.m_generation_ids.size() > 0) {
+                std::cout << "Partial result:" << std::endl;
+                print_generation_result(generation_result);
+            }
+            break;
+        case ov::genai::GenerationStatus::DROPPED_BY_PIPELINE:
+            std::cout << "Request was aborted." <<std::endl;
+            if (generation_result.m_generation_ids.size() > 0) {
+                std::cout << "Partial result:" << std::endl;
+                print_generation_result(generation_result);
+            }
+            break;   
+        default:
+            break;
+        }
+        std::cout << std::endl;
+    }
+
+    generation_results = pipe.generate({
+        "hello",
+        "Here is the longest novel ever: "
+    }, std::vector(2, prototype));
 
     for (size_t request_id = 0; request_id < generation_results.size(); ++request_id) {
         const ov::genai::GenerationResult & generation_result = generation_results[request_id];

--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -269,6 +269,7 @@ public:
             result.m_status = generation->get_status();
             results.push_back(result);
         }
+        m_sampler->clear_beam_search_info();
 
         OPENVINO_ASSERT(results.size() == prompts.size());
         return results;

--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -61,8 +61,8 @@ class ContinuousBatchingPipeline::Impl {
                 for (const auto& sequence: request->get_sequences()) {
                     m_scheduler->free_sequence(sequence->get_id());
                 }
-                requests_iterator = m_requests.erase(requests_iterator);
                 m_sampler->clear_beam_search_info(request->get_request_id());
+                requests_iterator = m_requests.erase(requests_iterator);
             } else {
                 requests_iterator++;
             }

--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -62,6 +62,7 @@ class ContinuousBatchingPipeline::Impl {
                     m_scheduler->free_sequence(sequence->get_id());
                 }
                 requests_iterator = m_requests.erase(requests_iterator);
+                m_sampler->clear_beam_search_info(request->get_request_id());
             } else {
                 requests_iterator++;
             }
@@ -269,7 +270,6 @@ public:
             result.m_status = generation->get_status();
             results.push_back(result);
         }
-        m_sampler->clear_beam_search_info();
 
         OPENVINO_ASSERT(results.size() == prompts.size());
         return results;

--- a/src/cpp/src/sampler.hpp
+++ b/src/cpp/src/sampler.hpp
@@ -248,7 +248,7 @@ public:
 
     void set_seed(size_t seed) { rng_engine.seed(seed); }
 
-    void clear_beam_search_info();
+    void clear_beam_search_info(uint64_t request_id);
 };
 
 SamplerOutput Sampler::sample(std::vector<SequenceGroup::Ptr> & sequence_groups, ov::Tensor logits) {
@@ -581,7 +581,7 @@ void GroupBeamSearcher::select_next_tokens(const ov::Tensor& logits, SamplerOutp
     }
 }
 
-void Sampler::clear_beam_search_info() { 
-    m_beam_search_info.clear();
+void Sampler::clear_beam_search_info(uint64_t request_id) { 
+    m_beam_search_info.erase(request_id);
 }
 }

--- a/src/cpp/src/sampler.hpp
+++ b/src/cpp/src/sampler.hpp
@@ -247,6 +247,8 @@ public:
     SamplerOutput sample(std::vector<SequenceGroup::Ptr> & sequence_groups, ov::Tensor logits);
 
     void set_seed(size_t seed) { rng_engine.seed(seed); }
+
+    void clear_beam_search_info();
 };
 
 SamplerOutput Sampler::sample(std::vector<SequenceGroup::Ptr> & sequence_groups, ov::Tensor logits) {
@@ -577,5 +579,9 @@ void GroupBeamSearcher::select_next_tokens(const ov::Tensor& logits, SamplerOutp
             group.ongoing = child_beams_per_group[group_id];
         }
     }
+}
+
+void Sampler::clear_beam_search_info() { 
+    m_beam_search_info.clear();
 }
 }


### PR DESCRIPTION
When generate() is launched multiple times `beam_search_info` is not cleared and cause failing of sampling.
To fix it added clearing of `beam_search_info` when generate() is finished.