### PR TITLE
Fix excluding stop str from output for some tokenizer

### DIFF
--- a/src/cpp/src/sampler.cpp
+++ b/src/cpp/src/sampler.cpp
@@ -132,7 +132,7 @@ MatchStopStringResult match_stop_string(Tokenizer& tokenizer,
                 // find token cnt to be removed from sequence by decoding token by token
                 std::string decoded_partially_string;
                 for (size_t i = 0; i < buffer.size(); ++i) {
-                    decoded_partially_string += tokenizer.decode(TokenIds{buffer[i]});
+                    decoded_partially_string = tokenizer.decode(TokenIds{buffer.begin(), buffer.begin() + i + 1});
                     if (decoded_partially_string.find(decoded_buffer) != std::string::npos) {
                         result.to_remove = buffer.size() - i - 1;
                         break;

--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -99,6 +99,7 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::add_request(uint64_t reques
     std::lock_guard<std::mutex> lock(m_draft_generations_mutex);
     auto draft_sampling_params = sampling_params;
     draft_sampling_params.ignore_eos = true;
+    draft_sampling_params.stop_strings = {};
     m_draft_generations.insert({request_id, m_draft_pipeline->add_request(request_id, input_ids, draft_sampling_params)});
     return m_main_pipeline->add_request(request_id, input_ids, sampling_params);
 };
@@ -111,6 +112,7 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::add_request(uint64_t reques
     std::lock_guard<std::mutex> lock(m_draft_generations_mutex);
     auto draft_sampling_params = sampling_params;
     draft_sampling_params.ignore_eos = true;
+    draft_sampling_params.stop_strings = {};
     m_draft_generations.insert({request_id, m_draft_pipeline->add_request(request_id, prompt, draft_sampling_params)});
     return m_main_pipeline->add_request(request_id, prompt, sampling_params);
 }
@@ -255,6 +257,7 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
         auto draft_sampling_params = sampling_params[request_id];
         // set the parameters do not stop draft generation without stopping of the same request for main pipeline
         draft_sampling_params.ignore_eos = true;
+        draft_sampling_params.stop_strings = {};
         std::lock_guard<std::mutex> lock(m_draft_generations_mutex);
         m_draft_generations.insert({request_id, m_draft_pipeline->add_request(request_id, input_ids[request_id], draft_sampling_params)});
     }

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -397,7 +397,7 @@ def test_pipelines_generate_with_streaming_empty_output(tmp_path, pipeline_type)
     convert_models(opt_model, hf_tokenizer, models_path)
     
     generation_config = GenerationConfig()
-    generation_config.stop_strings = {" the "}
+    generation_config.stop_strings = {" the"}
     generation_config.include_stop_str_in_output = False
 
     pipe, input, generation_config = get_data_by_pipeline_type(models_path, pipeline_type, generation_config)

--- a/tests/python_tests/test_sampling.py
+++ b/tests/python_tests/test_sampling.py
@@ -34,24 +34,25 @@ def test_basic_stop_criteria(tmp_path, generation_config, prompt):
 
 
 @pytest.mark.precommit
-@pytest.mark.parametrize("generation_config",
-                         [dict(max_new_tokens=50, min_new_tokens=15, stop_strings={"anag"}, include_stop_str_in_output=True), # expected match on "manage"
-                          dict(max_new_tokens=50, min_new_tokens=1, stop_strings={".", "software", "Intel"}, include_stop_str_in_output=True),
-                          dict(max_new_tokens=50, min_new_tokens=1, stop_strings={"Einstein", "sunny", "geothermal"}, include_stop_str_in_output=True), # expected no match
-                          dict(max_new_tokens=30, stop_strings={ "machines" }, include_stop_str_in_output=False),
-                          dict(max_new_tokens=30, stop_strings={ "machines" }, include_stop_str_in_output=True),
-                          dict(max_new_tokens=30, stop_strings={ "machines", "manage" }, include_stop_str_in_output=False),
-                          dict(max_new_tokens=30, stop_strings={ "machines", "manage" }, include_stop_str_in_output=True),],
+@pytest.mark.parametrize("generation_config,model_id",
+                         [(dict(max_new_tokens=50, min_new_tokens=15, stop_strings={"anag"}, include_stop_str_in_output=True), 'facebook/opt-125m'), # expected match on "manage"
+                          (dict(max_new_tokens=50, min_new_tokens=1, stop_strings={".", "software", "Intel"}, include_stop_str_in_output=True), 'facebook/opt-125m'),
+                          (dict(max_new_tokens=50, min_new_tokens=1, stop_strings={"Einstein", "sunny", "geothermal"}, include_stop_str_in_output=True), 'facebook/opt-125m'), # expected no match
+                          (dict(max_new_tokens=30, stop_strings={ "machines" }, include_stop_str_in_output=False),'facebook/opt-125m'),
+                          (dict(max_new_tokens=30, stop_strings={ "machines" }, include_stop_str_in_output=True), 'facebook/opt-125m'),
+                          (dict(max_new_tokens=30, stop_strings={ "machines", "manage" }, include_stop_str_in_output=False), 'facebook/opt-125m'),
+                          (dict(max_new_tokens=30, stop_strings={ "machines", "manage" }, include_stop_str_in_output=True), 'facebook/opt-125m'),
+                          (dict(max_new_tokens=30, stop_strings={ "software toolkit developed 1 by", "Intel" }, include_stop_str_in_output=False), 'TinyLlama/TinyLlama-1.1B-Chat-v1.0')],
                          ids=["single_stop_string",
                               "multiple_stop_strings_match",
                               "multiple_stop_strings_no_match",
                               "single_stop_string_exclude_from_output",
                               "single_stop_string_include_to_output",
                               "multiple_stop_strings_exclude_from_output",
-                              "multiple_stop_strings_include_to_output"])
-def test_stop_strings(tmp_path, generation_config):
+                              "multiple_stop_strings_include_to_output",
+                              "multiple_stop_strings_one_no_match_and_long_exclude_from_output"])
+def test_stop_strings(tmp_path, generation_config, model_id):
     prompts = [ "What is OpenVINO?" ]
-    model_id : str = "facebook/opt-125m"
     run_llm_pipeline_with_ref(model_id, prompts, generation_config, tmp_path)
 
 


### PR DESCRIPTION
For tokenizer of some model like TinyLlama/TinyLlama-1.1B-Chat-v1.0 , when detokenize happens token by token, spaces between detokenized word could be hide. And when we have several stop_str with different length it could affect result.

For example:
config.stop_strings = {"atoms with a large number of 11 protons", "ionized"}
prompt = `Why is the Sun yellow?`
answer = `The Sun is yellow because it is made up of hydrogen and helium atoms, which are composed of atoms with a large number of protons (hydrogen has 1 proton, helium has 2 protons). These atoms are highly ionized ...`

in `match_stop_string()` the first stop_str will not match, but then when the second one will be checked,  `decoded_partially_string` will eq `2protons).Theseatomsarehighlyionized` and the second stop_str will be stayed in output

