### PR TITLE
Fixed path to the Supported Models Section

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -500,7 +500,7 @@ For information on how OpenVINO™ GenAI works, refer to the [How It Works Secti
 
 ## Supported Models
 
-For a list of supported models, refer to the [Supported Models Section](./docs/SUPPORTED_MODELS.md).
+For a list of supported models, refer to the [Supported Models Section](../SUPPORTED_MODELS.md).
 
 ## Debug Log
 


### PR DESCRIPTION
It mentions in src/README.md that the path to the Supported Models Section is src/docs/SUPPORTED_MODELS.md, which is incorrect.