### PR TITLE
convert image to RGB before submit in python vlm sample

### DIFF
--- a/samples/python/visual_language_chat/visual_language_chat.py
+++ b/samples/python/visual_language_chat/visual_language_chat.py
@@ -34,7 +34,7 @@ def read_image(path: str) -> Tensor:
     Returns: the ov.Tensor containing the image.
 
     '''
-    pic = Image.open(path)
+    pic = Image.open(path).convert("RGB")
     image_data = np.array(pic.getdata()).reshape(1, 3, pic.size[1], pic.size[0]).astype(np.byte)
     return Tensor(image_data)
 


### PR DESCRIPTION
PIL reads grayscale images as 1 channel and also support reading RGBA images (4 channels), for avoid potential issues with image reshaping due to number of channels difference added conversion to RGB