### PR TITLE
[Image generation] Added conversion between pipelines

### DIFF
--- a/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
@@ -3,27 +3,10 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <random>
-#include <filesystem>
-
-#include "openvino/core/any.hpp"
-#include "openvino/runtime/tensor.hpp"
-
-#include "openvino/genai/image_generation/scheduler.hpp"
-#include "openvino/genai/image_generation/generation_config.hpp"
-
-#include "openvino/genai/image_generation/clip_text_model.hpp"
-#include "openvino/genai/image_generation/clip_text_model_with_projection.hpp"
-#include "openvino/genai/image_generation/unet2d_condition_model.hpp"
-#include "openvino/genai/image_generation/autoencoder_kl.hpp"
+#include "openvino/genai/image_generation/inpainting_pipeline.hpp"
 
 namespace ov {
 namespace genai {
-
-// forward declaration
-class DiffusionPipeline;
 
 //
 // Image to image pipeline
@@ -41,6 +24,8 @@ public:
                         const std::string& device,
                         Properties&&... properties)
         : Image2ImagePipeline(models_path, device, ov::AnyMap{std::forward<Properties>(properties)...}) { }
+
+    Image2ImagePipeline(const InpaintingPipeline& pipe);
 
     // creates either LCM or SD pipeline from building blocks
     static Image2ImagePipeline stable_diffusion(
@@ -99,6 +84,10 @@ private:
     std::shared_ptr<DiffusionPipeline> m_impl;
 
     explicit Image2ImagePipeline(const std::shared_ptr<DiffusionPipeline>& impl);
+
+    // to create other pipelines from image to image
+    friend class Text2ImagePipeline;
+    friend class InpaintingPipeline;
 };
 
 } // namespace genai

--- a/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
@@ -18,12 +18,17 @@
 #include "openvino/genai/image_generation/clip_text_model_with_projection.hpp"
 #include "openvino/genai/image_generation/unet2d_condition_model.hpp"
 #include "openvino/genai/image_generation/autoencoder_kl.hpp"
+#include "openvino/genai/image_generation/t5_encoder_model.hpp"
+#include "openvino/genai/image_generation/sd3_transformer_2d_model.hpp"
+#include "openvino/genai/image_generation/flux_transformer_2d_model.hpp"
 
 namespace ov {
 namespace genai {
 
 // forward declaration
 class DiffusionPipeline;
+class Text2ImagePipeline;
+class Image2ImagePipeline;
 
 //
 // Inpainting pipeline
@@ -41,6 +46,8 @@ public:
                        const std::string& device,
                        Properties&&... properties)
         : InpaintingPipeline(models_path, device, ov::AnyMap{std::forward<Properties>(properties)...}) { }
+
+    InpaintingPipeline(const Image2ImagePipeline& pipe);
 
     // creates either LCM or SD pipeline from building blocks
     static InpaintingPipeline stable_diffusion(
@@ -100,6 +107,10 @@ private:
     std::shared_ptr<DiffusionPipeline> m_impl;
 
     explicit InpaintingPipeline(const std::shared_ptr<DiffusionPipeline>& impl);
+
+    // to create other pipelines from inpainting
+    friend class Text2ImagePipeline;
+    friend class Image2ImagePipeline;
 };
 
 } // namespace genai

--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -225,6 +225,15 @@ public:
         initialize_generation_config("FluxPipeline");
     }
 
+    FluxPipeline(PipelineType pipeline_type, const FluxPipeline& pipe) :
+        FluxPipeline(pipe) {
+        OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
+            pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
+
+        m_pipeline_type = pipeline_type;
+        initialize_generation_config("FluxPipeline");
+    }
+
     void reshape(const int num_images_per_prompt,
                  const int height,
                  const int width,
@@ -232,13 +241,6 @@ public:
         check_image_size(height, width);
 
         m_clip_text_encoder->reshape(1);
-
-        // TODO: max_sequence_length cannot be specified easily outside, only via:
-        //   Text2ImagePipeline pipe("/path");
-        //   ImageGenerationConfig default_config = pipe.get_generation_config();
-        //   default_config.max_sequence_length = 30;
-        //   pipe.set_generation_config(default_config);
-        //   pipe.reshape(1, 512, 512, default_config.guidance_scale);
         m_t5_text_encoder->reshape(1, m_generation_config.max_sequence_length);
         m_transformer->reshape(num_images_per_prompt, height, width, m_generation_config.max_sequence_length);
 
@@ -321,23 +323,13 @@ public:
         m_custom_generation_config = m_generation_config;
         m_custom_generation_config.update_generation_config(properties);
 
-        if (!initial_image) {
-            // in case of typical text to image generation, we need to ignore 'strength'
-            m_custom_generation_config.strength = 1.0f;
-        }
-
-        if (!initial_image) {
-            // in case of typical text to image generation, we need to ignore 'strength'
-            m_custom_generation_config.strength = 1.0f;
-        }
-
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
         const auto& transformer_config = m_transformer->get_config();
 
         if (m_custom_generation_config.height < 0)
-            m_custom_generation_config.height = transformer_config.m_default_sample_size * vae_scale_factor;
+            compute_dim(m_custom_generation_config.height, initial_image, 1 /* assume NHWC */);
         if (m_custom_generation_config.width < 0)
-            m_custom_generation_config.width = transformer_config.m_default_sample_size * vae_scale_factor;
+            compute_dim(m_custom_generation_config.width, initial_image, 2 /* assume NHWC */);
 
         check_inputs(m_custom_generation_config, initial_image);
 
@@ -395,6 +387,29 @@ public:
     }
 
 private:
+    bool is_inpainting_model() const {
+        assert(m_transformer != nullptr);
+        assert(m_vae != nullptr);
+        return m_transformer->get_config().in_channels == (m_vae->get_config().latent_channels * 2 + 1);
+    }
+
+    void compute_dim(int64_t & generation_config_value, ov::Tensor initial_image, int dim_idx) {
+        const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
+        const auto& transformer_config = m_transformer->get_config();
+
+        // in case of image to image generation_config_value is just ignored and computed based on initial image
+        if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE) {
+            OPENVINO_ASSERT(initial_image, "Initial image is empty for image to image pipeline");
+            ov::Shape shape = initial_image.get_shape();
+            int64_t dim_val = shape[dim_idx];
+
+            generation_config_value = dim_val - (dim_val % vae_scale_factor);
+        }
+
+        if (generation_config_value < 0)
+            generation_config_value = transformer_config.m_default_sample_size * vae_scale_factor;
+    }
+
     void initialize_generation_config(const std::string& class_name) override {
         assert(m_transformer != nullptr);
         assert(m_vae != nullptr);
@@ -402,8 +417,12 @@ private:
         const auto& transformer_config = m_transformer->get_config();
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
 
-        m_generation_config.height = transformer_config.m_default_sample_size * vae_scale_factor;
-        m_generation_config.width = transformer_config.m_default_sample_size * vae_scale_factor;
+        m_generation_config = ImageGenerationConfig();
+
+        if (m_pipeline_type != PipelineType::IMAGE_2_IMAGE) {
+            m_generation_config.height = transformer_config.m_default_sample_size * vae_scale_factor;
+            m_generation_config.width = transformer_config.m_default_sample_size * vae_scale_factor;
+        }
 
         if (class_name == "FluxPipeline" || class_name == "FluxImg2ImgPipeline" || class_name == "FluxInpaintPipeline" ) {
             if (m_pipeline_type == PipelineType::TEXT_2_IMAGE) {

--- a/src/cpp/src/image_generation/image2image_pipeline.cpp
+++ b/src/cpp/src/image_generation/image2image_pipeline.cpp
@@ -39,6 +39,16 @@ Image2ImagePipeline::Image2ImagePipeline(const std::filesystem::path& root_dir, 
     }
 }
 
+Image2ImagePipeline::Image2ImagePipeline(const InpaintingPipeline& pipe) {
+    if (auto stable_diffusion_xl = std::dynamic_pointer_cast<StableDiffusionXLPipeline>(pipe.m_impl); stable_diffusion_xl != nullptr) {
+        m_impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::IMAGE_2_IMAGE, *stable_diffusion_xl);
+    } else if (auto stable_diffusion = std::dynamic_pointer_cast<StableDiffusionPipeline>(pipe.m_impl); stable_diffusion != nullptr) {
+        m_impl = std::make_shared<StableDiffusionPipeline>(PipelineType::IMAGE_2_IMAGE, *stable_diffusion);
+    } else {
+        OPENVINO_ASSERT("Cannot convert specified InpaintingPipeline to Image2ImagePipeline");
+    }
+}
+
 Image2ImagePipeline::Image2ImagePipeline(const std::shared_ptr<DiffusionPipeline>& impl)
     : m_impl(impl) {
     assert(m_impl != nullptr);

--- a/src/cpp/src/image_generation/inpainting_pipeline.cpp
+++ b/src/cpp/src/image_generation/inpainting_pipeline.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 
 #include "openvino/genai/image_generation/inpainting_pipeline.hpp"
+#include "openvino/genai/image_generation/image2image_pipeline.hpp"
 
 #include "image_generation/stable_diffusion_pipeline.hpp"
 #include "image_generation/stable_diffusion_xl_pipeline.hpp"
@@ -43,6 +44,16 @@ InpaintingPipeline::InpaintingPipeline(const std::filesystem::path& root_dir, co
     }
 }
 
+InpaintingPipeline::InpaintingPipeline(const Image2ImagePipeline& pipe) {
+    if (auto stable_diffusion_xl = std::dynamic_pointer_cast<StableDiffusionXLPipeline>(pipe.m_impl); stable_diffusion_xl != nullptr) {
+        m_impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::INPAINTING, *stable_diffusion_xl);
+    } else if (auto stable_diffusion = std::dynamic_pointer_cast<StableDiffusionPipeline>(pipe.m_impl); stable_diffusion != nullptr) {
+        m_impl = std::make_shared<StableDiffusionPipeline>(PipelineType::INPAINTING, *stable_diffusion);
+    } else {
+        OPENVINO_ASSERT("Cannot convert specified Image2ImagePipeline to InpaintingPipeline");
+    }
+}
+
 InpaintingPipeline::InpaintingPipeline(const std::shared_ptr<DiffusionPipeline>& impl)
     : m_impl(impl) {
     assert(m_impl != nullptr);
@@ -53,7 +64,7 @@ InpaintingPipeline InpaintingPipeline::stable_diffusion(
     const CLIPTextModel& clip_text_model,
     const UNet2DConditionModel& unet,
     const AutoencoderKL& vae) {
-    auto impl = std::make_shared<StableDiffusionPipeline>(PipelineType::IMAGE_2_IMAGE, clip_text_model, unet, vae);
+    auto impl = std::make_shared<StableDiffusionPipeline>(PipelineType::INPAINTING, clip_text_model, unet, vae);
 
     assert(scheduler != nullptr);
     impl->set_scheduler(scheduler);
@@ -66,7 +77,7 @@ InpaintingPipeline InpaintingPipeline::latent_consistency_model(
     const CLIPTextModel& clip_text_model,
     const UNet2DConditionModel& unet,
     const AutoencoderKL& vae) {
-    auto impl = std::make_shared<StableDiffusionPipeline>(PipelineType::IMAGE_2_IMAGE, clip_text_model, unet, vae);
+    auto impl = std::make_shared<StableDiffusionPipeline>(PipelineType::INPAINTING, clip_text_model, unet, vae);
 
     assert(scheduler != nullptr);
     impl->set_scheduler(scheduler);
@@ -80,7 +91,7 @@ InpaintingPipeline InpaintingPipeline::stable_diffusion_xl(
     const CLIPTextModelWithProjection& clip_text_model_with_projection,
     const UNet2DConditionModel& unet,
     const AutoencoderKL& vae) {
-    auto impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::IMAGE_2_IMAGE, clip_text_model, clip_text_model_with_projection, unet, vae);
+    auto impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::INPAINTING, clip_text_model, clip_text_model_with_projection, unet, vae);
 
     assert(scheduler != nullptr);
     impl->set_scheduler(scheduler);

--- a/src/cpp/src/image_generation/schedulers/scheduler.cpp
+++ b/src/cpp/src/image_generation/schedulers/scheduler.cpp
@@ -29,7 +29,6 @@ std::shared_ptr<Scheduler> Scheduler::from_config(const std::filesystem::path& s
 
     std::shared_ptr<Scheduler> scheduler = nullptr;
     if (scheduler_type == Scheduler::Type::LCM) {
-        // TODO: do we need to pass RNG generator somehow to LCM?
         scheduler = std::make_shared<LCMScheduler>(scheduler_config_path);
     } else if (scheduler_type == Scheduler::Type::LMS_DISCRETE) {
         scheduler = std::make_shared<LMSDiscreteScheduler>(scheduler_config_path);

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -218,6 +218,15 @@ public:
         initialize_generation_config("StableDiffusion3Pipeline");
     }
 
+    StableDiffusion3Pipeline(PipelineType pipeline_type, const StableDiffusion3Pipeline& pipe) :
+        StableDiffusion3Pipeline(pipe) {
+        OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
+            pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
+
+        m_pipeline_type = pipeline_type;
+        initialize_generation_config("StableDiffusion3Pipeline");
+    }
+
     void reshape(const int num_images_per_prompt,
                  const int height,
                  const int width,
@@ -426,21 +435,14 @@ public:
         ImageGenerationConfig generation_config = m_generation_config;
         generation_config.update_generation_config(properties);
 
-        if (!initial_image) {
-            // in case of typical text to image generation, we need to ignore 'strength'
-            generation_config.strength = 1.0f;
-        }
-
         const auto& transformer_config = m_transformer->get_config();
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
-        const size_t batch_size_multiplier = do_classifier_free_guidance(generation_config.guidance_scale)
-                                                 ? 2
-                                                 : 1;  // Transformer accepts 2x batch in case of CFG
+        const size_t batch_size_multiplier = do_classifier_free_guidance(generation_config.guidance_scale) ? 2 : 1;  // Transformer accepts 2x batch in case of CFG
 
         if (generation_config.height < 0)
-            generation_config.height = transformer_config.sample_size * vae_scale_factor;
+            compute_dim(generation_config.height, initial_image, 1 /* assume NHWC */);
         if (generation_config.width < 0)
-            generation_config.width = transformer_config.sample_size * vae_scale_factor;
+            compute_dim(generation_config.width, initial_image, 2 /* assume NHWC */);
 
         check_inputs(generation_config, initial_image);
 
@@ -525,6 +527,29 @@ public:
     }
 
 private:
+    bool is_inpainting_model() const {
+        assert(m_transformer != nullptr);
+        assert(m_vae != nullptr);
+        return m_transformer->get_config().in_channels == (m_vae->get_config().latent_channels * 2 + 1);
+    }
+
+    void compute_dim(int64_t & generation_config_value, ov::Tensor initial_image, int dim_idx) {
+        const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
+        const auto& transformer_config = m_transformer->get_config();
+
+        // in case of image to image generation_config_value is just ignored and computed based on initial image
+        if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE) {
+            OPENVINO_ASSERT(initial_image, "Initial image is empty for image to image pipeline");
+            ov::Shape shape = initial_image.get_shape();
+            int64_t dim_val = shape[dim_idx];
+
+            generation_config_value = dim_val - (dim_val % vae_scale_factor);
+        }
+
+        if (generation_config_value < 0)
+            generation_config_value = transformer_config.sample_size * vae_scale_factor;
+    }
+
     bool do_classifier_free_guidance(float guidance_scale) const {
         return guidance_scale > 1.0;
     }
@@ -536,8 +561,13 @@ private:
         const auto& transformer_config = m_transformer->get_config();
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
 
-        m_generation_config.height = transformer_config.sample_size * vae_scale_factor;
-        m_generation_config.width = transformer_config.sample_size * vae_scale_factor;
+        m_generation_config = ImageGenerationConfig();
+
+        // in case of image to image, the shape is computed based on initial image
+        if (m_pipeline_type != PipelineType::IMAGE_2_IMAGE) {
+            m_generation_config.height = transformer_config.sample_size * vae_scale_factor;
+            m_generation_config.width = transformer_config.sample_size * vae_scale_factor;
+        }
 
         if (class_name == "StableDiffusion3Pipeline" || class_name == "StableDiffusion3Img2ImgPipeline" || class_name == "StableDiffusion3InpaintPipeline") {
             m_generation_config.guidance_scale = 7.0f;

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -147,6 +147,18 @@ public:
         initialize_generation_config(pipeline_name);
     }
 
+    StableDiffusionPipeline(PipelineType pipeline_type, const StableDiffusionPipeline& pipe) :
+        StableDiffusionPipeline(pipe) {
+        OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
+            pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
+
+        m_pipeline_type = pipeline_type;
+
+        const bool is_lcm = m_unet->get_config().time_cond_proj_dim > 0;
+        const char * const pipeline_name = is_lcm ? "LatentConsistencyModelPipeline" : "StableDiffusionPipeline";
+        initialize_generation_config(pipeline_name);
+    }
+
     void reshape(const int num_images_per_prompt, const int height, const int width, const float guidance_scale) override {
         check_image_size(height, width);
 
@@ -206,8 +218,7 @@ public:
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
         const bool is_inpainting = m_pipeline_type == PipelineType::INPAINTING,
             is_strength_max = is_inpainting && generation_config.strength == 1.0f,
-            is_inpainting_model = is_inpainting && m_unet->get_config().in_channels == (m_vae->get_config().latent_channels * 2 + 1),
-            return_image_latent = is_inpainting && !is_inpainting_model;
+            return_image_latent = is_inpainting && !is_inpainting_model();
 
         ov::Shape latent_shape{generation_config.num_images_per_prompt, m_vae->get_config().latent_channels,
                                generation_config.height / vae_scale_factor, generation_config.width / vae_scale_factor};
@@ -254,7 +265,6 @@ public:
 
         const size_t batch_size_multiplier = m_unet->do_classifier_free_guidance(generation_config.guidance_scale) ? 2 : 1;  // Unet accepts 2x batch in case of CFG
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
-        const bool is_inpainting_model = m_unet->get_config().in_channels == (m_vae->get_config().latent_channels * 2 + 1);
         ov::Shape target_shape = processed_image.get_shape();
 
         ov::Tensor mask_condition = m_image_resizer->execute(mask_image, target_shape[2], target_shape[3]);
@@ -266,7 +276,7 @@ public:
 
         ov::Tensor masked_image_latent;
 
-        if (is_inpainting_model) {
+        if (is_inpainting_model()) {
             // create masked image
             ov::Tensor masked_image(ov::element::f32, processed_image.get_shape());
             const float * mask_condition_data = mask_condition.data<const float>();
@@ -300,11 +310,6 @@ public:
         ImageGenerationConfig generation_config = m_generation_config;
         generation_config.update_generation_config(properties);
 
-        if (!initial_image) {
-            // in case of typical text to image generation, we need to ignore 'strength'
-            generation_config.strength = 1.0f;
-        }
-
         // use callback if defined
         std::function<bool(size_t, ov::Tensor&)> callback;
         auto callback_iter = properties.find(ov::genai::callback.name());
@@ -319,12 +324,12 @@ public:
         const auto& unet_config = m_unet->get_config();
         const size_t batch_size_multiplier = m_unet->do_classifier_free_guidance(generation_config.guidance_scale) ? 2 : 1;  // Unet accepts 2x batch in case of CFG
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
-        const bool is_inpainting_model = unet_config.in_channels == (m_vae->get_config().latent_channels * 2 + 1);
 
         if (generation_config.height < 0)
             compute_dim(generation_config.height, initial_image, 1 /* assume NHWC */);
         if (generation_config.width < 0)
             compute_dim(generation_config.width, initial_image, 2 /* assume NHWC */);
+
         check_inputs(generation_config, initial_image);
 
         set_lora_adapters(generation_config.adapters);
@@ -365,7 +370,7 @@ public:
 
             m_scheduler->scale_model_input(latent_cfg, inference_step);
 
-            ov::Tensor latent_model_input = is_inpainting_model ? numpy_utils::concat(numpy_utils::concat(latent_cfg, mask, 1), masked_image_latent, 1) : latent_cfg;
+            ov::Tensor latent_model_input = is_inpainting_model() ? numpy_utils::concat(numpy_utils::concat(latent_cfg, mask, 1), masked_image_latent, 1) : latent_cfg;
             ov::Tensor timestep(ov::element::i64, {1}, &timesteps[inference_step]);
             ov::Tensor noise_pred_tensor = m_unet->infer(latent_model_input, timestep);
 
@@ -392,7 +397,7 @@ public:
             latent = scheduler_step_result["latent"];
 
             // in case of non-specialized inpainting model, we need manually mask current denoised latent and initial image latent
-            if (m_pipeline_type == PipelineType::INPAINTING && !is_inpainting_model) {
+            if (m_pipeline_type == PipelineType::INPAINTING && !is_inpainting_model()) {
                 blend_latents(image_latent, noise, mask, latent, inference_step);
             }
 
@@ -415,6 +420,12 @@ public:
     }
 
 protected:
+    bool is_inpainting_model() const {
+        assert(m_unet != nullptr);
+        assert(m_vae != nullptr);
+        return m_unet->get_config().in_channels == (m_vae->get_config().latent_channels * 2 + 1);
+    }
+
     void compute_dim(int64_t & generation_config_value, ov::Tensor initial_image, int dim_idx) {
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
         const auto& unet_config = m_unet->get_config();
@@ -438,13 +449,15 @@ protected:
         const auto& unet_config = m_unet->get_config();
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
 
+        m_generation_config = ImageGenerationConfig();
+
         // in case of image to image, the shape is computed based on initial image
         if (m_pipeline_type != PipelineType::IMAGE_2_IMAGE) {
             m_generation_config.height = unet_config.sample_size * vae_scale_factor;
             m_generation_config.width = unet_config.sample_size * vae_scale_factor;
         }
 
-        if (class_name == "StableDiffusionPipeline" || class_name == "StableDiffusionInpaintPipeline" || class_name == "StableDiffusionInpaintPipeline") {
+        if (class_name == "StableDiffusionPipeline" || class_name == "StableDiffusionImg2ImgPipeline" || class_name == "StableDiffusionInpaintPipeline") {
             m_generation_config.guidance_scale = 7.5f;
             m_generation_config.num_inference_steps = 50;
             m_generation_config.strength = m_pipeline_type == PipelineType::IMAGE_2_IMAGE ? 0.8f : 1.0f;

--- a/src/cpp/src/image_generation/text2image_pipeline.cpp
+++ b/src/cpp/src/image_generation/text2image_pipeline.cpp
@@ -51,6 +51,34 @@ Text2ImagePipeline::Text2ImagePipeline(const std::filesystem::path& root_dir, co
     }
 }
 
+Text2ImagePipeline::Text2ImagePipeline(const Image2ImagePipeline& pipe) {
+    if (auto stable_diffusion_xl = std::dynamic_pointer_cast<StableDiffusionXLPipeline>(pipe.m_impl); stable_diffusion_xl != nullptr) {
+        m_impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion_xl);
+    } else if (auto stable_diffusion = std::dynamic_pointer_cast<StableDiffusionPipeline>(pipe.m_impl); stable_diffusion != nullptr) {
+        m_impl = std::make_shared<StableDiffusionPipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion);
+    } else if (auto stable_diffusion_3 = std::dynamic_pointer_cast<StableDiffusion3Pipeline>(pipe.m_impl); stable_diffusion_3 != nullptr) {
+        m_impl = std::make_shared<StableDiffusion3Pipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion_3);
+    } else if (auto flux = std::dynamic_pointer_cast<FluxPipeline>(pipe.m_impl); flux != nullptr) {
+        m_impl = std::make_shared<FluxPipeline>(PipelineType::TEXT_2_IMAGE, *flux);
+    } else {
+        OPENVINO_ASSERT("Cannot convert specified Image2ImagePipeline to Text2ImagePipeline");
+    }
+}
+
+Text2ImagePipeline::Text2ImagePipeline(const InpaintingPipeline& pipe) {
+    if (auto stable_diffusion_xl = std::dynamic_pointer_cast<StableDiffusionXLPipeline>(pipe.m_impl); stable_diffusion_xl != nullptr) {
+        m_impl = std::make_shared<StableDiffusionXLPipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion_xl);
+    } else if (auto stable_diffusion = std::dynamic_pointer_cast<StableDiffusionPipeline>(pipe.m_impl); stable_diffusion != nullptr) {
+        m_impl = std::make_shared<StableDiffusionPipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion);
+    } else if (auto stable_diffusion_3 = std::dynamic_pointer_cast<StableDiffusion3Pipeline>(pipe.m_impl); stable_diffusion_3 != nullptr) {
+        m_impl = std::make_shared<StableDiffusion3Pipeline>(PipelineType::TEXT_2_IMAGE, *stable_diffusion_3);
+    } else if (auto flux = std::dynamic_pointer_cast<FluxPipeline>(pipe.m_impl); flux != nullptr) {
+        m_impl = std::make_shared<FluxPipeline>(PipelineType::TEXT_2_IMAGE, *flux);
+    } else {
+        OPENVINO_ASSERT("Cannot convert specified InpaintingPipeline to Text2ImagePipeline");
+    }
+}
+
 Text2ImagePipeline::Text2ImagePipeline(const std::shared_ptr<DiffusionPipeline>& impl)
     : m_impl(impl) {
     assert(m_impl != nullptr);

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -772,6 +772,9 @@ class Image2ImagePipeline:
                     device (str): Device to run the model on (e.g., CPU, GPU).
                     kwargs: Image2ImagePipeline properties
         """
+    @typing.overload
+    def __init__(self, pipe: InpaintingPipeline) -> None:
+        ...
     def compile(self, device: str, **kwargs) -> None:
         """
                         Compiles the model.
@@ -868,6 +871,9 @@ class InpaintingPipeline:
                     device (str): Device to run the model on (e.g., CPU, GPU).
                     kwargs: InpaintingPipeline properties
         """
+    @typing.overload
+    def __init__(self, pipe: Image2ImagePipeline) -> None:
+        ...
     def compile(self, device: str, **kwargs) -> None:
         """
                         Compiles the model.
@@ -1535,6 +1541,12 @@ class Text2ImagePipeline:
                     device (str): Device to run the model on (e.g., CPU, GPU).
                     kwargs: Text2ImagePipeline properties
         """
+    @typing.overload
+    def __init__(self, pipe: Image2ImagePipeline) -> None:
+        ...
+    @typing.overload
+    def __init__(self, pipe: InpaintingPipeline) -> None:
+        ...
     def compile(self, device: str, **kwargs) -> None:
         """
                         Compiles the model.

--- a/src/python/py_image_generation_pipelines.cpp
+++ b/src/python/py_image_generation_pipelines.cpp
@@ -85,9 +85,7 @@ void init_image_generation_pipelines(py::module_& m) {
         .def(py::init<>());
 
     py::class_<ov::genai::CppStdGenerator, ov::genai::Generator, std::shared_ptr<ov::genai::CppStdGenerator>>(m, "CppStdGenerator", "This class wraps std::mt19937 pseudo-random generator.")
-        .def(py::init([](
-            uint32_t seed
-        ) {
+        .def(py::init([](uint32_t seed) {
             return std::make_unique<ov::genai::CppStdGenerator>(seed);
         }), 
         py::arg("seed"))
@@ -140,9 +138,7 @@ void init_image_generation_pipelines(py::module_& m) {
         });
 
     auto text2image_pipeline = py::class_<ov::genai::Text2ImagePipeline>(m, "Text2ImagePipeline", "This class is used for generation with text-to-image models.")
-        .def(py::init([](
-            const std::filesystem::path& models_path
-        ) {
+        .def(py::init([](const std::filesystem::path& models_path) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
             return std::make_unique<ov::genai::Text2ImagePipeline>(models_path);
         }),
@@ -151,7 +147,6 @@ void init_image_generation_pipelines(py::module_& m) {
             Text2ImagePipeline class constructor.
             models_path (os.PathLike): Path to the folder with exported model files.
         )")
-
         .def(py::init([](
             const std::filesystem::path& models_path,
             const std::string& device,
@@ -211,9 +206,7 @@ void init_image_generation_pipelines(py::module_& m) {
 
 
     auto image2image_pipeline = py::class_<ov::genai::Image2ImagePipeline>(m, "Image2ImagePipeline", "This class is used for generation with image-to-image models.")
-        .def(py::init([](
-            const std::filesystem::path& models_path
-        ) {
+        .def(py::init([](const std::filesystem::path& models_path) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
             return std::make_unique<ov::genai::Image2ImagePipeline>(models_path);
         }),
@@ -222,7 +215,6 @@ void init_image_generation_pipelines(py::module_& m) {
             Image2ImagePipeline class constructor.
             models_path (os.PathLike): Path to the folder with exported model files.
         )")
-
         .def(py::init([](
             const std::filesystem::path& models_path,
             const std::string& device,
@@ -277,9 +269,7 @@ void init_image_generation_pipelines(py::module_& m) {
 
 
     auto inpainting_pipeline = py::class_<ov::genai::InpaintingPipeline>(m, "InpaintingPipeline", "This class is used for generation with inpainting models.")
-        .def(py::init([](
-            const std::filesystem::path& models_path
-        ) {
+        .def(py::init([](const std::filesystem::path& models_path) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
             return std::make_unique<ov::genai::InpaintingPipeline>(models_path);
         }),
@@ -288,7 +278,6 @@ void init_image_generation_pipelines(py::module_& m) {
             InpaintingPipeline class constructor.
             models_path (os.PathLike): Path to the folder with exported model files.
         )")
-
         .def(py::init([](
             const std::filesystem::path& models_path,
             const std::string& device,
@@ -342,4 +331,25 @@ void init_image_generation_pipelines(py::module_& m) {
             py::arg("mask_image"), "Mask image",
             (text2image_generate_docstring + std::string(" \n ")).c_str())
         .def("decode", &ov::genai::InpaintingPipeline::decode, py::arg("latent"));
+
+    // define constructors to create one pipeline from another
+    // NOTE: needs to be defined once all pipelines are created
+
+    text2image_pipeline
+        .def(py::init([](const ov::genai::Image2ImagePipeline& pipe) {
+            return std::make_unique<ov::genai::Text2ImagePipeline>(pipe);
+        }), py::arg("pipe"))
+        .def(py::init([](const ov::genai::InpaintingPipeline& pipe) {
+            return std::make_unique<ov::genai::Text2ImagePipeline>(pipe);
+        }), py::arg("pipe"));
+
+    image2image_pipeline
+        .def(py::init([](const ov::genai::InpaintingPipeline& pipe) {
+            return std::make_unique<ov::genai::Image2ImagePipeline>(pipe);
+        }), py::arg("pipe"));
+
+    inpainting_pipeline
+        .def(py::init([](const ov::genai::Image2ImagePipeline& pipe) {
+            return std::make_unique<ov::genai::InpaintingPipeline>(pipe);
+        }), py::arg("pipe"));
 }


### PR DESCRIPTION
Created constructors for image generation pipelines to share models between pipelines, but generation configs are initialized as default (because, text2image and image2image have different default values for some parameters and cannot be shared as is)