### PR TITLE
Add workaround for MSVC mutex constructor issue 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,8 @@ if(WIN32 OR APPLE)
 endif()
 
 # Workaround for an MSVC compiler issue in some versions of Visual Studio 2022.
-# The issue involves a null reference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
-if(MSVC AND CMAKE_GENERATOR MATCHES "Visual Studio 17 2022")
+# The issue involves a null dereference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930 AND MSVC_VERSION LESS 1941)
     add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,13 @@ if(WIN32 OR APPLE)
   set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
+# Workaround for an MSVC compiler issue in some versions of Visual Studio 2022.
+# The issue involves a null reference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+if(MSVC AND CMAKE_GENERATOR MATCHES "Visual Studio 17 2022")
+    add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
+
 add_subdirectory(thirdparty)
 add_subdirectory(src)
 if(EXISTS "${OpenVINOGenAI_SOURCE_DIR}/samples")


### PR DESCRIPTION
This issue is a MSVC compiler bug affecting certain versions of Visual Studio 2022. When using `std::mutex`  a null dereference may occur, leading to a silent crash in Release mode, as illustrated in the image below. 
![mutex](https://github.com/user-attachments/assets/07331f59-7e6d-47b4-a72a-887e01817fa8)

Adding the compiler option `/D"_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `serves as a workaround for this problem.
Reference:
https://hydrogenaud.io/index.php/topic,126070.0.html
https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710