### PR TITLE
Set stop token ids from default generation config

### DIFF
--- a/src/cpp/src/continuous_batching_impl.cpp
+++ b/src/cpp/src/continuous_batching_impl.cpp
@@ -248,6 +248,9 @@ GenerationHandle
 ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(uint64_t request_id,
                                                                const ov::Tensor& input_ids,
                                                                ov::genai::GenerationConfig sampling_params) {
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (sampling_params.stop_token_ids.empty())
+        sampling_params.stop_token_ids = m_generation_config.stop_token_ids;
     // If eos_token_id was not provided, take value from default m_generation_config
     if (sampling_params.eos_token_id == -1)
         sampling_params.set_eos_token_id(m_generation_config.eos_token_id);

--- a/src/cpp/src/llm_pipeline_base.hpp
+++ b/src/cpp/src/llm_pipeline_base.hpp
@@ -26,8 +26,12 @@ public:
 
     void set_generation_config(GenerationConfig config) {
         int64_t default_eos_token_id = m_generation_config.eos_token_id;
+        auto default_stop_token_ids = m_generation_config.stop_token_ids;
         m_generation_config = config;
 
+        // If stop_token_ids were not provided, take value from default config
+        if (m_generation_config.stop_token_ids.empty())
+            m_generation_config.stop_token_ids = default_stop_token_ids;
         // if eos_token_id was not provided in config forward from default config
         if (m_generation_config.eos_token_id == -1)
             m_generation_config.set_eos_token_id(default_eos_token_id);

--- a/src/cpp/src/llm_pipeline_stateful.cpp
+++ b/src/cpp/src/llm_pipeline_stateful.cpp
@@ -79,6 +79,9 @@ DecodedResults StatefulLLMPipeline::generate(
 
     auto start_time = std::chrono::steady_clock::now();
     GenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (config.stop_token_ids.empty())
+        config.stop_token_ids = m_generation_config.stop_token_ids;
     // If eos_token_id was not provided, take value from default m_generation_config
     if (config.eos_token_id == -1)
         config.set_eos_token_id(m_generation_config.eos_token_id);
@@ -246,6 +249,9 @@ EncodedResults StatefulLLMPipeline::generate(
 
     GenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
 
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (config.stop_token_ids.empty())
+        config.stop_token_ids = m_generation_config.stop_token_ids;
     // If eos_token_id was not provided, take value from default m_generation_config
     if (config.eos_token_id == -1)
         config.set_eos_token_id(m_generation_config.eos_token_id);

--- a/src/cpp/src/llm_pipeline_stateful.cpp
+++ b/src/cpp/src/llm_pipeline_stateful.cpp
@@ -140,8 +140,8 @@ DecodedResults StatefulLLMPipeline::generate(
                     trusted_history_length = m_kv_history_manager.trusted_history_length;
                 } else {
                     m_kv_history_manager.num_tokens_to_remove_from_kv_cache = m_tokenized_chat_history.size() - trusted_history_length;
-                    // if prev generation was finished because of max len was reached, kv cache is missed one last token, let's keep it
-                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= m_last_disappeared_token.has_value() ? 1 : 0;
+                    // last generated token is present in tokenized_history, but not included to attention mask, let's keep it in history
+                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= 1;
                 }
 
                 ov::Tensor new_tensor = ov::Tensor(new_chat_tokens.input_ids.get_element_type(),

--- a/src/cpp/src/llm_pipeline_static.cpp
+++ b/src/cpp/src/llm_pipeline_static.cpp
@@ -885,6 +885,9 @@ EncodedResults StatefulLLMPipeline::generate(
     OPENVINO_ASSERT(batch_size == 1u, "Currently only batch size=1 is supported");
 
     GenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (config.stop_token_ids.empty())
+        config.stop_token_ids = m_generation_config.stop_token_ids;
     // If eos_token_id was not provided, take value from default m_generation_config
     if (config.eos_token_id == -1)
         config.set_eos_token_id(m_generation_config.eos_token_id);
@@ -1362,6 +1365,9 @@ EncodedResults StatelessLLMPipeline::generate(
     }
 
     GenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (config.stop_token_ids.empty())
+        config.stop_token_ids = m_generation_config.stop_token_ids;
     // If eos_token_id was not provided, take value from default m_generation_config
     if (config.eos_token_id == -1)
         config.set_eos_token_id(m_generation_config.eos_token_id);

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -46,6 +46,7 @@ protected:
     // True if chat template should be applied for non-chat scenario
     bool m_apply_chat_template = true;
 
+    std::set<int64_t> m_stop_token_ids;
 public:
     virtual ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) = 0;
 
@@ -69,6 +70,10 @@ public:
 
     size_t get_num_tokens_to_remove_from_hist() const {
         return m_kv_history_manager.num_tokens_to_remove_from_kv_cache;
+    }
+
+    void set_stop_token_ids(const std::set<int64_t>& stop_token_ids) {
+        m_stop_token_ids = stop_token_ids;
     }
 
     void update_tokenized_history(const std::vector<int64_t>& encoded_result, std::optional<int64_t> last_disappeared_token, bool is_beam_search, size_t last_answer_len) {
@@ -215,8 +220,8 @@ protected:
             // so let's check it out, find the trusted part and use it in on the next step
             size_t trusted_history_length = 0;
             if (!m_tokenized_history.empty()) {
-                std::set<int64_t> stop_tokens = {m_tokenizer.get_eos_token_id()};
-                trusted_history_length = ov::genai::utils::get_first_history_difference(prev_chat_tokens, m_tokenized_history, stop_tokens);
+                OPENVINO_ASSERT(!m_stop_token_ids.empty(), "Stop tokens are not set for InputsEmbedder");
+                trusted_history_length = ov::genai::utils::get_first_history_difference(prev_chat_tokens, m_tokenized_history, m_stop_token_ids);
             }
 
             if (m_tokenized_history.empty()) {
@@ -2035,6 +2040,10 @@ std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::get_position_ids(c
 
 EmbeddingsModel InputsEmbedder::get_embedding_model() const {
     return m_impl->get_embedding_model();
+}
+
+void InputsEmbedder::set_stop_token_ids(const std::set<int64_t>& stop_token_ids) {
+    return m_impl->set_stop_token_ids(stop_token_ids);
 }
 
 std::vector<int64_t> InputsEmbedder::get_tokenized_history() const {

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -220,7 +220,6 @@ protected:
             // so let's check it out, find the trusted part and use it in on the next step
             size_t trusted_history_length = 0;
             if (!m_tokenized_history.empty()) {
-                OPENVINO_ASSERT(!m_stop_token_ids.empty(), "Stop tokens are not set for InputsEmbedder");
                 trusted_history_length = ov::genai::utils::get_first_history_difference(prev_chat_tokens, m_tokenized_history, m_stop_token_ids);
             }
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -234,9 +234,9 @@ protected:
                 if (m_kv_history_manager.does_kv_cache_need_to_update()) {
                     trusted_history_length = m_kv_history_manager.trusted_history_length;
                 } else {
-                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache = m_tokenized_history.size() - trusted_history_length;
+                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache = m_tokenized_history.size() - trusted_history_length - 1;
                     // if prev generation was finished because of max len was reached, kv cache is missed one last token, let's keep it
-                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= m_last_disappeared_token.has_value() ? 1 : 0;
+                    // m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= m_last_disappeared_token.has_value() ? 1 : 0;
                 }
 
                 ov::Tensor new_tensor = ov::Tensor(new_chat_tokens.get_element_type(),

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -234,9 +234,9 @@ protected:
                 if (m_kv_history_manager.does_kv_cache_need_to_update()) {
                     trusted_history_length = m_kv_history_manager.trusted_history_length;
                 } else {
-                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache = m_tokenized_history.size() - trusted_history_length - 1;
-                    // if prev generation was finished because of max len was reached, kv cache is missed one last token, let's keep it
-                    // m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= m_last_disappeared_token.has_value() ? 1 : 0;
+                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache = m_tokenized_history.size() - trusted_history_length;
+                    // last generated token is present in tokenized_history, but not included to attention mask, let's keep it in history
+                    m_kv_history_manager.num_tokens_to_remove_from_kv_cache -= 1;
                 }
 
                 ov::Tensor new_tensor = ov::Tensor(new_chat_tokens.get_element_type(),

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -43,6 +43,8 @@ public:
     // returns tokenizer
     Tokenizer get_tokenizer() const;
 
+    void set_stop_token_ids(const std::set<int64_t>& stop_token_ids);
+
     // returns tokenized chat history
     std::vector<int64_t> get_tokenized_history() const;
 

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -329,7 +329,18 @@ public:
     }
 
     void set_generation_config(const GenerationConfig& new_config) {
+        int64_t default_eos_token_id = m_generation_config.eos_token_id;
+        auto default_stop_token_ids = m_generation_config.stop_token_ids;
         m_generation_config = new_config;
+
+        // If stop_token_ids were not provided, take value from default config
+        if (m_generation_config.stop_token_ids.empty())
+            m_generation_config.stop_token_ids = default_stop_token_ids;
+        // if eos_token_id was not provided in config forward from default config
+        if (m_generation_config.eos_token_id == -1)
+            m_generation_config.set_eos_token_id(default_eos_token_id);
+
+        m_generation_config.validate();
     }
 };
 

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -158,10 +158,15 @@ public:
         VLMPerfMetrics perf_metrics;
         auto& raw_counters = perf_metrics.raw_metrics;
         auto& raw_vlm_counters = perf_metrics.vlm_raw_metrics;
+        // If stop_token_ids were not provided, take value from default m_generation_config
+        if (generation_config.stop_token_ids.empty())
+            generation_config.stop_token_ids = m_generation_config.stop_token_ids;
         // If eos_token_id was not provided, take value from default m_generation_config
         if (generation_config.eos_token_id == -1)
             generation_config.set_eos_token_id(m_generation_config.eos_token_id);
         generation_config.validate();
+        
+        m_inputs_embedder->set_stop_token_ids(generation_config.stop_token_ids);
 
         m_inputs_embedder->set_apply_chat_template_status(generation_config.apply_chat_template);
 

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -186,6 +186,7 @@ public:
 
         auto tokenized_history = m_inputs_embedder->get_tokenized_history();
         ov::Tensor prompt_ids(ov::element::i64, { history_size + inputs_embeds_size });
+        OPENVINO_ASSERT(prompt_ids.get_size() >= tokenized_history.size(), "Prompt ids size is less than tokenized history size");
         std::fill_n(prompt_ids.data<int64_t>(), prompt_ids.get_size(), m_tokenizer.get_pad_token_id());
         std::copy(tokenized_history.begin(), tokenized_history.end(), prompt_ids.data<int64_t>());
 

--- a/src/cpp/src/whisper_pipeline.cpp
+++ b/src/cpp/src/whisper_pipeline.cpp
@@ -76,6 +76,9 @@ public:
         auto start_time = std::chrono::steady_clock::now();
         WhisperGenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
 
+        // If stop_token_ids were not provided, take value from default m_generation_config
+        if (config.stop_token_ids.empty())
+            config.stop_token_ids = m_generation_config.stop_token_ids;
         // If eos_token_id was not provided, take value from default m_generation_config
         if (config.eos_token_id == -1)
             config.set_eos_token_id(m_generation_config.eos_token_id);

--- a/src/cpp/src/whisper_pipeline.cpp
+++ b/src/cpp/src/whisper_pipeline.cpp
@@ -199,7 +199,12 @@ ov::genai::Tokenizer ov::genai::WhisperPipeline::get_tokenizer() {
 
 void ov::genai::WhisperPipeline::set_generation_config(const WhisperGenerationConfig& config) {
     int64_t default_eos_token_id = m_impl->m_generation_config.eos_token_id;
+    auto default_stop_token_ids = m_impl->m_generation_config.stop_token_ids;
     m_impl->m_generation_config = config;
+
+    // If stop_token_ids were not provided, take value from default config
+    if (config.stop_token_ids.empty())
+        m_impl->m_generation_config.stop_token_ids = default_stop_token_ids;
     // if eos_token_id was not provided in config forward from default config
     if (config.eos_token_id == -1)
         m_impl->m_generation_config.set_eos_token_id(default_eos_token_id);

--- a/src/cpp/src/whisper_pipeline_static.cpp
+++ b/src/cpp/src/whisper_pipeline_static.cpp
@@ -567,6 +567,13 @@ WhisperDecodedResults WhisperPipeline::StaticWhisperPipeline::generate(
     ChunkStreamerVariant streamer) {
     auto start_time = std::chrono::steady_clock::now();
     WhisperGenerationConfig config = (generation_config.has_value()) ? *generation_config : m_generation_config;
+    
+    // If stop_token_ids were not provided, take value from default m_generation_config
+    if (config.stop_token_ids.empty())
+        config.stop_token_ids = m_generation_config.stop_token_ids;
+    // If eos_token_id was not provided, take value from default m_generation_config
+    if (config.eos_token_id == -1)
+        config.set_eos_token_id(m_generation_config.eos_token_id);
     config.validate();
 
     OPENVINO_ASSERT(!config.initial_prompt.has_value(), "'initial_prompt' parameter is not supported on NPU device.");


### PR DESCRIPTION
In VLM pipeline `generate()` method has `generation_config` parameter. If `eos_token_id` is not set explicitly in this generation config, it is taken from the default `m_generation_config` and as an effect it is added to the `stop_token_ids`.
However, if a model (e.g. Qwen2-VL or InternVL2) has multiple `eos_token_id` in its `generation_config.json`, `stop_token_ids` set is not updated as it includes only one `eos_token_id`.

This issue results in excessive output, e.g. when model (Qwen2-VL w/o instruct) adds system messages after real answer utill max new tokens limit is reached.

Closes https://github.com/openvinotoolkit/openvino.genai/issues/1631
Ticket CVS-162036