### PR TITLE
[Python API] Clean up utils

### DIFF
--- a/src/python/py_llm_pipeline.cpp
+++ b/src/python/py_llm_pipeline.cpp
@@ -71,7 +71,7 @@ py::object call_common_generate(
         DecodedResults res = pipe.generate(string_input, updated_config, streamer);
         // If input was a string return a single string otherwise return DecodedResults.
         if (updated_config.has_value() && (*updated_config).num_return_sequences == 1) {
-            results = py::cast<py::object>(pyutils::handle_utf8(res.texts)[0]);
+            results = py::cast<py::object>(pyutils::handle_utf8(res.texts[0]));
         } else {
             results = py::cast(res);
         }

--- a/src/python/py_utils.cpp
+++ b/src/python/py_utils.cpp
@@ -37,6 +37,8 @@ py::list handle_utf8(const std::vector<std::string>& decoded_res) {
     return res;
 }
 
+namespace {
+
 bool py_object_is_any_map(const py::object& py_obj) {
     if (!py::isinstance<py::dict>(py_obj)) {
         return false;
@@ -290,14 +292,15 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
     OPENVINO_THROW("Property \"" + property_name + "\" got unsupported type.");
 }
 
-std::map<std::string, ov::Any> properties_to_any_map(const std::map<std::string, py::object>& properties) {
+} // namespace
+
+ov::AnyMap properties_to_any_map(const std::map<std::string, py::object>& properties) {
     std::map<std::string, ov::Any> properties_to_cpp;
     for (const auto& property : properties) {
         properties_to_cpp[property.first] = py_object_to_any(property.second, property.first);
     }
     return properties_to_cpp;
 }
-
 
 ov::AnyMap kwargs_to_any_map(const py::kwargs& kwargs) {
     ov::AnyMap params = {};
@@ -356,7 +359,7 @@ ov::genai::OptionalGenerationConfig update_config_from_kwargs(const ov::genai::O
         return std::nullopt;
 
     ov::genai::GenerationConfig res_config;
-    if(config.has_value())
+    if (config.has_value())
         res_config = *config;
 
     if (!kwargs.empty())

--- a/src/python/py_utils.hpp
+++ b/src/python/py_utils.hpp
@@ -28,13 +28,7 @@ py::list handle_utf8(const std::vector<std::string>& decoded_res);
 
 py::str handle_utf8(const std::string& text);
 
-ov::Any py_object_to_any(const py::object& py_obj, std::string property_name);
-
-bool py_object_is_any_map(const py::object& py_obj);
-
-ov::AnyMap py_object_to_any_map(const py::object& py_obj);
-
-std::map<std::string, ov::Any> properties_to_any_map(const std::map<std::string, py::object>& properties);
+ov::AnyMap properties_to_any_map(const std::map<std::string, py::object>& properties);
 
 ov::AnyMap kwargs_to_any_map(const py::kwargs& kwargs);
 


### PR DESCRIPTION
Hide non-used functions from `src/python/py_utils.hpp`