### PR TITLE
Allow to build GenAI with OpenVINO via extra modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ elseif(NOT GENERATOR_IS_MULTI_CONFIG_VAR AND NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ...")
 endif()
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
 project(OpenVINOGenAI
         VERSION 2024.4.0.0
         DESCRIPTION "OpenVINO GenAI"
@@ -32,14 +40,6 @@ find_package(OpenVINODeveloperPackage QUIET
 if(NOT OpenVINODeveloperPackage_FOUND)
     find_package(OpenVINO REQUIRED COMPONENTS Runtime)
 endif()
-
-# check that SDPA to PA transformtion exists
-get_target_property(ov_include_dirs openvino::runtime INTERFACE_INCLUDE_DIRECTORIES)
-find_file(spda_to_pa_header sdpa_to_paged_attention.hpp
-    PATHS ${ov_include_dirs}
-    PATH_SUFFIXES openvino/pass
-    DOC "Path to sdpa_to_paged_attention.hpp header"
-    NO_CACHE REQUIRED NO_DEFAULT_PATH)
 
 include(cmake/features.cmake)
 
@@ -64,7 +64,9 @@ add_subdirectory(tests/cpp)
 
 install(FILES LICENSE DESTINATION docs/licensing COMPONENT licensing_genai RENAME LICENSE-GENAI)
 install(FILES third-party-programs.txt DESTINATION docs/licensing COMPONENT licensing_genai RENAME third-party-programs-genai.txt)
-set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+if(NOT DEFINED CPACK_ARCHIVE_COMPONENT_INSTALL)
+    set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+endif()
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 # Workaround https://gitlab.kitware.com/cmake/cmake/-/issues/2614
 set(CPACK_COMPONENTS_ALL core_genai core_genai_dev cpp_samples_genai licensing_genai openvino_tokenizers openvino_tokenizers_docs)

--- a/image_generation/common/diffusers/CMakeLists.txt
+++ b/image_generation/common/diffusers/CMakeLists.txt
@@ -21,6 +21,10 @@ target_link_libraries(diffusers PUBLIC openvino::runtime)
 
 include(FetchContent)
 
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
 FetchContent_Declare(eigen3)
 FetchContent_GetProperties(eigen3)
 if(NOT eigen3_POPULATED)

--- a/samples/cpp/benchmark_genai/CMakeLists.txt
+++ b/samples/cpp/benchmark_genai/CMakeLists.txt
@@ -1,11 +1,16 @@
 # Copyright (C) 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-
 find_package(OpenVINOGenAI REQUIRED PATHS
     "${CMAKE_BINARY_DIR}"  # Reuse the package from the build.
     ${OpenVINO_DIR}  # GenAI may be installed alogside OpenVINO.
 )
+
+include(FetchContent)
+
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
 
 FetchContent_Declare(cxxopts
     URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz
@@ -18,6 +23,7 @@ set_target_properties(benchmark_genai PROPERTIES
     COMPILE_PDB_NAME benchmark_genai
     # Ensure out of box LC_RPATH on macOS with SIP
     INSTALL_RPATH_USE_LINK_PATH ON)
+
 install(TARGETS benchmark_genai
     RUNTIME DESTINATION samples_bin/
     COMPONENT samples_bin

--- a/samples/cpp/continuous_batching_accuracy/CMakeLists.txt
+++ b/samples/cpp/continuous_batching_accuracy/CMakeLists.txt
@@ -5,16 +5,21 @@
 
 include(FetchContent)
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 FetchContent_Declare(cxxopts
     URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz
     URL_HASH SHA256=523175f792eb0ff04f9e653c90746c12655f10cb70f1d5e6d6d9491420298a08)
-
-FetchContent_Declare(nlohmann_json
-    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-    URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
-
 FetchContent_MakeAvailable(cxxopts)
-FetchContent_MakeAvailable(nlohmann_json)
+
+if(NOT TARGET nlohmann_json)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+        URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
 
 find_package(OpenVINO REQUIRED COMPONENTS Runtime)
 

--- a/samples/cpp/continuous_batching_benchmark/CMakeLists.txt
+++ b/samples/cpp/continuous_batching_benchmark/CMakeLists.txt
@@ -5,16 +5,21 @@
 
 include(FetchContent)
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 FetchContent_Declare(cxxopts
     URL https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz
     URL_HASH SHA256=523175f792eb0ff04f9e653c90746c12655f10cb70f1d5e6d6d9491420298a08)
-
-FetchContent_Declare(nlohmann_json
-    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-    URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
-
 FetchContent_MakeAvailable(cxxopts)
-FetchContent_MakeAvailable(nlohmann_json)
+
+if(NOT TARGET nlohmann_json)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+        URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
 
 find_package(OpenVINO REQUIRED COMPONENTS Runtime)
 find_package(Threads REQUIRED)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -6,10 +6,12 @@
 
 include(FetchContent)
 
-FetchContent_Declare(nlohmann_json
-    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-    URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
-FetchContent_MakeAvailable(nlohmann_json)
+if(NOT TARGET nlohmann_json)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+        URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406)
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
 
 function(ov_genai_build_jinja2cpp)
     FetchContent_Declare(jinja2cpp
@@ -56,7 +58,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/openvino_genai/>"
     RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/openvino_genai/>"
 )
-# Extract two last digits from CMAKE_PROJECT_VERSION_MAJOR because SOVERSION can only contain up to 4 symbols.
+# Extract two last digits from OpenVINOGenAI_VERSION_MAJOR because SOVERSION can only contain up to 4 symbols.
 string(REGEX MATCH [=[[0-9][0-9]$]=] MAJOR_SUFFIX ${OpenVINOGenAI_VERSION_MAJOR})
 if(DEFINED PY_BUILD_CMAKE_PACKAGE_NAME AND LINUX)
     # Don't pack symlinks but append version hash to the name for wheel
@@ -67,7 +69,7 @@ elseif(DEFINED PY_BUILD_CMAKE_PACKAGE_NAME AND APPELE)
         SUFFIX .${MAJOR_SUFFIX}${OpenVINOGenAI_VERSION_MINOR}${OpenVINOGenAI_VERSION_PATCH}${CMAKE_SHARED_LIBRARY_SUFFIX})
 else()
     set_target_properties(${TARGET_NAME} PROPERTIES
-        VERSION ${CMAKE_PROJECT_VERSION}
+        VERSION ${OpenVINOGenAI_VERSION}
         SOVERSION ${MAJOR_SUFFIX}${OpenVINOGenAI_VERSION_MINOR}${OpenVINOGenAI_VERSION_PATCH})
 endif()
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 include(FetchContent)
+
 FetchContent_Declare(
     pybind11
     URL https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.tar.gz


### PR DESCRIPTION
With these changes OpenVINO GenAI can be built with main OV via `cmake -DOPENVINO_EXTRA_MODULES=<path to GenAI>`