### PR TITLE
Enable Phi-3.5-vision in HF format. Enable use of LLMs as a text embedding models for similarity compute.

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/whowhat_metrics.py
+++ b/tools/who_what_benchmark/whowhatbench/whowhat_metrics.py
@@ -114,7 +114,7 @@ class TextSimilarity:
         if hasattr(tokenizer, "pad_token") and tokenizer.pad_token:
             pad_token = tokenizer.pad_token
         else:
-            pad_token = tokenizer.eos_token 
+            pad_token = tokenizer.eos_token
         self.model = SentenceTransformer(model_id, tokenizer_kwargs={"pad_token": pad_token}, trust_remote_code=True)
 
     def evaluate(self, gt, prediction):

--- a/tools/who_what_benchmark/whowhatbench/whowhat_metrics.py
+++ b/tools/who_what_benchmark/whowhatbench/whowhat_metrics.py
@@ -3,6 +3,7 @@ Metrics for text similarity
 """
 
 from difflib import SequenceMatcher
+from transformers import AutoTokenizer
 from PIL import Image
 import torch
 import torch.nn.functional as F
@@ -109,7 +110,12 @@ def evaluate_divergency(tokenizer, data_gold, data_prediction):
 
 class TextSimilarity:
     def __init__(self, model_id) -> None:
-        self.model = SentenceTransformer(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+        if hasattr(tokenizer, "pad_token") and tokenizer.pad_token:
+            pad_token = tokenizer.pad_token
+        else:
+            pad_token = tokenizer.eos_token 
+        self.model = SentenceTransformer(model_id, tokenizer_kwargs={"pad_token": pad_token}, trust_remote_code=True)
 
     def evaluate(self, gt, prediction):
         return evaluate_similarity(self.model, gt, prediction)

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -178,9 +178,14 @@ def load_visual_text_model(
                 model_id, trust_remote_code=True, device_map=device.lower()
             )
         except ValueError:
-            model = AutoModel.from_pretrained(
-                model_id, trust_remote_code=True, device_map=device.lower()
-            )
+            try:
+                model = AutoModel.from_pretrained(
+                    model_id, trust_remote_code=True, device_map=device.lower()
+                )
+            except ValueError:
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_id, trust_remote_code=True, device_map=device.lower(), _attn_implementation="eager", use_flash_attention_2=False
+                )
         model.eval()
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")


### PR DESCRIPTION
Now it is possible to use `--data-encoder Qwen/Qwen2.5-1.5B` to plug LLM as a model for embedding computation.