### PR TITLE
Bump product version to match openvino/tokenizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ elseif(NOT GENERATOR_IS_MULTI_CONFIG_VAR AND NOT DEFINED CMAKE_BUILD_TYPE)
 endif()
 
 project(OpenVINOGenAI
-        VERSION 2024.3.0.0
+        VERSION 2024.4.0.0
         DESCRIPTION "OpenVINO GenAI"
         HOMEPAGE_URL "https://github.com/openvinotoolkit/openvino.genai"
         LANGUAGES CXX)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openvino_genai"
-version = "2024.3.0.0"
+version = "2024.4.0.0"
 description = "Python bindings for https://github.com/openvinotoolkit/openvino.genai"
 requires-python = ">=3.8"
 readme = {file = "src/README.md", content-type="text/markdown"}
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "openvino_tokenizers~=2024.3.0.0.dev"
+    "openvino_tokenizers~=2024.4.0.0.dev"
 ]
 
 [tool.py-build-cmake.module]


### PR DESCRIPTION
Openvino and tokenizers are already bumped on master:
https://github.com/openvinotoolkit/openvino_tokenizers/pull/194
https://github.com/openvinotoolkit/openvino/pull/25520 