### PR TITLE
CMAKE: use object librry between shared OpenVINO GenAI and tests

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -62,31 +62,47 @@ configure_file("${OpenVINOGenAI_SOURCE_DIR}/cmake/templates/version.hpp.in"
 configure_file("${OpenVINOGenAI_SOURCE_DIR}/cmake/templates/version.cpp.in"
                "${CMAKE_CURRENT_BINARY_DIR}/version.cpp" @ONLY)
 
-# Library
+# Object library
 
 file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
 list(APPEND SOURCE_FILES "${CMAKE_CURRENT_BINARY_DIR}/version.cpp")
 
 set(TARGET_NAME openvino_genai)
+set(TARGET_NAME_OBJ ${TARGET_NAME}_obj)
 
-add_library(${TARGET_NAME} SHARED ${SOURCE_FILES})
-add_library(openvino::genai ALIAS ${TARGET_NAME})
+add_library(${TARGET_NAME_OBJ} OBJECT ${SOURCE_FILES})
 
 if(TARGET openvino_tokenizers)
-    add_dependencies(${TARGET_NAME} openvino_tokenizers)
+    add_dependencies(${TARGET_NAME_OBJ} openvino_tokenizers)
 endif()
 
-target_include_directories(${TARGET_NAME}
+target_include_directories(${TARGET_NAME_OBJ}
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-           "$<INSTALL_INTERFACE:runtime/include>"
            "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-target_include_directories(${TARGET_NAME} SYSTEM PRIVATE "${safetensors.h_SOURCE_DIR}")
+target_include_directories(${TARGET_NAME_OBJ} SYSTEM PRIVATE "${safetensors.h_SOURCE_DIR}")
 
-target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime PRIVATE openvino::threading nlohmann_json::nlohmann_json jinja2cpp)
+target_link_libraries(${TARGET_NAME_OBJ} PRIVATE openvino::runtime openvino::threading nlohmann_json::nlohmann_json jinja2cpp)
 
-target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
+target_compile_features(${TARGET_NAME_OBJ} PRIVATE cxx_std_17)
+
+target_compile_definitions(${TARGET_NAME_OBJ} PRIVATE openvino_genai_EXPORTS)
+
+set_target_properties(${TARGET_NAME_OBJ} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Shared library
+
+add_library(${TARGET_NAME} SHARED $<TARGET_OBJECTS:${TARGET_NAME_OBJ}>)
+add_library(openvino::genai ALIAS ${TARGET_NAME})
+
+target_include_directories(${TARGET_NAME} INTERFACE "$<INSTALL_INTERFACE:runtime/include>"
+                                                    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
+
+target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime PRIVATE openvino::threading nlohmann_json::nlohmann_json jinja2cpp ${CMAKE_DL_LIBS})
+
+target_compile_features(${TARGET_NAME} INTERFACE cxx_std_17)
 
 set_target_properties(${TARGET_NAME} PROPERTIES
     EXPORT_NAME genai

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -30,5 +30,5 @@ target_include_directories(${TEST_TARGET_NAME} PRIVATE "${OpenVINOGenAI_SOURCE_D
                                                        $<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_options(${TEST_TARGET_NAME} PRIVATE /IGNORE:LNK4207,LNK4286)
+  target_link_options(${TEST_TARGET_NAME} PRIVATE /IGNORE:4207,4286)
 endif()

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,22 +19,16 @@ if(NOT TARGET gtest)
   endforeach()
 endif()
 
-set(TEST_TARGET_NAME "tests_continuous_batching")
 file(GLOB tests_src "*.cpp")
-file(GLOB src_files "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/sequence_group.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/cache_eviction.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/sampler.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/speculative_decoding/*.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/prompt_lookup/*.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/paged_attention_transformations.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/utils.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/continuous_batching*.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/icontinuous_batching.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/lora_helper.cpp"
-                    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src/text_callback_streamer.cpp")
 
-add_executable(${TEST_TARGET_NAME} ${tests_src})
+set(TEST_TARGET_NAME "tests_continuous_batching")
 
-target_link_libraries(${TEST_TARGET_NAME} PRIVATE openvino::genai gtest_main gmock_main)
-target_include_directories(${TEST_TARGET_NAME} PRIVATE "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src")
-target_sources(${TEST_TARGET_NAME} PRIVATE ${src_files})
+add_executable(${TEST_TARGET_NAME} ${tests_src} $<TARGET_OBJECTS:openvino_genai_obj>)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE $<TARGET_PROPERTY:openvino::genai,LINK_LIBRARIES> gtest_main gmock_main)
+target_include_directories(${TEST_TARGET_NAME} PRIVATE "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src"
+                                                       $<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_link_options(${TEST_TARGET_NAME} PRIVATE /IGNORE:LNK4207,LNK4286)
+endif()


### PR DESCRIPTION
To prevent linker issues like here https://github.com/openvinotoolkit/openvino.genai/pull/1690#discussion_r1949175544

Currently, some sources files are compiled as part of unit tests and it leads to double symbols conflicts on Windows. With current PR can reuse the same objects files for tests and OpenVINO GenAI shared library