### PR TITLE
Use circular buffer of infer requests in VLM components

### DIFF
--- a/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
@@ -74,7 +74,8 @@ public:
                                const SchedulerConfig& scheduler_config,
                                const std::string& device,
                                const ov::AnyMap& properties = {},
-                               const ov::AnyMap& tokenizer_properties = {});
+                               const ov::AnyMap& tokenizer_properties = {},
+                               const ov::AnyMap& vision_encoder_properties = {});
 
     /**
     * @brief Constructs a ContinuousBatchingPipeline when ov::genai::Tokenizer is initialized manually using file from the different dirs.

--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -48,7 +48,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
                                                         const SchedulerConfig& scheduler_config,
                                                         const std::string& device,
                                                         const ov::AnyMap& properties,
-                                                        const ov::AnyMap& tokenizer_properties) {
+                                                        const ov::AnyMap& tokenizer_properties,
+                                                        const ov::AnyMap& vision_encoder_properties) {
     auto start_time = std::chrono::steady_clock::now();
 
     auto properties_without_draft_model = properties;
@@ -73,7 +74,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(directory / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(directory, device, properties);
+        embedder = std::make_shared<InputsEmbedder>(directory, device, vision_encoder_properties);
     }
 
     if (is_prompt_lookup_enabled) {

--- a/src/cpp/src/icontinuous_batching.cpp
+++ b/src/cpp/src/icontinuous_batching.cpp
@@ -214,12 +214,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(uint64_t re
                                         GenerationConfig sampling_params) {
     OPENVINO_ASSERT(m_model_input_type == ModelInputType::EMBEDDINGS, "Model doesn't support embeddings.");
     ov::genai::VLMPerfMetrics metrics;
-    ov::Tensor inputs;
-    {
-        const std::lock_guard<std::mutex> lock(m_inputs_embedder_mutex);
-        m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
-        inputs = m_inputs_embedder->get_inputs_embeds(prompt, rgbs, metrics);
-    }
+    m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
+    ov::Tensor inputs = m_inputs_embedder->get_inputs_embeds(prompt, rgbs, metrics);
     return add_request(request_id, inputs, sampling_params);
 }
 

--- a/src/cpp/src/icontinuous_batching.hpp
+++ b/src/cpp/src/icontinuous_batching.hpp
@@ -57,7 +57,6 @@ protected:
 
     ModelInputType m_model_input_type = ModelInputType::TOKENS;
     std::shared_ptr<InputsEmbedder> m_inputs_embedder;
-    std::mutex m_inputs_embedder_mutex;
 
     void stream_tokens(const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr, const GenerationHandle& handle);
 public:

--- a/src/cpp/src/llm_pipeline_stateful.cpp
+++ b/src/cpp/src/llm_pipeline_stateful.cpp
@@ -351,7 +351,7 @@ EncodedResults StatefulLLMPipeline::generate(
     }
 
     ov::genai::utils::GenerationFinishInfo finish_info = get_lm_encoded_results(m_model_runner, input_ids, concatenated_attention_mask, streamer_ptr, m_sampler,
-                                                                                requests, position_ids, m_kv_cache_state, std::nullopt, std::nullopt, m_max_kv_cache_size);
+                                                                                requests, position_ids, m_kv_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -83,7 +83,7 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
     std::vector<SequenceGroup::Ptr> sequence_groups,
     std::optional<ov::Tensor> position_ids,
     utils::KVCacheState& kv_cache_state,
-    std::optional<EmbeddingsModel> m_embedding,
+    EmbeddingsModel::Ptr m_embedding,
     std::optional<int64_t> rope_delta,
     const size_t max_kv_cache_size
 ) {
@@ -134,7 +134,7 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
 
     // Initialize inputs
 
-    if (m_embedding.has_value()) {
+    if (m_embedding) {
         m_llm.set_tensor("inputs_embeds", input_ids);
     } else {
         kv_cache_state.add_inputs(input_ids);
@@ -224,9 +224,9 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
             beam_offets[active_sequence_groups.at(i)->get_request_id()] = i == 0 ? 0 : (active_sequence_groups.at(i - 1)->num_running_seqs() + beam_offets[i - 1]);
         }
 
-        if (m_embedding.has_value()) {
+        if (m_embedding) {
             constexpr bool return_remote_tensor = true;
-            const ov::Tensor& embed_prompt_tensor = (*m_embedding).infer(new_input_ids, return_remote_tensor);
+            const ov::Tensor& embed_prompt_tensor = m_embedding->infer(new_input_ids, return_remote_tensor);
             m_llm.set_tensor("inputs_embeds", embed_prompt_tensor);
         } else {
             m_llm.set_tensor("input_ids", new_input_ids);

--- a/src/cpp/src/lm_encoding.hpp
+++ b/src/cpp/src/lm_encoding.hpp
@@ -10,7 +10,7 @@ namespace genai {
 
 ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(ov::InferRequest& m_llm, const ov::Tensor& input_ids, const ov::Tensor& attention_mask,
                                                               const std::shared_ptr<StreamerBase>& streamer_ptr, Sampler& sampler, std::vector<SequenceGroup::Ptr> sequence_groups,
-                                                              std::optional<ov::Tensor> position_ids, utils::KVCacheState& m_kv_cache_state, std::optional<EmbeddingsModel> m_embedding,
+                                                              std::optional<ov::Tensor> position_ids, utils::KVCacheState& m_kv_cache_state, EmbeddingsModel::Ptr m_embedding,
                                                               std::optional<int64_t> rope_delta = std::nullopt, const size_t max_kv_cache_size = std::numeric_limits<size_t>::max());
 
 

--- a/src/cpp/src/model_runner.hpp
+++ b/src/cpp/src/model_runner.hpp
@@ -44,7 +44,7 @@ class ModelRunner {
     // A model to compute token embeddings.
     // Input shape: [N, conversation length].
     // Output shape: [1, conversation length, hidden_size].
-    EmbeddingsModel m_embedding;
+    EmbeddingsModel::Ptr m_embedding;
 
 public:
     /**
@@ -81,7 +81,7 @@ public:
         return m_request;
     }
 
-    void set_embedding_model(const EmbeddingsModel& embedder) {
+    void set_embedding_model(const EmbeddingsModel::Ptr& embedder) {
         m_embedding = embedder;
     }
 
@@ -157,7 +157,6 @@ public:
         int64_t *input_ids_data = nullptr;
         
         if (sequence_group_type == SequenceGroupType::EMBEDDINGS) {
-            OPENVINO_ASSERT(m_embedding.get_request(), "Got sequence group with embeddings, but embeddings model wasn't set.");
             inputs_embeds_data = inputs_embeds.data<float>();
         } else if (sequence_group_type == SequenceGroupType::TOKENS) {
             input_ids_data = input_ids.data<int64_t>();
@@ -330,8 +329,6 @@ public:
 
         ov::Tensor generated_ids_embeds;
         float *generated_ids_embeds_data = nullptr;
-        
-        OPENVINO_ASSERT(m_embedding.get_request(), "Got sequence group with embeddings, but embeddings model wasn't set.");
 
         ov::Tensor generated_ids = ov::Tensor(ov::element::i64, {1, num_generated_ids_without_embeddings});
         int64_t *generated_ids_data = generated_ids.data<int64_t>();
@@ -348,7 +345,7 @@ public:
             }
         }
         if (pos > 0) {
-            generated_ids_embeds = m_embedding.infer(generated_ids);
+            generated_ids_embeds = m_embedding->infer(generated_ids);
             generated_ids_embeds_data = generated_ids_embeds.data<float>();
 
             for (size_t i = 0; i < num_sequence_groups; ++i) {

--- a/src/cpp/src/tokenizer.cpp
+++ b/src/cpp/src/tokenizer.cpp
@@ -438,8 +438,7 @@ public:
         set_state_if_necessary(infer_request_guard, tokenization_params);
         size_t batch_size = 1;
         infer_request_guard.get().set_input_tensor(ov::Tensor{ov::element::string, {batch_size}, &prompt});
-        infer_request_guard.get().start_async();
-        infer_request_guard.get().wait();
+        infer_request_guard.get().infer();
 
         return get_copied_results(
             infer_request_guard.get().get_tensor("input_ids"),
@@ -457,8 +456,7 @@ public:
             set_state_if_necessary(infer_request_guard, tokenization_params);
             infer_request_guard.get().set_input_tensor(ov::Tensor{ov::element::string, {prompts.size()}, prompts.data()});
             auto size_ = infer_request_guard.get().get_input_tensor().get_shape();
-            infer_request_guard.get().start_async();
-            infer_request_guard.get().wait();
+            infer_request_guard.get().infer();
 
             unpadded = get_copied_results(
                 infer_request_guard.get().get_tensor("input_ids"),
@@ -485,8 +483,7 @@ public:
         set_state_if_necessary(infer_request_guard, detokenization_params);
         size_t batch_size = 1;
         infer_request_guard.get().set_input_tensor(ov::Tensor{ov::element::i64, {batch_size, tokens.size()}, tokens.data()});
-        infer_request_guard.get().start_async();
-        infer_request_guard.get().wait();
+        infer_request_guard.get().infer();
         return infer_request_guard.get().get_output_tensor().data<std::string>()[0];
     }
 
@@ -498,8 +495,7 @@ public:
         CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_detokenizer.get());
         set_state_if_necessary(infer_request_guard, detokenization_params);
         infer_request_guard.get().set_input_tensor(tokens);
-        infer_request_guard.get().start_async();
-        infer_request_guard.get().wait();
+        infer_request_guard.get().infer();
 
         auto res = infer_request_guard.get().get_output_tensor();
         auto res_data = res.data<std::string>();
@@ -527,8 +523,7 @@ public:
         CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_detokenizer.get());
         set_state_if_necessary(infer_request_guard, detokenization_params);
         infer_request_guard.get().set_input_tensor(tokens);
-        infer_request_guard.get().start_async();
-        infer_request_guard.get().wait();
+        infer_request_guard.get().infer();
         auto res = infer_request_guard.get().get_output_tensor();
         auto res_data = res.data<std::string>();
         return std::vector<std::string>(res_data, res_data + res.get_shape()[0]);

--- a/src/cpp/src/visual_language/embedding_model.cpp
+++ b/src/cpp/src/visual_language/embedding_model.cpp
@@ -15,17 +15,24 @@
 
 namespace {
 
-std::tuple<ov::InferRequest, ov::Tensor, ov::Tensor> init(ov::CompiledModel& compiled) {
-    ov::InferRequest ireq = compiled.create_infer_request();
-    ov::Tensor cpu_tensor = ireq.get_output_tensor();
-    ov::RemoteContext context;
-    try {
-        context = compiled.get_context();
-    } catch (const ov::Exception&) {
-        return {std::move(ireq), cpu_tensor, cpu_tensor};
-    }
-    ov::RemoteTensor remote = context.create_tensor(ov::element::f32, cpu_tensor.get_shape());
-    return {std::move(ireq), std::move(cpu_tensor), std::move(remote)};
+std::unique_ptr<ov::genai::CircularBufferQueue<ov::genai::EmbeddingsRequest>> init(ov::CompiledModel& compiled) {
+    auto embeddings_requests_queue = std::make_unique<ov::genai::CircularBufferQueue<ov::genai::EmbeddingsRequest>>(
+        compiled.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled]() -> ov::genai::EmbeddingsRequest {
+            ov::genai::EmbeddingsRequest req;
+            req.ireq = compiled.create_infer_request();
+            req.cpu_tensor = req.ireq.get_output_tensor();
+            ov::RemoteContext context;
+            try {
+                context = compiled.get_context();
+            } catch (const ov::Exception&) {
+                req.remote_tensor = req.cpu_tensor;
+                return req;
+            }
+            req.remote_tensor = context.create_tensor(ov::element::f32, req.cpu_tensor.get_shape());
+            return req;
+        });
+    return embeddings_requests_queue;
 }
 
 }  // namespace
@@ -44,7 +51,7 @@ EmbeddingsModel::EmbeddingsModel(const std::filesystem::path& model_dir,
 
     ov::CompiledModel compiled_model = core.compile_model(m_model, device, properties);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "text embeddings model");
-    std::tie(m_request, m_cpu_tensor, m_remote_tensor) = init(compiled_model);
+    m_embeddings_requests_queue = init(compiled_model);
 }
 
 EmbeddingsModel::EmbeddingsModel(const std::string& model,
@@ -58,20 +65,21 @@ EmbeddingsModel::EmbeddingsModel(const std::string& model,
     merge_postprocess(m_model, scale_emb);
 
     ov::CompiledModel compiled_model = core.compile_model(m_model, device, properties);
-    std::tie(m_request, m_cpu_tensor, m_remote_tensor) = init(compiled_model);
+    m_embeddings_requests_queue = init(compiled_model);
 }
 
 ov::Tensor EmbeddingsModel::infer(const ov::Tensor& input_idx, bool return_remote_tensor) {
-    OPENVINO_ASSERT(m_request, "Text embeddings decoder model must be compiled first. Cannot infer non-compiled model");
-
-    m_request.set_input_tensor(input_idx);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(this->m_embeddings_requests_queue.get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    OPENVINO_ASSERT(req.ireq, "Text embeddings decoder model must be compiled first. Cannot infer non-compiled model");
+    req.ireq.set_input_tensor(input_idx);
     if (return_remote_tensor) {
-        m_request.set_output_tensor(m_remote_tensor);
+        req.ireq.set_output_tensor(req.remote_tensor);
     } else {
-        m_request.set_output_tensor(m_cpu_tensor);
+        req.ireq.set_output_tensor(req.cpu_tensor);
     }
-    m_request.infer();
-    return m_request.get_output_tensor();
+    req.ireq.infer();
+    return req.ireq.get_output_tensor();
 }
 
 void EmbeddingsModel::merge_postprocess(std::shared_ptr<ov::Model> model, float scale_emb) const {

--- a/src/cpp/src/visual_language/embedding_model.hpp
+++ b/src/cpp/src/visual_language/embedding_model.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <vector>
 #include <string>
+#include <memory>
 
 #include "openvino/core/any.hpp"
 #include "openvino/runtime/core.hpp"
@@ -17,12 +18,21 @@
 
 #include <openvino/openvino.hpp>
 #include "visual_language/processor_config.hpp"
+#include "circular_buffer_queue.hpp"
 
 namespace ov {
 namespace genai {
 
+struct EmbeddingsRequest {
+    ov::InferRequest ireq;
+    ov::Tensor cpu_tensor;
+    ov::Tensor remote_tensor;
+};
+
 class EmbeddingsModel {
 public:
+    using Ptr = std::shared_ptr<EmbeddingsModel>;
+
     EmbeddingsModel(const std::filesystem::path& model_dir,
                     const float scale_emb,
                     const std::string& device,
@@ -36,17 +46,26 @@ public:
 
     EmbeddingsModel() = default;
 
-    ov::Tensor infer(const ov::Tensor& input_idx, bool return_remote_tensor=false);
-
-    ov::InferRequest get_request() {
-        return m_request;
+    static Ptr create(const std::filesystem::path& model_dir,
+                      const float scale_emb,
+                      const std::string& device,
+                      const ov::AnyMap& properties) {
+        return std::make_shared<EmbeddingsModel>(model_dir, scale_emb, device, properties);
     }
+
+    static Ptr create(const std::string& model,
+                      const ov::Tensor& weights,
+                      const float scale_emb,
+                      const std::string& device,
+                      const ov::AnyMap& properties) {
+        return std::make_shared<EmbeddingsModel>(model, weights, scale_emb, device, properties);
+    }
+
+    ov::Tensor infer(const ov::Tensor& input_idx, bool return_remote_tensor=false);
 private:
     void merge_postprocess(std::shared_ptr<ov::Model> model, float scale_emb) const;
 
-    ov::InferRequest m_request;
-    ov::Tensor m_cpu_tensor;
-    ov::Tensor m_remote_tensor;
+    std::unique_ptr<CircularBufferQueue<EmbeddingsRequest>> m_embeddings_requests_queue;
 };
 
 } // namespace genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -83,7 +83,7 @@ InputsEmbedder::IInputsEmbedder::IInputsEmbedder(
         const ov::AnyMap device_config) :
     m_vlm_config{vlm_config},
     m_vision_encoder(VisionEncoder::create(model_dir, m_vlm_config.model_type, device, device_config)),
-    m_embedding(model_dir, m_vlm_config.scale_emb, device, device_config),
+    m_embedding(EmbeddingsModel::create(model_dir, m_vlm_config.scale_emb, device, device_config)),
     m_tokenizer{model_dir, device_config} { }
 
 InputsEmbedder::IInputsEmbedder::IInputsEmbedder(
@@ -102,13 +102,13 @@ InputsEmbedder::IInputsEmbedder::IInputsEmbedder(
         device,
         device_config
     )),
-    m_embedding(
+    m_embedding(EmbeddingsModel::create(
         utils::get_model_weights_pair(models_map, "text_embeddings").first,
         utils::get_model_weights_pair(models_map, "text_embeddings").second,
         m_vlm_config.scale_emb,
         device,
         device_config
-    ),
+    )),
     m_tokenizer(tokenizer) { }
 
 ov::Tensor InputsEmbedder::IInputsEmbedder::apply_chat_template_tokenize(const std::string& prompt, ov::genai::VLMPerfMetrics& metrics) {
@@ -243,7 +243,7 @@ std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::get_position_ids(c
     return m_impl->get_position_ids(inputs_embeds_size, history_size);
 }
 
-EmbeddingsModel InputsEmbedder::get_embedding_model() const {
+EmbeddingsModel::Ptr InputsEmbedder::get_embedding_model() const {
     return m_impl->get_embedding_model();
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -39,7 +39,7 @@ public:
     std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
 
     // returns embedding model which converts token_id(s) to embedding vectors
-    EmbeddingsModel get_embedding_model() const;
+    EmbeddingsModel::Ptr get_embedding_model() const;
 
     // returns tokenizer
     Tokenizer get_tokenizer() const;
@@ -71,7 +71,7 @@ private:
         // A model to compute token embeddings.
         // Input shape: [N, conversation length].
         // Output shape: [1, conversation length, hidden_size].
-        EmbeddingsModel m_embedding;
+        EmbeddingsModel::Ptr m_embedding;
         // A tokenizer encoding a prompt.
         Tokenizer m_tokenizer;
         // True if chat mode is activated to save conversation
@@ -95,7 +95,7 @@ private:
     
         virtual std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
     
-        EmbeddingsModel get_embedding_model() const {
+        EmbeddingsModel::Ptr get_embedding_model() const {
             return m_embedding;
         }
     

--- a/src/cpp/src/visual_language/internvl_chat/classes.cpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.cpp
@@ -129,14 +129,16 @@ ov::Tensor get_pixel_values_internvl(const ov::Tensor& image, const ProcessorCon
 } // namespace
 
 EncodedImage VisionEncoderInternVLChat::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     ov::Tensor pixel_values = get_pixel_values_internvl(image, config);
 
-    m_vision_encoder.set_tensor("pixel_values", pixel_values);
-    m_vision_encoder.infer();
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
 
-    const ov::Tensor& infer_output = m_vision_encoder.get_output_tensor();
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
     ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
     std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
 
@@ -253,7 +255,7 @@ ov::Tensor InputsEmbedderInternVLChat::get_inputs_embeds(const std::string& prom
     formatted_prompt += prompt;
 
     ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics);
-    ov::Tensor text_embeds = m_embedding.infer(input_ids);
+    ov::Tensor text_embeds = m_embedding->infer(input_ids);
 
     if (images.empty()) {
         return text_embeds;

--- a/src/cpp/src/visual_language/llava/classes.cpp
+++ b/src/cpp/src/visual_language/llava/classes.cpp
@@ -68,15 +68,17 @@ ov::Tensor get_pixel_values_llava(const ov::Tensor& image, const ProcessorConfig
 
 } // namespace
 
-EncodedImage VisionEncoderLLaVA::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+EncodedImage VisionEncoderLLaVA::encode( const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     ov::Tensor pixel_values = get_pixel_values_llava(image, config);
 
-    m_vision_encoder.set_tensor("pixel_values", pixel_values);
-    m_vision_encoder.infer();
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
 
-    const ov::Tensor& infer_output = m_vision_encoder.get_output_tensor();
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
     ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
     std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
 
@@ -122,7 +124,7 @@ ov::Tensor InputsEmbedderLLaVA::get_inputs_embeds(const std::string& prompt, con
     formatted_prompt += prompt;
 
     ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics);
-    ov::Tensor text_embeds = m_embedding.infer(input_ids);
+    ov::Tensor text_embeds = m_embedding->infer(input_ids);
 
     if (images.empty()) {
         return text_embeds;

--- a/src/cpp/src/visual_language/llava_next/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next/classes.cpp
@@ -50,14 +50,16 @@ ov::Tensor get_pixel_values_llava_next(const ov::Tensor& image, const ProcessorC
 } // namespace
 
 EncodedImage VisionEncoderLLaVANext::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     ov::Tensor pixel_values = get_pixel_values_llava_next(image, config);
 
-    m_vision_encoder.set_tensor("pixel_values", pixel_values);
-    m_vision_encoder.infer();
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
 
-    const ov::Tensor& infer_output = m_vision_encoder.get_output_tensor();
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
     ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
     std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
 
@@ -365,7 +367,7 @@ ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& prompt,
     formatted_prompt += prompt;
 
     ov::Tensor input_ids = get_encoded_input_ids(formatted_prompt, metrics);
-    ov::Tensor text_embeds = m_embedding.infer(input_ids);
+    ov::Tensor text_embeds = m_embedding->infer(input_ids);
 
     if (images.empty()) {
         return text_embeds;

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -404,13 +404,15 @@ EncodedImage llava_image_embed_make_with_bytes_slice(clip_ctx& ctx_clip, const o
 } // namespace
 
 EncodedImage VisionEncoderMiniCPM::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     clip_ctx ctx_clip;
     ctx_clip.image_size = config.image_size;
     std::copy(config.norm_mean.begin(), config.norm_mean.end(), ctx_clip.image_mean);
     std::copy(config.norm_std.begin(), config.norm_std.end(), ctx_clip.image_std);
-    return llava_image_embed_make_with_bytes_slice(ctx_clip, image, m_vision_encoder, config.max_slice_nums, config.scale_resolution, config.patch_size, 0 == config.max_slice_nums);
+    return llava_image_embed_make_with_bytes_slice(ctx_clip, image, encoder, config.max_slice_nums, config.scale_resolution, config.patch_size, 0 == config.max_slice_nums);
 }
 
 namespace {
@@ -549,7 +551,11 @@ InputsEmbedderMiniCPM::InputsEmbedderMiniCPM(
     auto compiled_model =
         utils::singleton_core().compile_model(model_dir / "openvino_resampler_model.xml", device, device_config);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "VLM resampler model");
-    m_resampler = compiled_model.create_infer_request();
+    m_ireq_queue_resampler = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
     m_pos_embed_cache = get_2d_sincos_pos_embed(m_vlm_config.hidden_size, {70, 70});
 }
 
@@ -561,12 +567,16 @@ InputsEmbedderMiniCPM::InputsEmbedderMiniCPM(
     const std::string& device,
     const ov::AnyMap device_config) :
     IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {
-    m_resampler = utils::singleton_core().compile_model(
+    auto compiled_model = utils::singleton_core().compile_model(
         utils::get_model_weights_pair(models_map, "resampler").first,
         utils::get_model_weights_pair(models_map, "resampler").second,
         device,
-        device_config
-    ).create_infer_request();
+        device_config);
+    m_ireq_queue_resampler = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
     m_pos_embed_cache = get_2d_sincos_pos_embed(m_vlm_config.hidden_size, {70, 70});
 }
 
@@ -609,7 +619,7 @@ ov::Tensor InputsEmbedderMiniCPM::get_inputs_embeds(const std::string& prompt, c
 
     ov::Tensor encoded_input = get_encoded_input_ids(unified_prompt, metrics);
 
-    ov::Tensor inputs_embeds = m_embedding.infer(encoded_input);
+    ov::Tensor inputs_embeds = m_embedding->infer(encoded_input);
     OPENVINO_ASSERT(
         m_vlm_config.hidden_size == inputs_embeds.get_shape().at(2),
         "Unexpected embedding size"
@@ -733,11 +743,13 @@ ov::Tensor InputsEmbedderMiniCPM::resample(const ov::Tensor& encoded_image, cons
         std::fill_n(mask_data + i * max_patch_len, patch_len[i], 0.0f);
         std::fill_n(mask_data + i * max_patch_len + patch_len[i], max_patch_len - patch_len[i], 1.0f);
     }
-    m_resampler.set_tensor("image_feature", encoded_image);  // [N, H*W, old_hidden_size]
-    m_resampler.set_tensor("pos_embed", pos_embed);  // [H*W, N, new_hidden_size]
-    m_resampler.set_tensor("key_padding_mask", key_padding_mask);  // [N, H*W]
-    m_resampler.infer();
-    return m_resampler.get_output_tensor();  // [N, query_num, new_hidden_size]
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_resampler.get());
+    ov::InferRequest& resampler = infer_request_guard.get();
+    resampler.set_tensor("image_feature", encoded_image);  // [N, H*W, old_hidden_size]
+    resampler.set_tensor("pos_embed", pos_embed);  // [H*W, N, new_hidden_size]
+    resampler.set_tensor("key_padding_mask", key_padding_mask);  // [N, H*W]
+    resampler.infer();
+    return resampler.get_output_tensor();  // [N, query_num, new_hidden_size]
 }
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/minicpm/classes.hpp
+++ b/src/cpp/src/visual_language/minicpm/classes.hpp
@@ -23,7 +23,7 @@ class InputsEmbedderMiniCPM : public InputsEmbedder::IInputsEmbedder {
     // A resampler model to resample image embeddings.
     // [N, H*W, old_hidden_size] is the input shape.
     // [N, query_num, hidden_size] is the output shape.
-    ov::InferRequest m_resampler;
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_resampler;
     // Precomputed positional embeddings for the resampler.
     // [70, 70, hidden_size]. 70 is the initial guess of the image
     // height and width after dividing by patch_size.

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -212,12 +212,14 @@ std::tuple<ov::Tensor, ImageSize> get_pixel_values_phi3_v(const ov::Tensor& imag
 } // namespace
 
 EncodedImage VisionEncoderPhi3V::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     const auto& [pixel_values, image_size] = get_pixel_values_phi3_v(image, config);
-    m_vision_encoder.set_input_tensor(pixel_values);
-    m_vision_encoder.infer();
-    return {m_vision_encoder.get_output_tensor(), image_size};
+    encoder.set_input_tensor(pixel_values);
+    encoder.infer();
+    return {encoder.get_output_tensor(), image_size};
 }
 
 namespace {
@@ -270,7 +272,7 @@ namespace {
 // print(test([inp, 2, 2])["o"].flatten())
 // 2. Run https://github.com/slyalin/openvino_devtools/blob/bcd4a51b1354b24b2316ac3e1c77b2f87ae7a497/openvino_devtools/ov2py.py with the IR.
 // 3. Translate the printed Python implementation to C++.
-ov::InferRequest create_hd_feature_transformer() {
+ov::CompiledModel create_hd_feature_transformer() {
     using namespace ov;
     using namespace element;
     using namespace opset13;
@@ -348,7 +350,7 @@ ov::InferRequest create_hd_feature_transformer() {
     shared_ptr<Model> model = make_shared<Model>(make_shared<Result>(t69), ParameterVector{t0, t1, t2});
     return utils::singleton_core().compile_model(
         model, "CPU"
-    ).create_infer_request();
+    );
 }
 
 ov::Tensor reshape_hd_patches_2x2merge(const ov::Tensor& image_features, size_t h_crop, size_t w_crop, InferRequest& hd_feature_transformer) {
@@ -511,16 +513,32 @@ InputsEmbedderPhi3V::InputsEmbedderPhi3V(
     const std::filesystem::path& model_dir,
     const std::string& device,
     const ov::AnyMap device_config
-) : IInputsEmbedder(vlm_config, model_dir, device, device_config),
-    m_hd_feature_transformer{create_hd_feature_transformer()},
-    m_vision_projection{utils::singleton_core().compile_model(model_dir / "openvino_vision_projection_model.xml", device, {}).create_infer_request()} {}
+) : IInputsEmbedder(vlm_config, model_dir, device, device_config) {
+        auto compiled_model = create_hd_feature_transformer();
+        m_ireq_queue_hd_feature_transformer = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled_model.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled_model]() -> ov::InferRequest {
+                return compiled_model.create_infer_request();
+            });
+
+        compiled_model = utils::singleton_core().compile_model(model_dir / "openvino_vision_projection_model.xml", device, {});
+        m_ireq_queue_vision_projection = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled_model.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled_model]() -> ov::InferRequest {
+                return compiled_model.create_infer_request();
+            });
+    }
 
 ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
     std::vector<ov::Tensor> images_features_proj;
     std::stringstream images_prompt;
+    CircularBufferQueueElementGuard<ov::InferRequest> hd_feature_transformer_ireq_guard(this->m_ireq_queue_hd_feature_transformer.get());
+    CircularBufferQueueElementGuard<ov::InferRequest> vision_projection_ireq_guard(this->m_ireq_queue_vision_projection.get());
+    ov::InferRequest& hd_feature_transformer = hd_feature_transformer_ireq_guard.get();
+    ov::InferRequest& vision_projection = vision_projection_ireq_guard.get();
     for (const ov::Tensor& image : to_single_image_tensors(images)) {
         EncodedImage encoded_image = m_vision_encoder->encode(image);
-        images_features_proj.push_back(hd_feature_transform(encoded_image, m_hd_feature_transformer, m_vlm_config.sub_GN, m_vlm_config.glb_GN, m_vision_projection));
+        images_features_proj.push_back(hd_feature_transform(encoded_image, hd_feature_transformer, m_vlm_config.sub_GN, m_vlm_config.glb_GN, vision_projection));
         m_tokens_per_images.push_back(images_features_proj.back().get_shape().at(1));
         images_prompt << "<|image_" << m_tokens_per_images.size() << "|>\n";
     }
@@ -569,7 +587,7 @@ ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, con
     ov::Tensor inputs_embeds{ov::element::f32, {1, features_length, m_vlm_config.hidden_size}};
     size_t offset = 0;
     if (tokens.size() > images_features_proj.size()) {
-        const ov::Tensor& text_embeds = m_embedding.infer(tokens.at(0));
+        const ov::Tensor& text_embeds = m_embedding->infer(tokens.at(0));
         size_t text_length = text_embeds.get_shape().at(1);
         std::copy_n(
             text_embeds.data<float>(),
@@ -588,7 +606,7 @@ ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, con
             inputs_embeds.data<float>() + offset * m_vlm_config.hidden_size
         );
         offset += im_length;
-        const ov::Tensor& text_embeds = m_embedding.infer(tokens.at(im_id));
+        const ov::Tensor& text_embeds = m_embedding->infer(tokens.at(im_id));
         size_t text_length = text_embeds.get_shape().at(1);
         std::copy_n(
             text_embeds.data<float>(),

--- a/src/cpp/src/visual_language/phi3_vision/classes.hpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.hpp
@@ -37,8 +37,8 @@ public:
     void finish_chat() override;
 
 private:
-    ov::InferRequest m_hd_feature_transformer;
-    ov::InferRequest m_vision_projection;
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_hd_feature_transformer;
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_projection;
     std::vector<size_t> m_tokens_per_images;
     std::vector<size_t> m_prev_tokens_per_images;
 };

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -29,7 +29,7 @@ class VLMPipeline::VLMPipelineImpl : public VLMPipelineBase{
     // A model to compute token embeddings.
     // Input shape: [N, conversation length].
     // Output shape: [1, conversation length, hidden_size].
-    EmbeddingsModel m_embedding;
+    EmbeddingsModel::Ptr m_embedding;
     // A language model used to generate a response.
     // Input shapes: inputs_embeds[N, conversation length, hidden_size],
     // position_ids[N, conversation length], beam_idx[N].

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -170,6 +170,8 @@ ov::Tensor transpose_image_patches_qwen2vl(const ov::Tensor& reshaped_patches) {
 } // namespace
 
 EncodedImage VisionEncoderQwen2VL::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
     ProcessorConfig config = utils::from_any_map(config_map, m_processor_config);
 
     ov::Shape image_shape = image.get_shape();
@@ -230,10 +232,10 @@ EncodedImage VisionEncoderQwen2VL::encode(const ov::Tensor& image, const ov::Any
     ov::Tensor flattened_patches(transposed_patches.get_element_type(), flattened_patches_shape);
     std::memcpy(flattened_patches.data(), transposed_patches.data(), transposed_patches.get_byte_size());
 
-    m_vision_encoder.set_tensor("hidden_states", flattened_patches);
-    m_vision_encoder.infer();
+    encoder.set_tensor("hidden_states", flattened_patches);
+    encoder.infer();
 
-    const ov::Tensor& infer_output = m_vision_encoder.get_output_tensor();
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
     ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
     std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
 
@@ -250,7 +252,11 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     IInputsEmbedder(vlm_config, model_dir, device, device_config) {
     auto compiled_model = utils::singleton_core().compile_model(model_dir / "openvino_vision_embeddings_merger_model.xml", device, device_config);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "VLM vision embeddings merger model");
-    m_vision_embeddings_merger = compiled_model.create_infer_request();
+    m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
 }
 
 InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
@@ -268,7 +274,11 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
         device_config
     );
     ov::genai::utils::print_compiled_model_properties(compiled_model, "VLM vision embeddings merger model");
-    m_vision_embeddings_merger = compiled_model.create_infer_request();
+    m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
 }
 
 ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
@@ -309,7 +319,7 @@ ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, c
     m_image_id = images_sequence.empty() ? m_image_id : *std::max_element(images_sequence.begin(), images_sequence.end()) + 1;
 
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
-    ov::Tensor text_embeds = m_embedding.infer(input_ids);
+    ov::Tensor text_embeds = m_embedding->infer(input_ids);
 
     auto start_tokenizer_time = std::chrono::steady_clock::now();
     ov::Tensor encoded_vision_start_token = m_tokenizer.encode(m_vlm_config.vision_start_token, ov::genai::add_special_tokens(false)).input_ids;
@@ -422,11 +432,13 @@ ov::Tensor InputsEmbedderQwen2VL::merge_text_and_image_embeddings_qwen2vl(
 
     ov::Tensor rotary_pos_emb = get_rotary_pos_emb(images_grid_thw);
 
-    m_vision_embeddings_merger.set_tensor("hidden_states", concatenated_images);
-    m_vision_embeddings_merger.set_tensor("attention_mask", attention_mask);
-    m_vision_embeddings_merger.set_tensor("rotary_pos_emb", rotary_pos_emb);
-    m_vision_embeddings_merger.infer();
-    ov::Tensor processed_vision_embeds = m_vision_embeddings_merger.get_output_tensor();
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_embeddings_merger.get());
+    ov::InferRequest& vision_embeddings_merger = infer_request_guard.get();
+    vision_embeddings_merger.set_tensor("hidden_states", concatenated_images);
+    vision_embeddings_merger.set_tensor("attention_mask", attention_mask);
+    vision_embeddings_merger.set_tensor("rotary_pos_emb", rotary_pos_emb);
+    vision_embeddings_merger.infer();
+    ov::Tensor processed_vision_embeds = vision_embeddings_merger.get_output_tensor();
 
     ov::Tensor merged_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
     std::memcpy(merged_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
@@ -529,7 +541,9 @@ ov::Tensor InputsEmbedderQwen2VL::get_rotary_pos_emb(const std::vector<std::arra
     }
 
     // Calculate rotary embeddings for max_grid_size
-    const size_t dim = m_vision_embeddings_merger.get_tensor("rotary_pos_emb").get_shape().at(1);
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_embeddings_merger.get());
+    ov::InferRequest& vision_embeddings_merger = infer_request_guard.get();
+    const size_t dim = vision_embeddings_merger.get_tensor("rotary_pos_emb").get_shape().at(1);
     const float theta = 10000.0f;
     
     std::vector<float> inv_freq(dim / 2);

--- a/src/cpp/src/visual_language/qwen2vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.hpp
@@ -26,7 +26,7 @@ class InputsEmbedderQwen2VL : public InputsEmbedder::IInputsEmbedder {
     //  - rotary_pos_emb: [?, 40]
     //  - attention_mask: [1, ?, ?]
     // Output: [N, hidden_size]
-    ov::InferRequest m_vision_embeddings_merger;
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_merger;
 
     ov::Tensor m_position_ids;
     int64_t m_rope_delta = 0;

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -17,7 +17,11 @@ namespace ov::genai {
 VisionEncoder::VisionEncoder(const std::filesystem::path& model_dir, const std::string& device, const ov::AnyMap properties) {
     auto compiled_model = utils::singleton_core().compile_model(model_dir / "openvino_vision_embeddings_model.xml", device, properties);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "VLM vision embeddings model");
-    m_vision_encoder = compiled_model.create_infer_request();
+    m_ireq_queue_vision_encoder = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
     m_processor_config = utils::from_config_json_if_exists<ProcessorConfig>(model_dir, "preprocessor_config.json");
 }
 
@@ -29,7 +33,11 @@ VisionEncoder::VisionEncoder(
     const ov::AnyMap device_config) {
     auto compiled_model = utils::singleton_core().compile_model(model, weights, device, device_config);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "VLM vision embeddings model");
-    m_vision_encoder = compiled_model.create_infer_request();
+    m_ireq_queue_vision_encoder = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_model.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_model]() -> ov::InferRequest {
+            return compiled_model.create_infer_request();
+        });
     m_processor_config = utils::from_config_json_if_exists<ProcessorConfig>(config_dir_path, "preprocessor_config.json");
 }
 

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-
+#include <memory>
 #include "openvino/runtime/infer_request.hpp"
 
 #include "visual_language/vlm_config.hpp"
 #include "visual_language/processor_config.hpp"
+#include "circular_buffer_queue.hpp"
 
 namespace ov::genai {
 /// @brief A pair describing image size.
@@ -93,8 +94,9 @@ public:
     ProcessorConfig get_processor_config() const;
 
 protected:
-    /// @brief A model for image encoding.
-    ov::InferRequest m_vision_encoder;
+    /// @brief  Infer requests queue for image encoding model.
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_encoder;
+
     /// @brief A config to follow.
     ProcessorConfig m_processor_config;
 

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -371,7 +371,7 @@ class ContinuousBatchingPipeline:
     This class is used for generation with LLMs with continuous batchig
     """
     @typing.overload
-    def __init__(self, models_path: os.PathLike, scheduler_config: SchedulerConfig, device: str, properties: dict[str, typing.Any] = {}, tokenizer_properties: dict[str, typing.Any] = {}, inputs_embedder_properties: dict[str, typing.Any] = {}) -> None:
+    def __init__(self, models_path: os.PathLike, scheduler_config: SchedulerConfig, device: str, properties: dict[str, typing.Any] = {}, tokenizer_properties: dict[str, typing.Any] = {}, vision_encoder_properties: dict[str, typing.Any] = {}) -> None:
         ...
     @typing.overload
     def __init__(self, models_path: os.PathLike, tokenizer: Tokenizer, scheduler_config: SchedulerConfig, device: str, **kwargs) -> None:

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -371,7 +371,7 @@ class ContinuousBatchingPipeline:
     This class is used for generation with LLMs with continuous batchig
     """
     @typing.overload
-    def __init__(self, models_path: os.PathLike, scheduler_config: SchedulerConfig, device: str, properties: dict[str, typing.Any] = {}, tokenizer_properties: dict[str, typing.Any] = {}) -> None:
+    def __init__(self, models_path: os.PathLike, scheduler_config: SchedulerConfig, device: str, properties: dict[str, typing.Any] = {}, tokenizer_properties: dict[str, typing.Any] = {}, inputs_embedder_properties: dict[str, typing.Any] = {}) -> None:
         ...
     @typing.overload
     def __init__(self, models_path: os.PathLike, tokenizer: Tokenizer, scheduler_config: SchedulerConfig, device: str, **kwargs) -> None:

--- a/src/python/py_continuous_batching_pipeline.cpp
+++ b/src/python/py_continuous_batching_pipeline.cpp
@@ -256,15 +256,18 @@ void init_continuous_batching_pipeline(py::module_& m) {
             .def_readonly("max_cache_usage", &PipelineMetrics::max_cache_usage);
 
     py::class_<ContinuousBatchingPipeline>(m, "ContinuousBatchingPipeline", "This class is used for generation with LLMs with continuous batchig")
-        .def(py::init([](const std::filesystem::path& models_path, const SchedulerConfig& scheduler_config, const std::string& device, const std::map<std::string, py::object>& llm_plugin_config, const std::map<std::string, py::object>& tokenizer_plugin_config) {
+        .def(py::init([](const std::filesystem::path& models_path, const SchedulerConfig& scheduler_config, const std::string& device, const std::map<std::string, py::object>& llm_plugin_config, 
+                const std::map<std::string, py::object>& tokenizer_plugin_config, const std::map<std::string, py::object>& inputs_embedder_plugin_config) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
-            return std::make_unique<ContinuousBatchingPipeline>(models_path, scheduler_config, device, pyutils::properties_to_any_map(llm_plugin_config), pyutils::properties_to_any_map(tokenizer_plugin_config));
+            return std::make_unique<ContinuousBatchingPipeline>(models_path, scheduler_config, device, pyutils::properties_to_any_map(llm_plugin_config), 
+                pyutils::properties_to_any_map(tokenizer_plugin_config), pyutils::properties_to_any_map(inputs_embedder_plugin_config));
         }),
         py::arg("models_path"),
         py::arg("scheduler_config"),
         py::arg("device"),
         py::arg("properties") = ov::AnyMap({}),
-        py::arg("tokenizer_properties") = ov::AnyMap({}))
+        py::arg("tokenizer_properties") = ov::AnyMap({}),
+        py::arg("vision_encoder_properties") = ov::AnyMap({}))
 
         .def(py::init([](const std::filesystem::path& models_path, const ov::genai::Tokenizer& tokenizer, const SchedulerConfig& scheduler_config, const std::string& device, const py::kwargs& kwargs) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());


### PR DESCRIPTION
Use circular buffer of infer requests in vision encoder to enable parallel processing of images for VLM pipelines. This will reduce synchronized section