### PR TITLE
llm_pipeline_static: flush streamer after generation loop is complete

### DIFF
--- a/src/cpp/src/llm_pipeline_static.cpp
+++ b/src/cpp/src/llm_pipeline_static.cpp
@@ -1092,6 +1092,11 @@ EncodedResults StaticLLMPipeline::generate(
             m_kvcache_request.get_tensor(output_name).copy_to(kvcache_in_slice);
         }
     }
+
+    if (streamer_ptr) {
+        streamer_ptr->end();
+    }
+
     auto stop_time = std::chrono::steady_clock::now();
     // If is called without tokenization then that stat will not be reported.
     auto& metrics = results.perf_metrics;


### PR DESCRIPTION
Without these changes, chat_sample with NPU device produces responses that are clipped by 4 characters:
![image](https://github.com/user-attachments/assets/e841bf36-948b-4899-820f-6b52460076e9)

Flushing the streamer (as *get_lm_encoded_results()* does in non-static LLM case) seems to resolve the issue.