### PR TITLE
CB: remove assert

### DIFF
--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -162,7 +162,6 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
     ManualTimer generate_timer("speculative_decoding: generate()");
     generate_timer.start();
     OPENVINO_ASSERT(!has_non_finished_requests(), "Generate cannot be called while ContinuousBatchingPipeline is already in running state. Use ContinuousBatchingPipeline::add_request");
-    OPENVINO_ASSERT(input_ids.size() == sampling_params.size());
     const std::shared_ptr<StreamerBase>& streamer_ptr = std::visit(overloaded{
         [](std::monostate) -> std::shared_ptr<StreamerBase> {
             return nullptr;


### PR DESCRIPTION
`~/r/ov/bin/intel64/Debug/continuous_batching_speculative_decoding -m chatglm3-6b/ -a Llama-2-7b-chat-hf/` fails with `Check 'input_ids.size() == sampling_params.size()' failed at /home/vzlobin/r/g/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp:165`. Removing the assert solves that and generates a reasonable output: Question: What is OpenVINO?
Answer 0 (-6.22052) :
OpenVINO is a software development kit (SDK) and toolkit developed by Intel that is designed to enable developers to build intelligent applications