### PR TITLE
Added mutex to get_inputs_embeds().

### DIFF
--- a/src/cpp/src/icontinuous_batching.cpp
+++ b/src/cpp/src/icontinuous_batching.cpp
@@ -147,17 +147,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     OPENVINO_ASSERT(prompts.size() == sampling_params.size(), "Number of prompts should be equal to the number of generation configs.");
     OPENVINO_ASSERT(prompts.size() == rgbs_vector.size(), "Number of prompts should be equal to the number of images vectors.");
 
-    for (auto config: sampling_params) {
-        // If eos_token_id was not provided, take value from default m_generation_config
-        if (config.eos_token_id == -1) {
-            config.set_eos_token_id(m_generation_config.eos_token_id);
-        }
-        if (config.stop_token_ids.empty()) {
-            config.stop_token_ids = m_generation_config.stop_token_ids;
-        }
-        config.validate();
-    }
-
     std::vector<ov::Tensor> input_embeds_list;
     for (size_t i = 0; i < prompts.size(); i++) {
         auto prompt = prompts[i];

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -1962,6 +1962,7 @@ InputsEmbedder::InputsEmbedder(const VLMConfig& vlm_config,
 }
 
 ov::Tensor InputsEmbedder::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
+    const std::lock_guard<std::mutex> lock(m_inputs_embedder_mutex);
     return m_impl->get_inputs_embeds(prompt, images, metrics);
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -67,6 +67,7 @@ public:
 private:
     class IInputsEmbedder;
     std::shared_ptr<IInputsEmbedder> m_impl;
+    std::mutex m_inputs_embedder_mutex;
 
     friend class InputsEmbedderMiniCPM;
     friend class InputsEmbedderLLaVA;


### PR DESCRIPTION
Currently `add_request()` for VLM's fails when executed in multiple threads, as the same embeddings model is used and infer request is busy. Added mutex to `get_inputs_embeds()` to fix this error.