### PR TITLE
[Image Generation] Supported force_zeros_for_empty_prompt in SDXL

### DIFF
--- a/src/cpp/include/openvino/genai/image_generation/clip_text_model.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/clip_text_model.hpp
@@ -22,8 +22,7 @@ class OPENVINO_GENAI_EXPORTS CLIPTextModel {
 public:
     struct OPENVINO_GENAI_EXPORTS Config {
         size_t max_position_embeddings = 77;
-        size_t hidden_size = 512;
-        size_t num_hidden_layers = 13;
+        size_t num_hidden_layers = 12;
 
         explicit Config(const std::filesystem::path& config_path);
     };

--- a/src/cpp/include/openvino/genai/image_generation/clip_text_model_with_projection.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/clip_text_model_with_projection.hpp
@@ -22,8 +22,7 @@ class OPENVINO_GENAI_EXPORTS CLIPTextModelWithProjection {
 public:
     struct OPENVINO_GENAI_EXPORTS Config {
         size_t max_position_embeddings = 77;
-        size_t hidden_size = 512;
-        size_t num_hidden_layers = 33;
+        size_t num_hidden_layers = 32;
 
         explicit Config(const std::filesystem::path& config_path);
     };

--- a/src/cpp/include/openvino/genai/image_generation/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/generation_config.hpp
@@ -43,9 +43,8 @@ struct OPENVINO_GENAI_EXPORTS ImageGenerationConfig {
     // SD XL: prompt2 and negative_prompt2
     // FLUX: prompt2 (prompt if prompt2 is not defined explicitly)
     // SD 3: prompt2, prompt3 (with fallback to prompt) and negative_prompt2, negative_prompt3
-    std::string negative_prompt;
     std::optional<std::string> prompt_2 = std::nullopt, prompt_3 = std::nullopt;
-    std::optional<std::string> negative_prompt_2 = std::nullopt, negative_prompt_3 = std::nullopt;
+    std::optional<std::string> negative_prompt = std::nullopt, negative_prompt_2 = std::nullopt, negative_prompt_3 = std::nullopt;
 
     size_t num_images_per_prompt = 1;
 

--- a/src/cpp/src/image_generation/generation_config.cpp
+++ b/src/cpp/src/image_generation/generation_config.cpp
@@ -68,7 +68,7 @@ void ImageGenerationConfig::update_generation_config(const ov::AnyMap& propertie
 }
 
 void ImageGenerationConfig::validate() const {
-    OPENVINO_ASSERT(guidance_scale > 1.0f || negative_prompt.empty(), "Guidance scale <= 1.0 ignores negative prompt");
+    OPENVINO_ASSERT(guidance_scale > 1.0f || negative_prompt == std::nullopt, "Guidance scale <= 1.0 ignores negative prompt");
     OPENVINO_ASSERT(guidance_scale > 1.0f || negative_prompt_2 == std::nullopt, "Guidance scale <= 1.0 ignores negative prompt 2");
     OPENVINO_ASSERT(guidance_scale > 1.0f || negative_prompt_3 == std::nullopt, "Guidance scale <= 1.0 ignores negative prompt 3");
 }

--- a/src/cpp/src/image_generation/models/clip_text_model.cpp
+++ b/src/cpp/src/image_generation/models/clip_text_model.cpp
@@ -20,7 +20,6 @@ CLIPTextModel::Config::Config(const std::filesystem::path& config_path) {
     using utils::read_json_param;
 
     read_json_param(data, "max_position_embeddings", max_position_embeddings);
-    read_json_param(data, "hidden_size", hidden_size);
     read_json_param(data, "num_hidden_layers", num_hidden_layers);
 }
 

--- a/src/cpp/src/image_generation/models/clip_text_model_with_projection.cpp
+++ b/src/cpp/src/image_generation/models/clip_text_model_with_projection.cpp
@@ -20,7 +20,6 @@ CLIPTextModelWithProjection::Config::Config(const std::filesystem::path& config_
     using utils::read_json_param;
 
     read_json_param(data, "max_position_embeddings", max_position_embeddings);
-    read_json_param(data, "hidden_size", hidden_size);
     read_json_param(data, "num_hidden_layers", num_hidden_layers);
 }
 

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -575,7 +575,7 @@ public:
                 timestep = ov::Tensor(ov::element::f32, {timestep_size});
                 std::fill_n(timestep.data<float>(), timestep.get_size(), timesteps[inference_step]);
             } else {
-                // just assign to save memory copy (not, )
+                // just assign to save memory copy
                 latent_cfg = latent;
                 timestep = ov::Tensor(ov::element::f32, {1}, &timesteps[inference_step]);
             }

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -289,7 +289,9 @@ public:
         std::string prompt_3_str =
             generation_config.prompt_3 != std::nullopt ? *generation_config.prompt_3 : positive_prompt;
 
-        std::string negative_prompt_1_str = generation_config.negative_prompt;
+        std::string negative_prompt_1_str = generation_config.negative_prompt != std::nullopt
+                                                ? *generation_config.negative_prompt_2
+                                                : std::string{};
         std::string negative_prompt_2_str = generation_config.negative_prompt_2 != std::nullopt
                                                 ? *generation_config.negative_prompt_2
                                                 : negative_prompt_1_str;
@@ -573,7 +575,7 @@ public:
                 timestep = ov::Tensor(ov::element::f32, {timestep_size});
                 std::fill_n(timestep.data<float>(), timestep.get_size(), timesteps[inference_step]);
             } else {
-                // just assign to save memory copy
+                // just assign to save memory copy (not, )
                 latent_cfg = latent;
                 timestep = ov::Tensor(ov::element::f32, {1}, &timesteps[inference_step]);
             }
@@ -657,7 +659,7 @@ private:
             generation_config.prompt_3 == std::nullopt || generation_config.negative_prompt_3 == std::nullopt,
             "T5Encoder is not currently supported, 'prompt_3' and 'negative_prompt_3' can't be used. Please, add "
             "support.");
-        OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt.empty(),
+        OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt == std::nullopt,
                         "Negative prompt is not used when guidance scale < 1.0");
         OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt_2 == std::nullopt,
                         "Negative prompt 2 is not used when guidance scale < 1.0");

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -290,7 +290,7 @@ public:
             generation_config.prompt_3 != std::nullopt ? *generation_config.prompt_3 : positive_prompt;
 
         std::string negative_prompt_1_str = generation_config.negative_prompt != std::nullopt
-                                                ? *generation_config.negative_prompt_2
+                                                ? *generation_config.negative_prompt
                                                 : std::string{};
         std::string negative_prompt_2_str = generation_config.negative_prompt_2 != std::nullopt
                                                 ? *generation_config.negative_prompt_2
@@ -584,9 +584,10 @@ public:
 
             ov::Shape noise_pred_shape = noise_pred_tensor.get_shape();
             noise_pred_shape[0] /= batch_size_multiplier;
-            noisy_residual_tensor.set_shape(noise_pred_shape);
 
             if (batch_size_multiplier > 1) {
+                noisy_residual_tensor.set_shape(noise_pred_shape);
+
                 // perform guidance
                 float* noisy_residual = noisy_residual_tensor.data<float>();
                 const float* noise_pred_uncond = noise_pred_tensor.data<const float>();

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -275,9 +275,10 @@ public:
 
             ov::Shape noise_pred_shape = noise_pred_tensor.get_shape();
             noise_pred_shape[0] /= batch_size_multiplier;
-            noisy_residual_tensor.set_shape(noise_pred_shape);
 
             if (batch_size_multiplier > 1) {
+                noisy_residual_tensor.set_shape(noise_pred_shape);
+
                 // perform guidance
                 float* noisy_residual = noisy_residual_tensor.data<float>();
                 const float* noise_pred_uncond = noise_pred_tensor.data<const float>();

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -66,6 +66,9 @@ public:
 
         // initialize generation config
         initialize_generation_config(data["_class_name"].get<std::string>());
+
+        // initialize force_zeros_for_empty_prompt, which is SDXL specific
+        read_json_param(data, "force_zeros_for_empty_prompt", m_force_zeros_for_empty_prompt);
     }
 
     StableDiffusionXLPipeline(PipelineType pipeline_type, const std::filesystem::path& root_dir, const std::string& device, const ov::AnyMap& properties) :
@@ -124,6 +127,9 @@ public:
         // initialize generation config
         initialize_generation_config(data["_class_name"].get<std::string>());
 
+        // initialize force_zeros_for_empty_prompt, which is SDXL specific
+        read_json_param(data, "force_zeros_for_empty_prompt", m_force_zeros_for_empty_prompt);
+
         update_adapters_from_properties(properties, m_generation_config.adapters);
     }
 
@@ -139,6 +145,8 @@ public:
           m_unet(std::make_shared<UNet2DConditionModel>(unet)),
           m_vae(std::make_shared<AutoencoderKL>(vae)) {
         initialize_generation_config("StableDiffusionXLPipeline");
+        // here we implicitly imply that force_zeros_for_empty_prompt is set to True as by default in diffusers
+        m_force_zeros_for_empty_prompt = true;
     }
 
     void reshape(const int num_images_per_prompt, const int height, const int width, const float guidance_scale) override {
@@ -226,38 +234,76 @@ public:
             std::copy(time_ids.begin(), time_ids.end(), add_time_ids_data + time_ids.size());
         }
 
-        ov::Tensor add_text_embeds = m_clip_text_encoder_with_projection->infer(positive_prompt, generation_config.negative_prompt, batch_size_multiplier > 1);
-        m_clip_text_encoder->infer(positive_prompt, generation_config.negative_prompt, batch_size_multiplier > 1);
+        // see https://github.com/huggingface/diffusers/blob/v0.31.0/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py#L423-L427
+        bool force_zeros_for_empty_prompt = generation_config.negative_prompt == std::nullopt && m_force_zeros_for_empty_prompt;
+        std::string negative_prompt = generation_config.negative_prompt != std::nullopt ? *generation_config.negative_prompt : std::string{};
+        bool compute_negative_prompt = !force_zeros_for_empty_prompt && batch_size_multiplier > 1;
 
-        // prompt_embeds = prompt_embeds.hidden_states[-2]
         size_t idx_hidden_state_1 = m_clip_text_encoder->get_config().num_hidden_layers;
-        ov::Tensor encoder_hidden_states_1 = m_clip_text_encoder->get_output_tensor(idx_hidden_state_1);
         size_t idx_hidden_state_2 = m_clip_text_encoder_with_projection->get_config().num_hidden_layers;
-        ov::Tensor encoder_hidden_states_2 = m_clip_text_encoder_with_projection->get_output_tensor(idx_hidden_state_2);
 
-        ov::Shape ehs_1_shape = encoder_hidden_states_1.get_shape();
-        ov::Shape ehs_2_shape = encoder_hidden_states_2.get_shape();
+        ov::Tensor encoder_hidden_states(ov::element::f32, {}), add_text_embeds(ov::element::f32, {});
 
-        OPENVINO_ASSERT(ehs_1_shape[0] == ehs_2_shape[0] && ehs_1_shape[1] == ehs_2_shape[1],
-                        "Tensors for concatenation must have the same dimensions");
+        if (compute_negative_prompt) {
+            add_text_embeds = m_clip_text_encoder_with_projection->infer(positive_prompt, negative_prompt, batch_size_multiplier > 1);
+            m_clip_text_encoder->infer(positive_prompt, negative_prompt, batch_size_multiplier > 1);
 
-        // concatenate hidden_states from two encoders
-        ov::Shape encoder_hidden_states_shape = {ehs_1_shape[0], ehs_1_shape[1], ehs_1_shape[2] + ehs_2_shape[2]};
-        ov::Tensor encoder_hidden_states(encoder_hidden_states_1.get_element_type(), encoder_hidden_states_shape);
+            // prompt_embeds = prompt_embeds.hidden_states[-2]
+            ov::Tensor encoder_hidden_states_1 = m_clip_text_encoder->get_output_tensor(idx_hidden_state_1);
+            ov::Tensor encoder_hidden_states_2 = m_clip_text_encoder_with_projection->get_output_tensor(idx_hidden_state_2);
 
-        const float* ehs_1_data = encoder_hidden_states_1.data<const float>();
-        const float* ehs_2_data = encoder_hidden_states_2.data<const float>();
-        float* encoder_hidden_states_data = encoder_hidden_states.data<float>();
+            ov::Shape ehs_1_shape = encoder_hidden_states_1.get_shape();
+            ov::Shape ehs_2_shape = encoder_hidden_states_2.get_shape();
 
-        for (size_t i = 0; i < ehs_1_shape[0]; ++i) {
-            for (size_t j = 0; j < ehs_1_shape[1]; ++j) {
-                size_t offset_1 = (i * ehs_1_shape[1] + j) * ehs_1_shape[2];
-                size_t offset_2 = (i * ehs_2_shape[1] + j) * ehs_2_shape[2];
+            OPENVINO_ASSERT(ehs_1_shape[0] == ehs_2_shape[0] && ehs_1_shape[1] == ehs_2_shape[1],
+                            "Tensors for concatenation must have the same dimensions");
 
-                size_t step = (i * ehs_1_shape[1] + j) * (ehs_1_shape[2] + ehs_2_shape[2]);
+            // concatenate hidden_states from two encoders
+            ov::Shape encoder_hidden_states_shape = {ehs_1_shape[0], ehs_1_shape[1], ehs_1_shape[2] + ehs_2_shape[2]};
+            encoder_hidden_states.set_shape(encoder_hidden_states_shape);
 
-                std::memcpy(encoder_hidden_states_data + step, ehs_1_data + offset_1, ehs_1_shape[2] * sizeof(float));
-                std::memcpy(encoder_hidden_states_data + step + ehs_1_shape[2], ehs_2_data + offset_2, ehs_2_shape[2] * sizeof(float));
+            const float* ehs_1_data = encoder_hidden_states_1.data<const float>();
+            const float* ehs_2_data = encoder_hidden_states_2.data<const float>();
+            float* encoder_hidden_states_data = encoder_hidden_states.data<float>();
+
+            for (size_t i = 0; i < ehs_1_shape[0] * ehs_1_shape[1]; ++i,
+                encoder_hidden_states_data += encoder_hidden_states_shape[2],
+                ehs_1_data += ehs_1_shape[2], ehs_2_data += ehs_2_shape[2]) {
+                std::memcpy(encoder_hidden_states_data                 , ehs_1_data, ehs_1_shape[2] * sizeof(float));
+                std::memcpy(encoder_hidden_states_data + ehs_1_shape[2], ehs_2_data, ehs_2_shape[2] * sizeof(float));
+            }
+        } else if (batch_size_multiplier > 1) {
+            ov::Tensor add_text_embeds_positive = m_clip_text_encoder_with_projection->infer(positive_prompt, negative_prompt, false);
+            m_clip_text_encoder->infer(positive_prompt, negative_prompt, false);
+
+            ov::Tensor encoder_hidden_states_1_positive = m_clip_text_encoder->get_output_tensor(idx_hidden_state_1);
+            ov::Tensor encoder_hidden_states_2_positive = m_clip_text_encoder_with_projection->get_output_tensor(idx_hidden_state_2);
+            
+            ov::Shape ehs_1_shape = encoder_hidden_states_1_positive.get_shape();
+            ov::Shape ehs_2_shape = encoder_hidden_states_2_positive.get_shape();
+
+            ov::Shape add_text_embeds_shape = add_text_embeds_positive.get_shape();
+            add_text_embeds_shape[0] *= batch_size_multiplier;
+            ov::Shape encoder_hidden_states_shape = {ehs_1_shape[0] * batch_size_multiplier, ehs_1_shape[1], ehs_1_shape[2] + ehs_2_shape[2]};
+
+            add_text_embeds.set_shape(add_text_embeds_shape);
+            encoder_hidden_states.set_shape(encoder_hidden_states_shape);
+
+            std::fill_n(add_text_embeds.data<float>(), add_text_embeds_positive.get_size(), 0.0f); // apply force_zeros_for_empty_prompt
+            std::copy_n(add_text_embeds_positive.data<float>(), add_text_embeds_positive.get_size(), add_text_embeds.data<float>() + add_text_embeds_positive.get_size());
+
+            float* encoder_hidden_states_data = encoder_hidden_states.data<float>();
+            std::fill_n(encoder_hidden_states_data, ov::shape_size(encoder_hidden_states_shape) / batch_size_multiplier, 0.0f); // apply force_zeros_for_empty_prompt
+
+            const float* ehs_1_data = encoder_hidden_states_1_positive.data<const float>();
+            const float* ehs_2_data = encoder_hidden_states_2_positive.data<const float>();
+            encoder_hidden_states_data += ov::shape_size(encoder_hidden_states_shape) / batch_size_multiplier;
+
+            for (size_t i = 0; i < ehs_1_shape[0] * ehs_1_shape[1]; ++i,
+                encoder_hidden_states_data += encoder_hidden_states_shape[2],
+                ehs_1_data += ehs_1_shape[2], ehs_2_data += ehs_2_shape[2]) {
+                std::memcpy(encoder_hidden_states_data                 , ehs_1_data, ehs_1_shape[2] * sizeof(float));
+                std::memcpy(encoder_hidden_states_data + ehs_1_shape[2], ehs_2_data, ehs_2_shape[2] * sizeof(float));
             }
         }
 
@@ -267,7 +313,6 @@ public:
             m_unet->set_hidden_states("encoder_hidden_states", encoder_hidden_states);
             m_unet->set_hidden_states("text_embeds", add_text_embeds);
             m_unet->set_hidden_states("time_ids", add_time_ids);
-
         } else {
             ov::Shape enc_shape = encoder_hidden_states.get_shape();
             enc_shape[0] *= generation_config.num_images_per_prompt;
@@ -323,12 +368,10 @@ public:
 
         ov::Tensor denoised, noisy_residual_tensor(ov::element::f32, {});
         for (size_t inference_step = 0; inference_step < generation_config.num_inference_steps; inference_step++) {
+            batch_copy(latent, latent_cfg, 0, 0, generation_config.num_images_per_prompt);
             // concat the same latent twice along a batch dimension in case of CFG
             if (batch_size_multiplier > 1) {
-                batch_copy(latent, latent_cfg, 0, 0, generation_config.num_images_per_prompt);
                 batch_copy(latent, latent_cfg, 0, generation_config.num_images_per_prompt, generation_config.num_images_per_prompt);
-            } else {
-                std::memcpy(latent_cfg.data<float>(), latent.data<float>(), latent_cfg.get_size() * sizeof(float));
             }
 
             m_scheduler->scale_model_input(latent_cfg, inference_step);
@@ -403,7 +446,7 @@ private:
         const char * const pipeline_name = "Stable Diffusion XL";
 
         OPENVINO_ASSERT(generation_config.prompt_3 == std::nullopt, "Prompt 3 is not used by ", pipeline_name);
-        OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt.empty(), "Negative prompt is not used when guidance scale <= 1.0");
+        OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt == std::nullopt, "Negative prompt is not used when guidance scale <= 1.0");
         OPENVINO_ASSERT(is_classifier_free_guidance || generation_config.negative_prompt_2 == std::nullopt, "Negative prompt 2 is not used when guidance scale <= 1.0");
         OPENVINO_ASSERT(generation_config.negative_prompt_3 == std::nullopt, "Negative prompt 3 is not used by ", pipeline_name);
 
@@ -438,6 +481,7 @@ private:
     friend class Text2ImagePipeline;
     friend class Image2ImagePipeline;
 
+    bool m_force_zeros_for_empty_prompt = true;
     std::shared_ptr<CLIPTextModel> m_clip_text_encoder;
     std::shared_ptr<CLIPTextModelWithProjection> m_clip_text_encoder_with_projection;
     std::shared_ptr<UNet2DConditionModel> m_unet;

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -247,8 +247,8 @@ public:
         bool force_zeros_for_empty_prompt = generation_config.negative_prompt == std::nullopt && m_force_zeros_for_empty_prompt;
         bool compute_negative_prompt = !force_zeros_for_empty_prompt && batch_size_multiplier > 1;
 
-        size_t idx_hidden_state_1 = m_clip_text_encoder->get_config().num_hidden_layers;
-        size_t idx_hidden_state_2 = m_clip_text_encoder_with_projection->get_config().num_hidden_layers;
+        size_t idx_hidden_state_1 = m_clip_text_encoder->get_config().num_hidden_layers + 1;
+        size_t idx_hidden_state_2 = m_clip_text_encoder_with_projection->get_config().num_hidden_layers + 1;
 
         ov::Tensor encoder_hidden_states(ov::element::f32, {}), add_text_embeds(ov::element::f32, {});
 
@@ -286,7 +286,7 @@ public:
 
             ov::Tensor encoder_hidden_states_1_positive = m_clip_text_encoder->get_output_tensor(idx_hidden_state_1);
             ov::Tensor encoder_hidden_states_2_positive = m_clip_text_encoder_with_projection->get_output_tensor(idx_hidden_state_2);
-            
+
             ov::Shape ehs_1_shape = encoder_hidden_states_1_positive.get_shape();
             ov::Shape ehs_2_shape = encoder_hidden_states_2_positive.get_shape();
 
@@ -305,13 +305,13 @@ public:
 
             // apply force_zeros_for_empty_prompt
             if (batch_size_multiplier > 1) {
-                size_t encoder_state_size = ov::shape_size(encoder_hidden_states_shape) / batch_size_multiplier;
+                size_t encoder_hidden_states_size = ov::shape_size(encoder_hidden_states_shape) / batch_size_multiplier;
 
                 std::fill_n(add_text_embeds_data, add_text_embeds_positive.get_size(), 0.0f);
-                std::fill_n(encoder_hidden_states_data, encoder_state_size, 0.0f);
+                std::fill_n(encoder_hidden_states_data, encoder_hidden_states_size, 0.0f);
 
                 add_text_embeds_data += add_text_embeds_positive.get_size();
-                encoder_hidden_states_data += encoder_state_size;
+                encoder_hidden_states_data += encoder_hidden_states_size;
             }
 
             std::copy_n(add_text_embeds_positive.data<float>(), add_text_embeds_positive.get_size(), add_text_embeds_data);

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -237,7 +237,7 @@ public:
         std::string prompt_2_str =
             generation_config.prompt_2 != std::nullopt ? *generation_config.prompt_2 : positive_prompt;
         std::string negative_prompt_1_str = generation_config.negative_prompt != std::nullopt
-                                                ? *generation_config.negative_prompt_2
+                                                ? *generation_config.negative_prompt
                                                 : std::string{};
         std::string negative_prompt_2_str = generation_config.negative_prompt_2 != std::nullopt
                                                 ? *generation_config.negative_prompt_2
@@ -401,9 +401,10 @@ public:
 
             ov::Shape noise_pred_shape = noise_pred_tensor.get_shape();
             noise_pred_shape[0] /= batch_size_multiplier;
-            noisy_residual_tensor.set_shape(noise_pred_shape);
 
             if (batch_size_multiplier > 1) {
+                noisy_residual_tensor.set_shape(noise_pred_shape);
+
                 // perform guidance
                 float* noisy_residual = noisy_residual_tensor.data<float>();
                 const float* noise_pred_uncond = noise_pred_tensor.data<const float>();

--- a/src/python/py_image_generation_models.cpp
+++ b/src/python/py_image_generation_models.cpp
@@ -67,7 +67,6 @@ void init_clip_text_model(py::module_& m) {
             return std::make_unique<ov::genai::CLIPTextModel::Config>(config_path);
         }))
         .def_readwrite("max_position_embeddings", &ov::genai::CLIPTextModel::Config::max_position_embeddings)
-        .def_readwrite("hidden_size", &ov::genai::CLIPTextModel::Config::hidden_size)
         .def_readwrite("num_hidden_layers", &ov::genai::CLIPTextModel::Config::num_hidden_layers);
 
     clip_text_model.def("get_config", &ov::genai::CLIPTextModel::get_config);
@@ -309,7 +308,6 @@ void init_clip_text_model_with_projection(py::module_& m) {
             return std::make_unique<ov::genai::CLIPTextModelWithProjection::Config>(config_path);
         }))
         .def_readwrite("max_position_embeddings", &ov::genai::CLIPTextModelWithProjection::Config::max_position_embeddings)
-        .def_readwrite("hidden_size", &ov::genai::CLIPTextModelWithProjection::Config::hidden_size)
         .def_readwrite("num_hidden_layers", &ov::genai::CLIPTextModelWithProjection::Config::num_hidden_layers);
 
     clip_text_model_with_projection.def("reshape", &ov::genai::CLIPTextModelWithProjection::reshape);


### PR DESCRIPTION
- Supported force_zeros_for_empty_prompt 
- Supported prompt_2, negative_prompt_2
- Fixed indexes of text encoders hidden state which are used to create UNet's encoder_hidden_state

Now implementation is fully aligned with vanilla HF implementation

CVS-156383