### PR TITLE
Fix running generate with encoded inputs one after another with the same input data

### DIFF
--- a/src/cpp/src/llm_pipeline_stateful.cpp
+++ b/src/cpp/src/llm_pipeline_stateful.cpp
@@ -211,17 +211,23 @@ EncodedResults StatefulLLMPipeline::generate(
     if (!is_chat_conversation) {
         reset_kv_state();
         m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
+        m_kv_cache_state.reset_state();
+        m_kv_history_trim_manager.reset();
     }
 
     auto start_time = std::chrono::steady_clock::now();
     ov::Tensor input_ids;
     ov::Tensor attention_mask;
     if (auto data = std::get_if<ov::Tensor>(&inputs)) {
-        input_ids = *data;
+        input_ids = ov::Tensor(data->get_element_type(), data->get_shape());
+        data->copy_to(input_ids);
         attention_mask = ov::genai::utils::init_attention_mask(input_ids);
     } else if (auto data = std::get_if<TokenizedInputs>(&inputs)) {
-        input_ids = data->input_ids;
-        attention_mask = data->attention_mask;
+        input_ids = ov::Tensor(data->input_ids.get_element_type(), data->input_ids.get_shape());
+        data->input_ids.copy_to(input_ids);
+
+        attention_mask = ov::Tensor{data->attention_mask.get_element_type(), data->attention_mask.get_shape()};
+        data->attention_mask.copy_to(attention_mask);
     }
 
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) 
@@ -363,8 +369,6 @@ EncodedResults StatefulLLMPipeline::generate(
         } else if (config.is_beam_search()) {
             m_kv_history_trim_manager.num_tokens_to_trim = m_model_runner.get_tensor("attention_mask").get_shape()[1] - prev_attn_mask_size;
         }
-    } else {
-        m_kv_cache_state.reset_state();
     }
 
     auto stop_time = std::chrono::steady_clock::now();

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -128,61 +128,6 @@ void initialize_position_ids(ov::Tensor& position_ids, const ov::Tensor& attenti
     }
 }
 
-void initialize_beam_inputs(const ov::Tensor& input_ids, const ov::Tensor& attention_mask, ov::InferRequest& request) {
-    request.set_tensor("input_ids", input_ids);
-    request.set_tensor("attention_mask", attention_mask);
-
-    ov::Shape input_shape = input_ids.get_shape();
-
-    ov::Tensor position_ids = request.get_tensor("position_ids");
-    position_ids.set_shape(input_shape);
-    initialize_position_ids(position_ids, attention_mask);
-
-    ov::Tensor beam_idx = request.get_tensor("beam_idx");
-    beam_idx.set_shape({input_shape.at(0)});
-    std::fill_n(beam_idx.data<int32_t>(), input_shape.at(0), 0);
-}
-
-void set_attention_mask(ov::Tensor&& attention_mask, std::vector<int32_t> next_beams) {
-    ov::Tensor original_mask{ov::element::i64, attention_mask.get_shape()};
-    ov::Shape original_shape = original_mask.get_shape();
-    attention_mask.copy_to(original_mask);
-
-    ov::Shape new_shape{next_beams.size(), original_mask.get_shape().at(1) + 1};
-    attention_mask.set_shape(new_shape);
-
-    for (size_t beam_id = 0; beam_id < next_beams.size(); beam_id++) {
-        const size_t original_prompt_offset = next_beams.at(beam_id) * original_shape.at(1);
-        const size_t result_prompt_offset = beam_id * new_shape.at(1);
-
-        int64_t* dest = attention_mask.data<int64_t>() + result_prompt_offset;
-        const int64_t* src = original_mask.data<int64_t>() + original_prompt_offset;
-
-        std::memcpy(dest, src, original_shape.at(1) * sizeof(int64_t));
-        attention_mask.data<int64_t>()[result_prompt_offset + new_shape.at(1) - 1] = 1;
-    }
-}
-
-/**
- * Get attention mask tensor for next token inference
- * Supports multi batch
- * Supports sparse attention_mask
- */
-ov::Tensor extend_attention(ov::Tensor attention_mask) {
-    auto shape = attention_mask.get_shape();
-    auto batch_size = shape[0];
-    auto seq_len = shape[1];
-
-    ov::Tensor new_atten_mask = ov::Tensor{attention_mask.get_element_type(), {batch_size, seq_len + 1}};
-    auto old_data = attention_mask.data<int64_t>();
-    auto new_data = new_atten_mask.data<int64_t>();
-    for (size_t batch = 0; batch < batch_size; ++batch) {
-        std::memcpy(new_data + batch * (seq_len + 1), old_data + batch * seq_len, seq_len * sizeof(int64_t));
-        new_data[batch * (seq_len + 1) + seq_len] = 1;
-    }
-    return new_atten_mask;
-}
-
 ov::genai::StreamerVariant get_streamer_from_map(const ov::AnyMap& config_map) {
     ov::genai::StreamerVariant streamer = std::monostate();
 

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -46,8 +46,6 @@ Tensor init_attention_mask(const Tensor& position_ids);
 
 void initialize_position_ids(ov::Tensor& position_ids, const ov::Tensor& attention_mask, int64_t start_pos = 0);
 
-ov::Tensor extend_attention(ov::Tensor attention_mask);
-
 template <typename T> struct OmitOptional { using value = T; };
 template <typename T> struct OmitOptional<std::optional<T>> { using value = T; };
 


### PR DESCRIPTION
in this case, the value of the attention_mask was changing during generation and set to 0 at the end