### PR TITLE
Replace openvino.runtime imports with openvino

### DIFF
--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -6,7 +6,7 @@ import sys
 import argparse
 import logging as log
 import llm_bench_utils.model_utils
-from openvino.runtime import get_version
+from openvino import get_version
 import torch
 import traceback
 from llm_bench_utils.memory_profile import MemConsumption

--- a/tools/llm_bench/convert.py
+++ b/tools/llm_bench/convert.py
@@ -20,7 +20,7 @@ from diffusers import (
 from diffusers import UNet2DConditionModel, AutoencoderTiny, LCMScheduler
 from nncf.torch.model_creation import is_wrapped_model
 from openvino import Type as OVType, PartialShape, save_model, convert_model
-from openvino.runtime import Core, get_version
+from openvino import Core, get_version
 from optimum.exporters import TasksManager
 from optimum.utils import DEFAULT_DUMMY_SHAPES
 from optimum.intel.openvino.configuration import OVConfig

--- a/tools/llm_bench/llm_bench_utils/ov_model_classes.py
+++ b/tools/llm_bench/llm_bench_utils/ov_model_classes.py
@@ -16,7 +16,7 @@ from diffusers.utils import PIL_INTERPOLATION
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline, ImagePipelineOutput
 from optimum.intel.openvino import OVModelForCausalLM
 from optimum.intel.openvino.utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME
-from openvino.runtime import Model, Core, Tensor, Type
+from openvino import Model, Core, Tensor, Type
 from transformers import PretrainedConfig
 from transformers.modeling_outputs import CausalLMOutputWithPast, ModelOutput
 from transformers import GenerationConfig, StoppingCriteriaList

--- a/tools/llm_bench/llm_bench_utils/ov_utils.py
+++ b/tools/llm_bench/llm_bench_utils/ov_utils.py
@@ -17,7 +17,10 @@ from llm_bench_utils.config_class import (
     DEFAULT_MODEL_CLASSES,
     IMAGE_GEN_CLS
 )
-import openvino.opset13 as opset
+try:
+    import openvino.opset13 as opset
+except ImportError:
+    import openvino.runtime.opset13 as opset
 from transformers import pipeline
 import openvino_genai as ov_genai
 import queue

--- a/tools/llm_bench/llm_bench_utils/ov_utils.py
+++ b/tools/llm_bench/llm_bench_utils/ov_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from transformers import AutoConfig, AutoProcessor, AutoTokenizer
-from openvino.runtime import Core
+from openvino import Core
 import openvino as ov
 import logging as log
 import torch
@@ -17,7 +17,7 @@ from llm_bench_utils.config_class import (
     DEFAULT_MODEL_CLASSES,
     IMAGE_GEN_CLS
 )
-import openvino.runtime.opset13 as opset
+import openvino.opset13 as opset
 from transformers import pipeline
 import openvino_genai as ov_genai
 import queue


### PR DESCRIPTION
openvino.runtime will be removed in 2026.0 and we now see DeprecationWarnings with nightly:

```
<frozen importlib.util>:262: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.
```

PR for OpenVINO Tokenizers: https://github.com/openvinotoolkit/openvino_tokenizers/pull/378