### PR TITLE
[JS] Add download binaries script for npm package

### DIFF
--- a/samples/js/text_generation/chat_sample.js
+++ b/samples/js/text_generation/chat_sample.js
@@ -1,5 +1,5 @@
 import readline from 'readline';
-import { Pipeline } from 'genai-node';
+import { LLMPipeline } from 'genai-node';
 
 main();
 
@@ -24,7 +24,7 @@ async function main() {
     output: process.stdout,
   });
 
-  const pipe = await Pipeline.LLMPipeline(MODEL_PATH, device);
+  const pipe = await LLMPipeline(MODEL_PATH, device);
   const config = { 'max_new_tokens': 100 };
 
   await pipe.startChat();

--- a/src/js/BUILD.md
+++ b/src/js/BUILD.md
@@ -1,0 +1,43 @@
+### Build OpenVINO™ GenAI Node.js bindings (preview)
+
+#### Build as OpenVINO Extra Module
+
+OpenVINO GenAI Node.js bindings can be built as an extra module during the OpenVINO build process. This method simplifies the build process by integrating OpenVINO GenAI directly into the OpenVINO build.
+
+1. Clone OpenVINO repository:
+   ```sh
+   git clone --recursive https://github.com/openvinotoolkit/openvino.git
+   ```
+1. Configure CMake with OpenVINO extra modules:
+   ```sh
+   cmake -DOPENVINO_EXTRA_MODULES=*path to genai repository directory* -DCPACK_ARCHIVE_COMPONENT_INSTALL=OFF \
+         -DCPACK_GENERATOR=NPM \
+         -DENABLE_PYTHON=OFF \
+         -DENABLE_WHEEL=OFF \
+         -DCPACK_PACKAGE_FILE_NAME=genai_nodejs_bindings \
+         -S ./openvino -B ./build
+   ```
+1. Build OpenVINO archive with GenAI:
+   ```sh
+   cmake --build ./build --target package -j
+   ```
+
+1. Put Node.js bindings into npm package `bin` directory and install dependencies:
+   ```sh
+   mkdir ./src/js/bin/
+   tar -xvf ./build/genai_nodejs_bindings.tar.gz --directory ./src/js/bin/
+   cd ./src/js/
+   npm install
+   ```
+1. Run tests to be sure that everything works:
+   ```sh
+   npm test
+   ```
+
+### Using as npm Dependency
+
+To use this package locally use `npm link` in `src/js/` directory
+and `npm link genai-node` in the folder where you want to add this package as a dependency
+
+To extract this package and use it as distributed npm package run `npm package`.
+This command creates archive that you may use in your projects.

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -13,9 +13,9 @@ npm install genai-node
 
 Use the **genai-node** package:
 ```js
-import { Pipeline } from 'genai-node';
+import { LLMPipeline } from 'genai-node';
 
-const pipe = await Pipeline.LLMPipeline(MODEL_PATH, device);
+const pipe = await LLMPipeline(MODEL_PATH, device);
 
 const input = 'What is the meaning of life?';
 const config = { 'max_new_tokens': 100 };

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -4,53 +4,39 @@
 
 This is preview version, do not use it in production!
 
-## Install and Run
+## Quick Start
+
+Install the **genai-node** package:
+```bash
+npm install genai-node
+```
+
+Use the **genai-node** package:
+```js
+import { Pipeline } from 'genai-node';
+
+const pipe = await Pipeline.LLMPipeline(MODEL_PATH, device);
+
+const input = 'What is the meaning of life?';
+const config = { 'max_new_tokens': 100 };
+
+await pipe.startChat();
+const result = await pipe.generate(input, config, streamer);
+await pipe.finishChat();
+
+// Output all generation result
+console.log(result);
+
+function streamer(subword) {
+  process.stdout.write(subword);
+}
+```
+
+### Build from source
+
+To build binaries from source, follow the instructions in the [BUILD.md](https://github.com/openvinotoolkit/openvino.genai/blob/master/src/js/BUILD.md) file.
 
 ### Requirements
 
 - Node.js v21+
-- Tested on Ubuntu, another OS didn't tested yet
-
-### Build Bindings
-
-#### Build OpenVINO GenAI as OpenVINO Extra Module
-
-OpenVINO GenAI Node.js bindings can be built as an extra module during the OpenVINO build process. This method simplifies the build process by integrating OpenVINO GenAI directly into the OpenVINO build.
-
-1. Clone OpenVINO repository:
-   ```sh
-   git clone --recursive https://github.com/openvinotoolkit/openvino.git
-   ```
-1. Configure CMake with OpenVINO extra modules:
-   ```sh
-   cmake -DOPENVINO_EXTRA_MODULES=*path to genai repository directory* -DCPACK_ARCHIVE_COMPONENT_INSTALL=OFF \
-         -DCPACK_GENERATOR=NPM \
-         -DENABLE_PYTHON=OFF \
-         -DENABLE_WHEEL=OFF \
-         -DCPACK_PACKAGE_FILE_NAME=genai_nodejs_bindings \
-         -S ./openvino -B ./build
-   ```
-1. Build OpenVINO archive with GenAI:
-   ```sh
-   cmake --build ./build --target package -j
-   ```
-
-1. Put Node.js bindings into npm package `bin` directory and install dependencies:
-   ```sh
-   mkdir ./src/js/bin/
-   tar -xvf ./build/genai_nodejs_bindings.tar.gz --directory ./src/js/bin/
-   cd ./src/js/
-   npm install
-   ```
-1. Run tests to be sure that everything works:
-   ```sh
-   npm test
-   ```
-
-### Using as npm Dependency
-
-To use this package locally use `npm link` in `src/js/` directory
-and `npm link genai-node` in the folder where you want to add this package as a dependency
-
-To extract this package and use it as distributed npm package run `npm package`.
-This command creates archive that you may use in your projects.
+- Tested on Ubuntu and Windows, another OS didn't tested yet

--- a/src/js/lib/module.js
+++ b/src/js/lib/module.js
@@ -125,7 +125,7 @@ class LLMPipeline {
   }
 }
 
-class Pipeline {
+class PipelineFactory {
   static async LLMPipeline(modelPath, device = 'CPU') {
     const pipeline = new LLMPipeline(modelPath, device);
     await pipeline.init();
@@ -135,7 +135,5 @@ class Pipeline {
 }
 
 
-export {
-  addon,
-  Pipeline,
-};
+export { addon };
+export const LLMPipeline = PipelineFactory.LLMPipeline;

--- a/src/js/lib/module.js
+++ b/src/js/lib/module.js
@@ -2,7 +2,7 @@ import util from 'node:util';
 
 import addon from './bindings.cjs';
 
-class LLMPipeline {
+class LLMPipelineEntity {
   modelPath = null;
   device = null;
   pipeline = null;
@@ -73,7 +73,7 @@ class LLMPipeline {
     if (typeof generationOptions !== 'object')
       throw new Error('Options must be an object');
 
-    const castedOptions = LLMPipeline.castOptionsToString(generationOptions);
+    const castedOptions = LLMPipelineEntity.castOptionsToString(generationOptions);
 
     const queue = [];
     let resolvePromise;
@@ -127,7 +127,7 @@ class LLMPipeline {
 
 class PipelineFactory {
   static async LLMPipeline(modelPath, device = 'CPU') {
-    const pipeline = new LLMPipeline(modelPath, device);
+    const pipeline = new LLMPipelineEntity(modelPath, device);
     await pipeline.init();
 
     return pipeline;

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "genai-node",
   "type": "module",
-  "version": "2024.5.0-preview",
+  "version": "2025.1.0-preview",
   "description": "OpenVINO™ GenAI pipelines for using from Node.js environment",
   "license": "Apache-2.0",
   "main": "./lib/module.js",
@@ -13,18 +13,27 @@
   "engines": {
     "node": ">=21.0.0"
   },
-  "keywords": [
-    "OpenVINO",
-    "OpenVINO GenAI",
-    "GenAI"
-  ],
   "scripts": {
     "test_setup": "node ./tests/setup.js",
-    "test": "npm run test_setup && node --test ./tests/*.test.js"
+    "test": "npm run test_setup && node --test ./tests/*.test.js",
+    "postinstall": "npm run install_runtime",
+    "download_runtime": "node ./scripts/download-runtime.cjs",
+    "install_runtime": "npm run download_runtime -- --ignore-if-exists"
   },
   "devDependencies": {
     "node-fetch": "^3.3.2",
     "global-agent": "^3.0.0",
     "@huggingface/hub": "^0.21.0"
+  },
+  "dependencies": {
+    "gunzip-maybe": "^1.4.2",
+    "https-proxy-agent": "^7.0.2",
+    "tar-fs": "^3.0.4"
+  },
+  "binary": {
+    "module_path": "./bin/",
+    "remote_path": "./repositories/openvino_genai/nodejs_bindings/{version}/{platform}/",
+    "package_name": "genai_nodejs_bindings_{platform}_{version}_{arch}.tar.gz",
+    "host": "https://storage.openvinotoolkit.org"
   }
 }

--- a/src/js/scripts/download-runtime.cjs
+++ b/src/js/scripts/download-runtime.cjs
@@ -1,0 +1,24 @@
+const { join } = require('node:path');
+
+const BinaryManager = require('./lib/binary-manager.cjs');
+const packageJson = require('../package.json');
+
+if (require.main === module) main();
+
+async function main() {
+  if (!BinaryManager.isCompatible()) process.exit(1);
+
+  const force = process.argv.includes('-f') || process.argv.includes('--force');
+  const ignoreIfExists = process.argv.includes('-i')
+    || process.argv.includes('--ignore-if-exists');
+
+  const { env } = process;
+  const proxy = env.http_proxy || env.HTTP_PROXY || env.npm_config_proxy;
+
+  await BinaryManager.prepareBinary(
+    join(__dirname, '..'),
+    packageJson.binary.version || packageJson.version,
+    packageJson.binary,
+    { force, ignoreIfExists, proxy },
+  );
+}

--- a/src/js/scripts/lib/binary-manager.cjs
+++ b/src/js/scripts/lib/binary-manager.cjs
@@ -1,0 +1,172 @@
+const os = require('node:os');
+const tar = require('tar-fs');
+const path = require('node:path');
+const gunzip = require('gunzip-maybe');
+const fs = require('node:fs/promises');
+const { createReadStream } = require('node:fs');
+
+const { downloadFile, checkIfPathExists, removeDirectory } = require('./utils.cjs');
+
+class BinaryManager {
+  constructor(packageRoot, version, binaryConfig) {
+    this.packageRoot = packageRoot;
+    this.version = version;
+    this.binaryConfig = binaryConfig;
+  }
+
+  getPlatformLabel() {
+    return os.platform();
+  }
+
+  getArchLabel() {
+    return os.arch();
+  }
+
+  getExtension() {
+    return 'tar.gz';
+  }
+
+  getArchiveUrl() {
+    const {
+      host,
+      package_name: packageNameTemplate,
+      remote_path: remotePathTemplate,
+    } = this.binaryConfig;
+    const fullPathTemplate = `${remotePathTemplate}${packageNameTemplate}`
+    const fullPath = fullPathTemplate
+      .replace(new RegExp('{version}', 'g'), this.version)
+      .replace(new RegExp('{platform}', 'g'), this.getPlatformLabel())
+      .replace(new RegExp('{arch}', 'g'), this.getArchLabel())
+      .replace(new RegExp('{extension}', 'g'), this.getExtension());
+
+    return new URL(fullPath, host).toString();
+  }
+
+  getDestinationPath() {
+    const modulePath = this.binaryConfig['module_path'];
+
+    return path.resolve(this.packageRoot, modulePath);
+  }
+
+  /**
+   * Prepares the binary by downloading and extracting the OpenVINO runtime archive.
+   *
+   * @param {string} packageRoot - The root directory of the package.
+   * @param {string} version - The version of the binary.
+   * @param {Object} binaryConfig - The configuration object for the binary.
+   * @param {Object} options - The options for preparing the binary.
+   * @param {boolean} options.force - Whether to force the download if the directory already exists.
+   * @param {boolean} options.ignoreIfExists - Whether to ignore the download if the directory already exists.
+   * @param {string} [options.proxy] - The proxy to use for downloading the file.
+   * @throws {Error} If the directory already exists and the force option is not set.
+   * @throws {Error} If the download or extraction fails.
+   * @returns {Promise<void>} A promise that resolves when the binary is prepared.
+   */
+  static async prepareBinary(packageRoot, version, binaryConfig, options) {
+    const binaryManager = new this(packageRoot, version, binaryConfig);
+    const destinationPath = binaryManager.getDestinationPath();
+    const isRuntimeDirectoryExists = await checkIfPathExists(destinationPath);
+
+    if (isRuntimeDirectoryExists && !options.force) {
+      if (options.ignoreIfExists) {
+        console.warn(
+          `Directory '${destinationPath}' already exists. Skipping `
+          + 'runtime downloading because "ignoreIfExists" flag is passed.'
+        );
+
+        return;
+      }
+
+      throw new Error(
+        `Directory '${destinationPath}' already exists. ` +
+          'To force runtime downloading use "force" flag.',
+      );
+    }
+
+    const archiveUrl = binaryManager.getArchiveUrl();
+    let tempDirectoryPath = null;
+
+    try {
+      tempDirectoryPath = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'temp-ov-runtime-archive-')
+      );
+
+      const filename = path.basename(archiveUrl);
+
+      console.log('Downloading OpenVINO runtime archive...');
+      const archiveFilePath = await downloadFile(
+        archiveUrl,
+        tempDirectoryPath,
+        filename,
+        options.proxy,
+      )
+      console.log('OpenVINO runtime archive downloaded.');
+
+      await removeDirectory(destinationPath);
+      await this.unarchive(archiveFilePath, destinationPath);
+      console.log('The archive was successfully extracted.');
+    } catch(error) {
+      console.error(`Failed to download OpenVINO runtime: ${error}.`);
+      throw error;
+    } finally {
+      if (tempDirectoryPath) await removeDirectory(tempDirectoryPath);
+    }
+  }
+
+  /**
+   * Checks if the current platform and architecture are compatible.
+   *
+   * Supported platforms: 'win32', 'linux', 'darwin'.
+   * Supported architectures: 'arm64', 'armhf', 'x64'.
+   *
+   * If the platform or architecture is not supported, an error message is logged to the console.
+   *
+   * @returns {boolean} Returns true if the platform and architecture are compatible, otherwise false.
+   */
+  static isCompatible() {
+    const missleadings = [];
+    const platform = os.platform();
+
+    if (!['win32', 'linux', 'darwin'].includes(platform))
+      missleadings.push(`Platform '${platform}' is not supported.`);
+
+    const arch = os.arch();
+
+    if (!['arm64', 'armhf', 'x64'].includes(arch))
+      missleadings.push(`Architecture '${arch}' is not supported.`);
+
+    if (platform === 'win32' && arch !== 'x64')
+      missleadings.push(`Version for windows and '${arch}' is not supported.`);
+
+    if (missleadings.length) {
+      console.error(missleadings.join(' '));
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Unarchive tar and tar.gz archives.
+   *
+   * @function unarchive
+   * @param {string} archivePath - Path to archive.
+   * @param {string} dest - Path where to unpack.
+   * @returns {Promise<void>}
+   */
+  static unarchive(archivePath, dest) {
+    return new Promise((resolve, reject) => {
+      createReadStream(archivePath)
+        .pipe(gunzip())
+        .pipe(tar.extract(dest)
+          .on('finish', () => {
+            resolve();
+          }).on('error', (err) => {
+            reject(err);
+          }),
+        );
+    });
+  }
+}
+
+module.exports = BinaryManager;

--- a/src/js/scripts/lib/utils.cjs
+++ b/src/js/scripts/lib/utils.cjs
@@ -1,0 +1,124 @@
+const path = require('node:path');
+const https = require('node:https');
+const fs = require('node:fs/promises');
+const { createWriteStream } = require('node:fs');
+
+const { HttpsProxyAgent } = require('https-proxy-agent');
+
+const codeENOENT = 'ENOENT';
+
+module.exports = {
+  removeDirectory,
+  checkIfPathExists,
+  downloadFile,
+};
+
+/**
+ * Remove directory and its content.
+ *
+ * @async
+ * @function removeDirectory
+ * @param {string} path - The directory path.
+ * @returns {Promise<void>}
+ */
+async function removeDirectory(path) {
+  try {
+    console.log(`Removing ${path}`);
+    await fs.rm(path, { recursive: true });
+  } catch (error) {
+    if (error.code !== codeENOENT) throw error;
+
+    console.warn(`Path: ${path} doesn't exist`);
+  }
+}
+
+/**
+ * Check if path exists.
+ *
+ * @async
+ * @function checkIfPathExists
+ * @param {string} path - The path to directory or file.
+ * @returns {Promise<boolean>}
+ */
+async function checkIfPathExists(path) {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (error) {
+    if (error.code === codeENOENT) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Download file by URL and save it to the destination path.
+ *
+ * @function downloadFile
+ * @param {string} url - The file URL.
+ * @param {string} filename - The filename of result file.
+ * @param {string} destination - The destination path of result file.
+ * @param {string} [proxy=null] - (Optional) The proxy URL.
+ * @returns {Promise<string>} - Path to downloaded file.
+ */
+function downloadFile(url, destination, filename, proxy = null) {
+  console.log(`Downloading file by link: ${url} to ${destination}`
+    + `with filename: ${filename}`);
+
+  const timeout = 5000;
+  const fullPath = path.resolve(destination, filename);
+  const file = createWriteStream(fullPath);
+
+  if (new URL(url).protocol === 'http:')
+    throw new Error('Http link doesn\'t support');
+
+  let agent;
+
+  if (proxy) {
+    agent = new HttpsProxyAgent(proxy);
+    console.log(`Proxy agent is configured with '${proxy}'.`);
+  }
+
+  return new Promise((resolve, reject) => {
+    file.on('error', (error) => {
+      reject(`Failed to open file stream: ${error}.`);
+    });
+
+    console.log(`Download file by link: ${url}`);
+
+    const requestFn = url => {
+      return https.get(url, { agent }, (res) => {
+        const { statusCode } = res;
+
+        if (statusCode === 301 || statusCode === 302) {
+          console.log(`Server returned status code ${statusCode}. Redirecting to ${res.headers.location}.`);
+          return requestFn(res.headers.location);
+        }
+
+        if (statusCode !== 200) {
+          return reject(`Server returned status code ${statusCode}.`);
+        }
+
+        res.pipe(file);
+
+        file.on('finish', () => {
+          file.close();
+          console.log(`File was successfully downloaded to '${fullPath}'.`);
+          resolve(fullPath);
+        });
+      });
+    };
+
+    const request = requestFn(url);
+
+    request.on('error', (error) => {
+      reject(`Failed to send request: ${error}.`);
+    });
+
+    request.setTimeout(timeout, () => {
+      request.destroy();
+      reject(`Request was timed out after ${timeout} ms.`);
+    });
+  });
+}

--- a/src/js/tests/module.test.js
+++ b/src/js/tests/module.test.js
@@ -1,4 +1,4 @@
-import { Pipeline } from '../lib/module.js';
+import { LLMPipeline } from '../lib/module.js';
 
 import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
@@ -11,7 +11,7 @@ describe('module', async () => {
   let pipeline = null;
 
   await before(async () => {
-    pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await pipeline.startChat();
   });
@@ -33,7 +33,7 @@ describe('module', async () => {
 
 describe('corner cases', async () => {
   it('should throw an error if pipeline is already initialized', async () => {
-    const pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    const pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await assert.rejects(
       async () => await pipeline.init(),
@@ -45,7 +45,7 @@ describe('corner cases', async () => {
   });
 
   it('should throw an error if chat is already started', async () => {
-    const pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    const pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await pipeline.startChat();
 
@@ -59,7 +59,7 @@ describe('corner cases', async () => {
   });
 
   it('should throw an error if chat is not started', async () => {
-    const pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    const pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await assert.rejects(
       () => pipeline.finishChat(),
@@ -75,7 +75,7 @@ describe('generation parameters validation', () => {
   let pipeline = null;
 
   before(async () => {
-    pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await pipeline.startChat();
   });
@@ -95,7 +95,7 @@ describe('generation parameters validation', () => {
   });
 
   it('should throw an error if generationCallback is not a function', async () => {
-    const pipeline = await Pipeline.LLMPipeline(MODEL_PATH, 'CPU');
+    const pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
 
     await pipeline.startChat();
 


### PR DESCRIPTION
When user installs `genai-node` package, first js sources downloads as the package content.
Then, as the part of post-install process `download_binaries` script runs. It downloads compiled binaries from openvino storage, based on detected user OS and architecture.

## Task
- 161447