### PR TITLE
Move chat history updates to general function and fix last generated token logic for streaming cases

### DIFF
--- a/src/cpp/src/llm_pipeline_stateful.hpp
+++ b/src/cpp/src/llm_pipeline_stateful.hpp
@@ -26,6 +26,8 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // so, let's keep info about amount of tokens to trim from kv cache and amount of tokens to keep in history
     ov::genai::utils::HistoryRemoveManager m_kv_history_manager = {0, 0};
     size_t m_kv_cache_seq_length_axis = 2;
+    // Finish reason of last generation for chat scenario
+    ov::genai::GenerationStatus m_chat_generation_finish_status = ov::genai::GenerationStatus::RUNNING;
 
     void reset_kv_state();
 public:

--- a/src/cpp/src/lm_encoding.hpp
+++ b/src/cpp/src/lm_encoding.hpp
@@ -8,9 +8,16 @@
 namespace ov {
 namespace genai {
 
-std::pair<EncodedResults, std::optional<int64_t>> get_lm_encoded_results(ov::InferRequest& m_llm, const ov::Tensor& input_ids, const ov::Tensor& attention_mask,
-                                                                         const std::shared_ptr<StreamerBase>& streamer_ptr, Sampler& sampler, std::vector<SequenceGroup::Ptr> sequence_groups,
-                                                                         std::optional<ov::Tensor> position_ids, std::optional<EmbeddingsModel> m_embedding, std::optional<int64_t> rope_delta = std::nullopt);
+ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(ov::InferRequest& m_llm, const ov::Tensor& input_ids, const ov::Tensor& attention_mask,
+                                                              const std::shared_ptr<StreamerBase>& streamer_ptr, Sampler& sampler, std::vector<SequenceGroup::Ptr> sequence_groups,
+                                                              std::optional<ov::Tensor> position_ids, std::optional<EmbeddingsModel> m_embedding, std::optional<int64_t> rope_delta = std::nullopt);
+
+void update_kv_history_manager(ov::genai::utils::HistoryRemoveManager& kv_history_manager, const ov::Tensor& prev_chat_tokens, const std::vector<int64_t> tokenized_history,
+                               const std::set<int64_t> stop_tokens, const ov::genai::GenerationStatus finish_status);
+
+TokenizedInputs get_chat_encoded_input(const ov::Tensor& new_chat_tokens, const ov::Tensor& prev_chat_tokens, const std::vector<int64_t> tokenized_history, ov::genai::utils::HistoryRemoveManager kv_history_manager);
+
+void update_tokenized_history(std::vector<int64_t>& tokenized_history, const ov::Tensor& new_chat_tokens);
 
 }
 }

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -7,6 +7,7 @@
 #include "openvino/genai/llm_pipeline.hpp"
 #include "openvino/runtime/core.hpp"
 
+#include "openvino/genai/generation_handle.hpp"
 #include "visual_language/processor_config.hpp"
 
 namespace ov {
@@ -34,13 +35,20 @@ struct HistoryRemoveManager
     size_t trusted_history_length = 0;
 
     bool does_kv_cache_need_to_update() {
-        return (trusted_history_length > 0 || num_tokens_to_remove_from_kv_cache > 0);
+        return (trusted_history_length > 0 && num_tokens_to_remove_from_kv_cache > 0);
     }
 
     void reset() {
         num_tokens_to_remove_from_kv_cache = 0;
         trusted_history_length = 0;
     }
+};
+
+struct GenerationFinishInfo
+{
+    EncodedResults results;
+    std::optional<int64_t> probably_disappeared_token = std::nullopt;
+    ov::genai::GenerationStatus streaming_finish_status;
 };
 
 Tensor init_attention_mask(const Tensor& position_ids);

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <filesystem>
 
+#include "utils.hpp"
 #include "openvino/genai/tokenizer.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -47,7 +48,7 @@ public:
     std::vector<int64_t> get_tokenized_history() const;
 
     // add new results to tokenized history
-    void update_tokenized_history(const std::vector<int64_t>& encoded_result, std::optional<int64_t> last_disappeared_token, bool is_beam_search, size_t last_answer_len);
+    void update_tokenized_history(const ov::genai::utils::GenerationFinishInfo& finish_info, bool is_beam_search, size_t last_answer_len);
 
     // returns amount of elements, which need to remove from the end of the KV cache
     size_t get_num_tokens_to_remove_from_hist() const;


### PR DESCRIPTION
- moved processing of chat history from LLM stateful and vlm pipelines to general functions: update_kv_history_manager, get_chat_encoded_input, update_tokenized_history
- if generation was stopped by streamer, last token was not added to history, so we don't need to remove it when we want to trim history and add it to second next sequence with prompt 

* also tried to added m_llm.cancel(), in case when generation was stopped by streamer(for purposes PR1476), but it didn't work out, because getting kv cache state after calling of cancel() aborted with `RuntimeError: Infer Request was canceled`.