### PR TITLE
Separate reset for KV state and LoRA state in LLMPipeline

### DIFF
--- a/src/cpp/include/openvino/genai/lora_adapter.hpp
+++ b/src/cpp/include/openvino/genai/lora_adapter.hpp
@@ -190,8 +190,9 @@ public:
     // Apply adapters configured in the current config set last time, or set and use new config given as optional `config` argument
     void apply(ov::InferRequest& request, const std::optional<AdapterConfig>& config = std::nullopt);
 
-    // the next call of apply will set all adapter tensors regardless of config change, use this method if full state.reset is called for the controlled model
-    void force_full_apply(bool full_apply = true);
+    // Returns true if a given name is one of the state names created by this adapter controller for dynamic LoRA
+    // Helps to distinguish LoRA states from other states (e.g. KV cache state) in the model for a partial state reset.
+    bool has_state_name(const std::string& name);
 
     operator bool() const {
         return bool(m_pimpl);

--- a/src/cpp/src/llm_pipeline.cpp
+++ b/src/cpp/src/llm_pipeline.cpp
@@ -86,7 +86,6 @@ public:
             m_adapter_controller = AdapterController(model, m_generation_config.adapters, device);   // TODO: Make the prefix name configurable
             utils::slice_matmul_statefull_model(model);
             m_model_runner = core.compile_model(model, device, compile_plugin_config).create_infer_request();
-            m_adapter_controller->apply(m_model_runner, m_generation_config.adapters);
         } else {
             auto [core_plugin_config, compile_plugin_config] = ov::genai::utils::split_core_complile_config(plugin_config);
             core.set_property(core_plugin_config);
@@ -177,6 +176,18 @@ public:
         decoded_results.perf_metrics.m_evaluated = false;
         decoded_results.perf_metrics.evaluate_statistics(start_time);
         return decoded_results;
+    }
+
+    void reset_kv_state() {
+        if(m_adapter_controller) {
+            for(auto& state: m_model_runner.query_state()) {
+                if(!m_adapter_controller->has_state_name(state.get_name())) {
+                    state.reset();
+                }
+            }
+        } else {
+            m_model_runner.reset_state();
+        }
     }
 
     EncodedResults generate(
@@ -273,11 +284,7 @@ public:
         }
 
         if (!is_chat_conversation) {
-            // FIXME: Reset only KV cache part of state, there is also can be LoRA applied in the states and full reset will need to reapply LoRA even if the LoRA config is not changed
-            m_model_runner.reset_state();
-            if(m_adapter_controller) {
-                m_adapter_controller->force_full_apply(); // FIXME: Reset only KV cache part to avoid this call
-            }
+            reset_kv_state();
             m_selected_beam = std::nullopt;
         } else {
             m_is_cache_empty = false;
@@ -297,7 +304,7 @@ public:
         is_chat_conversation = true;
         m_selected_beam  = std::nullopt;
         if (!m_is_cache_empty) {
-            m_model_runner.reset_state();
+            reset_kv_state();
             m_is_cache_empty = true;
             m_history = {};
             m_templated_chat_history = "";
@@ -315,7 +322,7 @@ public:
         is_chat_conversation = false;
         m_selected_beam = std::nullopt;
         if (!m_is_cache_empty) {
-            m_model_runner.reset_state();
+            reset_kv_state();
             m_is_cache_empty = true;
             m_history.clear();
             m_templated_chat_history.clear();


### PR DESCRIPTION
Fixing a bug when LoRA state is experienced reset each time when generate is invoked that brought unnecessary overhead in each generate call even if LoRA tensors/alphas are not changed.