### PR TITLE
Fixed Scheduler binding.

### DIFF
--- a/src/python/openvino_genai/__init__.py
+++ b/src/python/openvino_genai/__init__.py
@@ -29,6 +29,7 @@ from .py_openvino_genai import (
     PerfMetrics,
     RawPerfMetrics,
     SchedulerConfig,
+    Scheduler,
     StopCriteria,
     StreamerBase,
     TokenizedInputs,

--- a/src/python/py_image_generation_pipelines.cpp
+++ b/src/python/py_image_generation_pipelines.cpp
@@ -275,8 +275,7 @@ void init_image_generation_pipelines(py::module_& m) {
             (text2image_generate_docstring + std::string(" \n ")).c_str()
         );
 
-    auto image_generation_scheduler = py::class_<ov::genai::Scheduler>(m, "Scheduler", "Scheduler for image generation pipelines.")
-        .def(py::init<>())
+    auto image_generation_scheduler = py::class_<ov::genai::Scheduler, std::shared_ptr<ov::genai::Scheduler>>(m, "Scheduler", "Scheduler for image generation pipelines.")
         .def("from_config", &ov::genai::Scheduler::from_config);
 
     py::enum_<ov::genai::Scheduler::Type>(image_generation_scheduler, "Type")


### PR DESCRIPTION
Removed not needed `int()` without parameters from Scheduler binding.
Fixed error "Unable to load custom holder" during usage of `set_scheduler()`.