### PR TITLE
Try to drop pre-release extra-index-url from requirements.xt

### DIFF
--- a/.github/workflows/lcm_dreamshaper_cpp.yml
+++ b/.github/workflows/lcm_dreamshaper_cpp.yml
@@ -59,8 +59,7 @@ jobs:
       - name: Install python dependencies
         run: |
           source openvino_lcm_cpp/bin/activate
-          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
-          python -m pip install -r ./samples/requirements.txt
+          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] -r ./samples/requirements.txt --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 
       - name: Download and convert models and tokenizer
         run: |
@@ -119,8 +118,7 @@ jobs:
       - name: Install python dependencies
         run: |
           . "./openvino_lcm_cpp/Scripts/Activate.ps1"
-          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
-          python -m pip install -r ./samples/requirements.txt
+          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] -r ./samples/requirements.txt --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 
       - name: Download and convert models and tokenizer
         run: |

--- a/.github/workflows/stable_diffusion_1_5_cpp.yml
+++ b/.github/workflows/stable_diffusion_1_5_cpp.yml
@@ -59,8 +59,7 @@ jobs:
       - name: Install python dependencies
         run: |
           source openvino_sd_cpp/bin/activate
-          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
-          python -m pip install -r ./samples/requirements.txt
+          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] -r ./samples/requirements.txt --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 
       - name: Download and convert models and tokenizer
         run: |
@@ -146,8 +145,7 @@ jobs:
       - name: Install python dependencies
         run: |
           . "./openvino_sd_cpp/Scripts/Activate.ps1"
-          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
-          python -m pip install -r ./samples/requirements.txt
+          python -m pip install ./thirdparty/openvino_tokenizers/[transformers] -r ./samples/requirements.txt --pre --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 
       - name: Download and convert models and tokenizer
         run: |

--- a/samples/deployment-requirements.txt
+++ b/samples/deployment-requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 openvino_genai~=2024.6.0.0rc1
 librosa==0.10.2  # For Whisper
 pillow==11.0.0  # Image processing in VLMs

--- a/samples/export-requirements.txt
+++ b/samples/export-requirements.txt
@@ -1,5 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
 openvino-tokenizers~=2024.6.0.0rc1
 optimum-intel @ git+https://github.com/huggingface/optimum-intel.git
 numpy<2.0.0; sys_platform == 'darwin'


### PR DESCRIPTION
In this case, we can release requirements.txt files as is.
But now, they still refer to non-production packages