### PR TITLE
Sd3 text encoder refactoring

### DIFF
--- a/samples/cpp/text2image/main.cpp
+++ b/samples/cpp/text2image/main.cpp
@@ -15,7 +15,6 @@ int32_t main(int32_t argc, char* argv[]) try {
     ov::Tensor image = pipe.generate(prompt,
         ov::genai::width(512),
         ov::genai::height(512),
-        ov::genai::num_inference_steps(20),
         ov::genai::num_images_per_prompt(1));
 
     // writes `num_images_per_prompt` images by pattern name

--- a/samples/cpp/text2image/main.cpp
+++ b/samples/cpp/text2image/main.cpp
@@ -15,6 +15,7 @@ int32_t main(int32_t argc, char* argv[]) try {
     ov::Tensor image = pipe.generate(prompt,
         ov::genai::width(512),
         ov::genai::height(512),
+        ov::genai::num_inference_steps(20),
         ov::genai::num_images_per_prompt(1));
 
     // writes `num_images_per_prompt` images by pattern name

--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -399,7 +399,7 @@ private:
     void check_inputs(const ImageGenerationConfig& generation_config, ov::Tensor initial_image) const override {
         check_image_size(generation_config.width, generation_config.height);
 
-        OPENVINO_ASSERT(generation_config.max_sequence_length <= 512, "T5's 'max_sequence_length' must be less than 512");
+        OPENVINO_ASSERT(generation_config.max_sequence_length <= 512, "T5's 'max_sequence_length' must be less or equal to 512");
 
         OPENVINO_ASSERT(generation_config.negative_prompt == std::nullopt, "Negative prompt is not used by FluxPipeline");
         OPENVINO_ASSERT(generation_config.negative_prompt_2 == std::nullopt, "Negative prompt 2 is not used by FluxPipeline");

--- a/src/cpp/src/image_generation/numpy_utils.cpp
+++ b/src/cpp/src/image_generation/numpy_utils.cpp
@@ -181,7 +181,7 @@ ov::Tensor concat(ov::Tensor tensor_1, ov::Tensor tensor_2, int axis) {
     OPENVINO_ASSERT(concat_func != nullptr, "Unsupported combination of input tensors rank ", rank, " and axis ", axis);
 
     ov::Tensor dst_tensor(tensor_1.get_element_type(), dst_shape);
-    concat_func(tensor_1.data<const float>(), tensor_1.data<const float>(), dst_tensor.data<float>(), shape_1, shape_2);
+    concat_func(tensor_1.data<const float>(), tensor_2.data<const float>(), dst_tensor.data<float>(), shape_1, shape_2);
 
     return dst_tensor;
 }

--- a/src/cpp/src/image_generation/numpy_utils.cpp
+++ b/src/cpp/src/image_generation/numpy_utils.cpp
@@ -74,7 +74,9 @@ std::vector<float> interp(const std::vector<std::int64_t>& x, const std::vector<
     return interp_res;
 }
 
-void concat_3d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
+namespace {
+
+void concat_3d_axis_2(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
     OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
     OPENVINO_ASSERT(shape_1[0] == shape_2[0] && shape_1[1] == shape_2[1], "Tensors for concatenation must have the same dimensions");
 
@@ -91,7 +93,7 @@ void concat_3d_by_rows(const float* data_1, const float* data_2, float* res, con
     }
 }
 
-void concat_2d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
+void concat_2d_axis_1(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
     OPENVINO_ASSERT(shape_1.size() == 2 && shape_2.size() == 2, "Shape dimensions must be 2");
     OPENVINO_ASSERT(shape_1[0] == shape_2[0], "Tensors for concatenation must have the same dimensions");
 
@@ -108,7 +110,7 @@ void concat_2d_by_rows(const float* data_1, const float* data_2, float* res, con
     }
 }
 
-void concat_3d_by_cols(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
+void concat_3d_axis_1(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
     OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
     OPENVINO_ASSERT(shape_1[0] == shape_2[0] && shape_1[2] == shape_2[2], "Tensors for concatenation must have the same dimensions");
 
@@ -123,7 +125,7 @@ void concat_3d_by_cols(const float* data_1, const float* data_2, float* res, con
     }
 }
 
-void concat_3d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
+void concat_3d_axis_0(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
     OPENVINO_ASSERT(shape_1.size() == 3 && shape_2.size() == 3, "Shape dimensions must be 3");
     OPENVINO_ASSERT(shape_1[1] == shape_2[1] && shape_1[2] == shape_2[2], "Tensors for concatenation must have the same dimensions");
 
@@ -134,7 +136,7 @@ void concat_3d_by_channels(const float* data_1, const float* data_2, float* res,
     std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
 }
 
-void concat_2d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
+void concat_2d_axis_0(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2) {
     OPENVINO_ASSERT(shape_1.size() == 2 && shape_2.size() == 2, "Shape dimensions must be 2");
     OPENVINO_ASSERT(shape_1[1] == shape_2[1], "Tensors for concatenation must have the same dimensions");
 
@@ -143,6 +145,45 @@ void concat_2d_by_channels(const float* data_1, const float* data_2, float* res,
 
     std::memcpy(res, data_1, size_1 * sizeof(float));
     std::memcpy(res + size_1, data_2, size_2 * sizeof(float));
+}
+
+} // namespace
+
+ov::Tensor concat(ov::Tensor tensor_1, ov::Tensor tensor_2, int axis) {
+    ov::Shape shape_1 = tensor_1.get_shape(), shape_2 = tensor_2.get_shape();
+    size_t rank = shape_1.size();
+
+    const size_t MAX_RANK = 3;
+    OPENVINO_ASSERT(rank <= MAX_RANK, "Maximum support rank of concatenated tensors is ", MAX_RANK, ", given rank is ", rank);
+
+    OPENVINO_ASSERT(rank == shape_2.size(), "Shapes for concatenated tensors must have the same rank");
+    OPENVINO_ASSERT(tensor_1.get_element_type() == ov::element::f32 && tensor_2.get_element_type() == ov::element::f32,
+        "Concat supports only tensor of fp32 data type");
+
+    if (axis < 0) {
+        axis += rank;
+    }
+
+    ov::Shape dst_shape(rank);
+    for (size_t d = 0; d < rank; ++d) {
+        OPENVINO_ASSERT(d == axis || shape_1[d] == shape_2[d], "Dimension ", d, " must be the same for tensor_1 (", shape_1[d], ") and tensor_2 (", shape_2[d], ")");
+        dst_shape[d] = d == axis ? shape_1[d] + shape_2[d] : shape_1[d];
+    }
+
+    typedef void (*concat_func_type) (const float*, const float*, float*, const ov::Shape, const ov::Shape);
+    concat_func_type concat_funcs [MAX_RANK][MAX_RANK] = {
+        { nullptr, nullptr, nullptr },
+        { concat_2d_axis_0, concat_2d_axis_1, nullptr },
+        { concat_3d_axis_0, concat_3d_axis_1, concat_3d_axis_2 }
+    };
+
+    concat_func_type concat_func = concat_funcs[rank - 1][axis];
+    OPENVINO_ASSERT(concat_func != nullptr, "Unsupported combination of input tensors rank ", rank, " and axis ", axis);
+
+    ov::Tensor dst_tensor(tensor_1.get_element_type(), dst_shape);
+    concat_func(tensor_1.data<const float>(), tensor_1.data<const float>(), dst_tensor.data<float>(), shape_1, shape_2);
+
+    return dst_tensor;
 }
 
 void batch_copy(ov::Tensor src, ov::Tensor dst, size_t src_batch, size_t dst_batch, size_t batch_size) {

--- a/src/cpp/src/image_generation/numpy_utils.hpp
+++ b/src/cpp/src/image_generation/numpy_utils.hpp
@@ -46,11 +46,8 @@ void rescale_zero_terminal_snr(std::vector<float>& betas);
 // np.interp(...) implementation
 std::vector<float> interp(const std::vector<std::int64_t>& x, const std::vector<size_t>& xp, const std::vector<float>& fp);
 
-void concat_3d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2);
-void concat_3d_by_cols(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2);
-void concat_3d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2);
-void concat_2d_by_rows(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2);
-void concat_2d_by_channels(const float* data_1, const float* data_2, float* res, const ov::Shape shape_1, const ov::Shape shape_2);
+// concats two tensors by a given dimension
+ov::Tensor concat(ov::Tensor tensor_1, ov::Tensor tensor_2, int axis);
 
 void batch_copy(ov::Tensor src, ov::Tensor dst, size_t src_batch, size_t dst_batch, size_t batch_size = 1);
 ov::Tensor repeat(const ov::Tensor input, const size_t num_images_per_prompt);

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -227,42 +227,28 @@ public:
         ov::Tensor prompt_embeds_inp, pooled_prompt_embeds_inp;
 
         // 1. Encode positive prompt:
-        std::string prompt_2_str =
-            generation_config.prompt_2 != std::nullopt ? *generation_config.prompt_2 : positive_prompt;
-        std::string prompt_3_str =
-            generation_config.prompt_3 != std::nullopt ? *generation_config.prompt_3 : positive_prompt;
+        std::string prompt_2_str = generation_config.prompt_2 != std::nullopt ? *generation_config.prompt_2 : positive_prompt;
+        std::string prompt_3_str = generation_config.prompt_3 != std::nullopt ? *generation_config.prompt_3 : positive_prompt;
 
-        std::string negative_prompt_1_str = generation_config.negative_prompt != std::nullopt
-                                                ? *generation_config.negative_prompt
-                                                : std::string{};
-        std::string negative_prompt_2_str = generation_config.negative_prompt_2 != std::nullopt
-                                                ? *generation_config.negative_prompt_2
-                                                : negative_prompt_1_str;
-        std::string negative_prompt_3_str = generation_config.negative_prompt_3 != std::nullopt
-                                                ? *generation_config.negative_prompt_3
-                                                : negative_prompt_1_str;
+        std::string negative_prompt_1_str = generation_config.negative_prompt != std::nullopt ? *generation_config.negative_prompt : std::string{};
+        std::string negative_prompt_2_str = generation_config.negative_prompt_2 != std::nullopt ? *generation_config.negative_prompt_2 : negative_prompt_1_str;
+        std::string negative_prompt_3_str = generation_config.negative_prompt_3 != std::nullopt ? *generation_config.negative_prompt_3 : negative_prompt_1_str;
 
         // text_encoder_1_output - stores positive and negative pooled_prompt_embeds
-        ov::Tensor text_encoder_1_output =
-            m_clip_text_encoder_1->infer(positive_prompt,
-                                         negative_prompt_1_str,
-                                         do_classifier_free_guidance(generation_config.guidance_scale));
+        ov::Tensor text_encoder_1_output = m_clip_text_encoder_1->infer(positive_prompt, negative_prompt_1_str, do_classifier_free_guidance(generation_config.guidance_scale));
 
         // text_encoder_1_hidden_state - stores positive and negative prompt_embeds
         size_t idx_hidden_state_1 = m_clip_text_encoder_1->get_config().num_hidden_layers + 1;
         ov::Tensor text_encoder_1_hidden_state = m_clip_text_encoder_1->get_output_tensor(idx_hidden_state_1);
 
         // text_encoder_2_output - stores positive and negative pooled_prompt_2_embeds
-        ov::Tensor text_encoder_2_output =
-            m_clip_text_encoder_2->infer(prompt_2_str,
-                                         negative_prompt_2_str,
-                                         do_classifier_free_guidance(generation_config.guidance_scale));
+        ov::Tensor text_encoder_2_output = m_clip_text_encoder_2->infer(prompt_2_str, negative_prompt_2_str, do_classifier_free_guidance(generation_config.guidance_scale));
 
         // text_encoder_2_hidden_state - stores positive and negative prompt_2_embeds
         size_t idx_hidden_state_2 = m_clip_text_encoder_2->get_config().num_hidden_layers + 1;
         ov::Tensor text_encoder_2_hidden_state = m_clip_text_encoder_2->get_output_tensor(idx_hidden_state_2);
-        // get positive prompt_2_embed_out
 
+        // get positive prompt_2_embed_out
         ov::Tensor pooled_prompt_embed_out, prompt_embed_out, pooled_prompt_2_embed_out, prompt_2_embed_out;
 
         if (do_classifier_free_guidance(generation_config.guidance_scale)) {
@@ -291,62 +277,27 @@ public:
         }
 
         // concatenate hidden_states from two encoders
-        ov::Shape pr_emb_shape = prompt_embed.get_shape();
-        ov::Shape pr_emb_2_shape = prompt_2_embed.get_shape();
-
-        ov::Shape clip_prompt_embeds_shape = {pr_emb_shape[0], pr_emb_shape[1], pr_emb_shape[2] + pr_emb_2_shape[2]};
-        ov::Tensor clip_prompt_embeds(prompt_embed.get_element_type(), clip_prompt_embeds_shape);
-
-        const float* pr_emb_1_data = prompt_embed.data<const float>();
-        const float* pr_emb_2_data = prompt_2_embed.data<const float>();
-        float* clip_prompt_embeds_data = clip_prompt_embeds.data<float>();
-
-        numpy_utils::concat_3d_by_rows(pr_emb_1_data, pr_emb_2_data, clip_prompt_embeds_data, pr_emb_shape, pr_emb_2_shape);
+        ov::Tensor clip_prompt_embeds = numpy_utils::concat(prompt_embed, prompt_2_embed, -1);
+        ov::Shape clip_prompt_embeds_shape = clip_prompt_embeds.get_shape();
 
         // TODO: text_encoder_3
         ov::Shape t5_prompt_embed_shape = {generation_config.num_images_per_prompt,
                                            m_clip_text_encoder_1->get_config().max_position_embeddings,
                                            transformer_config.joint_attention_dim};
-
-        std::vector<float> t5_prompt_embed(ov::shape_size(t5_prompt_embed_shape), 0.0f);
+        ov::Tensor t5_prompt_embed(ov::element::f32, t5_prompt_embed_shape);
+        std::fill_n(t5_prompt_embed.data<float>(), t5_prompt_embed.get_size(), 0.0f);
 
         // padding for clip_prompt_embeds
-        ov::Shape pad_embeds_shape = {clip_prompt_embeds_shape[0],
-                                      clip_prompt_embeds_shape[1],
-                                      t5_prompt_embed_shape[2]};
+        ov::Shape pad_embeds_shape = {clip_prompt_embeds_shape[0], clip_prompt_embeds_shape[1], t5_prompt_embed_shape[2]};
+        ov::Tensor pad_embeds(ov::element::f32, pad_embeds_shape);
+        std::fill_n(pad_embeds.data<float>(), pad_embeds.get_size(), 0.0f);
 
-        std::vector<float> pad_embeds(ov::shape_size(pad_embeds_shape), 0.0f);
-        padding_right(clip_prompt_embeds_data, pad_embeds.data(), clip_prompt_embeds_shape, pad_embeds_shape);
+        padding_right(clip_prompt_embeds.data<const float>(), pad_embeds.data<float>(), clip_prompt_embeds_shape, pad_embeds_shape);
 
         // prompt_embeds = torch.cat([pad_embeds, t5_prompt_embed], dim=-2)
-        ov::Shape prompt_embeds_shape = {pad_embeds_shape[0],
-                                         pad_embeds_shape[1] + t5_prompt_embed_shape[1],
-                                         pad_embeds_shape[2]};
-        ov::Tensor prompt_embeds(ov::element::f32, prompt_embeds_shape);
-        float* prompt_embeds_data = prompt_embeds.data<float>();
-        numpy_utils::concat_3d_by_cols(pad_embeds.data(),
-                          t5_prompt_embed.data(),
-                          prompt_embeds_data,
-                          pad_embeds_shape,
-                          t5_prompt_embed_shape);
-
+        ov::Tensor prompt_embeds = numpy_utils::concat(pad_embeds, t5_prompt_embed, -2);
         // pooled_prompt_embeds = torch.cat([pooled_prompt_embed, pooled_prompt_2_embed], dim=-1)
-        ov::Shape p_pr_emb_shape = pooled_prompt_embed.get_shape();
-        ov::Shape p_pr_emb_2_shape = pooled_prompt_2_embed.get_shape();
-
-        const float* pooled_prompt_embed_data = pooled_prompt_embed.data<float>();
-        const float* pooled_prompt_2_embed_data = pooled_prompt_2_embed.data<float>();
-
-        ov::Shape pooled_prompt_embeds_shape = {p_pr_emb_shape[0], p_pr_emb_shape[1] + p_pr_emb_2_shape[1]};
-        ov::Tensor pooled_prompt_embeds(ov::element::f32, pooled_prompt_embeds_shape);
-        float* pooled_prompt_embeds_data = pooled_prompt_embeds.data<float>();
-
-        numpy_utils::concat_2d_by_rows(pooled_prompt_embed_data,
-                                       pooled_prompt_2_embed_data,
-                                       pooled_prompt_embeds_data,
-                                       p_pr_emb_shape,
-                                       p_pr_emb_2_shape);
-        // From steps above we'll use prompt_embeds and pooled_prompt_embeds tensors
+        ov::Tensor pooled_prompt_embeds = numpy_utils::concat(pooled_prompt_embed, pooled_prompt_2_embed, -1);
 
         if (do_classifier_free_guidance(generation_config.guidance_scale)) {
             // 2. Encode negative prompt:
@@ -356,8 +307,7 @@ public:
             ov::Tensor negative_pooled_prompt_2_embed_out = split_2d_by_batch(text_encoder_2_output, 0);
             ov::Tensor negative_prompt_2_embed_out = split_3d_by_batch(text_encoder_2_hidden_state, 0);
 
-            ov::Tensor negative_pooled_prompt_embed, negative_prompt_embed, negative_pooled_prompt_2_embed,
-                negative_prompt_2_embed;
+            ov::Tensor negative_pooled_prompt_embed, negative_prompt_embed, negative_pooled_prompt_2_embed, negative_prompt_2_embed;
             if (generation_config.num_images_per_prompt == 1) {
                 negative_pooled_prompt_embed = negative_pooled_prompt_embed_out;
                 negative_prompt_embed = negative_prompt_embed_out;
@@ -371,100 +321,24 @@ public:
             }
 
             // concatenate hidden_states from two encoders
-            ov::Shape n_pr_emb_1_shape = negative_prompt_embed.get_shape();
-            ov::Shape n_pr_emb_2_shape = negative_prompt_2_embed.get_shape();
+            ov::Tensor neg_clip_prompt_embeds = numpy_utils::concat(negative_prompt_embed, negative_prompt_2_embed, -1);
 
-            ov::Shape neg_clip_prompt_embeds_shape = {n_pr_emb_1_shape[0],
-                                                      n_pr_emb_1_shape[1],
-                                                      n_pr_emb_1_shape[2] + n_pr_emb_2_shape[2]};
-            ov::Tensor neg_clip_prompt_embeds(prompt_embed.get_element_type(), neg_clip_prompt_embeds_shape);
-
-            const float* neg_pr_emb_1_data = negative_prompt_embed.data<const float>();
-            const float* neg_pr_emb_2_data = negative_prompt_2_embed.data<const float>();
-            float* neg_clip_prompt_embeds_data = neg_clip_prompt_embeds.data<float>();
-
-            numpy_utils::concat_3d_by_rows(neg_pr_emb_1_data,
-                                           neg_pr_emb_2_data,
-                                           neg_clip_prompt_embeds_data,
-                                           n_pr_emb_1_shape,
-                                           n_pr_emb_2_shape);
-
-            std::vector<float> t5_neg_prompt_embed(
-                t5_prompt_embed_shape[0] * t5_prompt_embed_shape[1] * t5_prompt_embed_shape[2],
-                0.0f);
+            // TODO: replace with actual T5 embeddings once they are supported by SD3
+            ov::Tensor t5_neg_prompt_embed = t5_prompt_embed;
 
             // padding for neg_clip_prompt_embeds
-            ov::Shape neg_pad_embeds_shape = {neg_clip_prompt_embeds_shape[0],
-                                              neg_clip_prompt_embeds_shape[1],
-                                              t5_prompt_embed_shape[2]};
-
-            std::vector<float> neg_pad_embeds(
-                neg_pad_embeds_shape[0] * neg_pad_embeds_shape[1] * neg_pad_embeds_shape[2],
-                0.0f);
-
-            padding_right(neg_clip_prompt_embeds_data,
-                          neg_pad_embeds.data(),
-                          neg_clip_prompt_embeds_shape,
-                          neg_pad_embeds_shape);
+            padding_right(neg_clip_prompt_embeds.data<const float>(), pad_embeds.data<float>(), clip_prompt_embeds_shape, pad_embeds_shape);
 
             // negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
-            ov::Shape neg_prompt_embeds_shape = {neg_pad_embeds_shape[0],
-                                                 neg_pad_embeds_shape[1] + t5_prompt_embed_shape[1],
-                                                 neg_pad_embeds_shape[2]};
-            ov::Tensor neg_prompt_embeds(ov::element::f32, neg_prompt_embeds_shape);
-            float* neg_prompt_embeds_data = neg_prompt_embeds.data<float>();
+            ov::Tensor neg_prompt_embeds = numpy_utils::concat(pad_embeds, t5_neg_prompt_embed, -2);
+            // neg_pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1)
+            ov::Tensor neg_pooled_prompt_embeds = numpy_utils::concat(negative_pooled_prompt_embed, negative_pooled_prompt_2_embed, -1);
 
-            numpy_utils::concat_3d_by_cols(neg_pad_embeds.data(),
-                                           t5_neg_prompt_embed.data(),
-                                           neg_prompt_embeds_data,
-                                           neg_pad_embeds_shape,
-                                           t5_prompt_embed_shape);
-
-            // neg_pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embed, negative_pooled_prompt_2_embed],
-            // dim=-1)
-            ov::Shape neg_pooled_pr_emb_shape = negative_pooled_prompt_embed.get_shape();
-            ov::Shape neg_pooled_pr_2_emb_shape = negative_pooled_prompt_2_embed.get_shape();
-
-            const float* neg_pooled_pr_emb_data = negative_pooled_prompt_embed.data<float>();
-            const float* neg_pooled_pr_2_emb_data = negative_pooled_prompt_2_embed.data<float>();
-
-            ov::Shape neg_pooled_prompt_embeds_shape = {neg_pooled_pr_emb_shape[0],
-                                                        neg_pooled_pr_emb_shape[1] + neg_pooled_pr_2_emb_shape[1]};
-            ov::Tensor neg_pooled_prompt_embeds(ov::element::f32, neg_pooled_prompt_embeds_shape);
-            float* neg_pooled_prompt_embeds_data = neg_pooled_prompt_embeds.data<float>();
-
-            numpy_utils::concat_2d_by_rows(neg_pooled_pr_emb_data,
-                                           neg_pooled_pr_2_emb_data,
-                                           neg_pooled_prompt_embeds_data,
-                                           neg_pooled_pr_emb_shape,
-                                           neg_pooled_pr_2_emb_shape);
-            // From steps above we'll use neg_prompt_embeds and neg_pooled_prompt_embeds tensors
-
-            // Fill in transformer inputs: concat positive and negative prompt_embeds
-            ov::Shape prompt_embeds_inp_shape = {prompt_embeds_shape[0] + neg_prompt_embeds_shape[0],
-                                                 prompt_embeds_shape[1],
-                                                 prompt_embeds_shape[2]};
-            prompt_embeds_inp = ov::Tensor(ov::element::f32, prompt_embeds_inp_shape);
-            float* prompt_embeds_inp_data = prompt_embeds_inp.data<float>();
-            numpy_utils::concat_3d_by_channels(neg_prompt_embeds_data,
-                                               prompt_embeds_data,
-                                               prompt_embeds_inp_data,
-                                               neg_prompt_embeds_shape,
-                                               prompt_embeds_shape);
-
-            ov::Shape pooled_prompt_embeds_inp_shape = {
-                neg_pooled_prompt_embeds_shape[0] + pooled_prompt_embeds_shape[0],
-                pooled_prompt_embeds_shape[1]};
-
-            pooled_prompt_embeds_inp = ov::Tensor(ov::element::f32, pooled_prompt_embeds_inp_shape);
-            float* pooled_prompt_embeds_input_data = pooled_prompt_embeds_inp.data<float>();
-            numpy_utils::concat_2d_by_channels(neg_pooled_prompt_embeds_data,
-                                               pooled_prompt_embeds_data,
-                                               pooled_prompt_embeds_input_data,
-                                               neg_pooled_prompt_embeds_shape,
-                                               pooled_prompt_embeds_shape);
+            // 3. Fill in transformer inputs: concat positive and negative prompt_embeds
+            prompt_embeds_inp = numpy_utils::concat(neg_prompt_embeds, prompt_embeds, 0);
+            pooled_prompt_embeds_inp = numpy_utils::concat(neg_pooled_prompt_embeds, pooled_prompt_embeds, 0);
         } else {
-            // Fill in transformer inputs
+            // 3. Fill in transformer inputs
             prompt_embeds_inp = prompt_embeds;
             pooled_prompt_embeds_inp = pooled_prompt_embeds;
         }
@@ -642,7 +516,7 @@ private:
 
         const bool is_classifier_free_guidance = do_classifier_free_guidance(generation_config.guidance_scale);
 
-        OPENVINO_ASSERT(generation_config.max_sequence_length < 512, "T5's 'max_sequence_length' must be less than 512");
+        OPENVINO_ASSERT(generation_config.max_sequence_length <= 512, "T5's 'max_sequence_length' must be less or equal to 512");
         OPENVINO_ASSERT(
             generation_config.prompt_3 == std::nullopt || generation_config.negative_prompt_3 == std::nullopt,
             "T5Encoder is not currently supported, 'prompt_3' and 'negative_prompt_3' can't be used. Please, add "


### PR DESCRIPTION
- Added unified function `concat` which accepts tensors and axis to concat on
- Optimized `padding_right` function to avoid padding second tensor before calling this function
- Optimized split by batch to avoid memory copy