### PR TITLE
Revert torchvision constraint

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -7,7 +7,6 @@ openvino_genai
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch
-torchvision<0.19.0
 transformers>=4.40.0
 diffusers>=0.22.0
 #optimum is in dependency list of optimum-intel 


### PR DESCRIPTION
After the newest release of [torch==2.4.0](https://pypi.org/project/torch/2.4.0/) the issue with `torchvision` is gone. Installing the constraint `torchvision<0.19.0` with the mentioned `torch` version is a root cause of the following error:
`RuntimeError: operator torchvision::nms does not exist`

For more details please refer to the [link](https://ci-dlbenchmark-icv.iotg.sclab.intel.com/job/DL-Benchmark/job/prod/job/WW29-2024.3.0-16020-RC1/job/LN_CPU_compile_ubuntu22_xeon-gold-6338-atsm/9/).