### PR TITLE
[Port] Change Stable Diffusion v1.5 model

### DIFF
--- a/.github/workflows/stable_diffusion_1_5_cpp.yml
+++ b/.github/workflows/stable_diffusion_1_5_cpp.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           source openvino_sd_cpp/bin/activate
-          optimum-cli export openvino --model dreamlike-art/dreamlike-anime-1.0 --task stable-diffusion models/stable_diffusion_v1_5_ov/FP16
+          optimum-cli export openvino --model botp/stable-diffusion-v1-5 --task stable-diffusion models/stable_diffusion_v1_5_ov/FP16
 
       - name: Run app
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -124,7 +124,7 @@ jobs:
           working-directory: ${{ env.WORKING_DIRECTORY }}
           run: |
             . "./openvino_sd_cpp/Scripts/Activate.ps1"
-            optimum-cli export openvino --model dreamlike-art/dreamlike-anime-1.0 --task stable-diffusion models/stable_diffusion_v1_5_ov/FP16
+            optimum-cli export openvino --model botp/stable-diffusion-v1-5 --task stable-diffusion models/stable_diffusion_v1_5_ov/FP16
 
         - name: Run app
           working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/image_generation/stable_diffusion_1_5/cpp/README.md
+++ b/image_generation/stable_diffusion_1_5/cpp/README.md
@@ -57,7 +57,7 @@ The path to the OpenVINO install directory is referred as `<INSTALL_DIR>` throug
 2. Download the model from Huggingface and convert it to OpenVINO IR via [optimum-intel CLI](https://github.com/huggingface/optimum-intel).
 
     Example models to download:
-    - [runwayml/stable-diffusion-v1-5](https://huggingface.co/runwayml/stable-diffusion-v1-5)
+    - [botp/stable-diffusion-v1-5](https://huggingface.co/botp/stable-diffusion-v1-5)
     - [dreamlike-art/dreamlike-anime-1.0](https://huggingface.co/dreamlike-art/dreamlike-anime-1.0)
 
     Example command for downloading [dreamlike-art/dreamlike-anime-1.0](https://huggingface.co/dreamlike-art/dreamlike-anime-1.0) model and exporting it with FP16 precision:


### PR DESCRIPTION
This is a port of #824 to master branch

[RunwayML](https://huggingface.co/runwayml) is no longer maintaining a HuggingFace organization so `runwayml/stable-diffusion-v1-5` model is not available for downloading.
Replace it with a re-uploaded archive copy [`botp/stable-diffusion-v1-5`](https://huggingface.co/botp/stable-diffusion-v1-5)