### PR TITLE
remove redundant `.tolist()`

### DIFF
--- a/tools/llm_bench/task/text_generation.py
+++ b/tools/llm_bench/task/text_generation.py
@@ -301,7 +301,7 @@ def run_text_generation_genai(input_text, num, model, tokenizer, args, iter_data
         - np.array(perf_metrics.raw_metrics.m_new_token_times[:-1])
     ).tolist()
 
-    tm_list = np.array([first_token_time] + second_tokens_durations) / 1000
+    tm_list = (np.array([first_token_time] + second_tokens_durations) / 1000).tolist()
     inference_durations = (np.array(perf_metrics.raw_metrics.token_infer_durations) / 1000 / 1000).tolist()
     log.debug('latency of all tokens:')
     [log.debug('[{}]{:.4f}'.format(idx, tm)) for idx, tm in enumerate(tm_list)]
@@ -323,7 +323,7 @@ def run_text_generation_genai(input_text, num, model, tokenizer, args, iter_data
     metrics_print.print_metrics(
         num,
         iter_data,
-        tm_list.tolist(),
+        tm_list,
         inference_durations,
         warm_up=(num == 0),
         max_rss_mem=max_rss_mem_consumption,

--- a/tools/llm_bench/task/text_generation.py
+++ b/tools/llm_bench/task/text_generation.py
@@ -324,7 +324,7 @@ def run_text_generation_genai(input_text, num, model, tokenizer, args, iter_data
         num,
         iter_data,
         tm_list.tolist(),
-        inference_durations.tolist(),
+        inference_durations,
         warm_up=(num == 0),
         max_rss_mem=max_rss_mem_consumption,
         max_shared_mem=max_shared_mem_consumption,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/77013e49-d1bd-4f3a-99aa-1d17e9b8f6b5)


- To fix remove redundant `.tolist()` since it was already done above.

