### PR TITLE
Update README.md to update OV2025.0 GenAI Whisper NPU requirement

### DIFF
--- a/samples/cpp/whisper_speech_recognition/README.md
+++ b/samples/cpp/whisper_speech_recognition/README.md
@@ -13,6 +13,8 @@ pip install --upgrade-strategy eager -r ../../requirements.txt
 optimum-cli export openvino --trust-remote-code --model openai/whisper-base whisper-base
 ```
 
+If NPU is the inference device, an additional option `--disable-stateful` is required. See [NPU with OpenVINO GenAI](https://docs.openvino.ai/nightly/openvino-workflow-generative/inference-with-genai/inference-with-genai-on-npu.html) for the detail.
+
 ## Prepare audio file
 
 Prepare audio file in wav format with sampling rate 16k Hz.

--- a/samples/python/whisper_speech_recognition/README.md
+++ b/samples/python/whisper_speech_recognition/README.md
@@ -13,6 +13,8 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 optimum-cli export openvino --trust-remote-code --model openai/whisper-base whisper-base
 ```
 
+If NPU is the inference device, an additional option `--disable-stateful` is required. See [NPU with OpenVINO GenAI](https://docs.openvino.ai/nightly/openvino-workflow-generative/inference-with-genai/inference-with-genai-on-npu.html) for the detail.
+
 ## Prepare audio file
 
 Download example audio file: https://storage.openvinotoolkit.org/models_contrib/speech/2021.2/librispeech_s5/how_are_you_doing_today.wav


### PR DESCRIPTION
Currently, the Whisper pipeline only accepts models generated with the "--disable-stateful" flag

Link:
https://docs.openvino.ai/nightly/openvino-workflow-generative/inference-with-genai/inference-with-genai-on-npu.html

Without "--disable-stateful" flag, the required openvino_decoder_with_past_model for NPU won't be generated.

Ticket:
https://jira.devtools.intel.com/browse/EISW-157876