### PR TITLE
Support multiple prompt files

### DIFF
--- a/llm_bench/python/benchmark.py
+++ b/llm_bench/python/benchmark.py
@@ -551,8 +551,8 @@ def run_ldm_super_resolution_benchmark(model_path, framework, device, args, num_
         for image in input_image_list:
             if args['prompt'] is None and args['prompt_file'] is None:
                 raise RuntimeError('==Failure image is empty ==')
-            elif args['prompt_file'] is not None:
-                image['prompt'] = os.path.join(os.path.dirname(args['prompt_file']), image['prompt'].replace('./', ''))
+            elif args['prompt_file'] is not None and len(args['prompt_file']) > 0:
+                image['prompt'] = os.path.join(os.path.dirname(args['prompt_file'][0]), image['prompt'].replace('./', ''))
             image['prompt'] = Path(image['prompt'])
             images.append(image)
     else:
@@ -617,7 +617,8 @@ def get_argprser():
     parser.add_argument('-rj', '--report_json', help='report json')
     parser.add_argument('-f', '--framework', default='ov', help='framework')
     parser.add_argument('-p', '--prompt', default=None, help='one prompt')
-    parser.add_argument('-pf', '--prompt_file', default=None, help='prompt file in jsonl format')
+    parser.add_argument('-pf', '--prompt_file', nargs='+', default=None,
+                        help='prompt file in jsonl format. You can specify multiple prompt files, separated by spaces.')
     parser.add_argument('-pi', '--prompt_index', nargs='+', type=num_iters_type, default=None,
                         help='Run the specified prompt index. You can specify multiple prompt indexes, separated by spaces.')
     parser.add_argument(

--- a/llm_bench/python/benchmark.py
+++ b/llm_bench/python/benchmark.py
@@ -618,7 +618,7 @@ def get_argprser():
     parser.add_argument('-f', '--framework', default='ov', help='framework')
     parser.add_argument('-p', '--prompt', default=None, help='one prompt')
     parser.add_argument('-pf', '--prompt_file', nargs='+', default=None,
-                        help='prompt file in jsonl format. You can specify multiple prompt files, separated by spaces.')
+                        help='Prompt file(s) in jsonl format. Multiple prompt files should be separated with space(s).')
     parser.add_argument('-pi', '--prompt_index', nargs='+', type=num_iters_type, default=None,
                         help='Run the specified prompt index. You can specify multiple prompt indexes, separated by spaces.')
     parser.add_argument(

--- a/llm_bench/python/llm_bench_utils/model_utils.py
+++ b/llm_bench/python/llm_bench_utils/model_utils.py
@@ -25,24 +25,25 @@ def get_prompts(args):
             else:
                 raise RuntimeError('== prompt should not be empty string ==')
         else:
-            input_prompt = args['prompt_file']
-            if input_prompt.endswith('.jsonl'):
-                if os.path.exists(input_prompt):
-                    log.info(f'Read prompts from {input_prompt}')
-                    with open(input_prompt, 'r', encoding='utf-8') as f:
-                        for line in f:
-                            data = json.loads(line)
-                            if 'prompt' in data:
-                                if data['prompt'] != '':
-                                    prompts_list.append(data['prompt'])
+            input_prompt_list = args['prompt_file']
+            for input_prompt in input_prompt_list:
+                if input_prompt.endswith('.jsonl'):
+                    if os.path.exists(input_prompt):
+                        log.info(f'Read prompts from {input_prompt}')
+                        with open(input_prompt, 'r', encoding='utf-8') as f:
+                            for line in f:
+                                data = json.loads(line)
+                                if 'prompt' in data:
+                                    if data['prompt'] != '':
+                                        prompts_list.append(data['prompt'])
+                                    else:
+                                        raise RuntimeError(f'== prompt in prompt file:{input_prompt} should not be empty string ==')
                                 else:
-                                    raise RuntimeError('== prompt should not be empty string ==')
-                            else:
-                                raise RuntimeError('== key word "prompt" does not exist in prompt file ==')
+                                    raise RuntimeError(f'== key word "prompt" does not exist in prompt file:{input_prompt} ==')
+                    else:
+                        raise RuntimeError(f'== The prompt file:{input_prompt} does not exist ==')
                 else:
-                    raise RuntimeError('== The prompt file does not exist ==')
-            else:
-                raise RuntimeError('== The prompt file should be ended with .jsonl ==')
+                    raise RuntimeError(f'== The prompt file:{input_prompt} should be ended with .jsonl ==')
     return prompts_list
 
 
@@ -59,34 +60,35 @@ def get_image_param_from_prompt_file(args):
             else:
                 raise RuntimeError('== prompt should not be empty string ==')
         else:
-            input_prompt = args['prompt_file']
-            if input_prompt.endswith('.jsonl'):
-                if os.path.exists(input_prompt):
-                    log.info(f'Read prompts from {input_prompt}')
-                    with open(input_prompt, 'r', encoding='utf-8') as f:
-                        for line in f:
-                            image_param = {}
-                            data = json.loads(line)
-                            if 'prompt' in data:
-                                if data['prompt'] != '':
-                                    image_param['prompt'] = data['prompt']
+            input_prompt_list = args['prompt_file']
+            for input_prompt in input_prompt_list:
+                if input_prompt.endswith('.jsonl'):
+                    if os.path.exists(input_prompt):
+                        log.info(f'Read prompts from {input_prompt}')
+                        with open(input_prompt, 'r', encoding='utf-8') as f:
+                            for line in f:
+                                image_param = {}
+                                data = json.loads(line)
+                                if 'prompt' in data:
+                                    if data['prompt'] != '':
+                                        image_param['prompt'] = data['prompt']
+                                    else:
+                                        raise RuntimeError('== prompt in prompt file:{input_prompt} should not be empty string ==')
                                 else:
-                                    raise RuntimeError('== prompt should not be empty string ==')
-                            else:
-                                raise RuntimeError('== key word "prompt" does not exist in prompt file ==')
-                            if 'width' in data:
-                                image_param['width'] = int(data['width'])
-                            if 'height' in data:
-                                image_param['height'] = int(data['height'])
-                            if 'steps' in data:
-                                image_param['steps'] = int(data['steps'])
-                            if 'guidance_scale' in data:
-                                image_param['guidance_scale'] = float(data['guidance_scale'])
-                            image_param_list.append(image_param)
+                                    raise RuntimeError(f'== key word "prompt" does not exist in prompt file:{input_prompt} ==')
+                                if 'width' in data:
+                                    image_param['width'] = int(data['width'])
+                                if 'height' in data:
+                                    image_param['height'] = int(data['height'])
+                                if 'steps' in data:
+                                    image_param['steps'] = int(data['steps'])
+                                if 'guidance_scale' in data:
+                                    image_param['guidance_scale'] = float(data['guidance_scale'])
+                                image_param_list.append(image_param)
+                    else:
+                        raise RuntimeError(f'== The prompt file:{input_prompt} does not exist ==')
                 else:
-                    raise RuntimeError('== The prompt file does not exist ==')
-            else:
-                raise RuntimeError('== The prompt file should be ended with .jsonl ==')
+                    raise RuntimeError(f'== The prompt file:{input_prompt} should be ended with .jsonl ==')
     return image_param_list
 
 


### PR DESCRIPTION
Extend --prompt_file to support multiple prompt files. You can specify multiple prompt files, separated by spaces.
python benchmark.py -mc 1 -ic 128 -m <model> -d CPU -n 3 
-pf ../../../repo-prompts/32_1024/qwen1.5-14b-chat.jsonl ../../../repo-prompts/2048/qwen1.5-14b-chat.jsonl  ../../../repo-prompts/4096/qwen1.5-14b-chat.jsonl


[qwen-7b-chat_multi_prompt_files.txt](https://github.com/user-attachments/files/17000709/qwen-7b-chat_multi_prompt_files.txt)
[qwen-7b-chat_multi_prompt_files.csv](https://github.com/user-attachments/files/17000710/qwen-7b-chat_multi_prompt_files.csv)
