### PR TITLE
Update VLM example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ from PIL import Image
 
 # Choose GPU instead of CPU in the line below to run the model on Intel integrated or discrete GPU
 pipe = ov_genai.VLMPipeline("./InternVL2-1B", "CPU")
+pipe.start_chat()
 
 image = Image.open("dog.jpg")
 image_data = np.array(image.getdata()).reshape(1, image.size[1], image.size[0], 3).astype(np.uint8)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ image_data = np.array(image.getdata()).reshape(1, image.size[1], image.size[0], 
 image_data = ov.Tensor(image_data)  
 
 prompt = "Can you describe the image?"
-print(pipe.generate(prompt, image=image_data, max_new_tokens=100))
+result = pipe.generate(prompt, image=image_data, max_new_tokens=100)
+print(result.texts[0])
 ```
 
 ### Run generation using VLMPipeline in C++


### PR DESCRIPTION
Add `pipe.start_chat()` to VLM example. Without this, inference with several models results in empty outputs.

This can be removed if this will be the default for VLM models, but at the moment, the most basic example should work with supported models.

Also changed printing the VLMDecodedResults to getting the generated text and printing that (see comment from Ilya).