### PR TITLE
`create_image_gen_model` for PT framework does not return callback

### DIFF
--- a/tools/llm_bench/llm_bench_utils/pt_utils.py
+++ b/tools/llm_bench/llm_bench_utils/pt_utils.py
@@ -156,7 +156,7 @@ def create_image_gen_model(model_path, device, **kwargs):
         backend = kwargs['torch_compile_backend']
         compiled_model = run_torch_compile(pipe, backend)
         pipe = compiled_model
-    return pipe, from_pretrain_time, False
+    return pipe, from_pretrain_time, False, None
 
 
 def create_ldm_super_resolution_model(model_path, device, **kwargs):


### PR DESCRIPTION
When trying to benchmark a Stable diffusion 3 model with pt framework, the `create_image_gen_model` does not return the expected callback in [image generation task](https://github.com/openvinotoolkit/openvino.genai/blob/d294db9469c4795bed24ebfb1318cc68adc682e0/tools/llm_bench/task/image_generation.py#L168)

Error Traceback:
```
[ ERROR ] An exception occurred
[ INFO ] Traceback (most recent call last):
  File "openvino.genai/tools/llm_bench/benchmark.py", line 211, in main
    iter_data_list, pretrain_time, iter_timestamp = CASE_TO_BENCH[model_args['use_case']](
  File "openvino.genai/tools/llm_bench/task/image_generation.py", line 171, in run_image_generation_benchmark
    pipe, pretrain_time, use_genai, callback = FW_UTILS[framework].create_image_gen_model(model_path, device, **args)
ValueError: not enough values to unpack (expected 4, got 3)
```