### PR TITLE
Added mutex for sequence ID counter.

### DIFF
--- a/src/cpp/src/sequence_group.cpp
+++ b/src/cpp/src/sequence_group.cpp
@@ -6,6 +6,9 @@
 
 namespace ov {
 namespace genai {
+
+std::mutex Sequence::m_counter_mutex;
+
 size_t Sequence::_make_hash(size_t content_length) {
         auto sequence_group = get_sequence_group_ptr();
         auto block_size = sequence_group->get_block_size();

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -26,6 +26,7 @@ class SequenceGroup;
 class Sequence {
     // This can be a problem if we launch two pipelines in the same application.
     static uint64_t _get_next_global_sequence_id() {
+        const std::lock_guard<std::mutex> lock(m_counter_mutex);
         static uint64_t m_counter = 0;
         return m_counter++;
     }
@@ -38,6 +39,7 @@ class Sequence {
     float m_cumulative_log_prob = 0.0f;
     std::vector<int64_t> m_prefix_hashes;
     std::weak_ptr<SequenceGroup> m_sequence_group;
+    static std::mutex m_counter_mutex;
 
     size_t _make_hash(size_t content_length);
 public:


### PR DESCRIPTION
When `add_requests()` is executed in multiple threads global `m_counter` can be accessed simultaneously by multiple threads, this results in the same sequence IDs in different sequences.
Added mutex to prevent such situation. 

Ticket: 148119 