### PR TITLE
SAMPLES: fix benchmark_genai to have required args

### DIFF
--- a/samples/cpp/text_generation/benchmark_genai.cpp
+++ b/samples/cpp/text_generation/benchmark_genai.cpp
@@ -8,7 +8,7 @@ int main(int argc, char* argv[]) try {
     cxxopts::Options options("benchmark_vanilla_genai", "Help command");
 
     options.add_options()
-    ("m,model", "Path to model and tokenizers base directory", cxxopts::value<std::string>()->default_value("."))
+    ("m,model", "Path to model and tokenizers base directory", cxxopts::value<std::string>())
     ("p,prompt", "Prompt", cxxopts::value<std::string>()->default_value("The Sky is blue because"))
     ("nw,num_warmup", "Number of warmup iterations", cxxopts::value<size_t>()->default_value(std::to_string(1)))
     ("n,num_iter", "Number of iterations", cxxopts::value<size_t>()->default_value(std::to_string(3)))
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "TPOT: " << metrics.get_tpot().mean  << " ± " << metrics.get_tpot().std << " ms/token " << std::endl;
     std::cout << "Throughput: " << metrics.get_throughput().mean  << " ± " << metrics.get_throughput().std << " tokens/s" << std::endl;
 
-    return 0;
+    return EXIT_SUCCESS;
 } catch (const std::exception& error) {
     try {
         std::cerr << error.what() << '\n';

--- a/samples/python/text_generation/benchmark_genai.py
+++ b/samples/python/text_generation/benchmark_genai.py
@@ -6,7 +6,7 @@ import openvino_genai as ov_genai
 
 def main():
     parser = argparse.ArgumentParser(description="Help command")
-    parser.add_argument("-m", "--model", type=str, help="Path to model and tokenizers base directory")
+    parser.add_argument("-m", "--model", type=str, required=True, help="Path to model and tokenizers base directory")
     parser.add_argument("-p", "--prompt", type=str, default="The Sky is blue because", help="Prompt")
     parser.add_argument("-nw", "--num_warmup", type=int, default=1, help="Number of warmup iterations")
     parser.add_argument("-n", "--num_iter", type=int, default=2, help="Number of iterations")


### PR DESCRIPTION
Otherwise, it's easy to make a mistake like:
```bash
$ /home/devuser/ilavreno/openvino/bin/intel64/Debug/benchmark_genai /home/devuser/ilavreno/models/share-05-1/WW02_llm-optimum_2025.0.0-17771/llama-3-8b/pytorch/ov/OV_FP16-INT4_SYM
Check 'ov_tokenizer || ov_detokenizer' failed at /home/devuser/ilavreno/openvino.genai/src/cpp/src/tokenizer.cpp:196:
Neither tokenizer nor detokenzier models were provided
```