### PR TITLE
Add egg package name to avoid issues after pip freeze

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -11,8 +11,8 @@ torch
 transformers>=4.40.0
 diffusers>=0.22.0
 #optimum is in dependency list of optimum-intel 
-git+https://github.com/huggingface/optimum-intel.git@main
-git+https://github.com/openvinotoolkit/nncf.git@develop
+git+https://github.com/huggingface/optimum-intel.git@main#egg=optimum-intel
+git+https://github.com/openvinotoolkit/nncf.git@develop#egg=nncf
 packaging
 psutil
 timm


### PR DESCRIPTION
In CI we are reusing frozen requirements after `convert` job, installing them in `test` jobs. When there is no egg name defined, `pip freeze -r requirements.txt` is returning warning as following:

```
...
#optimum is in dependency list of optimum-intel
Skipping line in requirement file [repo_llm/tools/llm_bench/requirements.txt] because it's not clear what it would install: git+https://github.com/huggingface/optimum-intel.git@main
  (add #egg=PackageName to the URL to avoid this warning)
Skipping line in requirement file [repo_llm/tools/llm_bench/requirements.txt] because it's not clear what it would install: git+https://github.com/openvinotoolkit/nncf.git@develop
  (add #egg=PackageName to the URL to avoid this warning)
packaging==24.2
...
```

and that is causing `optimum-intel` and `nncf` not being installed in test jobs and benchmarks failing