### PR TITLE
Use 10.15 macos target platform because of changes in OpenVINO

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash
     runs-on: 'macos-12-large'
     env:
-      MACOSX_DEPLOYMENT_TARGET: '10.12'
+      MACOSX_DEPLOYMENT_TARGET: '10.15'
       CMAKE_BUILD_TYPE: 'Release'
       CMAKE_GENERATOR: 'Ninja Multi-Config'
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
See https://github.com/openvinotoolkit/openvino.genai/actions/runs/10470176019/job/28994760817