### PR TITLE
Produce a single archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ project(OpenVINOGenAI
         HOMEPAGE_URL "https://github.com/openvinotoolkit/openvino.genai"
         LANGUAGES CXX)
 
+option(GENAI_CPACK_ARCHIVE_COMPONENT_INSTALL "If enabled (ON) multiple packages are generated." ON)
 option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" OFF)
 option(RAPIDJSON_BUILD_DOC "Build rapidjson documentation." OFF)
 
@@ -64,7 +65,7 @@ add_subdirectory(tests/cpp)
 
 install(FILES LICENSE DESTINATION docs/licensing COMPONENT licensing_genai RENAME LICENSE-GENAI)
 install(FILES third-party-programs.txt DESTINATION docs/licensing COMPONENT licensing_genai RENAME third-party-programs-genai.txt)
-set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ${GENAI_CPACK_ARCHIVE_COMPONENT_INSTALL})
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 # Workaround https://gitlab.kitware.com/cmake/cmake/-/issues/2614
 set(CPACK_COMPONENTS_ALL core_genai core_genai_dev cpp_samples_genai licensing_genai openvino_tokenizers openvino_tokenizers_docs)

--- a/src/docs/BUILD.md
+++ b/src/docs/BUILD.md
@@ -118,7 +118,7 @@ The path to the OpenVINO install directory is referred as `<INSTALL_DIR>` throug
     The following command will generate an archive containing OpenVINO Tokenizers and OpenVINO GenAI. The archive won't include OpenVINO itself, run the command for OpenVINO to generate an OpenVINO only archive. Generation of an archive containig all the components isn't implemented.
 
     ```sh
-    cmake --build build --config Debug --target package
+    cmake --install ./build/ --config Release --target package
     ```
 
     #### Option 3 - setting paths to built OpenVINO GenAI artifacts manually:

--- a/src/docs/BUILD.md
+++ b/src/docs/BUILD.md
@@ -118,7 +118,7 @@ The path to the OpenVINO install directory is referred as `<INSTALL_DIR>` throug
     The following command will generate an archive containing OpenVINO Tokenizers and OpenVINO GenAI. The archive won't include OpenVINO itself, run the command for OpenVINO to generate an OpenVINO only archive. Generation of an archive containig all the components isn't implemented.
 
     ```sh
-    cmake --install ./build/ --config Release --target package
+    cmake --build ./build/ --config Release --target package
     ```
 
     #### Option 3 - setting paths to built OpenVINO GenAI artifacts manually:

--- a/src/docs/BUILD.md
+++ b/src/docs/BUILD.md
@@ -99,7 +99,7 @@ The path to the OpenVINO install directory is referred as `<INSTALL_DIR>` throug
 
 4. Build the project:
     ```sh
-    cmake -DCMAKE_BUILD_TYPE=Release -S ./ -B ./build/
+    cmake -DCMAKE_BUILD_TYPE=Release -DGENAI_CPACK_ARCHIVE_COMPONENT_INSTALL=OFF -S ./ -B ./build/
     cmake --build ./build/ --config Release -j
     ```
 
@@ -113,7 +113,15 @@ The path to the OpenVINO install directory is referred as `<INSTALL_DIR>` throug
     cmake --install ./build/ --config Release --prefix <INSTALL_DIR>
     ```
 
-    #### Option 2 - setting paths to built OpenVINO GenAI artifacts manually:
+    #### Option 2 - generate an archive
+
+    The following command will generate an archive containing OpenVINO Tokenizers and OpenVINO GenAI. The archive won't include OpenVINO itself, run the command for OpenVINO to generate an OpenVINO only archive. Generation of an archive containig all the components isn't implemented.
+
+    ```sh
+    cmake --build build --config Debug --target package
+    ```
+
+    #### Option 3 - setting paths to built OpenVINO GenAI artifacts manually:
 
     The path to the OpenVINO GenAI root directory is referred as `<GENAI_ROOT_DIR>` throughout the document.
 


### PR DESCRIPTION
It turns out cpack ignores cache vars.