### PR TITLE
Set torchvision to < 0.19.0

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -7,6 +7,7 @@ openvino_genai
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
+torchvision<0.19.0
 transformers>=4.40.0
 diffusers>=0.22.0
 #optimum is in dependency list of optimum-intel 


### PR DESCRIPTION
Using torchvision with version 0.19.0 causes the following issue:
```
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\site-packages\transformers\utils\import_utils.py", line 1567, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "C:\Program Files\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\Program Files\Python310\lib\site-packages\transformers\models\auto\image_processing_auto.py", line 27, in <module>
    from ...image_processing_utils import BaseImageProcessor, ImageProcessingMixin
  File "C:\Program Files\Python310\lib\site-packages\transformers\image_processing_utils.py", line 21, in <module>
    from .image_transforms import center_crop, normalize, rescale
  File "C:\Program Files\Python310\lib\site-packages\transformers\image_transforms.py", line 22, in <module>
    from .image_utils import (
  File "C:\Program Files\Python310\lib\site-packages\transformers\image_utils.py", line 58, in <module>
    from torchvision.transforms import InterpolationMode
  File "C:\Program Files\Python310\lib\site-packages\torchvision\__init__.py", line 10, in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils  # usort:skip
  File "C:\Program Files\Python310\lib\site-packages\torchvision\_meta_registrations.py", line 163, in <module>
    @torch.library.register_fake("torchvision::nms")
AttributeError: module 'torch.library' has no attribute 'register_fake'
```