### PR TITLE
Replace 'CACHE_DIR' with 'NPUW_CACHE_DIR' in StatefulLLMPipeline

### DIFF
--- a/src/cpp/src/llm_pipeline_static.cpp
+++ b/src/cpp/src/llm_pipeline_static.cpp
@@ -739,7 +739,10 @@ std::shared_ptr<ov::CompiledModel> StatefulLLMPipeline::setupAndCompileModel(
 
     rename_key(pipeline_config, "PREFILL_CONFIG", "NPUW_LLM_PREFILL_CONFIG");
     rename_key(pipeline_config, "GENERATE_CONFIG", "NPUW_LLM_GENERATE_CONFIG");
-  
+
+    // Replace CACHE_DIR option if NPUW is enabled
+    set_npuw_cache_dir(pipeline_config);
+
     return std::make_shared<ov::CompiledModel>(genai::utils::singleton_core().compile_model(model, "NPU", pipeline_config));
 }
 


### PR DESCRIPTION
Handle `CACHE_DIR` in `StatefulLLMPipeline` the same way as in `StatelessLLMPipeline` 