### PR TITLE
[CB] Fix Memory leak in CBPipeImpl Constructor

### DIFF
--- a/src/cpp/src/cache_state_dumper.hpp
+++ b/src/cpp/src/cache_state_dumper.hpp
@@ -83,7 +83,7 @@ public:
      */
     void dump_cache_state(const Scheduler &schdl, const std::vector <SequenceGroup::Ptr> &sequence_groups,
                           size_t dump_count) {
-        dump_cache_state(schdl.m_block_manager, sequence_groups, dump_count);
+        dump_cache_state(*schdl.m_block_manager, sequence_groups, dump_count);
 
     }
 

--- a/src/cpp/src/cache_state_dumper.hpp
+++ b/src/cpp/src/cache_state_dumper.hpp
@@ -40,15 +40,15 @@ public:
      * @param block_mgr A block manager owning the caches.
      * @param sequence_groups Sequence groups currently utilizing the cache.
      */
-    void dump_cache_state(const BlockManager &block_mgr, const std::vector <SequenceGroup::Ptr> &sequence_groups,
+    void dump_cache_state(const std::shared_ptr<BlockManager> block_mgr, const std::vector <SequenceGroup::Ptr> &sequence_groups,
                           size_t dump_count) {
-        for (size_t layer_idx = 0; layer_idx < block_mgr.m_num_layers; layer_idx++) {
+        for (size_t layer_idx = 0; layer_idx < block_mgr->m_num_layers; layer_idx++) {
             auto per_layer_folder = get_per_layer_folder(layer_idx);
             auto file_path = (per_layer_folder / (m_run_id + ".txt")).string();
             std::ofstream out_stream(file_path, std::ios::out);
             OPENVINO_ASSERT(out_stream.is_open());
 
-            out_stream << block_mgr.m_allocator.m_total_num_blocks << std::endl;
+            out_stream << block_mgr->m_allocator.m_total_num_blocks << std::endl;
             out_stream << sequence_groups.size() << std::endl;
             for (const auto &seq_group_ptr: sequence_groups) {
                 out_stream << seq_group_ptr->get_request_id() << ' ';
@@ -57,7 +57,7 @@ public:
                 }
                 out_stream << std::endl;
             }
-            for (const auto &seq_id_and_blocks: block_mgr.m_block_table) {
+            for (const auto &seq_id_and_blocks: block_mgr->m_block_table) {
                 for (const auto &block: seq_id_and_blocks.second[layer_idx]) {
                     const size_t seq_id = seq_id_and_blocks.first;
                     out_stream << seq_id << " " << block->get_index() << " " << block->get_references_count()
@@ -70,7 +70,7 @@ public:
             std::ofstream out_stream_cache_usage;
 
             out_stream_cache_usage.open(cache_usage_file_path, std::ios::app);
-            out_stream_cache_usage << dump_count << ' ' << block_mgr.get_used_percentage() << std::endl;
+            out_stream_cache_usage << dump_count << ' ' << block_mgr->get_used_percentage() << std::endl;
             out_stream_cache_usage.flush();
             dump_count++;
         }
@@ -83,7 +83,7 @@ public:
      */
     void dump_cache_state(const Scheduler &schdl, const std::vector <SequenceGroup::Ptr> &sequence_groups,
                           size_t dump_count) {
-        dump_cache_state(*schdl.m_block_manager, sequence_groups, dump_count);
+        dump_cache_state(schdl.m_block_manager, sequence_groups, dump_count);
 
     }
 

--- a/src/cpp/src/continuous_batching_impl.cpp
+++ b/src/cpp/src/continuous_batching_impl.cpp
@@ -61,7 +61,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
     ov::InferRequest infer_request = compiled_model.create_infer_request();
 
     // setup KV caches
-    m_cache_manager = std::make_shared<CacheManager>(device_config, infer_request, core);
+    std::shared_ptr<CacheManager> cache_manager = std::make_shared<CacheManager>(device_config, infer_request, core);
 
     SchedulerConfig updated_config = scheduler_config;
     // update KV blocks number in scheduler config
@@ -75,8 +75,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
         // as it may lead to performance slowdown
         can_use_partial_preemption = false;
     }
-    m_scheduler = std::make_shared<Scheduler>(device_config.get_block_size(), m_cache_manager, updated_config, device_config.get_num_layers(), can_use_partial_preemption);
-
+    m_scheduler = std::make_shared<Scheduler>(device_config.get_block_size(), cache_manager, updated_config, device_config.get_num_layers(), can_use_partial_preemption);
     // model runner
     bool is_use_cache_eviction = m_scheduler->get_config().use_cache_eviction;
     m_model_runner = std::make_shared<ModelRunner>(infer_request, m_scheduler->get_block_size(), device_config.get_num_layers(), is_use_cache_eviction);
@@ -158,11 +157,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
             SequenceGroup::CPtr sequence_group = m_requests[seq_group_id];
             m_batch_size += sequence_group->num_running_seqs();
         }
-
-        static ManualTimer copy_blocks_timer("scheduling");
-        copy_blocks_timer.start();
-        m_cache_manager->copy_blocks(scheduler_output.m_block_copy_map);
-        copy_blocks_timer.end();
     }
 
     // if no tokens were scheduled, we are out of memory => free all requests and return

--- a/src/cpp/src/continuous_batching_impl.cpp
+++ b/src/cpp/src/continuous_batching_impl.cpp
@@ -33,6 +33,12 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::ContinuousBatchingImpl(
     initialize_pipeline(model, scheduler_config, properties, device_config, core);
 }
 
+ContinuousBatchingPipeline::ContinuousBatchingImpl::~ContinuousBatchingImpl() {
+    if (m_scheduler) {
+        m_scheduler->release();
+    }
+}
+
 void ContinuousBatchingPipeline::ContinuousBatchingImpl::_pull_awaiting_requests() {
     std::lock_guard<std::mutex> lock{m_awaiting_requests_mutex};
     m_requests.insert(m_requests.end(), m_awaiting_requests.begin(), m_awaiting_requests.end());

--- a/src/cpp/src/continuous_batching_impl.hpp
+++ b/src/cpp/src/continuous_batching_impl.hpp
@@ -89,9 +89,7 @@ public:
                            const ov::genai::GenerationConfig& generation_config,
                            bool is_validation_mode_enabled = false);
     
-    virtual ~ContinuousBatchingImpl() {
-        m_scheduler->release();
-    }
+    virtual ~ContinuousBatchingImpl();
 
     GenerationHandle add_request(uint64_t request_id,
                                  const ov::Tensor& input_ids,

--- a/src/cpp/src/continuous_batching_impl.hpp
+++ b/src/cpp/src/continuous_batching_impl.hpp
@@ -13,7 +13,6 @@ namespace ov::genai {
 class ContinuousBatchingPipeline::ContinuousBatchingImpl : public ContinuousBatchingPipeline::IContinuousBatchingPipeline {
 protected:
     std::shared_ptr<Scheduler> m_scheduler;
-    std::shared_ptr<CacheManager> m_cache_manager;
     std::shared_ptr<ModelRunner> m_model_runner;
     std::optional<AdapterController> m_adapter_controller;
     std::shared_ptr<Sampler> m_sampler;
@@ -89,6 +88,10 @@ public:
                            const ov::AnyMap& properties,
                            const ov::genai::GenerationConfig& generation_config,
                            bool is_validation_mode_enabled = false);
+    
+    virtual ~ContinuousBatchingImpl() {
+        m_scheduler->release();
+    }
 
     GenerationHandle add_request(uint64_t request_id,
                                  const ov::Tensor& input_ids,

--- a/src/cpp/src/scheduler.hpp
+++ b/src/cpp/src/scheduler.hpp
@@ -13,13 +13,14 @@
 #include "block_manager.hpp"
 #include "sequence_group.hpp"
 #include "cache_manager.hpp"
+#include "timer.hpp"
 
 namespace ov::genai {
 class Scheduler {
     bool m_can_use_partial_preemption;
 
     SchedulerConfig m_config;
-    BlockManager m_block_manager;
+    std::shared_ptr<BlockManager> m_block_manager;
     friend class CacheStateDumper;
 
     bool m_dynamic_memory_allocation = false;
@@ -33,8 +34,6 @@ public:
     struct Output {
         // IDs of scheduled groups
         std::vector<uint64_t> m_scheduled_sequence_groups_ids;
-        // map of src -> dst blocks copies, which need to be performed by CacheManager
-        std::map<size_t, std::list<size_t>> m_block_copy_map;
         // block tables for scheduled sequences per each attention layer in the model
         std::map<uint64_t, std::vector<BlocksPerLayer>> m_block_tables;
         // total number of scheduled tokens
@@ -48,26 +47,32 @@ public:
     explicit Scheduler(size_t block_size, std::shared_ptr<CacheManager> cache_manager, const SchedulerConfig & config = {}, size_t num_layers = 1, bool can_use_partial_preemption = true) :
             m_cache_manager(cache_manager),
             m_can_use_partial_preemption(can_use_partial_preemption),
-            m_config(config),
-            m_block_manager(m_config.num_kv_blocks, m_config.enable_prefix_caching, block_size, num_layers) {
-        
+            m_config(config) {
+        m_block_manager = std::make_shared<BlockManager>(m_config.num_kv_blocks, m_config.enable_prefix_caching, block_size, num_layers);
         OPENVINO_ASSERT(num_layers != 0, "num_layers must be non-zero");
+    }
+
+    void release() {
+        m_cache_manager.reset();
+        m_block_manager.reset();
     }
 
     Output schedule(std::vector<SequenceGroup::Ptr>& sequence_groups) {
         Output scheduler_output;
+        // map of src -> dst blocks copies, which need to be performed by CacheManager
+        std::map<size_t, std::list<size_t>> block_copy_map;
 
         // free some blocks taken by non-confirmed condidates in SD / prompt look-up
         clean_empty_blocks(sequence_groups);
 
-        if (m_block_manager.get_total_number_of_kv_blocks() == 0) {
+        if (m_block_manager->get_total_number_of_kv_blocks() == 0) {
             _initialize_cache(sequence_groups);
         }
 
         if (m_config.dynamic_split_fuse) {
             // deepspeed-mii case
             // generation phase is always scheduled first
-            _schedule_generate_phase_dynamic_split_fuse(sequence_groups, scheduler_output);
+            _schedule_generate_phase_dynamic_split_fuse(sequence_groups, scheduler_output, block_copy_map);
             // some tokens from generation prompt are also scheduled
             _schedule_prompt_phase_dynamic_split_fuse(sequence_groups, scheduler_output);
         } else {
@@ -78,13 +83,19 @@ public:
 
             if (!scheduler_output.is_prompt) {
                 // prompt sequences are not scheduler => scheduler generation phase by dynamic_split_fuse implementation
-                _schedule_generate_phase_dynamic_split_fuse(sequence_groups, scheduler_output);
+                _schedule_generate_phase_dynamic_split_fuse(sequence_groups, scheduler_output, block_copy_map);
             }
         }
 
-        m_cache_manager->allocate_cache_if_needed(m_block_manager.get_total_number_of_kv_blocks());
+        m_cache_manager->allocate_cache_if_needed(m_block_manager->get_total_number_of_kv_blocks());
         _clear_waiting_sequences(sequence_groups);
-        scheduler_output.m_cache_usage = m_block_manager.get_used_percentage();
+        scheduler_output.m_cache_usage = m_block_manager->get_used_percentage();
+
+        static ManualTimer copy_blocks_timer("copy block");
+        copy_blocks_timer.start();
+        m_cache_manager->copy_blocks(block_copy_map);
+        copy_blocks_timer.end();
+
         return scheduler_output;
     }
 
@@ -94,31 +105,31 @@ public:
      */
     void clean_empty_blocks(std::vector<SequenceGroup::Ptr>& seq_groups) {
         for (const auto& seq_group : seq_groups)
-            m_block_manager.free_empty_physical_blocks(seq_group);
+            m_block_manager->free_empty_physical_blocks(seq_group);
     }
 
     const std::vector<BlocksPerLayer>& get_block_tables(const Sequence& seq) const {
-        return m_block_manager.get_block_tables(seq.get_id());
+        return m_block_manager->get_block_tables(seq.get_id());
     }
 
     const size_t get_block_size() const {
-        return m_block_manager.get_block_size();
+        return m_block_manager->get_block_size();
     }
 
     const bool has_block_table(uint64_t seq_id) {
-        return m_block_manager.has_block_table(seq_id);
+        return m_block_manager->has_block_table(seq_id);
     }
 
     void free_sequence(uint64_t seq_id) {
-        m_block_manager.free_sequence(seq_id);
+        m_block_manager->free_sequence(seq_id);
     }
 
     void fork_sequence(uint64_t parent_id, uint64_t child_id) {
-        m_block_manager.fork_sequence(parent_id, child_id);
+        m_block_manager->fork_sequence(parent_id, child_id);
     }
 
     void restore_cached_blocks(const SequenceGroup::Ptr& sequence_group) {
-        m_block_manager.restore_cached_blocks(sequence_group);
+        m_block_manager->restore_cached_blocks(sequence_group);
     }
 
     const SchedulerConfig& get_config() const {
@@ -126,7 +137,7 @@ public:
     }
 
     void free_blocks_from_sequence(size_t seq_id, const std::vector<std::set<size_t>>& per_layer_logical_block_indices_to_free) {
-        m_block_manager.free_blocks_from_sequence(seq_id, per_layer_logical_block_indices_to_free);
+        m_block_manager->free_blocks_from_sequence(seq_id, per_layer_logical_block_indices_to_free);
     }
 
 private:
@@ -143,31 +154,31 @@ private:
 
     bool _preempt_by_recompute(SequenceGroup::Ptr sequence_group, size_t blocks_needed) {
         size_t processed_tokens = sequence_group->get_num_processed_tokens();
-        size_t prev_blocks_count = m_block_manager.num_free_blocks();
+        size_t prev_blocks_count = m_block_manager->num_free_blocks();
         size_t preempted_tokens = 0;
-        size_t num_blocks_occupied_by_sequence = m_block_manager.get_number_of_blocks_occupied_by_sequence(sequence_group);
+        size_t num_blocks_occupied_by_sequence = m_block_manager->get_number_of_blocks_occupied_by_sequence(sequence_group);
         bool was_evicted_from = (sequence_group->get_num_evicted_tokens() != 0);
 
         if (num_blocks_occupied_by_sequence <= blocks_needed || !m_can_use_partial_preemption || was_evicted_from) {
             auto sequences = sequence_group->get_not_finished_sequences();
             for (size_t s = 0; s < sequences.size(); ++s) {
                 auto seq_id = sequences[s]->get_id();
-                m_block_manager.free_sequence(seq_id);
+                m_block_manager->free_sequence(seq_id);
             }
             sequence_group->preempt_tokens(processed_tokens);
             if (was_evicted_from) {
                 sequence_group->reset_eviction_token_count();
             }
             sequence_group->set_waiting();
-            return m_block_manager.num_free_blocks() > prev_blocks_count;
+            return m_block_manager->num_free_blocks() > prev_blocks_count;
         }
 
         size_t logical_blocks_released;
         if (sequence_group->get_sampling_parameters().is_beam_search()) {
-            logical_blocks_released = m_block_manager.free_partially_beam_search_group(sequence_group, blocks_needed);
+            logical_blocks_released = m_block_manager->free_partially_beam_search_group(sequence_group, blocks_needed);
         }
         else {
-            logical_blocks_released = m_block_manager.free_group_partially(sequence_group, blocks_needed);
+            logical_blocks_released = m_block_manager->free_group_partially(sequence_group, blocks_needed);
         }
 
         size_t block_size = get_block_size();
@@ -184,14 +195,14 @@ private:
             preempted_tokens = processed_tokens;
             for (auto sequence: sequence_group->get_not_finished_sequences()) {
                 auto seq_id = sequence->get_id();
-                if (m_block_manager.has_block_table(seq_id)) {
-                    m_block_manager.free_sequence(seq_id);
+                if (m_block_manager->has_block_table(seq_id)) {
+                    m_block_manager->free_sequence(seq_id);
                 }
             }
         }
         sequence_group->preempt_tokens(preempted_tokens);
         sequence_group->set_waiting();
-        return m_block_manager.num_free_blocks() > prev_blocks_count;
+        return m_block_manager->num_free_blocks() > prev_blocks_count;
     }
 
     static size_t _get_low_priority_sequence_group_id(const std::vector<SequenceGroup::Ptr>& sequence_groups) {
@@ -212,7 +223,7 @@ private:
         SequenceGroup::Ptr sequence_group = sequence_groups[sequence_group_id];
 
         // check whether current sequence requires a new slot / block
-        while (!m_block_manager.can_append_slots(sequence_group)) {
+        while (!m_block_manager->can_append_slots(sequence_group)) {
             // let's run a sequence for eviction
             size_t evicted_sequence_group_id = _get_low_priority_sequence_group_id(sequence_groups);
 
@@ -220,7 +231,7 @@ private:
                 // we have a cycle when current group need to evict itself to be in a running state
                 break;
             }
-            size_t blocks_needed = m_block_manager.required_blocks_count(sequence_group);
+            size_t blocks_needed = m_block_manager->required_blocks_count(sequence_group);
             if (!_preempt_by_recompute(sequence_groups[evicted_sequence_group_id], blocks_needed)){
                 break;
             }
@@ -259,12 +270,12 @@ private:
                 size_t available_slots = currently_allocated_token_slots - occupied_token_slots,
                        required_slots = num_scheduled_tokens > available_slots ? num_scheduled_tokens - available_slots : 0;
                 size_t num_required_blocks = (required_slots + block_size - 1) / block_size;
-                while (num_required_blocks > m_block_manager.num_free_blocks()) {
+                while (num_required_blocks > m_block_manager->num_free_blocks()) {
                     if (!_try_increase_cache()) {
                         break;
                     }
                 }
-                size_t num_scheduled_blocks = std::min(num_required_blocks, m_block_manager.num_free_blocks());
+                size_t num_scheduled_blocks = std::min(num_required_blocks, m_block_manager->num_free_blocks());
                 // some scheduled blocks can be no fully occupied, so we need to take min between num_scheduled_blocks
                 // and total "scheduled capacity"
                 num_scheduled_tokens = std::min(num_scheduled_tokens, available_slots + num_scheduled_blocks * block_size);
@@ -272,14 +283,14 @@ private:
                 if (num_scheduled_tokens > 0) {
                     // allocate KV blocks if required
                     if (num_scheduled_blocks > 0)
-                        m_block_manager.allocate(sequence, num_scheduled_blocks, sequence_group->get_prompt_ids());
+                        m_block_manager->allocate(sequence, num_scheduled_blocks, sequence_group->get_prompt_ids());
                     // and schedule tokens
                     sequence_group->schedule_tokens(num_scheduled_tokens);
 
                     // add information to scheduler_output
                     {
                         scheduler_output.m_scheduled_sequence_groups_ids.push_back(sequence_group_id);
-                        scheduler_output.m_block_tables[seq_id] = m_block_manager.get_block_tables(seq_id);
+                        scheduler_output.m_block_tables[seq_id] = m_block_manager->get_block_tables(seq_id);
                         scheduler_output.m_total_num_scheduled_tokens += num_scheduled_tokens * num_running_seqs;
                     }
                 }
@@ -291,7 +302,9 @@ private:
         }
     }
 
-    void _schedule_generate_phase_dynamic_split_fuse(const std::vector<SequenceGroup::Ptr>& sequence_groups, Output& scheduler_output) {
+    void _schedule_generate_phase_dynamic_split_fuse(const std::vector<SequenceGroup::Ptr>& sequence_groups,
+                                                     Output& scheduler_output,
+                                                     std::map<size_t, std::list<size_t>>& block_copy_map) {
         for (size_t sequence_group_id = 0; sequence_group_id < sequence_groups.size(); ++sequence_group_id) {
             SequenceGroup::Ptr sequence_group = sequence_groups[sequence_group_id];
             // Note, that can_generate_tokens will mix preempted sequence groups
@@ -316,7 +329,7 @@ private:
                 size_t num_scheduled_tokens_per_seq = std::min(available_tokens_per_seq_in_megabatch, num_available_tokens_per_seq);
                 sequence_group->schedule_tokens(num_scheduled_tokens_per_seq);
 
-                while (!m_block_manager.can_append_slots(sequence_group)){
+                while (!m_block_manager->can_append_slots(sequence_group)){
                     if (!_try_increase_cache()) {
                         break;
                     }
@@ -325,13 +338,13 @@ private:
                 _apply_preemption(sequence_group_id, sequence_groups);
 
                 // if we can't preemt any more sequences, clear scheduled tokens and move to next sequence
-                if (!m_block_manager.can_append_slots(sequence_group)) {
+                if (!m_block_manager->can_append_slots(sequence_group)) {
                     sequence_group->clear_scheduled_tokens();
                     continue;
                 }
 
                 // allocate new slots
-                std::map<size_t, std::list<size_t>> copy_blocks_map = m_block_manager.append_slots(sequence_group);
+                std::map<size_t, std::list<size_t>> copy_blocks_map = m_block_manager->append_slots(sequence_group);
 
                 // add information to scheduler_output
                 {
@@ -342,7 +355,7 @@ private:
                     // block tables for each running sequence within a group
                     std::vector<Sequence::Ptr> running_seqs = sequence_group->get_running_sequences();
                     for (const auto & seq : sequence_group->get_running_sequences()) {
-                        scheduler_output.m_block_tables[seq->get_id()] = m_block_manager.get_block_tables(seq->get_id());
+                        scheduler_output.m_block_tables[seq->get_id()] = m_block_manager->get_block_tables(seq->get_id());
                     }
 
                     // merge copy_blocks
@@ -350,7 +363,7 @@ private:
                         size_t src_index = src_dst.first;
                         const std::list<size_t>& dst_indexes = src_dst.second;
                         for (const auto dst_index : dst_indexes)
-                            scheduler_output.m_block_copy_map[src_index].push_back(dst_index);
+                            block_copy_map[src_index].push_back(dst_index);
                     }
                 }
 
@@ -403,12 +416,12 @@ private:
                 // apply KV cache limitations
                 size_t block_size = get_block_size();
                 const size_t num_required_blocks = (sequence_len + block_size - 1) / block_size;
-                while (!m_block_manager.can_allocate_blocks(num_required_blocks)){
+                while (!m_block_manager->can_allocate_blocks(num_required_blocks)){
                     if (!_try_increase_cache()) {
                         break;
                     }
                 }
-                if (!m_block_manager.can_allocate_blocks(num_required_blocks))
+                if (!m_block_manager->can_allocate_blocks(num_required_blocks))
                     break;
 
                 // add scheduling information
@@ -419,13 +432,13 @@ private:
                     sequence_group->schedule_tokens(sequence_len);
 
                     // allocate KV blocks
-                    m_block_manager.append_slots(sequence_group);
+                    m_block_manager->append_slots(sequence_group);
 
                     // add information to scheduler_output
                     {
                         scheduler_output.m_scheduled_sequence_groups_ids.push_back(sequence_group_id);
                         uint64_t seq_id = sequence_group->get_running_sequences()[0]->get_id();
-                        scheduler_output.m_block_tables[seq_id] = m_block_manager.get_block_tables(seq_id);
+                        scheduler_output.m_block_tables[seq_id] = m_block_manager->get_block_tables(seq_id);
                         scheduler_output.m_total_num_scheduled_tokens += sequence_len;
                     }
 
@@ -481,7 +494,7 @@ private:
             auto seq_length = sequence_groups[idx]->get_prompt_len() * m_kv_blocks_initial_multiplier;
             auto gen_config = sequence_groups[idx]->get_sampling_parameters();
             seq_length = std::min(seq_length, sequence_groups[idx]->get_prompt_len() + gen_config.get_max_new_tokens(sequence_groups[idx]->get_prompt_len()));
-            size_t blocks_num = std::ceil((float)seq_length / m_block_manager.get_block_size());
+            size_t blocks_num = std::ceil((float)seq_length / m_block_manager->get_block_size());
             if (gen_config.is_beam_search()) {
                 blocks_num *= gen_config.num_beams;
             } else if (gen_config.is_multinomial()) {
@@ -489,7 +502,7 @@ private:
             }
             blocks_sum  += blocks_num;
         }
-        m_block_manager.increase_kv_blocks_number(blocks_sum);
+        m_block_manager->increase_kv_blocks_number(blocks_sum);
         m_dynamic_memory_allocation = true;
     }
 
@@ -499,21 +512,21 @@ private:
         }
         auto device_config = m_cache_manager->get_device_config();
         auto device = device_config->get_device();
-        size_t current_num_of_kv_blocks = m_block_manager.get_total_number_of_kv_blocks();
+        size_t current_num_of_kv_blocks = m_block_manager->get_total_number_of_kv_blocks();
         size_t new_blocks_num = current_num_of_kv_blocks * m_cache_growth_factor;
 
         if (device.find("GPU") == std::string::npos) {
-            m_block_manager.increase_kv_blocks_number(new_blocks_num);
+            m_block_manager->increase_kv_blocks_number(new_blocks_num);
         }
         else {
             size_t available_gpu_memory = _get_available_gpu_memory();
             size_t required_memory = (new_blocks_num - current_num_of_kv_blocks) * device_config->get_block_size_in_bytes();
             if (required_memory <= available_gpu_memory) {
-                m_block_manager.increase_kv_blocks_number(new_blocks_num);
+                m_block_manager->increase_kv_blocks_number(new_blocks_num);
             } else {
                 size_t possible_blocks_to_add = available_gpu_memory / device_config->get_block_size_in_bytes();
                 if (possible_blocks_to_add > 0) {
-                    m_block_manager.increase_kv_blocks_number(current_num_of_kv_blocks + possible_blocks_to_add);
+                    m_block_manager->increase_kv_blocks_number(current_num_of_kv_blocks + possible_blocks_to_add);
                 }
                 else {
                     return false;


### PR DESCRIPTION
## Ticket:
* [160601](https://jira.devtools.intel.com/browse/CVS-160601)

## Reproducer:
* https://github.com/openvinotoolkit/openvino.genai/pull/1547

## Details:
* (Consequences) Infer Request object was weaked in `CacheManager` (3GB leak per iteration),  Not cleaned block manager ( +2 MB per iteration).
* (Reason) Scheduler object was not removed from CBImpl destructor (`CacheManager` and `BlockManager` are field of the class). We have another `Scheduler` with virtual destructor. So, compiler can not resolve the class destructor methods, call desctructor from another class and does nothing.

## Solution:
* To implement `release` method for `Scheduler` and call it from `CBPipeImpl` destructor.
* We should rename class  to call normal destructor in future

## Additional changes:
* to remove `cache_manager` field from pipeline because it is using only in scheduler 

## Results:
![image](https://github.com/user-attachments/assets/deef1944-9f35-427b-bff7-ed965004976d)
