### PR TITLE
Whisper pipeline: return timestamps

### DIFF
--- a/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
+++ b/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
@@ -21,15 +21,20 @@ int main(int argc, char* argv[]) try {
     // 'task' and 'language' parameters are supported for multilingual models only
     config.language = "<|en|>";
     config.task = "transcribe";
+    config.return_timestamps = true;
 
     auto streamer = [](std::string word) {
         std::cout << word;
         return false;
     };
 
-    pipeline.generate(raw_speech, config, streamer);
+    auto result = pipeline.generate(raw_speech, config, streamer);
 
-    std::cout << std::endl;
+    std::cout << "\n";
+
+    for (auto& chunk : *result.chunks) {
+        std::cout << "timestamps: [" << chunk.start_ts << ", " << chunk.end_ts << "] text: " << chunk.text << "\n";
+    }
 } catch (const std::exception& error) {
     try {
         std::cerr << error.what() << '\n';

--- a/samples/python/whisper_speech_recognition/whisper_speech_recognition.py
+++ b/samples/python/whisper_speech_recognition/whisper_speech_recognition.py
@@ -26,14 +26,18 @@ def main():
         print(word, end="")
         return False
 
-    pipe.generate(
+    result = pipe.generate(
         raw_speech,
         max_new_tokens=100,
         # 'task' and 'language' parameters are supported for multilingual models only
         language="<|en|>",
         task="transcribe",
+        return_timestamps=True,
         streamer=streamer,
     )
+
+    for chunk in result.chunks:
+        print(f"timestamps: [{chunk.start_ts}, {chunk.end_ts}] text: {chunk.text}")
 
     print()
 

--- a/src/cpp/include/openvino/genai/whisper_generation_config.hpp
+++ b/src/cpp/include/openvino/genai/whisper_generation_config.hpp
@@ -51,6 +51,8 @@ public:
     // Begin timestamps token id.
     int64_t begin_timestamps_token_id = 50364;
 
+    size_t max_initial_timestamp_index = 50;
+
     bool is_multilingual = true;
 
     // Language token to use for generation in the form of <|en|>.

--- a/src/cpp/include/openvino/genai/whisper_generation_config.hpp
+++ b/src/cpp/include/openvino/genai/whisper_generation_config.hpp
@@ -65,6 +65,16 @@ public:
     // Can be set for multilingual models only.
     std::optional<std::string> task = std::nullopt;
 
+    // If `true` the pipeline will return timestamps along the text for *segments* of words in the text.
+    // For instance, if you get
+    // WhisperDecodedResultChunk
+    //      start_ts = 0.5
+    //      end_ts = 1.5
+    //      text = " Hi there!"
+    // then it means the model predicts that the segment "Hi there!" was spoken after `0.5` and before `1.5` seconds.
+    // Note that a segment of text refers to a sequence of one or more words, rather than individual words.
+    bool return_timestamps = false;
+
     // A list containing tokens that will be supressed at the beginning of the sampling process.
     std::vector<int64_t> begin_suppress_tokens;
 
@@ -105,6 +115,7 @@ static constexpr ov::Property<int64_t> no_timestamps_token_id{"no_timestamps_tok
 static constexpr ov::Property<int64_t> begin_timestamps_token_id{"begin_timestamps_token_id"};
 static constexpr ov::Property<std::string> language{"language"};
 static constexpr ov::Property<std::string> task{"task"};
+static constexpr ov::Property<bool> return_timestamps{"return_timestamps"};
 static constexpr ov::Property<std::map<std::string, int64_t>> lang_to_id{"lang_to_id"};
 
 }  // namespace genai

--- a/src/cpp/include/openvino/genai/whisper_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/whisper_pipeline.hpp
@@ -17,7 +17,7 @@ using OptionalWhisperGenerationConfig = std::optional<WhisperGenerationConfig>;
 
 using RawSpeechInput = std::vector<float>;
 
-struct OPENVINO_GENAI_EXPORTS WhisperDecodedResultChunk {
+struct WhisperDecodedResultChunk {
     // start of chunk in seconds
     float start_ts;
 
@@ -28,8 +28,7 @@ struct OPENVINO_GENAI_EXPORTS WhisperDecodedResultChunk {
     std::string text;
 };
 
-class OPENVINO_GENAI_EXPORTS WhisperDecodedResults : public DecodedResults {
-public:
+struct WhisperDecodedResults : public DecodedResults {
     std::optional<std::vector<WhisperDecodedResultChunk>> chunks = std::nullopt;
 };
 

--- a/src/cpp/include/openvino/genai/whisper_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/whisper_pipeline.hpp
@@ -17,6 +17,22 @@ using OptionalWhisperGenerationConfig = std::optional<WhisperGenerationConfig>;
 
 using RawSpeechInput = std::vector<float>;
 
+struct OPENVINO_GENAI_EXPORTS WhisperDecodedResultChunk {
+    // start of chunk in seconds
+    float start_ts;
+
+    // end of chunk in seconds
+    // -1.0f if chunk started but model did not predict an ending timestamp
+    // can happen if audio is cut off in the middle of a word
+    float end_ts = -1.0f;
+    std::string text;
+};
+
+class OPENVINO_GENAI_EXPORTS WhisperDecodedResults : public DecodedResults {
+public:
+    std::optional<std::vector<WhisperDecodedResultChunk>> chunks = std::nullopt;
+};
+
 class OPENVINO_GENAI_EXPORTS WhisperPipeline {
     class Impl;
     std::unique_ptr<Impl> m_impl;
@@ -57,11 +73,11 @@ public:
      * sampling rate.
      * @param generation_config optional GenerationConfig
      * @param streamer optional streamer
-     * @return DecodedResults decoded resulting text transcription
+     * @return WhisperDecodedResults decoded resulting text transcription
      */
-    DecodedResults generate(const RawSpeechInput& raw_speech_input,
-                            OptionalWhisperGenerationConfig generation_config = std::nullopt,
-                            StreamerVariant streamer = std::monostate());
+    WhisperDecodedResults generate(const RawSpeechInput& raw_speech_input,
+                                   OptionalWhisperGenerationConfig generation_config = std::nullopt,
+                                   StreamerVariant streamer = std::monostate());
 
     /**
      * @brief High level generate that receives raw speech as a vector of floats and returns decoded output.
@@ -70,14 +86,14 @@ public:
      *
      * @param raw_speech_input raw speech input
      * @param properties properties
-     * @return DecodedResults decoded resulting text transcription
+     * @return WhisperDecodedResults decoded resulting text transcription
      */
     template <typename... Properties>
-    util::EnableIfAllStringAny<DecodedResults, Properties...> generate(const RawSpeechInput& raw_speech_input,
-                                                                       Properties&&... properties) {
+    util::EnableIfAllStringAny<WhisperDecodedResults, Properties...> generate(const RawSpeechInput& raw_speech_input,
+                                                                              Properties&&... properties) {
         return generate(raw_speech_input, AnyMap{std::forward<Properties>(properties)...});
     }
-    DecodedResults generate(const RawSpeechInput& raw_speech_input, const ov::AnyMap& config_map);
+    WhisperDecodedResults generate(const RawSpeechInput& raw_speech_input, const ov::AnyMap& config_map);
 
     ov::genai::Tokenizer get_tokenizer();
     WhisperGenerationConfig get_generation_config() const;

--- a/src/cpp/src/sampler.hpp
+++ b/src/cpp/src/sampler.hpp
@@ -30,6 +30,8 @@ inline bool is_stop_token_id_hit(int64_t generated_token, const std::set<int64_t
     return false;
 }
 
+std::vector<Token> log_softmax(const ov::Tensor& logits, size_t batch_idx);
+
 struct SamplerOutput {
     // IDs of sequences that need to be dropped
     std::vector<uint64_t> m_dropped_sequences;

--- a/src/cpp/src/whisper/logit_processor.cpp
+++ b/src/cpp/src/whisper/logit_processor.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <openvino/openvino.hpp>
+
+#include "openvino/genai/whisper_generation_config.hpp"
+#include "sampler.hpp"
+
+namespace ov {
+namespace genai {
+
+void do_suppress_tokens(ov::Tensor& logits, const size_t batch_idx, const std::vector<int64_t>& suppress_tokens) {
+    OPENVINO_ASSERT(logits.get_shape()[0] >= batch_idx, "logits batch size doesn't match the batch number");
+
+    size_t vocab_size = logits.get_shape().back();
+    size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
+    size_t sequence_offset = (logits.get_shape()[1] - 1) * vocab_size;
+    float* logits_data = logits.data<float>() + batch_offset + sequence_offset;
+
+    for (auto supress_token : suppress_tokens) {
+        logits_data[supress_token] = -std::numeric_limits<float>::infinity();
+    }
+}
+
+void process_whisper_timestamp_logits(ov::Tensor& logits,
+                                      const size_t batch_idx,
+                                      const ov::genai::WhisperGenerationConfig& config,
+                                      const std::vector<int64_t>& generated_tokens,
+                                      bool initial_step = false) {
+    const size_t batch_size = logits.get_shape().at(0);
+    OPENVINO_ASSERT(batch_size == 1, "Batch != 1 is not supported");
+
+    size_t vocab_size = logits.get_shape().back();
+    size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
+    size_t sequence_offset = (logits.get_shape()[1] - 1) * vocab_size;
+    float* logits_data = logits.data<float>() + batch_offset + sequence_offset;
+
+    // supress<|notimestamps|>
+    logits_data[config.no_timestamps_token_id] = -std::numeric_limits<float>::infinity();
+
+    size_t timestamp_begin = config.no_timestamps_token_id + 1;
+
+    // timestamps have to appear in pairs, except directly before eos_token; mask logits accordingly
+    size_t generated_length = generated_tokens.size();
+    bool last_was_timestamp = generated_length >= 1 && generated_tokens[generated_length - 1] >= timestamp_begin;
+    bool penultimate_was_timestamp = generated_length < 2 || generated_tokens[generated_length - 2] >= timestamp_begin;
+
+    if (last_was_timestamp) {
+        if (penultimate_was_timestamp) {
+            // has to be timestamp
+            for (size_t i = timestamp_begin; i < vocab_size; i++) {
+                logits_data[i] = -std::numeric_limits<float>::infinity();
+            }
+        } else {
+            // cannot be normal text token
+            for (size_t i = 0; i < config.eos_token_id; i++) {
+                logits_data[i] = -std::numeric_limits<float>::infinity();
+            }
+        }
+    }
+
+    // filter generated timestaps
+    std::vector<int64_t> timestamps;
+    for (const auto token : generated_tokens) {
+        if (token >= timestamp_begin) {
+            timestamps.push_back(token);
+        }
+    }
+
+    if (timestamps.size() > 0) {
+        size_t timestamp_last;
+        // `timestamps` shouldn't decrease; forbid timestamp tokens smaller than the last
+        // The following lines of code are copied from: https://github.com/openai/whisper/pull/914/files#r1137085090
+        if (last_was_timestamp && !penultimate_was_timestamp) {
+            timestamp_last = timestamps.back();
+        } else {
+            // Avoid to emit <|0.00|> again
+            timestamp_last = timestamps.back() + 1;
+        }
+
+        for (size_t i = timestamp_begin; i < timestamp_last; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    // apply the `max_initial_timestamp` option
+    // todo: read from generation config json
+    constexpr size_t max_initial_timestamp_index = 50;
+    if (initial_step) {
+        for (size_t i = 0; i < timestamp_begin; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+
+        size_t last_allowed = timestamp_begin + max_initial_timestamp_index;
+        for (size_t i = last_allowed + 1; i < vocab_size; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    auto tokens = ov::genai::log_softmax(logits, 0);
+    float timestamp_exp_prov_sum = 0;
+
+    for (size_t i = timestamp_begin; i < vocab_size; i++) {
+        timestamp_exp_prov_sum += std::exp(tokens[i].m_log_prob);
+    }
+    float timestamp_logprob = std::log(timestamp_exp_prov_sum);
+
+    float max_text_token_logprob = -std::numeric_limits<float>::infinity();
+    // todo: replace with max
+    for (size_t i = 0; i < timestamp_begin; i++) {
+        if (tokens[i].m_log_prob > max_text_token_logprob) {
+            max_text_token_logprob = tokens[i].m_log_prob;
+        }
+    }
+
+    if (timestamp_logprob > max_text_token_logprob) {
+        for (size_t i = 0; i < timestamp_begin; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+}
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/logit_processor.cpp
+++ b/src/cpp/src/whisper/logit_processor.cpp
@@ -103,15 +103,11 @@ void process_whisper_timestamp_logits(ov::Tensor& logits,
     }
     float timestamp_logprob = std::log(timestamp_exp_prov_sum);
 
-    float max_text_token_logprob = -std::numeric_limits<float>::infinity();
-    // todo: replace with max
-    for (size_t i = 0; i < timestamp_begin; i++) {
-        if (tokens[i].m_log_prob > max_text_token_logprob) {
-            max_text_token_logprob = tokens[i].m_log_prob;
-        }
-    }
+    auto max_logprob_token = std::max_element(tokens.begin(), tokens.end(), [](const Token& left, const Token& right) {
+        return left.m_log_prob < right.m_log_prob;
+    });
 
-    if (timestamp_logprob > max_text_token_logprob) {
+    if (timestamp_logprob > max_logprob_token->m_log_prob) {
         for (size_t i = 0; i < timestamp_begin; i++) {
             logits_data[i] = -std::numeric_limits<float>::infinity();
         }

--- a/src/cpp/src/whisper/logit_processor.cpp
+++ b/src/cpp/src/whisper/logit_processor.cpp
@@ -84,14 +84,12 @@ void process_whisper_timestamp_logits(ov::Tensor& logits,
     }
 
     // apply the `max_initial_timestamp` option
-    // todo: read from generation config json
-    constexpr size_t max_initial_timestamp_index = 50;
     if (initial_step) {
         for (size_t i = 0; i < timestamp_begin; i++) {
             logits_data[i] = -std::numeric_limits<float>::infinity();
         }
 
-        size_t last_allowed = timestamp_begin + max_initial_timestamp_index;
+        size_t last_allowed = timestamp_begin + config.max_initial_timestamp_index;
         for (size_t i = last_allowed + 1; i < vocab_size; i++) {
             logits_data[i] = -std::numeric_limits<float>::infinity();
         }

--- a/src/cpp/src/whisper/logit_processor.hpp
+++ b/src/cpp/src/whisper/logit_processor.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <openvino/openvino.hpp>
+
+#include "openvino/genai/whisper_generation_config.hpp"
+#include "vector"
+
+namespace ov {
+namespace genai {
+
+void do_suppress_tokens(ov::Tensor& logits, const size_t batch_idx, const std::vector<int64_t>& suppress_tokens);
+
+void process_whisper_timestamp_logits(ov::Tensor& logits,
+                                      const size_t batch_idx,
+                                      const ov::genai::WhisperGenerationConfig& config,
+                                      const std::vector<int64_t>& generated_tokens,
+                                      bool initial_step = false);
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/logit_processor.hpp
+++ b/src/cpp/src/whisper/logit_processor.hpp
@@ -6,7 +6,6 @@
 #include <openvino/openvino.hpp>
 
 #include "openvino/genai/whisper_generation_config.hpp"
-#include "vector"
 
 namespace ov {
 namespace genai {

--- a/src/cpp/src/whisper/timestamps.cpp
+++ b/src/cpp/src/whisper/timestamps.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "timestamps.hpp"
+
+namespace {
+float round_up(const float value, const int decimal_places) {
+    const float multiplier = std::pow(10, decimal_places);
+    return ceilf(value * multiplier) / multiplier;
+}
+}  // namespace
+
+namespace ov {
+namespace genai {
+
+std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segments(
+    const std::vector<int64_t>& tokens,
+    const ov::genai::WhisperGenerationConfig& config,
+    const float time_precision) {
+    std::vector<int64_t> non_timestamp_tokens;
+    std::vector<ov::genai::Segment> segments;
+    std::optional<int64_t> token_start = std::nullopt;
+    size_t idx_start = 0;
+
+    for (size_t i = 0; i < tokens.size(); i++) {
+        int64_t token = tokens[i];
+
+        bool is_timestamp = token >= config.begin_timestamps_token_id;
+
+        if (!is_timestamp) {
+            continue;
+        }
+
+        if (!token_start.has_value()) {
+            token_start = token;
+            idx_start = i;
+        } else {
+            if (token_start == token) {
+                // from HF:
+                // https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/tokenization_whisper.py#L1020
+                // This is a bug in timestamp token output where we're taking the duplicate token as a stop where it
+                // should be a start. This is an issue in the underlying model output. Let's just skip it so it becomes
+                // de-factor a start again.
+                continue;
+            }
+
+            ov::genai::Segment segment;
+            segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.begin() + i};
+            segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
+            segment.m_end = round_up((token - config.begin_timestamps_token_id) * time_precision, 2);
+            segments.push_back(segment);
+
+            non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.begin() + i);
+
+            token_start = std::nullopt;
+        }
+    }
+
+    // segment started but has no closing timestamp
+    // add new segment only if it has non timestamps tokens
+    // do not add new segment if previous segments exists
+    bool has_tokens_to_add = idx_start < tokens.size() - 1;
+    bool has_previous_segments = segments.size() > 0;
+    if (token_start.has_value() && has_tokens_to_add && !has_previous_segments) {
+        ov::genai::Segment segment;
+        segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.end()};
+        segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
+        segment.m_end = -1.0f;
+        segments.push_back(segment);
+
+        non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.end());
+    }
+
+    return {non_timestamp_tokens, segments};
+}
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/timestamps.cpp
+++ b/src/cpp/src/whisper/timestamps.cpp
@@ -3,13 +3,6 @@
 
 #include "timestamps.hpp"
 
-namespace {
-float round_up(const float value, const int decimal_places) {
-    const float multiplier = std::pow(10, decimal_places);
-    return ceilf(value * multiplier) / multiplier;
-}
-}  // namespace
-
 namespace ov {
 namespace genai {
 
@@ -46,8 +39,8 @@ std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segment
 
             ov::genai::Segment segment;
             segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.begin() + i};
-            segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
-            segment.m_end = round_up((token - config.begin_timestamps_token_id) * time_precision, 2);
+            segment.m_start = (*token_start - config.begin_timestamps_token_id) * time_precision;
+            segment.m_end = (token - config.begin_timestamps_token_id) * time_precision;
             segments.push_back(segment);
 
             non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.begin() + i);

--- a/src/cpp/src/whisper/timestamps.cpp
+++ b/src/cpp/src/whisper/timestamps.cpp
@@ -57,7 +57,7 @@ std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segment
     if (token_start.has_value() && has_tokens_to_add && !has_previous_segments) {
         ov::genai::Segment segment;
         segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.end()};
-        segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
+        segment.m_start = (*token_start - config.begin_timestamps_token_id) * time_precision;
         segment.m_end = -1.0f;
         segments.push_back(segment);
 

--- a/src/cpp/src/whisper/timestamps.hpp
+++ b/src/cpp/src/whisper/timestamps.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <openvino/openvino.hpp>
+
+#include "whisper.hpp"
+
+namespace ov {
+namespace genai {
+
+std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segments(
+    const std::vector<int64_t>& tokens,
+    const ov::genai::WhisperGenerationConfig& config,
+    const float time_precision);
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -174,7 +174,7 @@ std::vector<int64_t> prepare_input_ids(ov::Tensor& encoder_hidden_state,
 std::pair<bool, std::vector<int64_t>> full_decode(ov::Tensor& encoder_hidden_state,
                                                   const ov::genai::WhisperGenerationConfig& config,
                                                   ov::genai::WhisperInitializedModels& models,
-                                                  size_t max_new_tokens,
+                                                  const size_t max_new_tokens,
                                                   const std::shared_ptr<ov::genai::StreamerBase> streamer) {
     std::vector<int64_t> input_ids = prepare_input_ids(encoder_hidden_state, models.decoder, config);
 

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -277,6 +277,10 @@ std::pair<std::vector<int64_t>, std::optional<std::vector<Segment>>> whisper_gen
         }
     }
 
+    if (streamer) {
+        streamer->end();
+    }
+
     std::optional<std::vector<Segment>> segments = std::nullopt;
     if (config.return_timestamps) {
         // 0.02 by default

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 
 #include "../utils.hpp"
+#include "logit_processor.hpp"
 #include "openvino/genai/streamer_base.hpp"
 #include "openvino/genai/whisper_generation_config.hpp"
 #include "openvino/genai/whisper_pipeline.hpp"
@@ -16,148 +17,6 @@
 #include "whisper_models.hpp"
 
 namespace {
-
-struct Token {
-    float m_log_prob = 0.;
-    int64_t m_index = 0;
-
-    Token(float log_prob, int64_t index) : m_log_prob(log_prob), m_index(index) {}
-    Token() = default;
-};
-
-std::vector<Token> log_softmax(const ov::Tensor& logits, size_t batch_idx) {
-    ov::Shape shape = logits.get_shape();
-    OPENVINO_ASSERT(shape.size() == 3);
-    size_t batch = shape[0], seq_len = shape[1], vocab_size = shape[2];
-    OPENVINO_ASSERT(batch_idx < batch, "Logits batch size doesn't match the number of beams");
-
-    size_t batch_offset = batch_idx * seq_len * vocab_size, sequence_offset = (seq_len - 1) * vocab_size;
-    const float* beam_logits = logits.data<const float>() + batch_offset + sequence_offset;
-    float max_logit = *std::max_element(beam_logits, beam_logits + vocab_size);
-    float log_sum = std::log(
-        std::accumulate(beam_logits, beam_logits + vocab_size, 0.0f, [max_logit](float accumulated, float to_add) {
-            return accumulated + std::exp(to_add - max_logit);
-        }));
-
-    std::vector<Token> tokens;
-    tokens.reserve(vocab_size);
-    for (size_t idx = 0; idx < vocab_size; ++idx)
-        tokens.push_back({beam_logits[idx] - max_logit - log_sum, int64_t(idx)});
-
-    return tokens;
-}
-
-void suppress_tokens(ov::Tensor& logits, const size_t batch_idx, const std::vector<int64_t>& suppress_tokens) {
-    OPENVINO_ASSERT(logits.get_shape()[0] >= batch_idx, "logits batch size doesn't match the batch number");
-
-    size_t vocab_size = logits.get_shape().back();
-    size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
-    size_t sequence_offset = (logits.get_shape()[1] - 1) * vocab_size;
-    float* logits_data = logits.data<float>() + batch_offset + sequence_offset;
-
-    for (auto supress_token : suppress_tokens) {
-        logits_data[supress_token] = -std::numeric_limits<float>::infinity();
-    }
-}
-
-void process_timestamp_logits(ov::Tensor& logits,
-                              const size_t batch_idx,
-                              const ov::genai::WhisperGenerationConfig& config,
-                              const std::vector<int64_t>& generated_tokens,
-                              bool initial_step = false) {
-    const size_t batch_size = logits.get_shape().at(0);
-    OPENVINO_ASSERT(batch_size == 1, "Batch != 1 is not supported");
-
-    size_t vocab_size = logits.get_shape().back();
-    size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
-    size_t sequence_offset = (logits.get_shape()[1] - 1) * vocab_size;
-    float* logits_data = logits.data<float>() + batch_offset + sequence_offset;
-
-    // supress<|notimestamps|>
-    logits_data[config.no_timestamps_token_id] = -std::numeric_limits<float>::infinity();
-
-    size_t timestamp_begin = config.no_timestamps_token_id + 1;
-
-    // timestamps have to appear in pairs, except directly before eos_token; mask logits accordingly
-    size_t generated_length = generated_tokens.size();
-    bool last_was_timestamp = generated_length >= 1 && generated_tokens[generated_length - 1] >= timestamp_begin;
-    bool penultimate_was_timestamp = generated_length < 2 || generated_tokens[generated_length - 2] >= timestamp_begin;
-
-    if (last_was_timestamp) {
-        if (penultimate_was_timestamp) {
-            // has to be timestamp
-            for (size_t i = timestamp_begin; i < vocab_size; i++) {
-                logits_data[i] = -std::numeric_limits<float>::infinity();
-            }
-        } else {
-            // cannot be normal text token
-            for (size_t i = 0; i < config.eos_token_id; i++) {
-                logits_data[i] = -std::numeric_limits<float>::infinity();
-            }
-        }
-    }
-
-    // filter generated timestaps
-    std::vector<int64_t> timestamps;
-    for (const auto token : generated_tokens) {
-        if (token >= timestamp_begin) {
-            timestamps.push_back(token);
-        }
-    }
-
-    if (timestamps.size() > 0) {
-        size_t timestamp_last;
-        // `timestamps` shouldn't decrease; forbid timestamp tokens smaller than the last
-        // The following lines of code are copied from: https://github.com/openai/whisper/pull/914/files#r1137085090
-        if (last_was_timestamp && !penultimate_was_timestamp) {
-            timestamp_last = timestamps.back();
-        } else {
-            // Avoid to emit <|0.00|> again
-            timestamp_last = timestamps.back() + 1;
-        }
-
-        for (size_t i = timestamp_begin; i < timestamp_last; i++) {
-            logits_data[i] = -std::numeric_limits<float>::infinity();
-        }
-    }
-
-    // apply the `max_initial_timestamp` option
-    // todo: read from generation config json
-    constexpr size_t max_initial_timestamp_index = 50;
-    if (initial_step) {
-        for (size_t i = 0; i < timestamp_begin; i++) {
-            logits_data[i] = -std::numeric_limits<float>::infinity();
-        }
-
-        size_t last_allowed = timestamp_begin + max_initial_timestamp_index;
-        for (size_t i = last_allowed + 1; i < vocab_size; i++) {
-            logits_data[i] = -std::numeric_limits<float>::infinity();
-        }
-    }
-
-    // todo: check if log_softmax can be optimized (skip copying to vector)
-    auto tokens = log_softmax(logits, 0);
-    float timestamp_exp_prov_sum = 0;
-
-    for (size_t i = timestamp_begin; i < vocab_size; i++) {
-        timestamp_exp_prov_sum += std::exp(tokens[i].m_log_prob);
-    }
-    float timestamp_logprob = std::log(timestamp_exp_prov_sum);
-
-    float max_text_token_logprob = -std::numeric_limits<float>::infinity();
-    // todo: replace with max
-    for (size_t i = 0; i < timestamp_begin; i++) {
-        if (tokens[i].m_log_prob > max_text_token_logprob) {
-            max_text_token_logprob = tokens[i].m_log_prob;
-        }
-    }
-
-    if (timestamp_logprob > max_text_token_logprob) {
-        for (size_t i = 0; i < timestamp_begin; i++) {
-            logits_data[i] = -std::numeric_limits<float>::infinity();
-        }
-    }
-}
 
 float round_up(const float value, const int decimal_places) {
     const float multiplier = std::pow(10, decimal_places);
@@ -292,11 +151,11 @@ int64_t decode(ov::Tensor& encoder_hidden_state,
     auto output_tensor = decoder.get_tensor("logits");
 
     if (apply_logit_processors) {
-        suppress_tokens(output_tensor, 0, config.begin_suppress_tokens);
-        suppress_tokens(output_tensor, 0, config.suppress_tokens);
+        ov::genai::do_suppress_tokens(output_tensor, 0, config.begin_suppress_tokens);
+        ov::genai::do_suppress_tokens(output_tensor, 0, config.suppress_tokens);
 
         if (config.return_timestamps) {
-            process_timestamp_logits(output_tensor, 0, config, {}, true);
+            ov::genai::process_whisper_timestamp_logits(output_tensor, 0, config, {}, true);
         }
     }
 
@@ -325,10 +184,10 @@ int64_t decode_with_past(ov::Tensor& encoder_hidden_state,
 
     auto output_tensor = decoder_with_past.get_tensor("logits");
 
-    suppress_tokens(output_tensor, 0, config.suppress_tokens);
+    ov::genai::do_suppress_tokens(output_tensor, 0, config.suppress_tokens);
 
     if (config.return_timestamps) {
-        process_timestamp_logits(output_tensor, 0, config, generated_tokens);
+        ov::genai::process_whisper_timestamp_logits(output_tensor, 0, config, generated_tokens);
     }
 
     int64_t output_token = ov::genai::utils::argmax(output_tensor, 0);

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "whisper.hpp"
+
 #include <iostream>
 #include <openvino/openvino.hpp>
 #include <regex>
@@ -15,8 +17,38 @@
 
 namespace {
 
+struct Token {
+    float m_log_prob = 0.;
+    int64_t m_index = 0;
+
+    Token(float log_prob, int64_t index) : m_log_prob(log_prob), m_index(index) {}
+    Token() = default;
+};
+
+std::vector<Token> log_softmax(const ov::Tensor& logits, size_t batch_idx) {
+    ov::Shape shape = logits.get_shape();
+    OPENVINO_ASSERT(shape.size() == 3);
+    size_t batch = shape[0], seq_len = shape[1], vocab_size = shape[2];
+    OPENVINO_ASSERT(batch_idx < batch, "Logits batch size doesn't match the number of beams");
+
+    size_t batch_offset = batch_idx * seq_len * vocab_size, sequence_offset = (seq_len - 1) * vocab_size;
+    const float* beam_logits = logits.data<const float>() + batch_offset + sequence_offset;
+    float max_logit = *std::max_element(beam_logits, beam_logits + vocab_size);
+    float log_sum = std::log(
+        std::accumulate(beam_logits, beam_logits + vocab_size, 0.0f, [max_logit](float accumulated, float to_add) {
+            return accumulated + std::exp(to_add - max_logit);
+        }));
+
+    std::vector<Token> tokens;
+    tokens.reserve(vocab_size);
+    for (size_t idx = 0; idx < vocab_size; ++idx)
+        tokens.push_back({beam_logits[idx] - max_logit - log_sum, int64_t(idx)});
+
+    return tokens;
+}
+
 void suppress_tokens(ov::Tensor& logits, const size_t batch_idx, const std::vector<int64_t>& suppress_tokens) {
-    OPENVINO_ASSERT(logits.get_shape()[0] >= batch_idx, "logits batch size doesn't match the number of beams");
+    OPENVINO_ASSERT(logits.get_shape()[0] >= batch_idx, "logits batch size doesn't match the batch number");
 
     size_t vocab_size = logits.get_shape().back();
     size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
@@ -26,6 +58,171 @@ void suppress_tokens(ov::Tensor& logits, const size_t batch_idx, const std::vect
     for (auto supress_token : suppress_tokens) {
         logits_data[supress_token] = -std::numeric_limits<float>::infinity();
     }
+}
+
+void process_timestamp_logits(ov::Tensor& logits,
+                              const size_t batch_idx,
+                              const ov::genai::WhisperGenerationConfig& config,
+                              const std::vector<int64_t>& generated_tokens,
+                              bool initial_step = false) {
+    const size_t batch_size = logits.get_shape().at(0);
+    OPENVINO_ASSERT(batch_size == 1, "Batch != 1 is not supported");
+
+    size_t vocab_size = logits.get_shape().back();
+    size_t batch_offset = batch_idx * logits.get_shape()[1] * vocab_size;
+    size_t sequence_offset = (logits.get_shape()[1] - 1) * vocab_size;
+    float* logits_data = logits.data<float>() + batch_offset + sequence_offset;
+
+    // supress<|notimestamps|>
+    logits_data[config.no_timestamps_token_id] = -std::numeric_limits<float>::infinity();
+
+    size_t timestamp_begin = config.no_timestamps_token_id + 1;
+
+    // timestamps have to appear in pairs, except directly before eos_token; mask logits accordingly
+    size_t generated_length = generated_tokens.size();
+    bool last_was_timestamp = generated_length >= 1 && generated_tokens[generated_length - 1] >= timestamp_begin;
+    bool penultimate_was_timestamp = generated_length < 2 || generated_tokens[generated_length - 2] >= timestamp_begin;
+
+    if (last_was_timestamp) {
+        if (penultimate_was_timestamp) {
+            // has to be timestamp
+            for (size_t i = timestamp_begin; i < vocab_size; i++) {
+                logits_data[i] = -std::numeric_limits<float>::infinity();
+            }
+        } else {
+            // cannot be normal text token
+            for (size_t i = 0; i < config.eos_token_id; i++) {
+                logits_data[i] = -std::numeric_limits<float>::infinity();
+            }
+        }
+    }
+
+    // filter generated timestaps
+    std::vector<int64_t> timestamps;
+    for (const auto token : generated_tokens) {
+        if (token >= timestamp_begin) {
+            timestamps.push_back(token);
+        }
+    }
+
+    if (timestamps.size() > 0) {
+        size_t timestamp_last;
+        // `timestamps` shouldn't decrease; forbid timestamp tokens smaller than the last
+        // The following lines of code are copied from: https://github.com/openai/whisper/pull/914/files#r1137085090
+        if (last_was_timestamp && !penultimate_was_timestamp) {
+            timestamp_last = timestamps.back();
+        } else {
+            // Avoid to emit <|0.00|> again
+            timestamp_last = timestamps.back() + 1;
+        }
+
+        for (size_t i = timestamp_begin; i < timestamp_last; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    // apply the `max_initial_timestamp` option
+    // todo: read from generation config json
+    constexpr size_t max_initial_timestamp_index = 50;
+    if (initial_step) {
+        for (size_t i = 0; i < timestamp_begin; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+
+        size_t last_allowed = timestamp_begin + max_initial_timestamp_index;
+        for (size_t i = last_allowed + 1; i < vocab_size; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    // todo: check if log_softmax can be optimized (skip copying to vector)
+    auto tokens = log_softmax(logits, 0);
+    float timestamp_exp_prov_sum = 0;
+
+    for (size_t i = timestamp_begin; i < vocab_size; i++) {
+        timestamp_exp_prov_sum += std::exp(tokens[i].m_log_prob);
+    }
+    float timestamp_logprob = std::log(timestamp_exp_prov_sum);
+
+    float max_text_token_logprob = -std::numeric_limits<float>::infinity();
+    // todo: replace with max
+    for (size_t i = 0; i < timestamp_begin; i++) {
+        if (tokens[i].m_log_prob > max_text_token_logprob) {
+            max_text_token_logprob = tokens[i].m_log_prob;
+        }
+    }
+
+    if (timestamp_logprob > max_text_token_logprob) {
+        for (size_t i = 0; i < timestamp_begin; i++) {
+            logits_data[i] = -std::numeric_limits<float>::infinity();
+        }
+    }
+}
+
+float round_up(const float value, const int decimal_places) {
+    const float multiplier = std::pow(10, decimal_places);
+    return ceilf(value * multiplier) / multiplier;
+}
+
+std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segments(
+    const std::vector<int64_t>& tokens,
+    const ov::genai::WhisperGenerationConfig& config,
+    const float time_precision) {
+    std::vector<int64_t> non_timestamp_tokens;
+    std::vector<ov::genai::Segment> segments;
+    std::optional<int64_t> token_start = std::nullopt;
+    size_t idx_start = 0;
+
+    for (size_t i = 0; i < tokens.size(); i++) {
+        int64_t token = tokens[i];
+
+        bool is_timestamp = token >= config.begin_timestamps_token_id;
+
+        if (!is_timestamp) {
+            continue;
+        }
+
+        if (!token_start.has_value()) {
+            token_start = token;
+            idx_start = i;
+        } else {
+            if (token_start == token) {
+                // from HF:
+                // https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/tokenization_whisper.py#L1020
+                // This is a bug in timestamp token output where we're taking the duplicate token as a stop where it
+                // should be a start. This is an issue in the underlying model output. Let's just skip it so it becomes
+                // de-factor a start again.
+                continue;
+            }
+
+            ov::genai::Segment segment;
+            segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.begin() + i};
+            segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
+            segment.m_end = round_up((token - config.begin_timestamps_token_id) * time_precision, 2);
+            segments.push_back(segment);
+
+            non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.begin() + i);
+
+            token_start = std::nullopt;
+        }
+    }
+
+    // segment started but has no closing timestamp
+    // add new segment only if it has non timestamps tokens
+    // do not add new segment if previous segments exists
+    bool has_tokens_to_add = idx_start < tokens.size() - 1;
+    bool has_previous_segments = segments.size() > 0;
+    if (token_start.has_value() && has_tokens_to_add && !has_previous_segments) {
+        ov::genai::Segment segment;
+        segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.end()};
+        segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
+        segment.m_end = -1.0f;
+        segments.push_back(segment);
+
+        non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.end());
+    }
+
+    return {non_timestamp_tokens, segments};
 }
 
 ov::Tensor encode(ov::InferRequest& request,
@@ -84,7 +281,7 @@ int64_t decode(ov::Tensor& encoder_hidden_state,
                ov::InferRequest& decoder,
                std::vector<int64_t>& input_ids,
                const ov::genai::WhisperGenerationConfig& config,
-               bool do_suppress_tokens = true) {
+               bool apply_logit_processors = true) {
     decoder.set_tensor("encoder_hidden_states", ov::Tensor{encoder_hidden_state});
 
     ov::Tensor input_ids_tensor(ov::element::i64, {1, input_ids.size()}, input_ids.data());
@@ -94,9 +291,13 @@ int64_t decode(ov::Tensor& encoder_hidden_state,
 
     auto output_tensor = decoder.get_tensor("logits");
 
-    if (do_suppress_tokens) {
+    if (apply_logit_processors) {
         suppress_tokens(output_tensor, 0, config.begin_suppress_tokens);
         suppress_tokens(output_tensor, 0, config.suppress_tokens);
+
+        if (config.return_timestamps) {
+            process_timestamp_logits(output_tensor, 0, config, {}, true);
+        }
     }
 
     int64_t output_token = ov::genai::utils::argmax(output_tensor, 0);
@@ -108,7 +309,8 @@ int64_t decode_with_past(ov::Tensor& encoder_hidden_state,
                          ov::InferRequest& decoder_with_past,
                          int64_t input_id,
                          const size_t cache_position,
-                         const ov::genai::WhisperGenerationConfig& config) {
+                         const ov::genai::WhisperGenerationConfig& config,
+                         const std::vector<int64_t>& generated_tokens) {
     decoder_with_past.set_tensor("encoder_hidden_states", ov::Tensor{encoder_hidden_state});
 
     std::vector<int64_t> input_ids = {input_id};
@@ -124,6 +326,10 @@ int64_t decode_with_past(ov::Tensor& encoder_hidden_state,
     auto output_tensor = decoder_with_past.get_tensor("logits");
 
     suppress_tokens(output_tensor, 0, config.suppress_tokens);
+
+    if (config.return_timestamps) {
+        process_timestamp_logits(output_tensor, 0, config, generated_tokens);
+    }
 
     int64_t output_token = ov::genai::utils::argmax(output_tensor, 0);
 
@@ -161,6 +367,10 @@ std::vector<int64_t> prepare_input_ids(ov::Tensor& encoder_hidden_state,
         task_token_id = config.translate_token_id;
     }
 
+    if (config.return_timestamps) {
+        return std::vector<int64_t>{config.decoder_start_token_id, language_token_id, task_token_id};
+    }
+
     return std::vector<int64_t>{config.decoder_start_token_id,
                                 language_token_id,
                                 task_token_id,
@@ -170,7 +380,7 @@ std::vector<int64_t> prepare_input_ids(ov::Tensor& encoder_hidden_state,
 std::pair<bool, std::vector<int64_t>> full_decode(ov::Tensor& encoder_hidden_state,
                                                   const ov::genai::WhisperGenerationConfig& config,
                                                   ov::genai::WhisperInitializedModels& models,
-                                                  const size_t max_new_tokens,
+                                                  size_t max_new_tokens,
                                                   const std::shared_ptr<ov::genai::StreamerBase> streamer) {
     std::vector<int64_t> input_ids = prepare_input_ids(encoder_hidden_state, models.decoder, config);
 
@@ -178,7 +388,8 @@ std::pair<bool, std::vector<int64_t>> full_decode(ov::Tensor& encoder_hidden_sta
 
     std::vector<int64_t> output_tokens{output_token};
 
-    if (streamer && streamer->put(output_token)) {
+    bool is_timestamp = output_token >= config.begin_timestamps_token_id;
+    if (!is_timestamp && streamer && streamer->put(output_token)) {
         return {true, output_tokens};
     }
 
@@ -193,7 +404,8 @@ std::pair<bool, std::vector<int64_t>> full_decode(ov::Tensor& encoder_hidden_sta
                                              models.decoder_with_past,
                                              output_tokens.back(),
                                              input_ids.size() + output_tokens.size() - 1,
-                                             config);
+                                             config,
+                                             output_tokens);
 
         if (i == 0) {
             set_past_key_value(models.decoder_with_past, models.decoder_with_past);
@@ -204,8 +416,9 @@ std::pair<bool, std::vector<int64_t>> full_decode(ov::Tensor& encoder_hidden_sta
         }
 
         output_tokens.push_back(output_token);
+        bool is_timestamp = output_token >= config.begin_timestamps_token_id;
 
-        if (streamer && streamer->put(output_token)) {
+        if (!is_timestamp && streamer && streamer->put(output_token)) {
             return {true, output_tokens};
         }
     }
@@ -232,11 +445,12 @@ namespace genai {
 //          remove eos tokens if not finished yet
 //          remove pad tokens
 // 7. Concatenate output tokens
-std::vector<int64_t> whisper_generate(const ov::genai::WhisperGenerationConfig& config,
-                                      const RawSpeechInput& raw_speech,
-                                      ov::genai::WhisperInitializedModels& models,
-                                      WhisperFeatureExtractor& feature_extractor,
-                                      const std::shared_ptr<StreamerBase> streamer) {
+std::pair<std::vector<int64_t>, std::optional<std::vector<Segment>>> whisper_generate(
+    const ov::genai::WhisperGenerationConfig& config,
+    const RawSpeechInput& raw_speech,
+    ov::genai::WhisperInitializedModels& models,
+    WhisperFeatureExtractor& feature_extractor,
+    const std::shared_ptr<StreamerBase> streamer) {
     std::vector<int64_t> output_tokens;
     size_t max_new_tokens = config.get_max_new_tokens();
 
@@ -267,7 +481,12 @@ std::vector<int64_t> whisper_generate(const ov::genai::WhisperGenerationConfig& 
         }
     }
 
-    return output_tokens;
+    std::optional<std::vector<Segment>> segments = std::nullopt;
+    if (config.return_timestamps) {
+        std::tie(output_tokens, segments) = extract_segments(output_tokens, config, feature_extractor.time_precision);
+    }
+
+    return {output_tokens, segments};
 }
 }  // namespace genai
 }  // namespace ov

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -13,76 +13,11 @@
 #include "openvino/genai/streamer_base.hpp"
 #include "openvino/genai/whisper_generation_config.hpp"
 #include "openvino/genai/whisper_pipeline.hpp"
+#include "timestamps.hpp"
 #include "whisper_feature_extractor.hpp"
 #include "whisper_models.hpp"
 
 namespace {
-
-float round_up(const float value, const int decimal_places) {
-    const float multiplier = std::pow(10, decimal_places);
-    return ceilf(value * multiplier) / multiplier;
-}
-
-std::pair<std::vector<int64_t>, std::vector<ov::genai::Segment>> extract_segments(
-    const std::vector<int64_t>& tokens,
-    const ov::genai::WhisperGenerationConfig& config,
-    const float time_precision) {
-    std::vector<int64_t> non_timestamp_tokens;
-    std::vector<ov::genai::Segment> segments;
-    std::optional<int64_t> token_start = std::nullopt;
-    size_t idx_start = 0;
-
-    for (size_t i = 0; i < tokens.size(); i++) {
-        int64_t token = tokens[i];
-
-        bool is_timestamp = token >= config.begin_timestamps_token_id;
-
-        if (!is_timestamp) {
-            continue;
-        }
-
-        if (!token_start.has_value()) {
-            token_start = token;
-            idx_start = i;
-        } else {
-            if (token_start == token) {
-                // from HF:
-                // https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/tokenization_whisper.py#L1020
-                // This is a bug in timestamp token output where we're taking the duplicate token as a stop where it
-                // should be a start. This is an issue in the underlying model output. Let's just skip it so it becomes
-                // de-factor a start again.
-                continue;
-            }
-
-            ov::genai::Segment segment;
-            segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.begin() + i};
-            segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
-            segment.m_end = round_up((token - config.begin_timestamps_token_id) * time_precision, 2);
-            segments.push_back(segment);
-
-            non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.begin() + i);
-
-            token_start = std::nullopt;
-        }
-    }
-
-    // segment started but has no closing timestamp
-    // add new segment only if it has non timestamps tokens
-    // do not add new segment if previous segments exists
-    bool has_tokens_to_add = idx_start < tokens.size() - 1;
-    bool has_previous_segments = segments.size() > 0;
-    if (token_start.has_value() && has_tokens_to_add && !has_previous_segments) {
-        ov::genai::Segment segment;
-        segment.m_tokens = {tokens.begin() + idx_start + 1, tokens.end()};
-        segment.m_start = round_up((*token_start - config.begin_timestamps_token_id) * time_precision, 2);
-        segment.m_end = -1.0f;
-        segments.push_back(segment);
-
-        non_timestamp_tokens.insert(non_timestamp_tokens.end(), tokens.begin() + idx_start + 1, tokens.end());
-    }
-
-    return {non_timestamp_tokens, segments};
-}
 
 ov::Tensor encode(ov::InferRequest& request,
                   std::vector<float>& mel_data,
@@ -342,7 +277,8 @@ std::pair<std::vector<int64_t>, std::optional<std::vector<Segment>>> whisper_gen
 
     std::optional<std::vector<Segment>> segments = std::nullopt;
     if (config.return_timestamps) {
-        std::tie(output_tokens, segments) = extract_segments(output_tokens, config, feature_extractor.time_precision);
+        std::tie(output_tokens, segments) =
+            ov::genai::extract_segments(output_tokens, config, feature_extractor.time_precision);
     }
 
     return {output_tokens, segments};

--- a/src/cpp/src/whisper/whisper.hpp
+++ b/src/cpp/src/whisper/whisper.hpp
@@ -7,6 +7,7 @@
 
 #include "openvino/genai/whisper_generation_config.hpp"
 #include "openvino/genai/whisper_pipeline.hpp"
+#include "whisper_config.hpp"
 #include "whisper_feature_extractor.hpp"
 #include "whisper_models.hpp"
 
@@ -21,6 +22,7 @@ struct Segment {
 
 std::pair<std::vector<int64_t>, std::optional<std::vector<Segment>>> whisper_generate(
     const ov::genai::WhisperGenerationConfig& config,
+    const ov::genai::WhisperConfig& model_config,
     const ov::genai::RawSpeechInput& raw_speech,
     ov::genai::WhisperInitializedModels& models,
     ov::genai::WhisperFeatureExtractor& feature_extractor,

--- a/src/cpp/src/whisper/whisper.hpp
+++ b/src/cpp/src/whisper/whisper.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <openvino/openvino.hpp>
+
+#include "openvino/genai/whisper_generation_config.hpp"
+#include "openvino/genai/whisper_pipeline.hpp"
+#include "whisper_feature_extractor.hpp"
+#include "whisper_models.hpp"
+
+namespace ov {
+namespace genai {
+
+struct Segment {
+    float m_start;
+    float m_end;
+    std::vector<int64_t> m_tokens;
+};
+
+std::pair<std::vector<int64_t>, std::optional<std::vector<Segment>>> whisper_generate(
+    const ov::genai::WhisperGenerationConfig& config,
+    const ov::genai::RawSpeechInput& raw_speech,
+    ov::genai::WhisperInitializedModels& models,
+    ov::genai::WhisperFeatureExtractor& feature_extractor,
+    const std::shared_ptr<StreamerBase> streamer);
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/whisper_config.cpp
+++ b/src/cpp/src/whisper/whisper_config.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "whisper_config.hpp"
+
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <openvino/runtime/core.hpp>
+
+#include "utils.hpp"
+
+namespace ov {
+namespace genai {
+
+WhisperConfig::WhisperConfig(const std::string& json_path) {
+    // preprocessor_config.json not found. Skip parameters initialization from file, use defaults.
+    if (!std::filesystem::exists(json_path)) {
+        return;
+    }
+
+    using ov::genai::utils::read_json_param;
+
+    std::ifstream f(json_path);
+    OPENVINO_ASSERT(f.is_open(), "Failed to open '" + json_path + "' with config");
+
+    nlohmann::json data = nlohmann::json::parse(f);
+
+    read_json_param(data, "max_source_positions", max_source_positions);
+}
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/whisper_config.hpp
+++ b/src/cpp/src/whisper/whisper_config.hpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+namespace ov {
+namespace genai {
+
+/**
+ * @brief Structure to keep whisper config parameters.
+ */
+class WhisperConfig {
+public:
+    explicit WhisperConfig(const std::string& json_path);
+
+    size_t max_source_positions = 1500;
+};
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/whisper/whisper_feature_extractor.hpp
+++ b/src/cpp/src/whisper/whisper_feature_extractor.hpp
@@ -20,8 +20,6 @@ public:
     size_t chunk_length = 30;
     size_t n_samples = 480000;
     size_t nb_max_frames = 3000;
-    // todo: read from config
-    float time_precision = 0.02;
 
     explicit WhisperFeatureExtractor(const std::string& preprocessor_json_path);
 

--- a/src/cpp/src/whisper/whisper_feature_extractor.hpp
+++ b/src/cpp/src/whisper/whisper_feature_extractor.hpp
@@ -20,6 +20,8 @@ public:
     size_t chunk_length = 30;
     size_t n_samples = 480000;
     size_t nb_max_frames = 3000;
+    // todo: read from config
+    float time_precision = 0.02;
 
     explicit WhisperFeatureExtractor(const std::string& preprocessor_json_path);
 

--- a/src/cpp/src/whisper_generation_config.cpp
+++ b/src/cpp/src/whisper_generation_config.cpp
@@ -71,6 +71,7 @@ void WhisperGenerationConfig::update_generation_config(const ov::AnyMap& config_
     read_anymap_param(config_map, "language", language);
     read_anymap_param(config_map, "lang_to_id", lang_to_id);
     read_anymap_param(config_map, "task", task);
+    read_anymap_param(config_map, "return_timestamps", return_timestamps);
 }
 
 size_t WhisperGenerationConfig::get_max_new_tokens(size_t prompt_length) const {

--- a/src/cpp/src/whisper_generation_config.cpp
+++ b/src/cpp/src/whisper_generation_config.cpp
@@ -30,6 +30,7 @@ WhisperGenerationConfig::WhisperGenerationConfig(const std::string& json_path) {
     read_json_param(data, "pad_token_id", pad_token_id);
     read_json_param(data, "no_timestamps_token_id", no_timestamps_token_id);
     read_json_param(data, "begin_timestamps_token_id", begin_timestamps_token_id);
+    read_json_param(data, "max_initial_timestamp_index", max_initial_timestamp_index);
 
     read_json_param(data, "is_multilingual", is_multilingual);
     if (is_multilingual) {
@@ -67,6 +68,7 @@ void WhisperGenerationConfig::update_generation_config(const ov::AnyMap& config_
     read_anymap_param(config_map, "translate_token_id", translate_token_id);
     read_anymap_param(config_map, "no_timestamps_token_id", no_timestamps_token_id);
     read_anymap_param(config_map, "begin_timestamps_token_id", begin_timestamps_token_id);
+    read_anymap_param(config_map, "max_initial_timestamp_index", max_initial_timestamp_index);
     read_anymap_param(config_map, "is_multilingual", is_multilingual);
     read_anymap_param(config_map, "language", language);
     read_anymap_param(config_map, "lang_to_id", lang_to_id);

--- a/src/python/py_whisper_pipeline.cpp
+++ b/src/python/py_whisper_pipeline.cpp
@@ -154,6 +154,8 @@ OptionalWhisperGenerationConfig update_whisper_config_from_kwargs(const Optional
             res_config.no_timestamps_token_id = py::cast<int>(item.second);
         } else if (key == "begin_timestamps_token_id") {
             res_config.begin_timestamps_token_id = py::cast<int>(item.second);
+        } else if (key == "max_initial_timestamp_index") {
+            res_config.max_initial_timestamp_index = py::cast<size_t>(item.second);
         } else if (key == "begin_suppress_tokens") {
             res_config.begin_suppress_tokens = py::cast<std::vector<int64_t>>(item.second);
         } else if (key == "suppress_tokens") {
@@ -243,6 +245,7 @@ void init_whisper_pipeline(py::module_& m) {
         .def_readwrite("translate_token_id", &WhisperGenerationConfig::translate_token_id)
         .def_readwrite("transcribe_token_id", &WhisperGenerationConfig::transcribe_token_id)
         .def_readwrite("begin_timestamps_token_id", &WhisperGenerationConfig::begin_timestamps_token_id)
+        .def_readwrite("max_initial_timestamp_index", &WhisperGenerationConfig::max_initial_timestamp_index)
         .def_readwrite("no_timestamps_token_id", &WhisperGenerationConfig::no_timestamps_token_id)
         .def_readwrite("is_multilingual", &WhisperGenerationConfig::is_multilingual)
         .def_readwrite("language", &WhisperGenerationConfig::language)

--- a/src/python/py_whisper_pipeline.cpp
+++ b/src/python/py_whisper_pipeline.cpp
@@ -17,6 +17,8 @@ using ov::genai::RawSpeechInput;
 using ov::genai::StreamerBase;
 using ov::genai::StreamerVariant;
 using ov::genai::Tokenizer;
+using ov::genai::WhisperDecodedResultChunk;
+using ov::genai::WhisperDecodedResults;
 using ov::genai::WhisperGenerationConfig;
 using ov::genai::WhisperPipeline;
 
@@ -41,6 +43,25 @@ auto whisper_generate_docstring = R"(
 
     :return: return results in encoded, or decoded form depending on inputs type
     :rtype: DecodedResults
+)";
+
+auto whisper_decoded_results_docstring = R"(
+    Structure to store resulting batched text outputs and scores for each batch.
+    The first num_return_sequences elements correspond to the first batch element.
+
+    Parameters: 
+    texts:      vector of resulting sequences.
+    scores:     scores for each sequence.
+    metrics:    performance metrics with tpot, ttft, etc. of type ov::genai::PerfMetrics.
+    shunks:     chunk of resulting sequences with timestamps
+)";
+
+auto whisper_decoded_result_chunk = R"(
+    Structure to store decoded text with corresponding timestamps
+
+    :param start_ts chunk start time in seconds
+    :param end_ts   chunk end time in seconds
+    :param text     chunk text
 )";
 
 auto whisper_generation_config_docstring = R"(
@@ -145,6 +166,8 @@ OptionalWhisperGenerationConfig update_whisper_config_from_kwargs(const Optional
             res_config.lang_to_id = py::cast<std::map<std::string, int64_t>>(item.second);
         } else if (key == "task") {
             res_config.task = py::cast<std::string>(item.second);
+        } else if (key == "return_timestamps") {
+            res_config.return_timestamps = py::cast<bool>(item.second);
         } else if (key == "eos_token_id") {
             res_config.set_eos_token_id(py::cast<int>(item.second));
         } else {
@@ -190,6 +213,15 @@ py::object call_whisper_common_generate(WhisperPipeline& pipe,
 
     return py::cast(pipe.generate(raw_speech_input, updated_config, streamer));
 }
+
+py::str handle_utf8_text(const std::string& text) {
+    // pybind11 decodes strings similar to Pythons's
+    // bytes.decode('utf-8'). It raises if the decoding fails.
+    // generate() may return incomplete Unicode points if max_new_tokens
+    // was reached. Replace such points with � instead of raising an exception
+    PyObject* py_s = PyUnicode_DecodeUTF8(text.data(), text.length(), "replace");
+    return py::reinterpret_steal<py::object>(py_s);
+}
 }  // namespace
 
 void init_whisper_pipeline(py::module_& m) {
@@ -216,7 +248,19 @@ void init_whisper_pipeline(py::module_& m) {
         .def_readwrite("language", &WhisperGenerationConfig::language)
         .def_readwrite("lang_to_id", &WhisperGenerationConfig::lang_to_id)
         .def_readwrite("task", &WhisperGenerationConfig::task)
+        .def_readwrite("return_timestamps", &WhisperGenerationConfig::return_timestamps)
         .def("set_eos_token_id", &WhisperGenerationConfig::set_eos_token_id);
+
+    py::class_<WhisperDecodedResultChunk>(m, "WhisperDecodedResultChunk", whisper_decoded_result_chunk)
+        .def(py::init<>())
+        .def_readonly("start_ts", &WhisperDecodedResultChunk::start_ts)
+        .def_readonly("end_ts", &WhisperDecodedResultChunk::end_ts)
+        .def_property_readonly("text", [](WhisperDecodedResultChunk& chunk) {
+            return handle_utf8_text(chunk.text);
+        });
+
+    py::class_<WhisperDecodedResults, DecodedResults>(m, "WhisperDecodedResults", whisper_decoded_results_docstring)
+        .def_readonly("chunks", &WhisperDecodedResults::chunks);
 
     py::class_<WhisperPipeline>(m, "WhisperPipeline")
         .def(py::init([](const std::string& model_path,


### PR DESCRIPTION
This PR adds return_timestamps support for Whisper pipeline.
Common Todos for Whisper support:
- [ ] Longer audio inputs (>30s) chunking border poor quality results. Long audio inputs splitted by 30s chunks. This leads to a loss of context on a chunking border. This could be partially solved by [chunking with stride](https://huggingface.co/blog/asr-chunking).
- [ ] add perf metrics
- [ ] update documentation
- [ ] add cpp, python samples tests
- [x] support different languages, language autodetection
- [x] support translation
- [x] support timestamps
- [ ] support timestamps streaming
- [ ] expose only meaningful parameters in `GenerationConfig` (`task`, `language`, `return_timestamps`, etc)
- [ ] Move all whisper pipeline files to dedicated subfolder
- [ ] Whisper pipeline doesn't need tokenizer, it uses detokenizer only. Implement detokenizer only initialization for `ov::genai::Tokenizer`
- [ ] Check discrete GPU. Integrated GPU works as expected.
- [ ] Investigate use of `RemoteTensor` for GPU
- [ ] Add batch
- [ ] Add sampler, inherit WhisperGenerationConfig from GenerationConfig
- [ ] Investigate language autodetection with single decoder (without past) call
- [ ] Update python bindings cmake to include whole directory instead of explicit list of files
- [ ] Add samples with audio preparation examples
- [ ] Add links to audio files so users can download them in samples
- [ ] Move supported models list from samples README to common supported models section
- [ ] Avoid building GenAI in each tests job as it takes a lot of time
- [ ] Double check FP32 support
- [ ] Fix tests sporadic fails. Sometimes whisper model cannot be downloaded from HF due to network issues
- [ ] Fix stop criteria. Current approach stops on eos_token which is no speech token. But there could be more speech tokens further which are wrongly skipped now.

Current limitations:
- No resampling during preprocessing. Input raw speech should have 16k Hz sampling rate
- No normalization during preprocessing. Input raw speech should be normalized to near [-1, 1] range

Tickets: CVS-147994, CVS-146010, CVS-152543