### PR TITLE
Update _check_default_4bit_configs usage

### DIFF
--- a/llm_bench/python/requirements.txt
+++ b/llm_bench/python/requirements.txt
@@ -11,7 +11,7 @@ torchvision<0.19.0
 transformers>=4.40.0
 diffusers>=0.22.0
 #optimum is in dependency list of optimum-intel 
-git+https://github.com/huggingface/optimum-intel.git@439d61f79cf55d5d0b28334f577b6ac3c5ced28f#egg=optimum-intel
+git+https://github.com/huggingface/optimum-intel.git@a863f4dd946545bfa5caec43e470bd6ffccf589e#egg=optimum-intel
 git+https://github.com/openvinotoolkit/nncf.git@develop#egg=nncf
 packaging
 psutil

--- a/llm_bench/python/utils/conversion_utils/helpers.py
+++ b/llm_bench/python/utils/conversion_utils/helpers.py
@@ -189,7 +189,7 @@ def compress_ov_model_weights_helper(ov_model, tok, config, out_path, compress_w
     if "INT8" in compress_weights_format and "INT8_ASYM" in COMPRESSION_OPTIONS:
         warnings.warn("Usage INT8 mode is deprecated and will be removed soon. Please use INT8_ASYM instead", DeprecationWarning)
     if "4BIT_DEFAULT" in compress_weights_format:
-        compression_args = _check_default_4bit_configs(config)
+        compression_args = _check_default_4bit_configs(config.name_or_path)
         if compression_args:
             sym = compression_args.pop("sym", False)
             compression_args.pop("bits", 4)

--- a/llm_bench/python/utils/conversion_utils/helpers.py
+++ b/llm_bench/python/utils/conversion_utils/helpers.py
@@ -189,7 +189,11 @@ def compress_ov_model_weights_helper(ov_model, tok, config, out_path, compress_w
     if "INT8" in compress_weights_format and "INT8_ASYM" in COMPRESSION_OPTIONS:
         warnings.warn("Usage INT8 mode is deprecated and will be removed soon. Please use INT8_ASYM instead", DeprecationWarning)
     if "4BIT_DEFAULT" in compress_weights_format:
-        compression_args = _check_default_4bit_configs(config.name_or_path)
+        try:
+            # TODO: remove this path when support of an older version optimum-intel is deprecated
+            compression_args = _check_default_4bit_configs(config)
+        except TypeError:
+            compression_args = _check_default_4bit_configs(config.name_or_path)
         if compression_args:
             sym = compression_args.pop("sym", False)
             compression_args.pop("bits", 4)


### PR DESCRIPTION
Compression currently fails with the latest `optimum-intel` version

Changes:
- Update usage of `_check_default_4bit_configs ` after https://github.com/huggingface/optimum-intel/pull/843
- Update optimum-intel version