### PR TITLE
Don't update missing requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"
+    directory: "./tools/llm_bench/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "./tools/who_what_benchmark/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
     directory: "samples/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "./"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "image_generation/stable_diffusion_1_5/cpp/scripts/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "image_generation/lcm_dreamshaper_v7/cpp/scripts/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
     directory: "./tests/python_tests/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
image_generation was removed. There's nothing to update in root project.toml. ./tests/python_tests/ update fails with an error that it can't resolve the path, but maybe it gets fixed later, so keep it.