### PR TITLE
[Inpainting] Added single channel mask support

### DIFF
--- a/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
@@ -67,7 +67,14 @@ public:
         return compile(device, ov::AnyMap{std::forward<Properties>(properties)...});
     }
 
-    // Returns a tensor with the following dimensions [num_images_per_prompt, height, width, 3]
+    /**
+     * Peforms initial image editing conditioned on a text prompt.
+     * @param positive_prompt Prompt to generate image(s) from
+     * @param initial_image RGB/BGR image of [1, height, width, 3] shape used to initialize latent image
+     * @param properties Image generation parameters specified as properties. Values in 'properties' override default value for generation parameters.
+     * @returns A tensor which has dimensions [num_images_per_prompt, height, width, 3]
+     * @note Output image size is the same as initial image size, but rounded down to be divisible by VAE scale factor (usually, 8)
+     */
     ov::Tensor generate(const std::string& positive_prompt, ov::Tensor initial_image, const ov::AnyMap& properties = {});
 
     template <typename... Properties>

--- a/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
@@ -89,7 +89,14 @@ public:
         return compile(device, ov::AnyMap{std::forward<Properties>(properties)...});
     }
 
-    // Returns a tensor with the following dimensions [num_images_per_prompt, height, width, 3]
+    /**
+     * Inpaints an initial image within an area defined by mask and conditioned on prompt
+     * @param positive_prompt Prompt to generate image(s) from
+     * @param initial_image RGB/BGR image of [1, height, width, 3] shape used to initialize latent image
+     * @param mask_image RGB/BGR or GRAY/BINARY image of [1, height, width, 3 or 1] shape used as a mask
+     * @param properties Image generation parameters specified as properties. Values in 'properties' override default value for generation parameters.
+     * @returns A tensor which has dimensions [num_images_per_prompt, height, width, 3]
+     */
     ov::Tensor generate(const std::string& positive_prompt, ov::Tensor initial_image, ov::Tensor mask_image, const ov::AnyMap& properties = {});
 
     template <typename... Properties>

--- a/src/cpp/include/openvino/genai/image_generation/text2image_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/text2image_pipeline.hpp
@@ -200,7 +200,7 @@ public:
     }
 
     /**
-     * Generates image(s) based on prompt and other image generarion parameters
+     * Generates image(s) based on prompt and other image generation parameters
      * @param positive_prompt Prompt to generate image(s) from
      * @param properties Image generation parameters specified as properties. Values in 'properties' override default value for generation parameters.
      * @returns A tensor which has dimensions [num_images_per_prompt, height, width, 3]

--- a/src/cpp/src/image_generation/image_processor.hpp
+++ b/src/cpp/src/image_generation/image_processor.hpp
@@ -28,9 +28,9 @@ protected:
 
 class ImageProcessor : public IImageProcessor {
 public:
-    explicit ImageProcessor(const std::string& device, bool do_normalize = true, bool do_binarize = false);
+    explicit ImageProcessor(const std::string& device, bool do_normalize = true, bool do_binarize = false, bool gray_scale_source = false);
 
-    static void merge_image_preprocessing(std::shared_ptr<ov::Model> model, bool do_normalize = true, bool do_binarize = false);
+    static void merge_image_preprocessing(std::shared_ptr<ov::Model> model, bool do_normalize = true, bool do_binarize = false, bool gray_scale_source = false);
 };
 
 class ImageResizer {

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -33,14 +33,15 @@ public:
         const std::string device = "CPU";
 
         if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
-            const bool do_normalize = true, do_binarize = false;
-            m_image_processor = std::make_shared<ImageProcessor>(device, do_normalize, do_binarize);
+            const bool do_normalize = true, do_binarize = false, gray_scale_source = false;
+            m_image_processor = std::make_shared<ImageProcessor>(device, do_normalize, do_binarize, gray_scale_source);
             m_image_resizer = std::make_shared<ImageResizer>(device, ov::element::u8, "NHWC", ov::op::v11::Interpolate::InterpolateMode::BICUBIC_PILLOW);
         }
 
         if (m_pipeline_type == PipelineType::INPAINTING) {
-            const bool do_normalize = false, do_binarize = true;
-            m_mask_processor = std::make_shared<ImageProcessor>(device, do_normalize, do_binarize);
+            bool do_normalize = false, do_binarize = true;
+            m_mask_processor_rgb = std::make_shared<ImageProcessor>(device, do_normalize, do_binarize, false);
+            m_mask_processor_gray = std::make_shared<ImageProcessor>(device, do_normalize, do_binarize, true);
             m_mask_resizer = std::make_shared<ImageResizer>(device, ov::element::f32, "NCHW", ov::op::v11::Interpolate::InterpolateMode::NEAREST);
         }
     }
@@ -267,7 +268,8 @@ public:
         ov::Shape target_shape = processed_image.get_shape();
 
         ov::Tensor mask_condition = m_image_resizer->execute(mask_image, target_shape[2], target_shape[3]);
-        mask_condition = m_mask_processor->execute(mask_condition);
+        std::shared_ptr<IImageProcessor> mask_processor = mask_condition.get_shape()[3] == 1 ? m_mask_processor_gray : m_mask_processor_rgb;
+        mask_condition = mask_processor->execute(mask_condition);
 
         // resize mask to shape of latent space
         ov::Tensor mask = m_mask_resizer->execute(mask_condition, target_shape[2] / vae_scale_factor, target_shape[3] / vae_scale_factor);
@@ -501,7 +503,7 @@ protected:
     std::shared_ptr<CLIPTextModel> m_clip_text_encoder = nullptr;
     std::shared_ptr<UNet2DConditionModel> m_unet = nullptr;
     std::shared_ptr<AutoencoderKL> m_vae = nullptr;
-    std::shared_ptr<IImageProcessor> m_image_processor = nullptr, m_mask_processor = nullptr;
+    std::shared_ptr<IImageProcessor> m_image_processor = nullptr, m_mask_processor_rgb = nullptr, m_mask_processor_gray = nullptr;
     std::shared_ptr<ImageResizer> m_image_resizer = nullptr, m_mask_resizer = nullptr;
 };
 


### PR DESCRIPTION
Current PR brings a single channel masks support (both GRAY and BINARY; GRAY is converted in BINARY anyway within mask image processor)
Based on passed mask type, we dynamically select proper mask processor and convert all mask images types to BINARY.

CVS-159222