### PR TITLE
Prefix caching optimization 

### DIFF
--- a/src/cpp/src/block_manager.hpp
+++ b/src/cpp/src/block_manager.hpp
@@ -156,20 +156,6 @@ public:
     KVCacheBlock::Ptr allocate_block(size_t hash, std::map<uint64_t, KVCacheBlock::Ptr>& cached_blocks) {
         OPENVINO_ASSERT(m_enable_prefix_caching);
         OPENVINO_ASSERT(can_allocate_blocks(1));
-        auto block = m_evictor.get_block(hash);
-        auto it = cached_blocks.find(hash);
-        if (block != nullptr) {
-            // use cached block from evictor
-            return block;
-        }
-        // TODO: Currently we cache all allocated blocks which might be redundant for beam search,
-        // where blocks of non-used candidates are not needed in cache.
-        // This part can be improved if we cache only blocks for prompt.
-        if (it != cached_blocks.end()) {
-            // use cashed block from cached_blocks
-            it->second->increment();
-            return it->second;
-        }
         if (m_free_blocks.size() > 0) {
             // allocate new empty block
             KVCacheBlock::Ptr allocated_block = m_free_blocks.front();


### PR DESCRIPTION
Removed not needed attempt to restore cached blocks during block allocation, as the chance that newly generated sequence will be found in cached blocks is too small.

Time comparison on Meta-Llama-3-8B, 10 chat iterations:

Master:
Total execution time: 770.27 seconds. 
Avg time to first token: 1909.4 ms

This branch: 
Total execution time: 767.14 seconds. 
Avg time to first token: 1907.2 ms