### PR TITLE
[CMAKE]: use different version for macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ requires = [
     "py-build-cmake==0.3.4",
     "openvino~=2025.1.0.0.dev",
     "pybind11-stubgen==2.5.1",
-    "cmake~=3.23.0"
+    "cmake~=3.23.0; platform_system != 'Darwin' or platform_machine == 'x86_64'",
+    "cmake~=3.24.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 build-backend = "py_build_cmake.build"
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,2 +1,3 @@
-cmake~=3.23.0
+cmake~=3.23.0; platform_system != 'Darwin' or platform_machine == 'x86_64'
+cmake~=3.24.0; platform_system == 'Darwin' and platform_machine == 'arm64'
 pybind11-stubgen==2.5.1


### PR DESCRIPTION
W/ current version I have:

![image](https://github.com/user-attachments/assets/3547e01e-8a30-4112-ad18-d599d7fadb98)
