### PR TITLE
CB: fixed test_python_generation_config_validation

### DIFF
--- a/src/cpp/src/continuous_batching_impl.cpp
+++ b/src/cpp/src/continuous_batching_impl.cpp
@@ -88,7 +88,7 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(uint64_t request
                                                                ov::genai::GenerationConfig sampling_params) {
     // If eos_token_id was not provided, take value from default m_generation_config
     if (sampling_params.eos_token_id == -1)
-        sampling_params.eos_token_id = m_generation_config.eos_token_id;
+        sampling_params.set_eos_token_id(m_generation_config.eos_token_id);
     sampling_params.validate();
 
     SequenceGroup::Ptr sequence_group = std::make_shared<SequenceGroup>(request_id, input_ids,

--- a/src/cpp/src/continuous_batching_impl.cpp
+++ b/src/cpp/src/continuous_batching_impl.cpp
@@ -17,10 +17,11 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::ContinuousBatchingImpl(
     const std::string& device,
     const ov::AnyMap& properties) {
     m_tokenizer = tokenizer;
+    m_generation_config = utils::from_config_json_if_exists(models_path);
 
     ov::Core core;
 
-    auto [core_properties, compile_properties] = ov::genai::utils::split_core_complile_config(properties);
+    auto [core_properties, compile_properties] = utils::split_core_complile_config(properties);
     core.set_property(core_properties);
 
     // The model can be compiled for GPU as well

--- a/src/cpp/src/continuous_batching_impl_interface.hpp
+++ b/src/cpp/src/continuous_batching_impl_interface.hpp
@@ -17,7 +17,7 @@ protected:
     Tokenizer m_tokenizer;
 
     // TODO (mzegla): GenerationConfig is request specific object
-    // and pipeline only uses default rng_seed. 
+    // and pipeline only uses default rng_seed and some special tokens.
     ov::genai::GenerationConfig m_generation_config;
 
     PipelineMetrics m_pipeline_metrics;

--- a/src/cpp/src/generation_config.cpp
+++ b/src/cpp/src/generation_config.cpp
@@ -171,9 +171,9 @@ void GenerationConfig::validate() const {
     }
     if (is_speculative_decoding()) {
         if (assistant_confidence_threshold != 0.f) {
-            OPENVINO_ASSERT(num_assistant_tokens == 0, "Parameters `assistant_confidence_threshold` and `num_assistant_tokens` are mutually excluded in `GenerationConfig`");
+            OPENVINO_ASSERT(num_assistant_tokens == 0, "Parameters `assistant_confidence_threshold` and `num_assistant_tokens` are mutually exclusive in `GenerationConfig`");
         } else {
-            OPENVINO_ASSERT(num_assistant_tokens > 0, "Parameters `assistant_confidence_threshold` and `num_assistant_tokens` are mutually excluded in `GenerationConfig`");
+            OPENVINO_ASSERT(num_assistant_tokens > 0, "Parameters `assistant_confidence_threshold` and `num_assistant_tokens` are mutually exclusive in `GenerationConfig`");
         };
     }
 }
@@ -207,7 +207,6 @@ GenerationConfig multinomial() {
     multinomial_config.max_new_tokens = 30;
     return multinomial_config;
 }
-
 
 }  // namespace genai
 }  // namespace ov

--- a/src/cpp/src/llm_pipeline.cpp
+++ b/src/cpp/src/llm_pipeline.cpp
@@ -195,7 +195,7 @@ public:
 
         // If eos_token_id was not provided, take value from default m_generation_config
         if (config.eos_token_id == -1)
-            config.eos_token_id = m_generation_config.eos_token_id;
+            config.set_eos_token_id(m_generation_config.eos_token_id);
         config.validate();
 
         // Stateful pipeline does not provide logprobs for prompt tokens
@@ -622,7 +622,7 @@ void ov::genai::LLMPipeline::set_generation_config(const GenerationConfig& confi
     m_pimpl->m_generation_config = config;
     // if eos_token_id was not provided in config forward from default config
     if (config.eos_token_id == -1)
-        m_pimpl->m_generation_config.eos_token_id = default_eos_token_id;
+        m_pimpl->m_generation_config.set_eos_token_id(default_eos_token_id);
 
     m_pimpl->m_generation_config.validate();
 }

--- a/src/cpp/src/sampler.cpp
+++ b/src/cpp/src/sampler.cpp
@@ -566,20 +566,20 @@ std::vector<int64_t> Sampler::_try_finish_generation(SequenceGroup::Ptr & sequen
             running_sequence->set_status(SequenceStatus::FINISHED);
 
             if (is_stop_token_id_hit(running_sequence->get_generated_ids().back(), sampling_params.stop_token_ids) && !sampling_params.ignore_eos) {
-            running_sequence->set_finish_reason(GenerationFinishReason::STOP);
-        } else if (sampling_params.max_new_tokens == generated_len) {
-            running_sequence->set_finish_reason(GenerationFinishReason::LENGTH);
-        }
-        
-        dropped_seq_ids.push_back(running_sequence->get_id());
-        continue;
-    }
+                running_sequence->set_finish_reason(GenerationFinishReason::STOP);
+            } else if (sampling_params.max_new_tokens == generated_len) {
+                running_sequence->set_finish_reason(GenerationFinishReason::LENGTH);
+            }
 
-    if (!sampling_params.stop_strings.empty()) {
-        int num_matched_last_tokens = match_stop_string(m_tokenizer, running_sequence->get_generated_ids(), sampling_params.stop_strings);
-        if (num_matched_last_tokens) {
-            if (!sampling_params.include_stop_str_in_output)
-                running_sequence->remove_last_tokens(num_matched_last_tokens);
+            dropped_seq_ids.push_back(running_sequence->get_id());
+            continue;
+        }
+
+        if (!sampling_params.stop_strings.empty()) {
+            int num_matched_last_tokens = match_stop_string(m_tokenizer, running_sequence->get_generated_ids(), sampling_params.stop_strings);
+            if (num_matched_last_tokens) {
+                if (!sampling_params.include_stop_str_in_output)
+                    running_sequence->remove_last_tokens(num_matched_last_tokens);
                 running_sequence->set_status(SequenceStatus::FINISHED);
                 running_sequence->set_finish_reason(GenerationFinishReason::STOP);
                 dropped_seq_ids.push_back(running_sequence->get_id());

--- a/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.cpp
@@ -8,14 +8,16 @@ ContinuousBatchingPipeline::ContinuousBatchingForSpeculativeDecodingImpl::Contin
     ov::Core& core,
     const std::shared_ptr<ov::Model>& model,
     const Tokenizer& tokenizer,
+    const GenerationConfig& generation_config,
     const DeviceConfig& device_config,
     const SchedulerConfig& scheduler_config,
     const std::string& device,
     const ov::AnyMap& plugin_config,
     bool is_validation_mode_enabled) {
     m_tokenizer = tokenizer;
+    m_generation_config = generation_config;
     m_is_validation_mode_enabled = is_validation_mode_enabled;
-    init(model, scheduler_config, plugin_config,  device_config, core);
+    init(model, scheduler_config, plugin_config, device_config, core);
 }
 
 void

--- a/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.hpp
@@ -16,6 +16,7 @@ public:
     ContinuousBatchingForSpeculativeDecodingImpl(ov::Core& core,
                                                  const std::shared_ptr<ov::Model>& model,
                                                  const Tokenizer& tokenizer,
+                                                 const GenerationConfig& generation_config,
                                                  const DeviceConfig& device_config,
                                                  const SchedulerConfig& scheduler_config,
                                                  const std::string& device,

--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -85,8 +85,12 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::SpeculativeDecodingImpl(
     m_tokenizer = main_model_tokenizer;
 
     // to create `main_pipeline` with enabled validation_mode and `draft_pipeline` with disabled validation mode
-    m_main_pipeline = std::make_shared<ContinuousBatchingForSpeculativeDecodingImpl>(core, main_model, main_model_tokenizer, main_device_config, main_scheduler_config, main_device, compile_properties, true);
-    m_draft_pipeline = std::make_shared<ContinuousBatchingForSpeculativeDecodingImpl>(core, draft_model, draft_model_tokenizer, draft_device_config, draft_scheduler_config, draft_device, draft_properties, false);
+    m_main_pipeline = std::make_shared<ContinuousBatchingForSpeculativeDecodingImpl>(core,
+        main_model, main_model_tokenizer, utils::from_config_json_if_exists(main_models_path),
+        main_device_config, main_scheduler_config, main_device, compile_properties, true);
+    m_draft_pipeline = std::make_shared<ContinuousBatchingForSpeculativeDecodingImpl>(core,
+        draft_model, draft_model_tokenizer, utils::from_config_json_if_exists(draft_models_path),
+        draft_device_config, draft_scheduler_config, draft_device, draft_properties, false);
 }
 
 GenerationHandle
@@ -182,7 +186,7 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
 std::vector<EncodedGenerationResult>
 ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<ov::Tensor>& input_ids,
                                                               const std::vector<GenerationConfig>& sampling_params,
-                                                              const StreamerVariant& streamer) {                                                  
+                                                              const StreamerVariant& streamer) {
     ManualTimer generate_timer("speculative_decoding: generate()");
     generate_timer.start();
     OPENVINO_ASSERT(!has_non_finished_requests(), "Generate cannot be called while ContinuousBatchingPipeline is already in running state. Use ContinuousBatchingPipeline::add_request");
@@ -198,6 +202,9 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
             return std::make_unique<TextCallbackStreamer>(m_tokenizer, streamer);
         }
     }, streamer);
+
+    OPENVINO_ASSERT(streamer_ptr == nullptr || input_ids.size() == 1 && (sampling_params[0].is_greedy_decoding() || sampling_params[0].is_multinomial()),
+        "Currently streaming is possible only with batch size=1 and only for greedy or multinomial decoding");
 
     std::vector<GenerationHandle> main_generations;
     for (size_t request_id = 0; request_id < input_ids.size(); ++request_id) {

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -57,7 +57,7 @@ public:
         const ov::AnyMap& properties
     ) :
         m_vlm_config{
-            utils::from_config_json_if_exists<ov::genai::VLMConfig>(
+            utils::from_config_json_if_exists<VLMConfig>(
                 models_dir, "config.json"
             )
         },

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -73,6 +73,11 @@ public:
         ).create_infer_request();
 
         m_language.get_tensor("attention_mask").set_shape({1, 0});
+
+        // If eos_token_id was not provided, take value
+        if (m_generation_config.eos_token_id == -1) {
+            m_generation_config.set_eos_token_id(m_tokenizer.get_eos_token_id());
+        }
     }
 
     DecodedResults generate(
@@ -81,10 +86,10 @@ public:
         GenerationConfig generation_config,
         const StreamerVariant& streamer
     ) {
-        // If eos_token_id was not provided, take value
-        if (generation_config.eos_token_id == -1) {
-            generation_config.set_eos_token_id(m_tokenizer.get_eos_token_id());
-        }
+        // If eos_token_id was not provided, take value from default m_generation_config
+        if (generation_config.eos_token_id == -1)
+            generation_config.eos_token_id = m_generation_config.eos_token_id;
+        generation_config.validate();
 
         ov::Tensor inputs_embeds = m_inputs_embedder->get_inputs_embeds(prompt, rgbs);
 

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -88,7 +88,7 @@ public:
     ) {
         // If eos_token_id was not provided, take value from default m_generation_config
         if (generation_config.eos_token_id == -1)
-            generation_config.eos_token_id = m_generation_config.eos_token_id;
+            generation_config.set_eos_token_id(m_generation_config.eos_token_id);
         generation_config.validate();
 
         ov::Tensor inputs_embeds = m_inputs_embedder->get_inputs_embeds(prompt, rgbs);

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -613,7 +613,7 @@ ov::Tensor get_pixel_values_internvl(const ov::Tensor& image, const ProcessorCon
 VisionEncoder::VisionEncoder(const std::filesystem::path& model_dir, const VLMModelType model_type, const std::string& device, const ov::AnyMap device_config, ov::Core core) :
     model_type(model_type) {
         m_vision_encoder = core.compile_model(model_dir / "openvino_vision_embeddings_model.xml", device, device_config).create_infer_request();
-        m_processor_config = ov::genai::utils::from_config_json_if_exists<ov::genai::ProcessorConfig>(
+        m_processor_config = utils::from_config_json_if_exists<ProcessorConfig>(
             model_dir, "preprocessor_config.json"
         );
 }

--- a/src/cpp/src/whisper_pipeline.cpp
+++ b/src/cpp/src/whisper_pipeline.cpp
@@ -185,7 +185,7 @@ void ov::genai::WhisperPipeline::set_generation_config(const WhisperGenerationCo
     m_impl->m_generation_config = config;
     // if eos_token_id was not provided in config forward from default config
     if (config.eos_token_id == -1)
-        m_impl->m_generation_config.eos_token_id = default_eos_token_id;
+        m_impl->m_generation_config.set_eos_token_id(default_eos_token_id);
 
     m_impl->m_generation_config.validate();
 }

--- a/src/cpp/src/whisper_pipeline_base.hpp
+++ b/src/cpp/src/whisper_pipeline_base.hpp
@@ -7,16 +7,8 @@
 #include "whisper/whisper_config.hpp"
 #include "whisper/whisper_feature_extractor.hpp"
 
-namespace {
-ov::genai::WhisperGenerationConfig from_config_json_if_exists(const std::filesystem::path& model_path) {
-    auto config_file_path = model_path / "generation_config.json";
-    if (std::filesystem::exists(config_file_path)) {
-        return ov::genai::WhisperGenerationConfig((config_file_path).string());
-    } else {
-        return ov::genai::WhisperGenerationConfig{};
-    }
-}
-}  // namespace
+#include "utils.hpp"
+
 
 namespace ov {
 namespace genai {
@@ -31,10 +23,10 @@ public:
     float m_load_time_ms = 0;
 
     WhisperPipelineImplBase(const std::filesystem::path& models_path)
-        : m_generation_config(from_config_json_if_exists(models_path)),
+        : m_generation_config(utils::from_config_json_if_exists<WhisperGenerationConfig>(models_path)),
           m_tokenizer{models_path},
-          m_feature_extractor{(models_path / "preprocessor_config.json").string()},
-          m_model_config{(models_path / "config.json").string()} {}
+          m_feature_extractor{models_path / "preprocessor_config.json"},
+          m_model_config{models_path / "config.json"} {}
 
     virtual WhisperDecodedResults generate(const RawSpeechInput& raw_speech_input,
                                            OptionalWhisperGenerationConfig generation_config,


### PR DESCRIPTION
Fixed
```
model_tmp_path = ('katuni4ka/tiny-random-phi3', WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/katuni4ka_tiny-random-phi31'))
generation_config = {'eos_token_id': 42, 'ignore_eos': True}

    @pytest.mark.precommit
    @pytest.mark.nightly
    @pytest.mark.parametrize("generation_config", invalid_py_configs)
    def test_python_generation_config_validation(model_tmp_path, generation_config):
        model_id, temp_path = model_tmp_path
        pipe = load_pipe([({"eos_token_id": 37}, "config.json")], temp_path)
    
        # 'unexisting_key_name' key validity is checked in pybind and ValueError will be returned
        #  instead of RuntimeError, which is returned when GenerationConfig values are validated
        return_exception_type = ValueError if 'unexisting_key_name' in generation_config else RuntimeError
>       with pytest.raises(return_exception_type):
E       Failed: DID NOT RAISE <class 'RuntimeError'>
```