### PR TITLE
WA to fix TTFT in CB for Linux 

### DIFF
--- a/src/cpp/src/cache_manager.hpp
+++ b/src/cpp/src/cache_manager.hpp
@@ -5,11 +5,13 @@
 
 #include <vector>
 #include <list>
-#include <sys/mman.h>
 #include "openvino/runtime/tensor.hpp"
-#include "openvino/core/shape.hpp"
-
 #include "device_config.hpp"
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include "openvino/core/shape.hpp"
+#endif
 
 namespace ov::genai {
 class CacheManager {

--- a/src/cpp/src/cache_manager.hpp
+++ b/src/cpp/src/cache_manager.hpp
@@ -103,7 +103,7 @@ public:
                 // so NAN * 0 returns non-zero invalid data.
                 // So we need to set zeros to all newly allocated tensors data.
                 std::memset(key_cache_roi_end, 0, key_cache.get_byte_size() - key_roi_size_byte);
-                std::memset(value_cache_roi_end, 0, value_cache.get_byte_size() - value_roi_size_byte);          
+                std::memset(value_cache_roi_end, 0, value_cache.get_byte_size() - value_roi_size_byte);
 #endif
                 // set new cache tensors
                 if (m_key_cache.size() > decoder_layer_id) {


### PR DESCRIPTION
mmap() with flag MAP_ANONYMOUS can be used to guarantee zero-filled memory allocation. In this case we can avoid memset().

Ticket: CVS-160408