### PR TITLE
Bump openvino_tokenizers submodule to 2025.0.1

### DIFF
--- a/.github/workflows/causal_lm_cpp.yml
+++ b/.github/workflows/causal_lm_cpp.yml
@@ -19,7 +19,7 @@ env:
   l_ov_link: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/l_openvino_toolkit_ubuntu20_2025.0.0.dev20250116_x86_64.tgz
   l_u22_ov_link: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/l_openvino_toolkit_ubuntu22_2025.0.0.dev20250116_x86_64.tgz
   m_ov_link: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/m_openvino_toolkit_macos_12_6_2025.0.0.dev20250116_x86_64.tgz
-  w_ov_link: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/w_openvino_toolkit_windows_2025.0.0.dev20250116_x86_64.zip
+  w_ov_link: https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.0.1/windows/openvino_toolkit_windows_2025.0.1.17971.1ba1ed4f524_x86_64.zip
 
 jobs:
   cpp-multinomial-greedy_causal_lm-ubuntu:

--- a/.github/workflows/lcm_dreamshaper_cpp.yml
+++ b/.github/workflows/lcm_dreamshaper_cpp.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   PYTHON_VERSION: '3.9'
   LINUX_OV_ARCHIVE_URL: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/l_openvino_toolkit_ubuntu22_2025.0.0.dev20250116_x86_64.tgz
-  WINDOWS_OV_ARCHIVE_URL: https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.0.0rc1/w_openvino_toolkit_windows_2025.0.0.dev20250116_x86_64.zip
+  WINDOWS_OV_ARCHIVE_URL: https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.0.1/windows/openvino_toolkit_windows_2025.0.1.17971.1ba1ed4f524_x86_64.zip
   OV_INSTALL_DIR: ${{ github.workspace }}/ov
 
 jobs:

--- a/.github/workflows/stable_diffusion_1_5_cpp.yml
+++ b/.github/workflows/stable_diffusion_1_5_cpp.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         platform: ubuntu22
         commit_packages_to_provide: wheels
-        revision: 2025.0.0rc1
+        revision: 2025.0.1
 
   openvino_download_windows:
     name: Download OpenVINO for Windows
@@ -71,7 +71,7 @@ jobs:
       with:
         platform: windows
         commit_packages_to_provide: wheels
-        revision: 2025.0.0rc1
+        revision: 2025.0.1
 
   stable_diffusion_1_5_cpp-linux:
     runs-on: ubuntu-22.04-8-cores


### PR DESCRIPTION
That change fixes the following build use case:
```
pip wheel ./thirdparty/openvino_tokenizers/[transformers]
pip wheel .
```