### PR TITLE
Adjust the LLM pipeline C API to ensure it can determine the required sufficient size for the output.

### DIFF
--- a/samples/c/text_generation/benchmark_genai_c.c
+++ b/samples/c/text_generation/benchmark_genai_c.c
@@ -124,7 +124,8 @@ int main(int argc, char* argv[]) {
     ov_genai_decoded_results* results = NULL;
     ov_genai_perf_metrics* metrics = NULL;
     ov_genai_perf_metrics* cumulative_metrics = NULL;
-    char output[MAX_OUTPUT_LENGTH];
+    char* output = NULL;     // The output of the generation function. The caller is responsible for freeing the memory.
+    size_t output_size = 0;  // Used to store the required size of the output buffer.
 
     CHECK_STATUS(ov_genai_llm_pipeline_create(options.model, options.device, &pipe));
 
@@ -132,7 +133,7 @@ int main(int argc, char* argv[]) {
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, options.max_new_tokens));
 
     for (size_t i = 0; i < options.num_warmup; i++) {
-        CHECK_STATUS(ov_genai_llm_pipeline_generate(pipe, options.prompt, config, NULL, output, MAX_OUTPUT_LENGTH));
+        CHECK_STATUS(ov_genai_llm_pipeline_generate(pipe, options.prompt, config, NULL, &output, &output_size));
     }
 
     CHECK_STATUS(ov_genai_llm_pipeline_generate_decoded_results(pipe, options.prompt, config, NULL, &results));
@@ -184,5 +185,8 @@ err:
         ov_genai_decoded_results_perf_metrics_free(cumulative_metrics);
     if (results)
         ov_genai_decoded_results_free(results);
+    if (output)
+        free(output);
+
     return EXIT_SUCCESS;
 }

--- a/samples/c/text_generation/chat_sample_c.c
+++ b/samples/c/text_generation/chat_sample_c.c
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
     ov_genai_generation_config* config = NULL;
     ov_genai_llm_pipeline* pipeline = NULL;
     stream_callback streamer = &print_callback;
-    char prompt[MAX_PROMPT_LENGTH], output[MAX_OUTPUT_LENGTH];
+    char prompt[MAX_PROMPT_LENGTH];
 
     CHECK_STATUS(ov_genai_llm_pipeline_create(models_path, device, &pipeline));
     CHECK_STATUS(ov_genai_generation_config_create(&config));
@@ -48,7 +48,13 @@ int main(int argc, char* argv[]) {
     printf("question:\n");
     while (fgets(prompt, MAX_PROMPT_LENGTH, stdin)) {
         prompt[strcspn(prompt, "\n")] = 0;
-        CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline, prompt, config, &streamer, output, sizeof(output)));
+        CHECK_STATUS(ov_genai_llm_pipeline_generate(
+            pipeline,
+            prompt,
+            config,
+            &streamer,
+            NULL,
+            0));  // Only the streamer functionality is used here, so output is allowed to be NULL.
         printf("\n----------\nquestion:\n");
     }
     CHECK_STATUS(ov_genai_llm_pipeline_finish_chat(pipeline));

--- a/samples/c/text_generation/chat_sample_c.c
+++ b/samples/c/text_generation/chat_sample_c.c
@@ -48,13 +48,11 @@ int main(int argc, char* argv[]) {
     printf("question:\n");
     while (fgets(prompt, MAX_PROMPT_LENGTH, stdin)) {
         prompt[strcspn(prompt, "\n")] = 0;
-        CHECK_STATUS(ov_genai_llm_pipeline_generate(
-            pipeline,
-            prompt,
-            config,
-            &streamer,
-            NULL,
-            0));  // Only the streamer functionality is used here, so output is allowed to be NULL.
+        CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline,
+                                                    prompt,
+                                                    config,
+                                                    &streamer,
+                                                    NULL));  // Only the streamer functionality is used here.
         printf("\n----------\nquestion:\n");
     }
     CHECK_STATUS(ov_genai_llm_pipeline_finish_chat(pipeline));

--- a/samples/c/text_generation/greedy_causal_lm_c.c
+++ b/samples/c/text_generation/greedy_causal_lm_c.c
@@ -23,13 +23,25 @@ int main(int argc, char* argv[]) {
     ov_genai_generation_config* config = NULL;
     ov_genai_decoded_results* results = NULL;
     const char* device = "CPU";  // GPU, NPU can be used as well
-    char* output = NULL;     // The output of the generation function. The caller is responsible for freeing the memory.
+    char* output = NULL;  // The output of the generation function. The caller is responsible for allocating and freeing
+                          // the memory.
     size_t output_size = 0;  // Used to store the required size of the output buffer.
 
     CHECK_STATUS(ov_genai_llm_pipeline_create(model_dir, device, &pipeline));
     CHECK_STATUS(ov_genai_generation_config_create(&config));
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, 100));
-    CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline, prompt, config, NULL, &output, &output_size));
+    CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline, prompt, config, NULL, &results));
+
+    // The function is called with NULL as the output to determine the required buffer size.
+    CHECK_STATUS(ov_genai_decoded_results_get_string(results, NULL, &output_size));
+    output = (char*)malloc(output_size);  // Allocate memory for the output string based on the determined size.
+    if (!output) {
+        fprintf(stderr, "Failed to allocate memory for output\n");
+        goto err;
+    }
+
+    // Retrieve the actual output string from the results into the allocated buffer.
+    CHECK_STATUS(ov_genai_decoded_results_get_string(results, output, &output_size));
     printf("%s\n", output);
 
 err:

--- a/samples/c/text_generation/greedy_causal_lm_c.c
+++ b/samples/c/text_generation/greedy_causal_lm_c.c
@@ -21,15 +21,33 @@ int main(int argc, char* argv[]) {
 
     ov_genai_llm_pipeline* pipeline = NULL;
     ov_genai_generation_config* config = NULL;
-    const char* device = "CPU";  // GPU, NPU can be used as well
-    char output[1024];
+    ov_genai_decoded_results* results = NULL;
+    const char* device = "CPU";        // GPU, NPU can be used as well
+    char* output = (char*)malloc(16);  // Firstly, malloc a small size (though it may not necessarily be that small),
+                                       // used only for testing to allow realloc logic to run.
+    size_t required_size = 0;          // Used to store the required size of the output buffer.
 
+    if (!output) {
+        fprintf(stderr, "[Error] Memory allocation failed (malloc 5 bytes).\n");
+        goto err;
+    }
     CHECK_STATUS(ov_genai_llm_pipeline_create(model_dir, device, &pipeline));
     CHECK_STATUS(ov_genai_generation_config_create(&config));
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, 100));
-
-    CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline, prompt, config, NULL, output, sizeof(output)));
-
+    CHECK_STATUS(ov_genai_llm_pipeline_generate_decoded_results(pipeline, prompt, config, NULL, &results));
+    CHECK_STATUS(ov_genai_decoded_results_get_string(results,
+                                                     NULL,
+                                                     0,
+                                                     &required_size));  // get the required size of the output buffer.
+    if (required_size > sizeof(output)) {
+        char* temp = (char*)realloc(output, required_size);
+        if (!temp) {
+            fprintf(stderr, "[Error] Memory allocation failed (malloc %zu bytes).\n", required_size);
+            goto err;
+        }
+        output = temp;
+    }
+    CHECK_STATUS(ov_genai_decoded_results_get_string(results, output, required_size, NULL));
     printf("%s\n", output);
 
 err:
@@ -37,6 +55,8 @@ err:
         ov_genai_llm_pipeline_free(pipeline);
     if (config)
         ov_genai_generation_config_free(config);
+    if (output)
+        free(output);
 
     return EXIT_SUCCESS;
 }

--- a/samples/c/text_generation/greedy_causal_lm_c.c
+++ b/samples/c/text_generation/greedy_causal_lm_c.c
@@ -5,6 +5,10 @@
 
 #include "openvino/genai/c/llm_pipeline.h"
 
+#define DEFAULT_OUTPUT_SIZE \
+    16  // Allocate a small size for output by default (though it may not always be that small), used for testing
+        // purposes to allow realloc logic to execute.
+
 #define CHECK_STATUS(return_status)                                                      \
     if (return_status != OK) {                                                           \
         fprintf(stderr, "[ERROR] return status %d, line %d\n", return_status, __LINE__); \
@@ -22,10 +26,9 @@ int main(int argc, char* argv[]) {
     ov_genai_llm_pipeline* pipeline = NULL;
     ov_genai_generation_config* config = NULL;
     ov_genai_decoded_results* results = NULL;
-    const char* device = "CPU";        // GPU, NPU can be used as well
-    char* output = (char*)malloc(16);  // Firstly, malloc a small size (though it may not necessarily be that small),
-                                       // used only for testing to allow realloc logic to run.
-    size_t required_size = 0;          // Used to store the required size of the output buffer.
+    const char* device = "CPU";  // GPU, NPU can be used as well
+    char* output = (char*)malloc(DEFAULT_OUTPUT_SIZE);
+    size_t required_size = 0;  // Used to store the required size of the output buffer.
 
     if (!output) {
         fprintf(stderr, "[Error] Memory allocation failed (malloc 5 bytes).\n");

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -52,7 +52,7 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
  * @param output A pointer to the pre-allocated output string buffer.
  * @param output_size The maximum size of the output buffer. If output_size is too small, output will contain a
  * truncated string.
- * @param needed_size If not NULL, it is set to the minimum buffer size required, including the size of null
+ * @param required_size If not NULL, it is set to the minimum buffer size required, including the size of null
  * terminator.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
@@ -60,7 +60,7 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* results,
                                                                          char* output,
                                                                          size_t output_size,
-                                                                         size_t* needed_size);
+                                                                         size_t* required_size);
 
 /**
  * @struct ov_genai_llm_pipeline
@@ -107,7 +107,8 @@ typedef ov_genai_streamming_status_e(OPENVINO_C_API_CALLBACK* stream_callback)(c
  * @param config A pointer to the ov_genai_generation_config, This is optional, the pointer can be NULL.
  * @param streamer A pointer to the stream callback. Either this or output must be non-NULL.
  * @param output A pointer to the pre-allocated output string buffer. Either this or streamer must be non-NULL.
- * @param output_max_size The maximum size of the output buffer. If output_size is too small, output will contain a truncated string.
+ * @param output_max_size The maximum size of the output buffer. If output_size is too small, output will contain a
+ * truncated string.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
  */

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -50,13 +50,17 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
  * @brief Get string result from ov_genai_decoded_results.
  * @param results A pointer to the ov_genai_decoded_results instance.
  * @param output A pointer to the pre-allocated output string buffer.
- * @param max_size The maximum size of the output buffer.
+ * @param output_size The maximum size of the output buffer. If output_size is too small, output will contain a
+ * truncated string.
+ * @param needed_size If not `NULL`, it is set to the minimum buffer size required, including the size of null
+ * terminator.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* results,
                                                                          char* output,
-                                                                         size_t max_size);
+                                                                         size_t output_size,
+                                                                         size_t* needed_size);
 
 /**
  * @struct ov_genai_llm_pipeline

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -101,7 +101,7 @@ typedef enum {
 typedef ov_genai_streamming_status_e(OPENVINO_C_API_CALLBACK* stream_callback)(const char*);
 
 /**
- * @brief Generate text by ov_genai_llm_pipeline and return ov_genai_decoded_results.
+ * @brief Generate results by ov_genai_llm_pipeline
  * @param pipe A pointer to the ov_genai_llm_pipeline instance.
  * @param inputs A pointer to the input string.
  * @param config A pointer to the ov_genai_generation_config, the pointer can be NULL.

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -52,7 +52,7 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
  * @param output A pointer to the pre-allocated output string buffer.
  * @param output_size The maximum size of the output buffer. If output_size is too small, output will contain a
  * truncated string.
- * @param needed_size If not `NULL`, it is set to the minimum buffer size required, including the size of null
+ * @param needed_size If not NULL, it is set to the minimum buffer size required, including the size of null
  * terminator.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
@@ -105,9 +105,9 @@ typedef ov_genai_streamming_status_e(OPENVINO_C_API_CALLBACK* stream_callback)(c
  * @param pipe A pointer to the ov_genai_llm_pipeline instance.
  * @param inputs A pointer to the input string.
  * @param config A pointer to the ov_genai_generation_config, This is optional, the pointer can be NULL.
- * @param streamer A pointer to the stream callback. This is optional; set to NULL if no callback is needed.
- * @param output A pointer to the pre-allocated output string buffer.
- * @param output_max_size The maximum size of the output buffer.
+ * @param streamer A pointer to the stream callback. Either this or output must be non-NULL.
+ * @param output A pointer to the pre-allocated output string buffer. Either this or streamer must be non-NULL.
+ * @param output_max_size The maximum size of the output buffer. If output_size is too small, output will contain a truncated string.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
  */

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -49,7 +49,7 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
 /**
  * @brief Get string result from ov_genai_decoded_results.
  * @param results A pointer to the ov_genai_decoded_results instance.
- * @param output A Pointer to the pre-allocated output string buffer. It can be set to NULL, in which case the
+ * @param output A pointer to the pre-allocated output string buffer. It can be set to NULL, in which case the
  * *output_size will provide the needed buffer size. The user should then allocate the required buffer size and call
  * this function again to obtain the entire output.
  * @param output_size A Pointer to the size of the output string from the results, including the null terminator. If

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -49,16 +49,16 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
 /**
  * @brief Get string result from ov_genai_decoded_results.
  * @param results A pointer to the ov_genai_decoded_results instance.
- * @param output A Pointer to a char* that will receive the address of the output string.
- *               - If *output is nullptr, the function will allocate new memory.
- *               - If *output is not nullptr, the function will free the existing memory and allocate new memory.
- *              - The caller is responsible for freeing the memory allocated by this function.
- * @param output_size A Pointer to the size of the currently allocated memory for output.
- * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
- * to store the result.
+ * @param output A Pointer to the pre-allocated output string buffer. It can be set to NULL, in which case the
+ * *output_size will provide the needed buffer size. The user should then allocate the required buffer size and call
+ * this function again to obtain the entire output.
+ * @param output_size A Pointer to the size of the output string from the results, including the null terminator. If
+ * output is not NULL, *output_size should be greater than or equal to the result string size; otherwise, the function
+ * will return OUT_OF_BOUNDS(-6).
+ * @return ov_status_e A status code, return OK(0) if successful.
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* results,
-                                                                         char** output,
+                                                                         char* output,
                                                                          size_t* output_size);
 
 /**
@@ -99,42 +99,23 @@ typedef enum {
  * @brief Callback function for streaming output.
  */
 typedef ov_genai_streamming_status_e(OPENVINO_C_API_CALLBACK* stream_callback)(const char*);
-/**
- * @brief Generate text by ov_genai_llm_pipeline.
- * @param pipe A pointer to the ov_genai_llm_pipeline instance.
- * @param inputs A pointer to the input string.
- * @param config A pointer to the ov_genai_generation_config, This is optional, the pointer can be NULL.
- * @param streamer A pointer to the stream callback. Either this or output must be non-NULL.
- * @param output A Pointer to a char* that will receive the address of the output string. Either this or streamer must
- * be non-NULL.
- *               - If *output is nullptr, the function will allocate new memory.
- *              - If *output is not nullptr, the function will free the existing memory and allocate new memory.
- *              - The caller is responsible for freeing the memory allocated by this function.
- * @param output_size A Pointer to the size of the currently allocated memory for output.
- * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
- * to store the result.
- */
-OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_generate(ov_genai_llm_pipeline* pipe,
-                                                                    const char* inputs,
-                                                                    const ov_genai_generation_config* config,
-                                                                    const stream_callback* streamer,
-                                                                    char** output,
-                                                                    size_t* output_size);
+
 /**
  * @brief Generate text by ov_genai_llm_pipeline and return ov_genai_decoded_results.
  * @param pipe A pointer to the ov_genai_llm_pipeline instance.
  * @param inputs A pointer to the input string.
  * @param config A pointer to the ov_genai_generation_config, the pointer can be NULL.
- * @param streamer A pointer to the stream callback. This is optional; set to NULL if no callback is needed.
- * @param ov_genai_decoded_results A pointer to the ov_genai_decoded_results.
+ * @param streamer A pointer to the stream callback. Set to NULL if no callback is needed. Either this or results must
+ * be non-NULL.
+ * @param results A pointer to the ov_genai_decoded_results, which retrieves the results of the generation. Either this
+ * or streamer must be non-NULL.
  * @return Status code of the operation: OK(0) for success.
  */
-OPENVINO_GENAI_C_EXPORTS ov_status_e
-ov_genai_llm_pipeline_generate_decoded_results(ov_genai_llm_pipeline* pipe,
-                                               const char* inputs,
-                                               const ov_genai_generation_config* config,
-                                               const stream_callback* streamer,
-                                               ov_genai_decoded_results** results);
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_generate(ov_genai_llm_pipeline* pipe,
+                                                                    const char* inputs,
+                                                                    const ov_genai_generation_config* config,
+                                                                    const stream_callback* streamer,
+                                                                    ov_genai_decoded_results** results);
 /**
  * @brief Start chat with keeping history in kv cache.
  * @param pipe A pointer to the ov_genai_llm_pipeline instance.

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -49,18 +49,17 @@ OPENVINO_GENAI_C_EXPORTS void ov_genai_decoded_results_perf_metrics_free(ov_gena
 /**
  * @brief Get string result from ov_genai_decoded_results.
  * @param results A pointer to the ov_genai_decoded_results instance.
- * @param output A pointer to the pre-allocated output string buffer.
- * @param output_size The maximum size of the output buffer. If output_size is too small, output will contain a
- * truncated string.
- * @param required_size If not NULL, it is set to the minimum buffer size required, including the size of null
- * terminator.
+ * @param output A Pointer to a char* that will receive the address of the output string.
+ *               - If *output is nullptr, the function will allocate new memory.
+ *               - If *output is not nullptr, the function will free the existing memory and allocate new memory.
+ *              - The caller is responsible for freeing the memory allocated by this function.
+ * @param output_size A Pointer to the size of the currently allocated memory for output.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* results,
-                                                                         char* output,
-                                                                         size_t output_size,
-                                                                         size_t* required_size);
+                                                                         char** output,
+                                                                         size_t* output_size);
 
 /**
  * @struct ov_genai_llm_pipeline
@@ -106,9 +105,12 @@ typedef ov_genai_streamming_status_e(OPENVINO_C_API_CALLBACK* stream_callback)(c
  * @param inputs A pointer to the input string.
  * @param config A pointer to the ov_genai_generation_config, This is optional, the pointer can be NULL.
  * @param streamer A pointer to the stream callback. Either this or output must be non-NULL.
- * @param output A pointer to the pre-allocated output string buffer. Either this or streamer must be non-NULL.
- * @param output_max_size The maximum size of the output buffer. If output_size is too small, output will contain a
- * truncated string.
+ * @param output A Pointer to a char* that will receive the address of the output string. Either this or streamer must
+ * be non-NULL.
+ *               - If *output is nullptr, the function will allocate new memory.
+ *              - If *output is not nullptr, the function will free the existing memory and allocate new memory.
+ *              - The caller is responsible for freeing the memory allocated by this function.
+ * @param output_size A Pointer to the size of the currently allocated memory for output.
  * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS if output_size is insufficient
  * to store the result.
  */
@@ -116,8 +118,8 @@ OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_generate(ov_genai_llm
                                                                     const char* inputs,
                                                                     const ov_genai_generation_config* config,
                                                                     const stream_callback* streamer,
-                                                                    char* output,
-                                                                    size_t output_max_size);
+                                                                    char** output,
+                                                                    size_t* output_size);
 /**
  * @brief Generate text by ov_genai_llm_pipeline and return ov_genai_decoded_results.
  * @param pipe A pointer to the ov_genai_llm_pipeline instance.

--- a/src/c/src/llm_pipeline.cpp
+++ b/src/c/src/llm_pipeline.cpp
@@ -48,7 +48,7 @@ ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* 
                                                 char* output,
                                                 size_t output_size,
                                                 size_t* needed_size) {
-    if (!results || !(results->object) || !(output || needed_size)) {
+    if (!results || !(results->object) || !(output && output_size || needed_size)) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
@@ -94,7 +94,7 @@ ov_status_e ov_genai_llm_pipeline_generate(ov_genai_llm_pipeline* pipe,
                                            const stream_callback* streamer,
                                            char* output,
                                            size_t output_max_size) {
-    if (!pipe || !(pipe->object) || !inputs || !(streamer || output)) {
+    if (!pipe || !(pipe->object) || !inputs || !(streamer || output && output_max_size)) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {

--- a/src/c/src/llm_pipeline.cpp
+++ b/src/c/src/llm_pipeline.cpp
@@ -47,8 +47,8 @@ void ov_genai_decoded_results_perf_metrics_free(ov_genai_perf_metrics* metrics) 
 ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* results,
                                                 char* output,
                                                 size_t output_size,
-                                                size_t* needed_size) {
-    if (!results || !(results->object) || !(output && output_size || needed_size)) {
+                                                size_t* required_size) {
+    if (!results || !(results->object) || !(output && output_size || required_size)) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
@@ -60,8 +60,8 @@ ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* 
                 return ov_status_e::OUT_OF_BOUNDS;
             }
         }
-        if (needed_size) {
-            *needed_size = str.length() + 1;
+        if (required_size) {
+            *required_size = str.length() + 1;
         }
     } catch (...) {
         return ov_status_e::UNKNOW_EXCEPTION;


### PR DESCRIPTION
Based on the discussion in #1778, I have adjusted the LLM pipeline C APIs to ensure it can determine the required sufficient size for the output string.  `ov_genai_llm_pipeline_generate_decoded_results` has been removed and `ov_genai_llm_pipeline_generate`  has been modified to get decoded results.
```C
ov_genai_decoded_results* results = NULL;
size_t output_size=0; 
char* output = NULL; // the caller is responsible for allocating and freeing the memory. 
ov_genai_llm_pipeline_generate(pipeline, prompt, config, NULL &results);
ov_genai_decoded_results_get_string(results,NULL,&output_size); // The function is called with NULL as the output to determine the required buffer size.
output = (char*)malloc(output_size);
// check..
ov_genai_decoded_results_get_string(results,output,&output_size); // Get the actual output string
// print and free
 
```
Another change is to allow the `ov_genai_llm_pipeline_generate` to have either the `results` or `streamer` as an option, but one of them must not be null. This facilitates users who only need the streamer functionality, preventing them from allocating excessive unnecessary memory.