### PR TITLE
Fix compile warnings in tokenizer.cpp

### DIFF
--- a/src/cpp/src/tokenizer.cpp
+++ b/src/cpp/src/tokenizer.cpp
@@ -235,7 +235,7 @@ public:
         // Initialize tokenizer's cache to save time later.
         if (m_tokenizer) {
             // TODO CVS-150630: Empty strings sporadically can fail, therefore use nonempty string for warmup.
-            encode("non empty string").input_ids;
+            encode("non empty string");
         }
         if (m_detokenizer) {
             decode({1, 33, 199, 42, 42});


### PR DESCRIPTION
```
  /Users/runner/work/openvino.genai/openvino.genai/src/cpp/src/tokenizer.cpp:238:40: warning: expression result unused [-Wunused-value]
              encode("non empty string").input_ids;
```