### PR TITLE
Fix speculative decoding internal metrics

### DIFF
--- a/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
+++ b/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) try {
 
     std::cout << result << "\n";
 
-    std::cout << std::setprecision(2);
+    std::cout << std::fixed << std::setprecision(2);
     for (auto& chunk : *result.chunks) {
         std::cout << "timestamps: [" << chunk.start_ts << ", " << chunk.end_ts << "] text: " << chunk.text << "\n";
     }

--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -210,6 +210,7 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
         m_sd_metrics.print(true);
         m_sd_metrics.clean_up();
     }
+    step_timer.end();
 }
 
 std::vector<EncodedGenerationResult>

--- a/src/cpp/src/speculative_decoding/speculative_decoding_metrics.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_metrics.cpp
@@ -122,9 +122,9 @@ void SpeculativeDecodingMetrics::print(bool is_printing_per_request) {
         total_duration = draft_duration + main_duration;
     }
     std::cout << "\n=============================== " << std::endl;
-    std::cout << "Total duration, ms: " << total_duration << std::endl;
-    std::cout << "Draft model duration, ms: " << draft_duration << std::endl;
-    std::cout << "Main model duration, ms: " << main_duration << std::endl;
+    std::cout << "Total duration, sec: " << total_duration << std::endl;
+    std::cout << "Draft model duration, sec: " << draft_duration << std::endl;
+    std::cout << "Main model duration, sec: " << main_duration << std::endl;
     std::cout << "Draft model duration, %: " << get_draft_duration_percentage() << std::endl;
     std::cout << "Main model duration, %: " << get_main_duration_percentage() << std::endl;
     std::cout << "AVG acceptance rate, %: " << get_avg_acceptance_rate(-1) << std::endl;

--- a/src/cpp/src/timer.hpp
+++ b/src/cpp/src/timer.hpp
@@ -43,6 +43,6 @@ public:
     }
 
     ~ManualTimer() {
-        // std::cout << m_title << ": " << m_total / 1e6. << " secs" << std::endl;
+        // std::cout << m_title << ": " << m_total / 1e6 << " secs" << std::endl;
     }
 };


### PR DESCRIPTION
- Add missing `step_timer.end();` in ContinuousBatchingPipeline::SpeculativeDecodingImpl::step()
- Set correct unit as `second` instead of `ms` for total duration, draft duration and main duration since timer.get_duration() return seconds: 
https://github.com/openvinotoolkit/openvino.genai/blob/4595a870d14b7bcf128b68912f226efe9be54025/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp#L170
https://github.com/openvinotoolkit/openvino.genai/blob/4595a870d14b7bcf128b68912f226efe9be54025/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp#L154
https://github.com/openvinotoolkit/openvino.genai/blob/4595a870d14b7bcf128b68912f226efe9be54025/src/cpp/src/timer.hpp#L38
- Fix build issue when uncomment internal print in ~ManualTimer()