### PR TITLE
VLMPipeline: remove duplicate reset

### DIFF
--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -252,10 +252,6 @@ public:
         decoded.perf_metrics.m_evaluated = false;
         decoded.perf_metrics.evaluate_statistics(generate_start_time);
 
-        if (!m_is_chat_conversation) {
-            m_language.get_tensor("attention_mask").set_shape({0, 0});
-        }
-
         return decoded;
     }
 


### PR DESCRIPTION
This also fixed generate() start_chat() generate() sequence