### PR TITLE
Callback is not an expected argument in in `openvino_genai.Text2ImagePipeline.generate`

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -3,7 +3,7 @@ numpy
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 openvino
 openvino-tokenizers
-openvino_genai
+openvino_genai~=2025.0.0.0.dev
 auto-gptq>=0.5.1 # for gptq
 pillow
 torch


### PR DESCRIPTION
callback is not an expected kwarg in `openvino_genai.Text2ImagePipeline.generate` [here](https://github.com/openvinotoolkit/openvino.genai/blob/d294db9469c4795bed24ebfb1318cc68adc682e0/tools/llm_bench/task/image_generation.py#L130). It seems to be due to the `openvino_genai` version which according to [this sample's requirement](https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/deployment-requirements.txt) is `2025.0.0.0` but seems to be of older version in this tool's requirements.