### PR TITLE
Fixed streamer without corrupting hieroglyphs

### DIFF
--- a/samples/python/text_generation/multinomial_causal_lm.py
+++ b/samples/python/text_generation/multinomial_causal_lm.py
@@ -135,6 +135,7 @@ class ChunkStreamer(IterableStreamer):
     def put(self, token_id: int) -> bool:
         if (len(self.tokens_cache) + 1) % self.tokens_len != 0:
             self.tokens_cache.append(token_id)
+            self.decoded_lengths.append(-1)
             return False
         return super().put(token_id)
 

--- a/src/cpp/src/text_callback_streamer.cpp
+++ b/src/cpp/src/text_callback_streamer.cpp
@@ -15,23 +15,36 @@ bool TextCallbackStreamer::put(int64_t token) {
     std::stringstream res;
     m_tokens_cache.push_back(token);
     std::string text = m_tokenizer.decode(m_tokens_cache);
-    if (!text.empty() && '\n' == text.back() && text.size() > print_len) {
+    m_decoded_lengths.push_back(text.length());
+    
+    if (!text.empty() && '\n' == text.back() && text.size() > m_printed_len) {
         // Flush the cache after the new line symbol
-        res << std::string_view{text.data() + print_len, text.size() - print_len};
+        res << std::string_view{text.data() + m_printed_len, text.size() - m_printed_len};
         m_tokens_cache.clear();
-        print_len = 0;
+        m_decoded_lengths.clear();
+        m_printed_len = 0;
         return on_finalized_subword_callback(res.str());
     }
 
+    constexpr size_t delay_n_tokens = 3;
+    auto print_until = m_decoded_lengths[m_decoded_lengths.size() - delay_n_tokens];
     constexpr char replacement[] = "\xef\xbf\xbd";  // MSVC with /utf-8 fails to compile � directly with newline in string literal error.
     if (text.size() >= 3 && text.compare(text.size() - 3, 3, replacement) == 0) {
+        m_decoded_lengths[m_decoded_lengths.size() - 1] = -1;
         // Don't print incomplete text
         return on_finalized_subword_callback(res.str());
-    } else if (text.size() > print_len) {
+    } 
+    // In some cases adding the next token can shorten the text, 
+    // e.g. when apostrophe removing regex had worked after adding new tokens.
+    // Printing several last tokens is delayed.
+    if (m_tokens_cache.size() < delay_n_tokens) {
+        return on_finalized_subword_callback(res.str());
+    }
+    if (print_until != -1 && print_until > m_printed_len) {
         // It is possible to have a shorter text after adding new token.
         // Print to output only if text length is increaesed.
-        res << std::string_view{text.data() + print_len, text.size() - print_len} << std::flush;
-        print_len = text.size();
+        res << std::string_view{text.data() + m_printed_len, print_until - m_printed_len} << std::flush;
+        m_printed_len = print_until;
     }
 
     return on_finalized_subword_callback(res.str());
@@ -40,11 +53,12 @@ bool TextCallbackStreamer::put(int64_t token) {
 void TextCallbackStreamer::end() {
     std::stringstream res;
     std::string text = m_tokenizer.decode(m_tokens_cache);
-    if (text.size() <= print_len)
-        return ;
-    res << std::string_view{text.data() + print_len, text.size() - print_len} << std::flush;
+    if (text.size() <= m_printed_len)
+        return;
+    res << std::string_view{text.data() + m_printed_len, text.size() - m_printed_len} << std::flush;
     m_tokens_cache.clear();
-    print_len = 0;
+    m_decoded_lengths.clear();
+    m_printed_len = 0;
     on_finalized_subword_callback(res.str());
     return;
 }

--- a/src/cpp/src/text_callback_streamer.cpp
+++ b/src/cpp/src/text_callback_streamer.cpp
@@ -27,19 +27,19 @@ bool TextCallbackStreamer::put(int64_t token) {
     }
 
     constexpr size_t delay_n_tokens = 3;
-    auto print_until = m_decoded_lengths[m_decoded_lengths.size() - delay_n_tokens];
+    // In some cases adding the next token can shorten the text, 
+    // e.g. when apostrophe removing regex had worked after adding new tokens.
+    // Printing several last tokens is delayed.
+    if (m_decoded_lengths.size() < delay_n_tokens) {
+        return on_finalized_subword_callback(res.str());
+    }
     constexpr char replacement[] = "\xef\xbf\xbd";  // MSVC with /utf-8 fails to compile � directly with newline in string literal error.
     if (text.size() >= 3 && text.compare(text.size() - 3, 3, replacement) == 0) {
         m_decoded_lengths[m_decoded_lengths.size() - 1] = -1;
         // Don't print incomplete text
         return on_finalized_subword_callback(res.str());
-    } 
-    // In some cases adding the next token can shorten the text, 
-    // e.g. when apostrophe removing regex had worked after adding new tokens.
-    // Printing several last tokens is delayed.
-    if (m_tokens_cache.size() < delay_n_tokens) {
-        return on_finalized_subword_callback(res.str());
     }
+    auto print_until = m_decoded_lengths[m_decoded_lengths.size() - delay_n_tokens];
     if (print_until != -1 && print_until > m_printed_len) {
         // It is possible to have a shorter text after adding new token.
         // Print to output only if text length is increaesed.

--- a/src/cpp/src/text_callback_streamer.hpp
+++ b/src/cpp/src/text_callback_streamer.hpp
@@ -21,7 +21,8 @@ public:
 protected:
     Tokenizer m_tokenizer;
     std::vector<int64_t> m_tokens_cache;
-    size_t print_len = 0;
+    std::vector<int64_t> m_decoded_lengths;
+    size_t m_printed_len = 0;
 };
 
 }  // namespace genai

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -474,3 +474,22 @@ def get_image_by_link(link):
         image = image.convert('RGB')
     image_data = np.array((np.array(image.getdata()) - 128).astype(np.byte)).reshape(1, 3, image.size[1], image.size[0])
     return Tensor(image_data)
+
+def get_streamer_with_results():
+    # Return a streamer which accumulates results in order to compare with results returned from generate.
+    class StreamerWithResults:
+        results: List[str] = []
+        def __init__(self):
+            self.results = []
+
+        def accumulate(self, subword) -> bool:
+            self.results.append(subword)
+            return False
+        
+        def get_result_str(self) -> str:
+            return ''.join(self.results)
+        
+        def reset(self):
+            self.results = []
+
+    return StreamerWithResults()

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -335,8 +335,10 @@ class StreamerWithResults:
         self.results.append(subword)
         return False
     
-    def get_result_str(self) -> str:
-        return ''.join(self.results)
+    def get_results(self) -> List[GenerationResult]:
+        streaming_result = GenerationResult()
+        streaming_result.m_generation_ids = [''.join(self.results)]
+        return [streaming_result]
     
     def reset(self):
         self.results = []

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -453,7 +453,7 @@ def run_llm_pipeline_with_ref(model_id: str,
     ov_results = run_llm_pipeline(models_path, prompts, generation_config, use_cb, streamer=streamer.accumulate if isinstance(streamer, StreamerWithResults) else streamer)
     hf_results = run_hugging_face(opt_model, hf_tokenizer, prompts, generation_config)
     if (isinstance(streamer, StreamerWithResults)):
-        compare_generation_results(prompts, ov_results, streamer.s(), generation_config)
+        compare_generation_results(prompts, ov_results, streamer.get_results(), generation_config)
 
     compare_generation_results(prompts, hf_results, ov_results, generation_config)
 

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -440,6 +440,27 @@ def convert_models(opt_model : OVModelForCausalLM, hf_tokenizer : AutoTokenizer,
     serialize(detokenizer, models_path / "openvino_detokenizer.xml")
 
 
+def run_llm_pipeline_with_streamer(model_id: str, 
+                                   prompts: List[str], 
+                                   generation_config: GenerationConfig | dict, 
+                                   tmp_path: Path, 
+                                   streamer: StreamerWithResults,
+                                   use_cb : bool = False):
+    models_path : Path = tmp_path / model_id
+
+    opt_model, hf_tokenizer = get_hugging_face_models(model_id)
+    if type(generation_config) is dict:
+        generation_config = GenerationConfig(**generation_config)
+
+    convert_models(opt_model, hf_tokenizer, models_path)
+
+    results = run_llm_pipeline(models_path=models_path, 
+                               prompts=prompts, generation_config=generation_config, 
+                               streamer=streamer,
+                               use_cb=use_cb)
+    compare_generation_results(prompts, results, streamer.get_results(), generation_config)
+    
+
 def run_llm_pipeline_with_ref(model_id: str, prompts: List[str], generation_config: GenerationConfig | dict, tmp_path: Path, use_cb : bool = False):
     models_path : Path = tmp_path / model_id
     opt_model, hf_tokenizer = get_hugging_face_models(model_id)

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -447,12 +447,11 @@ def run_llm_pipeline_with_ref(model_id: str,
     if streamer is None and not (generation_config.is_beam_search() or generation_config.num_return_sequences > 1) and len(prompts) == 1:
         # We can use streamer only if we have a single prompt and not beam search.
         streamer = StreamerWithResults()
-
-    convert_models(opt_model, hf_tokenizer, models_path)
-
     if isinstance(streamer, StreamerWithResults):
         # Clear the accumulated strings to avoid side effects
         streamer.reset()
+
+    convert_models(opt_model, hf_tokenizer, models_path)
 
     ov_results = run_llm_pipeline(models_path, prompts, generation_config, use_cb, streamer=streamer.accumulate if isinstance(streamer, StreamerWithResults) else streamer)
     hf_results = run_hugging_face(opt_model, hf_tokenizer, prompts, generation_config)

--- a/tests/python_tests/common.py
+++ b/tests/python_tests/common.py
@@ -444,7 +444,7 @@ def run_llm_pipeline_with_ref(model_id: str,
     if type(generation_config) is dict:
         generation_config = GenerationConfig(**generation_config)
 
-    if streamer is None and (not generation_config.is_beam_search()) and len(prompts) == 1:
+    if streamer is None and not (generation_config.is_beam_search() or generation_config.num_return_sequences > 1) and len(prompts) == 1:
         # We can use streamer only if we have a single prompt and not beam search.
         streamer = StreamerWithResults()
 

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 import torch
 
-from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline, StreamerWithResults
+from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline, compare_generation_results, StreamerWithResults
 from ov_genai_test_utils import (
     get_models_list,
     read_model,
@@ -215,8 +215,7 @@ def test_streamer_compare_texts(model_descr, generation_config_dict, prompt, str
                                prompts=[prompt], generation_config=GenerationConfig(**generation_config_dict), 
                                streamer=streamer,
                                use_cb=use_cb)
-    for res in results:
-        assert res.m_generation_ids[0] == streamer.get_result_str()
+    compare_generation_results([prompt], results, streamer.get_results(), GenerationConfig(**generation_config_dict))
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -387,7 +387,7 @@ def test_unicode_pybind_decoding_one_string_streamer():
     ov_pipe = read_model((model_id, path))[4]
     res_str = []
     ov_pipe.generate(",", max_new_tokens=4, streamer=lambda x: res_str.append(x))
-    assert '�' == res_str[-1]
+    assert '�' == ''.join(res_str)[-1]
 
 #
 # Perf metrics

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 import torch
 
-from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline, compare_generation_results, StreamerWithResults
+from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline_with_streamer, StreamerWithResults
 from ov_genai_test_utils import (
     get_models_list,
     read_model,
@@ -201,21 +201,18 @@ def test_callback_kwargs_one_string(callback):
     '你好！ 你好嗎？'
     'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
 ])
-@pytest.mark.parametrize("generation_config_dict", [dict(max_new_tokens=10), dict(max_new_tokens=300)])
+@pytest.mark.parametrize("generation_config", [dict(max_new_tokens=10), dict(max_new_tokens=300)])
 @pytest.mark.parametrize("model_descr", get_models_list())
 @pytest.mark.parametrize("use_cb", [True, False])
 @pytest.mark.precommit
 @pytest.mark.nightly
-def test_streamer_compare_texts(model_descr, generation_config_dict, prompt, streamer, use_cb):
-    model_id = model_descr[0]
-    tmp_path = model_descr[1]
-    model_path : Path = tmp_path / model_id
-
-    results = run_llm_pipeline(models_path=model_path, 
-                               prompts=[prompt], generation_config=GenerationConfig(**generation_config_dict), 
-                               streamer=streamer,
-                               use_cb=use_cb)
-    compare_generation_results([prompt], results, streamer.get_results(), GenerationConfig(**generation_config_dict))
+def test_streamer_compare_texts(model_descr, generation_config, prompt, streamer, use_cb):
+    run_llm_pipeline_with_streamer(model_id=model_descr[0], 
+                                   prompts=[prompt], 
+                                   generation_config=generation_config, 
+                                   tmp_path=model_descr[1],
+                                   streamer=streamer,
+                                   use_cb=use_cb)
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 import torch
 
-from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline_with_streamer, StreamerWithResults
+from common import run_llm_pipeline_with_ref, convert_to_hf, StreamerWithResults
 from ov_genai_test_utils import (
     get_models_list,
     read_model,
@@ -207,12 +207,12 @@ def test_callback_kwargs_one_string(callback):
 @pytest.mark.precommit
 @pytest.mark.nightly
 def test_streamer_compare_texts(model_descr, generation_config, prompt, streamer, use_cb):
-    run_llm_pipeline_with_streamer(model_id=model_descr[0], 
-                                   prompts=[prompt], 
-                                   generation_config=generation_config, 
-                                   tmp_path=model_descr[1],
-                                   streamer=streamer,
-                                   use_cb=use_cb)
+    run_llm_pipeline_with_ref(model_id=model_descr[0], 
+                              prompts=[prompt], 
+                              generation_config=generation_config, 
+                              tmp_path=model_descr[1],
+                              use_cb=use_cb,
+                              streamer=streamer)
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -203,14 +203,18 @@ def test_callback_kwargs_one_string(callback):
 ])
 @pytest.mark.parametrize("generation_config_dict", [dict(max_new_tokens=10), dict(max_new_tokens=300)])
 @pytest.mark.parametrize("model_descr", get_models_list())
+@pytest.mark.parametrize("use_cb", [True, False])
 @pytest.mark.precommit
 @pytest.mark.nightly
-def test_streamer_compare_texts(model_descr, generation_config_dict, prompt, streamer):
+def test_streamer_compare_texts(model_descr, generation_config_dict, prompt, streamer, use_cb):
     model_id = model_descr[0]
     tmp_path = model_descr[1]
     model_path : Path = tmp_path / model_id
 
-    results = run_llm_pipeline(models_path=model_path, prompts=[prompt], generation_config=GenerationConfig(**generation_config_dict), streamer=streamer)
+    results = run_llm_pipeline(models_path=model_path, 
+                               prompts=[prompt], generation_config=GenerationConfig(**generation_config_dict), 
+                               streamer=streamer,
+                               use_cb=use_cb)
     for res in results:
         assert res.m_generation_ids[0] == streamer.get_result_str()
 

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 import torch
 
-from common import run_llm_pipeline_with_ref, convert_to_hf, StreamerWithResults
+from common import run_llm_pipeline_with_ref, convert_to_hf
 from ov_genai_test_utils import (
     get_models_list,
     read_model,
@@ -192,27 +192,6 @@ def test_callback_batch_throws(callback):
 def test_callback_kwargs_one_string(callback):
     pipe = read_model(get_models_list()[0])[4]
     pipe.generate('table is made of', max_new_tokens=10, streamer=callback)
-
-
-@pytest.mark.parametrize("streamer", [StreamerWithResults()])
-@pytest.mark.parametrize("prompt", [
-    'table is made of', 
-    'The Sun is yellow because', 
-    '你好！ 你好嗎？'
-    'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
-])
-@pytest.mark.parametrize("generation_config", [dict(max_new_tokens=10), dict(max_new_tokens=300)])
-@pytest.mark.parametrize("model_descr", get_models_list())
-@pytest.mark.parametrize("use_cb", [True, False])
-@pytest.mark.precommit
-@pytest.mark.nightly
-def test_streamer_compare_texts(model_descr, generation_config, prompt, streamer, use_cb):
-    run_llm_pipeline_with_ref(model_id=model_descr[0], 
-                              prompts=[prompt], 
-                              generation_config=generation_config, 
-                              tmp_path=model_descr[1],
-                              use_cb=use_cb,
-                              streamer=streamer)
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 import torch
 
-from common import run_llm_pipeline_with_ref, convert_to_hf, get_streamer_with_results
+from common import run_llm_pipeline_with_ref, convert_to_hf, run_llm_pipeline, StreamerWithResults
 from ov_genai_test_utils import (
     get_models_list,
     read_model,
@@ -194,15 +194,25 @@ def test_callback_kwargs_one_string(callback):
     pipe.generate('table is made of', max_new_tokens=10, streamer=callback)
 
 
-@pytest.mark.parametrize("streamer", [get_streamer_with_results()])
-@pytest.mark.parametrize("prompt", ['table is made of', 'The Sun is yellow because', '你好！ 你好嗎？'])
+@pytest.mark.parametrize("streamer", [StreamerWithResults()])
+@pytest.mark.parametrize("prompt", [
+    'table is made of', 
+    'The Sun is yellow because', 
+    '你好！ 你好嗎？'
+    'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
+])
+@pytest.mark.parametrize("generation_config_dict", [dict(max_new_tokens=10), dict(max_new_tokens=300)])
+@pytest.mark.parametrize("model_descr", get_models_list())
 @pytest.mark.precommit
 @pytest.mark.nightly
-def test_callback_kwargs_one_string(prompt, streamer):
-    pipe = read_model(get_models_list()[0])[4]
-    streamer.reset()
-    res = pipe.generate(prompt, max_new_tokens=10, streamer=streamer.accumulate)
-    assert res == streamer.get_result_str()
+def test_streamer_compare_texts(model_descr, generation_config_dict, prompt, streamer):
+    model_id = model_descr[0]
+    tmp_path = model_descr[1]
+    model_path : Path = tmp_path / model_id
+
+    results = run_llm_pipeline(models_path=model_path, prompts=[prompt], generation_config=GenerationConfig(**generation_config_dict), streamer=streamer)
+    for res in results:
+        assert res.m_generation_ids[0] == streamer.get_result_str()
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])
@@ -217,21 +227,6 @@ def test_callback_decoding_metallama(model_descr, callback):
         pytest.skip()
     ov_pipe = read_model(model_descr)[4]
     ov_pipe.generate(prompt, max_new_tokens=300, streamer=callback)
-
-@pytest.mark.parametrize("streamer", [get_streamer_with_results()])
-@pytest.mark.precommit
-@pytest.mark.nightly
-@pytest.mark.parametrize("model_descr", get_models_list())
-def test_callback_decoding_metallama_with_accumlation(model_descr, streamer):
-    # On metallama this prompt generates output which can shorten after adding new tokens.
-    # Test that streamer correctly handles such cases.
-    prompt = 'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
-    if model_descr[0] != 'meta-llama/Meta-Llama-3-8B-Instruct':
-        pytest.skip()
-    ov_pipe = read_model(model_descr)[4]
-    streamer.reset()
-    res = ov_pipe.generate(prompt, max_new_tokens=300, streamer=streamer.accumulate)
-    assert res == streamer.get_result_str()
 
 
 @pytest.mark.parametrize("callback", [print, user_defined_callback, lambda subword: print(subword)])

--- a/tests/python_tests/test_sampling.py
+++ b/tests/python_tests/test_sampling.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from openvino_genai import GenerationConfig, StopCriteria
 from typing import List, TypedDict
 
-from common import get_hugging_face_models, convert_models, run_llm_pipeline_with_ref, run_llm_pipeline
+from common import get_hugging_face_models, convert_models, run_llm_pipeline_with_ref, run_llm_pipeline, StreamerWithResults
 
 
 @pytest.mark.precommit
@@ -58,13 +58,26 @@ def test_stop_strings(tmp_path, generation_config):
 @pytest.mark.precommit
 @pytest.mark.parametrize("generation_config",
                          [dict(max_new_tokens=30),
-                          dict(max_new_tokens=30, repetition_penalty=2.0),],
-                         ids=["basic",
-                              "repetition_penalty",])
-def test_greedy(tmp_path, generation_config):
-    prompts = [ "What is OpenVINO?" ]
+                          dict(max_new_tokens=30, repetition_penalty=2.0),
+                          dict(max_new_tokens=300)],
+                         ids=["basic", "repetition_penalty", "long_max_new_tokens"])
+@pytest.mark.parametrize("streamer", [StreamerWithResults()])
+@pytest.mark.parametrize("prompt", [
+    'What is OpenVINO?',
+    'table is made of', 
+    'The Sun is yellow because', 
+    '你好！ 你好嗎？'
+    'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
+])
+@pytest.mark.parametrize("use_cb", [True, False])
+def test_greedy(tmp_path, generation_config, prompt, streamer, use_cb):
     model_id : str = "katuni4ka/tiny-random-phi3"
-    run_llm_pipeline_with_ref(model_id, prompts, generation_config, tmp_path)
+    run_llm_pipeline_with_ref(model_id=model_id, 
+                            prompts=[prompt], 
+                            generation_config=generation_config, 
+                            tmp_path=tmp_path,
+                            use_cb=use_cb,
+                            streamer=streamer)
 
 
 @pytest.mark.precommit

--- a/tests/python_tests/test_sampling.py
+++ b/tests/python_tests/test_sampling.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from openvino_genai import GenerationConfig, StopCriteria
 from typing import List, TypedDict
 
-from common import get_hugging_face_models, convert_models, run_llm_pipeline_with_ref, run_llm_pipeline, StreamerWithResults
+from common import get_hugging_face_models, convert_models, run_llm_pipeline_with_ref, run_llm_pipeline, compare_generation_results, StreamerWithResults
 
 
 @pytest.mark.precommit
@@ -332,6 +332,10 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     prompts = test_struct.prompts
     generation_config.rng_seed = 0
     generation_configs = generation_config
+
+    # We can use streamer only if we have a single batch
+    streamer = StreamerWithResults() if len(prompts) == 1 else None
+
     model_id : str = "facebook/opt-125m"
     model, hf_tokenizer = get_hugging_face_models(model_id)
 
@@ -339,7 +343,10 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     convert_models(model, hf_tokenizer, models_path)
 
     # run multinomial without comparison with reference
-    _ = run_llm_pipeline(models_path, prompts, generation_configs)
+    ov_results = run_llm_pipeline(models_path, prompts, generation_configs, streamer=streamer.accumulate if streamer is not None else None)
+
+    if streamer is not None:
+        compare_generation_results(prompts, ov_results, streamer.get_results(), generation_config)
 
     # Reference comparison is not performed as sampling results are non-deterministic.
     # Discrete_distribution impl depends on platform, model inference results may depend on CPU.

--- a/tests/python_tests/test_sampling.py
+++ b/tests/python_tests/test_sampling.py
@@ -331,9 +331,6 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     generation_config.rng_seed = 0
     generation_configs = generation_config
 
-    # We can use streamer only if we have a single batch.
-    streamer = StreamerWithResults() if len(prompts) == 1 else None
-
     model_id : str = "facebook/opt-125m"
     model, hf_tokenizer = get_hugging_face_models(model_id)
 
@@ -341,11 +338,7 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     convert_models(model, hf_tokenizer, models_path)
 
     # Run multinomial without comparison with HF reference.
-    ov_results = run_llm_pipeline(models_path, prompts, generation_configs, streamer=streamer.accumulate if streamer is not None else None)
-
-    # Compare with streamers text.
-    if streamer is not None:
-        compare_generation_results(prompts, ov_results, streamer.get_results(), generation_config)
+    _ = run_llm_pipeline(models_path, prompts, generation_configs)
 
     # Reference comparison is not performed as sampling results are non-deterministic.
     # Discrete_distribution impl depends on platform, model inference results may depend on CPU.

--- a/tests/python_tests/test_sampling.py
+++ b/tests/python_tests/test_sampling.py
@@ -61,7 +61,6 @@ def test_stop_strings(tmp_path, generation_config):
                           dict(max_new_tokens=30, repetition_penalty=2.0),
                           dict(max_new_tokens=300)],
                          ids=["basic", "repetition_penalty", "long_max_new_tokens"])
-@pytest.mark.parametrize("streamer", [StreamerWithResults()])
 @pytest.mark.parametrize("prompt", [
     'What is OpenVINO?',
     'table is made of', 
@@ -70,14 +69,13 @@ def test_stop_strings(tmp_path, generation_config):
     'I have an interview about product speccing with the company Weekend Health. Give me an example of a question they might ask with regards about a new feature'
 ])
 @pytest.mark.parametrize("use_cb", [True, False])
-def test_greedy(tmp_path, generation_config, prompt, streamer, use_cb):
+def test_greedy(tmp_path, generation_config, prompt, use_cb):
     model_id : str = "katuni4ka/tiny-random-phi3"
     run_llm_pipeline_with_ref(model_id=model_id, 
                             prompts=[prompt], 
                             generation_config=generation_config, 
                             tmp_path=tmp_path,
-                            use_cb=use_cb,
-                            streamer=streamer)
+                            use_cb=use_cb)
 
 
 @pytest.mark.precommit
@@ -333,7 +331,7 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     generation_config.rng_seed = 0
     generation_configs = generation_config
 
-    # We can use streamer only if we have a single batch
+    # We can use streamer only if we have a single batch.
     streamer = StreamerWithResults() if len(prompts) == 1 else None
 
     model_id : str = "facebook/opt-125m"
@@ -342,9 +340,10 @@ def test_multinomial_sampling_against_reference(tmp_path, test_struct: RandomSam
     models_path : Path = tmp_path / model_id
     convert_models(model, hf_tokenizer, models_path)
 
-    # run multinomial without comparison with reference
+    # Run multinomial without comparison with HF reference.
     ov_results = run_llm_pipeline(models_path, prompts, generation_configs, streamer=streamer.accumulate if streamer is not None else None)
 
+    # Compare with streamers text.
     if streamer is not None:
         compare_generation_results(prompts, ov_results, streamer.get_results(), generation_config)
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -46,6 +46,8 @@ image_links_for_testing = [
 @pytest.mark.nightly
 def test_vlm_pipeline(cache):
     def streamer(word: str) -> bool:
+        nonlocal result_from_streamer
+        result_from_streamer.append(word)
         return False
 
     models_path = get_ov_model(cache)
@@ -59,10 +61,14 @@ def test_vlm_pipeline(cache):
         ov_pipe = VLMPipeline(models_path, "CPU")
         ov_pipe.start_chat()
 
-        ov_pipe.generate(prompts[0], images=images, generation_config=generation_config, streamer=streamer)
+        result_from_streamer = []
+        res = ov_pipe.generate(prompts[0], images=images, generation_config=generation_config, streamer=streamer)
+        assert res.texts[0] == ''.join(result_from_streamer)
 
         for prompt in prompts[1:]:
-            ov_pipe.generate(prompt, generation_config=generation_config, streamer=streamer)
+            result_from_streamer = []
+            res = ov_pipe.generate(prompt, generation_config=generation_config, streamer=streamer)
+            assert res.texts[0] == ''.join(result_from_streamer)
 
         ov_pipe.finish_chat()
 


### PR DESCRIPTION
- Cherry-pick of #1492 and #1302
- Fix for streamer when adding new tokens can shorten result. This is the fix CVS-157216 which was merged to the previous release branch and did not make it into master. And this is a correct fix this does not break hieroglyphs.

Ticket: CVS-157216 