### PR TITLE
Fixed stubgen issue

### DIFF
--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -1197,7 +1197,7 @@ class LLMPipeline:
                     kwargs: Device properties.
         """
     @typing.overload
-    def __init__(self, model: str, weights: openvino._pyopenvino.Tensor, tokenizer: Tokenizer, device: str, generation_config: GenerationConfig = ..., **kwargs) -> None:
+    def __init__(self, model: str, weights: openvino._pyopenvino.Tensor, tokenizer: Tokenizer, device: str, generation_config: GenerationConfig | None = None, **kwargs) -> None:
         """
                     LLMPipeline class constructor.
                     model (str): Pre-read model.

--- a/src/python/py_llm_pipeline.cpp
+++ b/src/python/py_llm_pipeline.cpp
@@ -175,18 +175,21 @@ void init_llm_pipeline(py::module_& m) {
             const ov::Tensor& weights,
             const ov::genai::Tokenizer& tokenizer,
             const std::string& device,
-            const ov::genai::GenerationConfig& generation_config,
+            OptionalGenerationConfig generation_config,
             const py::kwargs& kwargs
         ) {
             ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
             ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
-            return std::make_unique<LLMPipeline>(model, weights, tokenizer, device, properties, generation_config);
+            if (!generation_config.has_value()) {
+                generation_config = ov::genai::GenerationConfig();
+            }
+            return std::make_unique<LLMPipeline>(model, weights, tokenizer, device, properties, *generation_config);
         }),
         py::arg("model"), "string with pre-read model",
         py::arg("weights"), "ov::Tensor with pre-read model weights",
         py::arg("tokenizer"), "genai Tokenizers",
         py::arg("device"), "device on which inference will be done",
-        py::arg("generation_config") = ov::genai::GenerationConfig(), "genai GenerationConfig",
+        py::arg("generation_config") = py::none(), "genai GenerationConfig (default: None, will use empty config)",
         R"(
             LLMPipeline class constructor.
             model (str): Pre-read model.

--- a/src/python/py_openvino_genai.cpp
+++ b/src/python/py_openvino_genai.cpp
@@ -100,14 +100,14 @@ PYBIND11_MODULE(py_openvino_genai, m) {
         .def_readonly("tokens", &EncodedResults::tokens)
         .def_readonly("scores", &EncodedResults::scores)
         .def_readonly("perf_metrics", &EncodedResults::perf_metrics);
-    
-    init_tokenizer(m);
-    init_streamers(m);
+
     init_lora_adapter(m);
     init_generation_config(m);
+    init_tokenizer(m);
+    init_streamers(m);
 
-    init_continuous_batching_pipeline(m);
     init_llm_pipeline(m);
+    init_continuous_batching_pipeline(m);
     init_image_generation_pipelines(m);
     init_vlm_pipeline(m);
     init_whisper_pipeline(m);


### PR DESCRIPTION
```bash
[100%] [pybind11-stubgen==2.5.3] Generate .pyi files
pybind11_stubgen - [  ERROR] In openvino_genai.py_openvino_genai.LLMPipeline.__init__ : Invalid expression '<openvino_genai.py_openvino_genai.GenerationConfig object at 0x7f65fd5e2d70>'
pybind11_stubgen - [WARNING] Raw C++ types/values were found in signatures extracted from docstrings.
Please check the corresponding sections of pybind11 documentation to avoid common mistakes in binding code:
 - https://pybind11.readthedocs.io/en/latest/advanced/misc.html#avoiding-cpp-types-in-docstrings
 - https://pybind11.readthedocs.io/en/latest/advanced/functions.html#default-arguments-revisited
[100%] Built target py_openvino_genai_stub
```

We cannot use `ov::genai::GenerationConfig()` as a default value.

Introduced here https://github.com/openvinotoolkit/openvino.genai/pull/1751