### PR TITLE
llm_pipeline_static: flush streamer after generation loop is complete…

### DIFF
--- a/src/cpp/src/llm_pipeline_static.cpp
+++ b/src/cpp/src/llm_pipeline_static.cpp
@@ -1102,6 +1102,11 @@ EncodedResults StaticLLMPipeline::generate(
             m_kvcache_request.get_tensor(output_name).copy_to(kvcache_in_slice);
         }
     }
+
+    if (streamer_ptr) {
+        streamer_ptr->end();
+    }
+
     auto stop_time = std::chrono::steady_clock::now();
     // If is called without tokenization then that stat will not be reported.
     auto& metrics = results.perf_metrics;


### PR DESCRIPTION
… (#1350)

Without these changes, chat_sample with NPU device produces responses that are clipped by 4 characters:

![image](https://github.com/user-attachments/assets/e841bf36-948b-4899-820f-6b52460076e9)

Flushing the streamer (as
[get_lm_encoded_results()](https://github.com/openvinotoolkit/openvino.genai/blob/71ea7aae7357fa0bb21a5161ef078bef8ce7af7c/src/cpp/src/lm_encoding.cpp#L224) does in non-static LLM cases) seems to resolve the issue.