### PR TITLE
[tokenizer] Fix setting max_legth and special tokens flags

### DIFF
--- a/src/cpp/src/tokenizer.cpp
+++ b/src/cpp/src/tokenizer.cpp
@@ -137,10 +137,8 @@ public:
 
     // To change the adding special tokens mode we use a statefull subgraph,
     // this flag holds the current state value of the CompiledModel.
-    bool m_add_special_tokens = true;
-    bool m_skip_special_tokens = true;
-    bool m_pad_to_max_length = false;
-    std::optional<int32_t> m_max_length;
+    ov::AnyMap m_state_flags;
+
     bool m_older_than_24_5 = false;
 
     int64_t m_pad_token_id = -1;
@@ -153,70 +151,69 @@ public:
 
     std::string m_chat_template = {};
 
+    template <typename T>
+    void set_state_value(ov::VariableState& state, std::optional<T> value) {
+        
+        // better to store which value is in the state locally so that get_state is not called every infer request
+        std::optional<T> last_value;
+        ov::genai::utils::read_anymap_param(m_state_flags, state.get_name(), last_value);
+        
+        // If requested add[skip]_special_tokens, max_length, pading mode, etc.
+        // is different from the stored state, need to set state variable.
+        // Or if we run for the first time and don't know the latest state we need to set it.
+        if (value.has_value() && (!last_value.has_value() || *value != *last_value)) {
+            ov::Tensor value_tensor = ov::Tensor(ov::element::from<T>(), state.get_state().get_shape());
+            OPENVINO_ASSERT(value_tensor.get_size() == 1, "Only flags or single elements values are supported");
+            
+            *value_tensor.data<T>() = *value;
+            state.set_state(value_tensor);
+            m_state_flags[state.get_name()] = *value;
+        } else if (!value.has_value()) {
+            // If user called with params, e.g. tokenizer.encode(prompt, add_special_tokens|max_length=...)
+            // After that called without params, e.g. tokenizer.encode(prompt) we should reset to the default state.
+            state.reset();
+            m_state_flags.erase(state.get_name());
+        }
+    }
+
     void set_state_if_necessary(CircularBufferQueueElementGuard<ov::InferRequest>& infer_request_guard, const ov::AnyMap& params) {
         // These values should be equal to default values in py_tokenizer.cpp
         // in order to get the same behavior in C++ when arguments are not specified.
-        bool add_special_tokens_flag = true;
-        bool skip_special_tokens_flag = true;
+        std::optional<bool> add_special_tokens_flag = true;
+        std::optional<bool> skip_special_tokens_flag = true;
         std::optional<int32_t> max_length_val;
-        bool pad_to_max_length_val = false;
+        std::optional<bool> pad_to_max_length_val = false;
         
         ov::genai::utils::read_anymap_param(params, add_special_tokens.name(), add_special_tokens_flag);
         ov::genai::utils::read_anymap_param(params, skip_special_tokens.name(), skip_special_tokens_flag);
         ov::genai::utils::read_anymap_param(params, pad_to_max_length.name(), pad_to_max_length_val);
         ov::genai::utils::read_anymap_param(params, max_length.name(), max_length_val);
 
-        // If requested add[skip]_special_tokens, max_length or pading mode 
-        // is different from the stored state, need to set state variable.
-        if (add_special_tokens_flag == m_add_special_tokens 
-            && skip_special_tokens_flag == m_skip_special_tokens
-            && max_length_val == m_max_length
-            && pad_to_max_length_val == m_pad_to_max_length) {
-            return;
-        }
         if (m_older_than_24_5) {
             // Changing add_special_tokens at runtime was introduced in
             // 24.5. Older tokenizers still allow manipulating their
             // state but the effect is incorrect.
             return;
         }
-
-        // add_special_tokens is managed by Select op with a bool input.
-        ov::Tensor add_special_tensor = ov::Tensor(ov::element::boolean, {});
-        *add_special_tensor.data<bool>() = add_special_tokens_flag;
-
-        // skip_special_tokens is managed by multiplication with a number, therefore i32.
-        ov::Tensor skip_special_tensor = ov::Tensor(ov::element::i32, {1});
-        *skip_special_tensor.data<int32_t>() = skip_special_tokens_flag;
-
-        ov::Tensor max_length_tensor = ov::Tensor(ov::element::i32, {});
-        // Exact value will bet set below depending whether optional max_length is defined.
-        ov::Tensor pad_to_max_length_tensor = ov::Tensor(ov::element::boolean, {1});
-        *pad_to_max_length_tensor.data<bool>() = pad_to_max_length_val;
         
         for (auto& state: infer_request_guard.get().query_state()) {
             auto name = state.get_name();
             if (state.get_name() == add_special_tokens.name()) {
-                state.set_state(add_special_tensor);
+                set_state_value(state, add_special_tokens_flag);
             } else if (state.get_name() == skip_special_tokens.name()) {
-                state.set_state(skip_special_tensor);
+                set_state_value(state, skip_special_tokens_flag);
             } else if (state.get_name() == MAX_LENGTH_VAR_ID) {
                 if (max_length_val.has_value()) {
-                    *max_length_tensor.data<int32_t>() = *max_length_val;
-                    state.set_state(max_length_tensor);
+                    set_state_value(state, max_length_val);
                 } else {
                     // If after some time user called encode without max_length we should return
                     // to the default value stored in constant from IR.
                     state.reset();
                 }
             } else if (state.get_name() == PAD_TO_MAX_LENGTH_VAR_ID) {
-                state.set_state(pad_to_max_length_tensor);
+                set_state_value(state, pad_to_max_length_val);
             }
         }
-        m_add_special_tokens = add_special_tokens_flag;
-        m_skip_special_tokens = skip_special_tokens_flag;
-        m_max_length = max_length_val;
-        m_pad_to_max_length = pad_to_max_length_val;
     }
 
     TokenizerImpl(const std::filesystem::path& models_path, const ov::AnyMap& properties) {

--- a/src/cpp/src/tokenizer.cpp
+++ b/src/cpp/src/tokenizer.cpp
@@ -153,7 +153,6 @@ public:
 
     template <typename T>
     void set_state_value(ov::VariableState& state, std::optional<T> value) {
-        
         // better to store which value is in the state locally so that get_state is not called every infer request
         std::optional<T> last_value;
         ov::genai::utils::read_anymap_param(m_state_flags, state.get_name(), last_value);
@@ -198,19 +197,14 @@ public:
         
         for (auto& state: infer_request_guard.get().query_state()) {
             auto name = state.get_name();
-            if (state.get_name() == add_special_tokens.name()) {
+
+            if (name == add_special_tokens.name()) {
                 set_state_value(state, add_special_tokens_flag);
-            } else if (state.get_name() == skip_special_tokens.name()) {
+            } else if (name == skip_special_tokens.name()) {
                 set_state_value(state, skip_special_tokens_flag);
-            } else if (state.get_name() == MAX_LENGTH_VAR_ID) {
-                if (max_length_val.has_value()) {
-                    set_state_value(state, max_length_val);
-                } else {
-                    // If after some time user called encode without max_length we should return
-                    // to the default value stored in constant from IR.
-                    state.reset();
-                }
-            } else if (state.get_name() == PAD_TO_MAX_LENGTH_VAR_ID) {
+            } else if (name == MAX_LENGTH_VAR_ID) {
+                set_state_value(state, max_length_val);
+            } else if (name == PAD_TO_MAX_LENGTH_VAR_ID) {
                 set_state_value(state, pad_to_max_length_val);
             }
         }

--- a/tests/python_tests/test_tokenizer.py
+++ b/tests/python_tests/test_tokenizer.py
@@ -284,14 +284,19 @@ def test_special_tokens(tmp_path, prompt, model_id):
 def hf_ov_genai_models(tmp_path_factory):
 
     @functools.lru_cache(maxsize=2)
-    def _get_model_path(model_id, subfolder):
+    def _get_model_path(model_id, **args):
+        hf_args = args.copy()  # to overcome mutable default argument side effects
+        if "padding_side" in hf_args and hf_args["padding_side"] is None:
+            # HF does not accept None.
+            # Need to remove padding_side and let HF to choose default value,
+            hf_args.pop("padding_side")
+        else:
+            hf_args["truncation_side"] = hf_args["padding_side"]
         model_dir = tmp_path_factory.getbasetemp() / model_id.replace('/', '_')
         model_dir.mkdir(exist_ok=True, parents=True)
-        tokenizer_path = model_dir / "openvino_tokenizer.xml"
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(model_id, subfolder=subfolder)
-        if not tokenizer_path.exists():
-            convert_and_save_tokenizer(hf_tokenizer, model_dir)
+        hf_tokenizer = AutoTokenizer.from_pretrained(model_id, **hf_args)
+        convert_and_save_tokenizer(hf_tokenizer, model_dir)
         genai_tokenzier = Tokenizer(model_dir)
         return hf_tokenizer, genai_tokenzier
     return _get_model_path
@@ -314,19 +319,23 @@ prompts = [
 @pytest.mark.precommit
 @pytest.mark.nightly
 @pytest.mark.parametrize("add_special_tokens", [True, False])
-@pytest.mark.parametrize("max_length", [None, 10, 16, 64, 77, 103, 512, 1024])
+@pytest.mark.parametrize("max_length", [None, 16, 103, 512, 1024])
 @pytest.mark.parametrize("pad_to_max_length", [None, True, False])
 @pytest.mark.parametrize("prompt", prompts)
 @pytest.mark.parametrize("model_id", [
     "katuni4ka/tiny-random-phi3",
     "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    ("katuni4ka/tiny-random-llava-next", dict(padding_side="right")),
+    ("katuni4ka/tiny-random-llava-next", dict(padding_side="left")),
     "BAAI/bge-small-en-v1.5",  # model with 2 RaggedToDense ops
     # ("black-forest-labs/FLUX.1-dev", dict(subfolder="tokenizer")),  # FLUX.1-dev has tokenizer in subfolder
 ])
 def test_padding(hf_ov_genai_models, add_special_tokens, max_length, pad_to_max_length, prompt, model_id):
     model_id, hf_tok_load_params = (model_id[0], model_id[1]) if isinstance(model_id, tuple) else (model_id, {})
     
-    hf_tokenizer, genai_tokenzier = hf_ov_genai_models(model_id, subfolder=hf_tok_load_params.get("subfolder", None))
+    hf_tokenizer, genai_tokenzier = hf_ov_genai_models(model_id, 
+                                                       subfolder=hf_tok_load_params.get("subfolder", None),
+                                                       padding_side=hf_tok_load_params.get("padding_side", None))
 
     # In openvino_tokenizers if sequences are of different length by default padding is applied 
     # to the longest sequence in the batch since resulting tokenization is stored as a signe ov::Tensor 


### PR DESCRIPTION
- `MakePaddingSatateful` was skipping left padding graphs during match because it was checking for `Subtract` on the wrong `1st input`, while it should've do this on `0th input`. We did miss that, because models list in test by default was testing only right padding - now added explicitly check left padding as well.
- There was an issue with `add_special_tokens`, Even when we called `decode` it was rewriting `m_add_special_tokens` values as if we called `set_state`, therefore if we subsequently requested `encode` even with different params Tokenizer wrongly assumed that InferReuest already has that param in state and did not modify it and we end up having wrong output, e.g. below on the second call there should been 1 at the begining. Fixed this issue as well.

![image](https://github.com/user-attachments/assets/79b3b27a-238a-4440-8ec6-4a85fd45e59b)

CVS-163154