### PR TITLE
Add MSVC Support For UTF-8 in Chat Sample

### DIFF
--- a/samples/cpp/chat_sample/CMakeLists.txt
+++ b/samples/cpp/chat_sample/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(OpenVINOGenAI REQUIRED
     NO_CMAKE_FIND_ROOT_PATH
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Specifies both the source character set and the execution character set as UTF-8.
+    # For details, refer to link: https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 add_executable(chat_sample chat_sample.cpp)
 target_link_libraries(chat_sample PRIVATE openvino::genai)
 set_target_properties(chat_sample PROPERTIES

--- a/samples/cpp/chat_sample/CMakeLists.txt
+++ b/samples/cpp/chat_sample/CMakeLists.txt
@@ -12,6 +12,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Specifies both the source character set and the execution character set as UTF-8.
     # For details, refer to link: https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif()
 
 add_executable(chat_sample chat_sample.cpp)
 target_link_libraries(chat_sample PRIVATE openvino::genai)

--- a/samples/cpp/chat_sample/CMakeLists.txt
+++ b/samples/cpp/chat_sample/CMakeLists.txt
@@ -8,12 +8,6 @@ find_package(OpenVINOGenAI REQUIRED
     NO_CMAKE_FIND_ROOT_PATH
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Specifies both the source character set and the execution character set as UTF-8.
-    # For details, refer to link: https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-endif()
-
 add_executable(chat_sample chat_sample.cpp)
 target_link_libraries(chat_sample PRIVATE openvino::genai)
 set_target_properties(chat_sample PROPERTIES

--- a/samples/cpp/chat_sample/chat_sample.cpp
+++ b/samples/cpp/chat_sample/chat_sample.cpp
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "openvino/genai/llm_pipeline.hpp"
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
 int main(int argc, char* argv[]) try {
+    #ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    system("chcp 65001"); //Using UTF-8 Encoding
+    #endif
     if (2 != argc) {
         throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR>");
     }


### PR DESCRIPTION
- Specifies both the source character set and the execution character set as UTF-8.
- Avoid garbled text during Chinese character to UTF-8 conversion.