### PR TITLE
[CB] Fix test valid configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ temp/
 .repo/
 CMakeLists.txt.user
 CMakeUserPresets.json
+.env
 
 *.project
 *.cproject

--- a/src/cpp/src/llm_pipeline.cpp
+++ b/src/cpp/src/llm_pipeline.cpp
@@ -433,8 +433,9 @@ public:
         tokenizer,
         scheduler_config,
         device,
-        plugin_config
-    } {}
+        plugin_config} {
+        m_generation_config = m_impl.get_config();
+    }
 
     ContinuousBatchingAdapter(
         const std::filesystem::path& models_path,
@@ -446,8 +447,9 @@ public:
         m_tokenizer,
         scheduler_config,
         device,
-        plugin_config
-    } {}
+        plugin_config} {
+        m_generation_config = m_impl.get_config();
+    }
 
     DecodedResults generate(
         StringInputs inputs,


### PR DESCRIPTION
Fixed `test_valid_configs`:
```
FAILED tests/python_tests/test_generate_api.py::test_valid_configs - RuntimeError: Check 'eos_token_id != -1 || max_new_tokens != (18446744073709551615UL) || max_length != (18446744073709551615UL)' failed at /home/runner/work/openvino.genai/openvino.genai/src/cpp/src/generation_config.cpp:164:
Either 'eos_token_id', or 'max_new_tokens', or 'max_length' should be defined.
```
See https://github.com/openvinotoolkit/openvino.genai/actions/runs/11797566325/job/32862069017?pr=882