### PR TITLE
Allow overriding eos_token_id

### DIFF
--- a/src/cpp/src/generation_config.cpp
+++ b/src/cpp/src/generation_config.cpp
@@ -96,14 +96,7 @@ GenerationConfig::GenerationConfig(const std::filesystem::path& json_path) {
 }
 
 void GenerationConfig::set_eos_token_id(size_t tokenizer_eos_token_id) {
-    if (eos_token_id < 0) {
-        eos_token_id = tokenizer_eos_token_id;
-    } else {
-        OPENVINO_ASSERT(eos_token_id == tokenizer_eos_token_id,
-            "EOS token ID is different in generation config (", eos_token_id, ") and tokenizer (",
-            tokenizer_eos_token_id, ")");
-    }
-    // Merge user defined stop tokens with model EOS token
+    eos_token_id = tokenizer_eos_token_id;
     stop_token_ids.insert(eos_token_id);
 }
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -55,16 +55,16 @@ def test_vlm_pipeline(model_id, cache):
         return False
 
     models_path = get_ov_model(model_id, cache)
+    ov_pipe = VLMPipeline(models_path, "CPU")
+    generation_config = ov_pipe.get_generation_config()
+    generation_config.max_new_tokens = 30
+    generation_config.set_eos_token_id(ov_pipe.get_tokenizer().get_eos_token_id())
 
     for links in image_links_for_testing:
         images = []
         for link in links:
             images.append(get_image_by_link(link))
 
-        ov_pipe = VLMPipeline(models_path, "CPU")
-        generation_config = ov_pipe.get_generation_config()
-        generation_config.max_new_tokens = 30
-        generation_config.set_eos_token_id(ov_pipe.get_tokenizer().get_eos_token_id())
         ov_pipe.start_chat()
 
         result_from_streamer = []

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -55,7 +55,6 @@ def test_vlm_pipeline(model_id, cache):
         return False
 
     models_path = get_ov_model(model_id, cache)
-    generation_config = GenerationConfig(max_new_tokens=30)
 
     for links in image_links_for_testing:
         images = []
@@ -63,6 +62,9 @@ def test_vlm_pipeline(model_id, cache):
             images.append(get_image_by_link(link))
 
         ov_pipe = VLMPipeline(models_path, "CPU")
+        generation_config = ov_pipe.get_generation_config()
+        generation_config.max_new_tokens = 30
+        generation_config.set_eos_token_id(ov_pipe.get_tokenizer().get_eos_token_id())
         ov_pipe.start_chat()
 
         result_from_streamer = []


### PR DESCRIPTION
Phi3_V eos_token_id has different values for GenerationConfig and Tokenizer. It's required to allow overriding the token_id to align with the sample from model cards.

My patches to the original models are ignored:
1. https://huggingface.co/microsoft/Phi-3-vision-128k-instruct/discussions/68
2. https://huggingface.co/microsoft/Phi-3.5-vision-instruct/discussions/35