### PR TITLE
get_lm_encoded_results: use remote tensor

### DIFF
--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -125,7 +125,12 @@ std::pair<EncodedResults, std::optional<int64_t>> get_lm_encoded_results(
     raw_perf_counters.m_inference_durations = {{ MicroSeconds(0.0f) }};
 
     // Initialize inputs
-    m_llm.set_tensor(m_embedding.has_value() ? "inputs_embeds" : "input_ids", input_ids);
+    if (m_embedding.has_value()) {
+        (*m_embedding).set_remote_out_tensor();
+        m_llm.set_tensor("inputs_embeds", input_ids);
+    } else {
+        m_llm.set_tensor("input_ids", input_ids);
+    }
     m_llm.set_tensor("attention_mask", attention_mask);
     if (position_ids.has_value())
         m_llm.set_tensor("position_ids", *position_ids);

--- a/src/cpp/src/visual_language/embedding_model.cpp
+++ b/src/cpp/src/visual_language/embedding_model.cpp
@@ -13,6 +13,23 @@
 
 #include "embedding_model.hpp"
 
+namespace {
+
+std::tuple<ov::InferRequest, ov::Tensor, ov::Tensor> init(ov::CompiledModel& compiled) {
+    ov::InferRequest request = compiled.create_infer_request();
+    ov::Tensor cpu_tensor = request.get_output_tensor();
+    ov::RemoteContext context;
+    try {
+        context = compiled.get_context();
+    } catch (const ov::Exception&) {
+        return {std::move(request), cpu_tensor, cpu_tensor};
+    }
+    ov::RemoteTensor remote = context.create_tensor(ov::element::f32, cpu_tensor.get_shape());
+    return {std::move(request), std::move(cpu_tensor), std::move(remote)};
+}
+
+}  // namespace
+
 namespace ov {
 namespace genai {
 
@@ -27,7 +44,7 @@ EmbeddingsModel::EmbeddingsModel(const std::filesystem::path& model_dir,
 
     ov::CompiledModel compiled_model = core.compile_model(m_model, device, properties);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "text embeddings model");
-    m_request = compiled_model.create_infer_request();
+    std::tie(m_request, m_cpu_tensor, m_remote_tensor) = init(compiled_model);
 }
 
 EmbeddingsModel::EmbeddingsModel(const std::string& model,
@@ -41,7 +58,7 @@ EmbeddingsModel::EmbeddingsModel(const std::string& model,
     merge_postprocess(m_model, scale_emb);
 
     ov::CompiledModel compiled_model = core.compile_model(m_model, device, properties);
-    m_request = compiled_model.create_infer_request();
+    std::tie(m_request, m_cpu_tensor, m_remote_tensor) = init(compiled_model);
 }
 
 ov::Tensor EmbeddingsModel::infer(ov::Tensor input_idx) {
@@ -50,6 +67,14 @@ ov::Tensor EmbeddingsModel::infer(ov::Tensor input_idx) {
     m_request.set_input_tensor(input_idx);
     m_request.infer();
     return m_request.get_output_tensor();
+}
+
+void EmbeddingsModel::set_cpu_out_tensor() {
+    m_request.set_output_tensor(m_cpu_tensor);
+}
+
+void EmbeddingsModel::set_remote_out_tensor() {
+    m_request.set_output_tensor(m_remote_tensor);
 }
 
 void EmbeddingsModel::merge_postprocess(std::shared_ptr<ov::Model> model, float scale_emb) const {

--- a/src/cpp/src/visual_language/embedding_model.hpp
+++ b/src/cpp/src/visual_language/embedding_model.hpp
@@ -39,10 +39,15 @@ public:
 
     ov::Tensor infer(ov::Tensor input_idx);
 
+    void set_cpu_out_tensor();
+    void set_remote_out_tensor();
+
 private:
     void merge_postprocess(std::shared_ptr<ov::Model> model, float scale_emb) const;
 
     ov::InferRequest m_request;
+    ov::Tensor m_cpu_tensor;
+    ov::Tensor m_remote_tensor;
 };
 
 } // namespace genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -386,6 +386,7 @@ public:
 
         ov::Tensor encoded_input = get_encoded_input_ids(images_prompt, metrics);
 
+        m_embedding.set_cpu_out_tensor();
         ov::Tensor inputs_embeds = m_embedding.infer(encoded_input);
         OPENVINO_ASSERT(
             m_vlm_config.hidden_size == inputs_embeds.get_shape().at(2),
@@ -667,6 +668,7 @@ public:
         formatted_prompt += prompt;
 
         ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics, chat_template_fallback);
+        m_embedding.set_cpu_out_tensor();
         ov::Tensor text_embeds = m_embedding.infer(input_ids);
 
         if (images.empty()) {
@@ -796,6 +798,7 @@ public:
         formatted_prompt += prompt;
 
         ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics, chat_template_fallback);
+        m_embedding.set_cpu_out_tensor();
         ov::Tensor text_embeds = m_embedding.infer(input_ids);
 
         if (images.empty()) {
@@ -1119,6 +1122,7 @@ public:
         formatted_prompt += prompt;
 
         ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics);
+        m_embedding.set_cpu_out_tensor();
         ov::Tensor text_embeds = m_embedding.infer(input_ids);
 
         if (images.empty()) {
@@ -1538,6 +1542,7 @@ public:
         features_length += tokens.back().get_shape().at(1);
         ov::Tensor inputs_embeds{ov::element::f32, {1, features_length, m_vlm_config.hidden_size}};
         size_t offset = 0;
+        m_embedding.set_cpu_out_tensor();
         for (size_t im_id = 0; im_id < images_features_proj.size(); ++im_id) {
             const ov::Tensor& text_embeds = m_embedding.infer(tokens.at(im_id));
             const ov::Tensor& image_embeds = images_features_proj.at(im_id);
@@ -1655,6 +1660,7 @@ public:
         // Adapted from Qwen/Qwen2-7B-Instruct
         std::string chat_template_fallback = "{% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}";
         ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics, chat_template_fallback);
+        m_embedding.set_cpu_out_tensor();
         ov::Tensor text_embeds = m_embedding.infer(input_ids);
 
         auto start_tokenizer_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
The speedup for without image input on my iGPU is 0.1% for Phi-3.5-vision-instruct and 2% for tiny-random-phi3-vision.