### PR TITLE
Corrected performance data when batch size is greater than 1

### DIFF
--- a/src/cpp/src/perf_metrics.cpp
+++ b/src/cpp/src/perf_metrics.cpp
@@ -112,7 +112,6 @@ void PerfMetrics::evaluate_statistics(std::optional<TimePoint> start_time) {
             raw_metrics.m_durations[i] = tok_times[i] - start_time_val;
             
             // If in 10 ms a batch of 5 new tokens is generated then TPOT is 10 / 5 = 2 tok/ms.
-            raw_metrics.m_durations[i] /= batch_sizes[i];
             num_generated_tokens += batch_sizes[i];
             start_time_val = tok_times[i];
         }


### PR DESCRIPTION
[openvino.genai/src/cpp/src/perf_metrics.cpp](https://github.com/openvinotoolkit/openvino.genai/blob/fa324cfaca838591a86cecc14cb44253b7fb7632/src/cpp/src/perf_metrics.cpp#L115)

Line 115 in [fa324cf](https://github.com/openvinotoolkit/openvino.genai/commit/fa324cfaca838591a86cecc14cb44253b7fb7632)

 raw_metrics.m_durations[i] /= batch_sizes[i];
@m_durations[i] should be the duration for one inference which may generate one or more (batch_size > 1) tokens. In the case batch_size>1, it means @batch_size tokens are generated together in @m_durations[i] time, not one token is generated in @m_durations[i]/@batch_size time