### PR TITLE
[Image generation] Fixed SD3 pipeline to use proper tokenizers

### DIFF
--- a/src/cpp/src/image_generation/models/clip_text_model.cpp
+++ b/src/cpp/src/image_generation/models/clip_text_model.cpp
@@ -12,6 +12,17 @@
 namespace ov {
 namespace genai {
 
+std::filesystem::path get_tokenizer_path_by_text_encoder(const std::filesystem::path& text_encoder_path) {
+    const std::string to_replace = "text_encoder", replacement = "tokenizer";
+    std::string text_encoder_path_str = text_encoder_path.string();
+
+    size_t pos = text_encoder_path_str.find(to_replace);
+    OPENVINO_ASSERT(pos != std::string::npos, "Failed to find '", to_replace, "' substring in '", text_encoder_path_str, "'");
+    text_encoder_path_str.replace(pos, to_replace.length(), replacement);
+
+    return text_encoder_path_str;
+}
+
 CLIPTextModel::Config::Config(const std::filesystem::path& config_path) {
     std::ifstream file(config_path);
     OPENVINO_ASSERT(file.is_open(), "Failed to open ", config_path);
@@ -24,7 +35,7 @@ CLIPTextModel::Config::Config(const std::filesystem::path& config_path) {
 }
 
 CLIPTextModel::CLIPTextModel(const std::filesystem::path& root_dir) :
-    m_clip_tokenizer(root_dir.parent_path() / "tokenizer"),
+    m_clip_tokenizer(get_tokenizer_path_by_text_encoder(root_dir)),
     m_config(root_dir / "config.json") {
     ov::Core core = utils::singleton_core();
     m_model = core.read_model((root_dir / "openvino_model.xml").string());

--- a/src/cpp/src/image_generation/models/clip_text_model_with_projection.cpp
+++ b/src/cpp/src/image_generation/models/clip_text_model_with_projection.cpp
@@ -12,6 +12,8 @@
 namespace ov {
 namespace genai {
 
+std::filesystem::path get_tokenizer_path_by_text_encoder(const std::filesystem::path& text_encoder_path);
+
 CLIPTextModelWithProjection::Config::Config(const std::filesystem::path& config_path) {
     std::ifstream file(config_path);
     OPENVINO_ASSERT(file.is_open(), "Failed to open ", config_path);
@@ -24,7 +26,7 @@ CLIPTextModelWithProjection::Config::Config(const std::filesystem::path& config_
 }
 
 CLIPTextModelWithProjection::CLIPTextModelWithProjection(const std::filesystem::path& root_dir) :
-    m_clip_tokenizer(root_dir.parent_path() / "tokenizer_2"),
+    m_clip_tokenizer(get_tokenizer_path_by_text_encoder(root_dir)),
     m_config(root_dir / "config.json") {
     ov::Core core = utils::singleton_core();
     m_model = core.read_model((root_dir / "openvino_model.xml").string());

--- a/src/cpp/src/image_generation/numpy_utils.cpp
+++ b/src/cpp/src/image_generation/numpy_utils.cpp
@@ -64,7 +64,7 @@ std::vector<float> interp(const std::vector<std::int64_t>& x, const std::vector<
 
             float x0 = xp[idx], x1 = xp[idx + 1];
             float y0 = fp[idx], y1 = fp[idx + 1];
-    
+
             float interp_val = (y1 - y0) / (x1 - x0) * (i - x0) + y0;
 
             interp_res.push_back(interp_val);
@@ -75,9 +75,8 @@ std::vector<float> interp(const std::vector<std::int64_t>& x, const std::vector<
 }
 
 void concat_3d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
-    OPENVINO_ASSERT(
-            shape_1[0] == shape_2[0] && shape_1[1] == shape_2[1],
-            "Tensors for concatenation must have the same dimensions");
+    OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
+    OPENVINO_ASSERT(shape_1[0] == shape_2[0] && shape_1[1] == shape_2[1], "Tensors for concatenation must have the same dimensions");
 
     for (size_t i = 0; i < shape_1[0]; ++i) {
         for (size_t j = 0; j < shape_1[1]; ++j) {
@@ -87,36 +86,32 @@ void concat_3d_by_rows(const float* data_1, const float* data_2, float* res, con
             size_t step = (i * shape_1[1] + j) * (shape_1[2] + shape_2[2]);
 
             std::memcpy(res + step, data_1 + offset_1, shape_1[2] * sizeof(float));
-            std::memcpy(res + step + shape_1[2],
-                        data_2 + offset_2,
-                        shape_2[2] * sizeof(float));
+            std::memcpy(res + step + shape_1[2], data_2 + offset_2, shape_2[2] * sizeof(float));
         }
     }
 }
 
 void concat_2d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
-    OPENVINO_ASSERT(
-            shape_1[0] == shape_2[0],
-            "Tensors for concatenation must have the same dimensions");
+    OPENVINO_ASSERT(shape_1.size() == 2 && shape_2.size() == 2, "Shape dimensions must be 2");
+    OPENVINO_ASSERT(shape_1[0] == shape_2[0], "Tensors for concatenation must have the same dimensions");
 
-        for (size_t i = 0; i < shape_1[0]; ++i) {
-            size_t offset_1 = i * shape_1[1];
-            size_t offset_2 = i * shape_2[1];
+    for (size_t i = 0; i < shape_1[0]; ++i) {
+        size_t offset_1 = i * shape_1[1];
+        size_t offset_2 = i * shape_2[1];
 
-            size_t step = i * (shape_1[1] + shape_2[1]);
+        size_t step = i * (shape_1[1] + shape_2[1]);
 
-            std::memcpy(res + step, data_1 + offset_1, shape_1[1] * sizeof(float));
-            std::memcpy(res + step + shape_1[1],
-                        data_2 + offset_2,
-                        shape_2[1] * sizeof(float));
-        }
+        std::memcpy(res + step, data_1 + offset_1, shape_1[1] * sizeof(float));
+        std::memcpy(res + step + shape_1[1],
+                    data_2 + offset_2,
+                    shape_2[1] * sizeof(float));
+    }
 }
 
 void concat_3d_by_cols(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
-    OPENVINO_ASSERT(
-            shape_1[0] == shape_2[0] && shape_1[2] == shape_2[2],
-            "Tensors for concatenation must have the same dimensions");
-    
+    OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
+    OPENVINO_ASSERT(shape_1[0] == shape_2[0] && shape_1[2] == shape_2[2], "Tensors for concatenation must have the same dimensions");
+
     for (size_t i = 0; i < shape_1[0]; ++i) {
         size_t shift_1 = i * shape_1[1] * shape_1[2];
         size_t shift_2 = i * shape_2[1] * shape_2[2];
@@ -129,27 +124,25 @@ void concat_3d_by_cols(const float* data_1, const float* data_2, float* res, con
 }
 
 void concat_3d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
-    OPENVINO_ASSERT(
-            shape_1[1] == shape_2[1] && shape_1[2] == shape_2[2],
-            "Tensors for concatenation must have the same dimensions");
-    
-        size_t size_1 = shape_1[0] * shape_1[1] * shape_1[2];
-        size_t size_2 = shape_2[0] * shape_2[1] * shape_2[2];
+    OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
+    OPENVINO_ASSERT(shape_1[1] == shape_2[1] && shape_1[2] == shape_2[2], "Tensors for concatenation must have the same dimensions");
 
-        std::memcpy(res, data_1, size_1 * sizeof(float));
-        std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
+    size_t size_1 = shape_1[0] * shape_1[1] * shape_1[2];
+    size_t size_2 = shape_2[0] * shape_2[1] * shape_2[2];
+
+    std::memcpy(res, data_1, size_1 * sizeof(float));
+    std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
 }
 
 void concat_2d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
-    OPENVINO_ASSERT(
-            shape_1[1] == shape_2[1],
-            "Tensors for concatenation must have the same dimensions");
-    
-        size_t size_1 = shape_1[0] * shape_1[1];
-        size_t size_2 = shape_2[0] * shape_2[1];
+    OPENVINO_ASSERT(shape_1.size() == 2 && shape_2.size() == 2, "Shape dimensions must be 2");
+    OPENVINO_ASSERT(shape_1[1] == shape_2[1], "Tensors for concatenation must have the same dimensions");
 
-        std::memcpy(res, data_1, size_1 * sizeof(float));
-        std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
+    size_t size_1 = shape_1[0] * shape_1[1];
+    size_t size_2 = shape_2[0] * shape_2[1];
+
+    std::memcpy(res, data_1, size_1 * sizeof(float));
+    std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
 }
 
 

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -328,7 +328,7 @@ public:
             pooled_prompt_2_embed_out = split_2d_by_batch(text_encoder_2_output, 1);
             prompt_2_embed_out = split_3d_by_batch(text_encoder_2_hidden_state, 1);
         } else {
-            pooled_prompt_embed_out =text_encoder_1_output;
+            pooled_prompt_embed_out = text_encoder_1_output;
             prompt_embed_out = text_encoder_1_hidden_state;
             pooled_prompt_2_embed_out = text_encoder_2_output;
             prompt_2_embed_out = text_encoder_2_hidden_state;
@@ -371,16 +371,14 @@ public:
                                            m_clip_text_encoder_1->get_config().max_position_embeddings,
                                            transformer_config.joint_attention_dim};
 
-        std::vector<float> t5_prompt_embed(
-            t5_prompt_embed_shape[0] * t5_prompt_embed_shape[1] * t5_prompt_embed_shape[2],
-            0.0f);
+        std::vector<float> t5_prompt_embed(ov::shape_size(t5_prompt_embed_shape), 0.0f);
 
         // padding for clip_prompt_embeds
         ov::Shape pad_embeds_shape = {clip_prompt_embeds_shape[0],
                                       clip_prompt_embeds_shape[1],
                                       t5_prompt_embed_shape[2]};
 
-        std::vector<float> pad_embeds(pad_embeds_shape[0] * pad_embeds_shape[1] * pad_embeds_shape[2], 0.0f);
+        std::vector<float> pad_embeds(ov::shape_size(pad_embeds_shape), 0.0f);
         padding_right(clip_prompt_embeds_data, pad_embeds.data(), clip_prompt_embeds_shape, pad_embeds_shape);
 
         // prompt_embeds = torch.cat([pad_embeds, t5_prompt_embed], dim=-2)

--- a/src/cpp/src/tokenizer.cpp
+++ b/src/cpp/src/tokenizer.cpp
@@ -114,7 +114,7 @@ public:
         : m_chat_template{chat_template_from_tokenizer_json_if_exists(tokenizer_path)} {
         ov::Core core;
 
-        OPENVINO_ASSERT(tokenizer_path.extension() != ".xml", "ov_tokenizer_path should be a path to a dir not a xml file");
+        OPENVINO_ASSERT(tokenizer_path.extension() != ".xml", "'tokenizer_path' parameter should be a path to a dir not a xml file");
 
         const char* ov_tokenizer_path = getenv(ScopedVar::ENVIRONMENT_VARIABLE_NAME);
         OPENVINO_ASSERT(ov_tokenizer_path, "openvino_tokenizers path is not set");


### PR DESCRIPTION
Both text encoder mistakenly used `tokenizer_2`

CVS-156384