### PR TITLE
Store EncodedImage's in VLM CB chat history.

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -15759,9 +15759,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/src/cpp/src/icontinuous_batching.cpp
+++ b/src/cpp/src/icontinuous_batching.cpp
@@ -165,8 +165,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             prompt_with_tags = add_image_tags_to_prompt(prompt_with_tags, rgbs, m_history_images.size());
         }
         m_history.push_back({{"role", "user"}, {"content", prompt_with_tags}});
-        // TODO: save embeddings, instead of image tensors and compare performance
-        m_history_images.insert(m_history_images.end(), rgbs.begin(), rgbs.end());
+        const auto encoded_images = m_inputs_embedder->encode_images(rgbs);
+        m_history_images.insert(m_history_images.end(), encoded_images.begin(), encoded_images.end());
         std::string templated_history = m_tokenizer.apply_chat_template(m_history, true);
 
         m_inputs_embedder->set_apply_chat_template_status(false);

--- a/src/cpp/src/icontinuous_batching.hpp
+++ b/src/cpp/src/icontinuous_batching.hpp
@@ -49,7 +49,7 @@ protected:
 
     bool m_is_chat_conversation = false;
     ChatHistory m_history;
-    std::vector<ov::Tensor> m_history_images;
+    std::vector<ov::genai::EncodedImage> m_history_images;
 
     float m_load_time_ms = 0.0f;
     // to access m_load_time_ms

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -35,6 +35,10 @@ public:
     // compute input embedding for prompt and multiple images
     ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics);
 
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics);
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images);
+
     // compute position ids for language model input
     std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
 
@@ -90,8 +94,13 @@ private:
         // Verifies no previous image is referenced.
         // InputsEmbedderMiniCPM Uses to insert <image_id>i</image_id> per image (not a slice).
         size_t m_image_id = 0;
+
     public:
-        virtual ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) = 0;
+        virtual ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) = 0;
+
+        ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics);
+
+        virtual std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images);
     
         virtual std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
     

--- a/src/cpp/src/visual_language/internvl_chat/classes.cpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.cpp
@@ -224,19 +224,16 @@ InputsEmbedderInternVLChat::InputsEmbedderInternVLChat(
     const ov::AnyMap device_config) :
     IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) { }
 
-ov::Tensor InputsEmbedderInternVLChat::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
+ov::Tensor InputsEmbedderInternVLChat::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
     std::string image_start_token = m_vlm_config.image_start_token;
     std::string image_context_token = m_vlm_config.image_context_token;
     std::string image_end_token = m_vlm_config.image_end_token;
-    
-    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
 
     std::string formatted_prompt;
     std::vector<ov::Tensor> image_embeds;
-    image_embeds.reserve(single_images.size());
+    image_embeds.reserve(images.size());
     
-    for (const auto& image : single_images) {
-        EncodedImage encoded_image = m_vision_encoder->encode(image);
+    for (const auto& encoded_image : images) {
         ov::Tensor single_image_embeds = encoded_image.resized_source;
 
         const size_t num_patches = single_image_embeds.get_shape().at(0);

--- a/src/cpp/src/visual_language/internvl_chat/classes.hpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.hpp
@@ -35,7 +35,7 @@ public:
         const std::string& device,
         const ov::AnyMap device_config);
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
 };
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/llava/classes.hpp
+++ b/src/cpp/src/visual_language/llava/classes.hpp
@@ -35,8 +35,9 @@ public:
         const std::string& device,
         const ov::AnyMap device_config);
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
 
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
 protected:
     ov::Tensor merge_text_and_image_embeddings_llava(
         const ov::Tensor& input_ids,

--- a/src/cpp/src/visual_language/llava_next/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next/classes.cpp
@@ -261,7 +261,6 @@ ov::Tensor add_image_newline(const ov::Tensor& image_feature, const ov::Tensor& 
  */
 ov::Tensor pack_image_features_llava_next(
     const EncodedImage& encoded_image,
-    const ImageSize& original_image_size,
     const ov::Tensor& image_newline) {
     auto image_feature = encoded_image.resized_source;
     auto image_feature_shape = image_feature.get_shape();
@@ -294,7 +293,7 @@ ov::Tensor pack_image_features_llava_next(
 
         ov::Tensor reshaped_image_feature = reshape_and_rearrange_image_feature(patches_image_feature, num_patch_height, num_patch_width, height, width);
 
-        ov::Tensor unpadded_image_feature = unpad_image(reshaped_image_feature, original_image_size);
+        ov::Tensor unpadded_image_feature = unpad_image(reshaped_image_feature, encoded_image.original_image_size);
 
         ov::Tensor image_feature_with_newline = add_image_newline(unpadded_image_feature, image_newline);
 
@@ -358,9 +357,7 @@ ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& prompt,
             std::copy(m_vlm_config.image_newline.begin(), m_vlm_config.image_newline.end(), image_newline_data);
         }
 
-        ImageSize original_image_size{encoded_image.original_image_size.height, encoded_image.original_image_size.width}; // [height, width]
-
-        ov::Tensor packed_features = pack_image_features_llava_next(encoded_image, original_image_size, image_newline);
+        ov::Tensor packed_features = pack_image_features_llava_next(encoded_image, image_newline);
         for (size_t idx = 0; idx < packed_features.get_shape().at(1); ++idx) {
             formatted_prompt += image_token;
         }

--- a/src/cpp/src/visual_language/llava_next/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next/classes.cpp
@@ -73,6 +73,7 @@ EncodedImage VisionEncoderLLaVANext::encode(const ov::Tensor& image, const ov::A
     encoded_image.resized_source = std::move(image_features);
     encoded_image.resized_source_size = resized_source_size;
     encoded_image.patches_grid = {num_patches_h, num_patches_w};
+    encoded_image.original_image_size = original_image_size;
     return encoded_image;
 }
 
@@ -331,21 +332,25 @@ ov::Tensor pack_image_features_llava_next(
 
 } // namespace
 
-ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
-    std::string image_token = m_vlm_config.im_start;
-
+std::vector<ov::genai::EncodedImage> InputsEmbedderLLaVANext::encode_images(const std::vector<ov::Tensor>& images) {
+    std::vector<EncodedImage> embeds;
+    ov::AnyMap vision_config = {{"patch_size", m_vlm_config.vision_config_patch_size}};
     std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
+    for (const ov::Tensor& image : single_images) {
+        embeds.emplace_back(m_vision_encoder->encode(image, vision_config));
+    }
+    return embeds;
+}
+
+ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
+    std::string image_token = m_vlm_config.im_start;
 
     std::string formatted_prompt;
     std::vector<ov::Tensor> image_embeds;
-    image_embeds.reserve(single_images.size());
-    
+    image_embeds.reserve(images.size());
     ov::Tensor image_newline;
 
-    for (const auto& image : single_images) {
-        ov::AnyMap vision_config = {{"patch_size", m_vlm_config.vision_config_patch_size}};
-        EncodedImage encoded_image = m_vision_encoder->encode(image, vision_config);
-
+    for (const auto& encoded_image : images) {
         if (!image_newline) {
             size_t embed_dim = encoded_image.resized_source.get_shape().at(2);
             image_newline = ov::Tensor(encoded_image.resized_source.get_element_type(), {embed_dim});
@@ -353,7 +358,7 @@ ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& prompt,
             std::copy(m_vlm_config.image_newline.begin(), m_vlm_config.image_newline.end(), image_newline_data);
         }
 
-        ImageSize original_image_size{image.get_shape().at(1), image.get_shape().at(2)}; // [height, width]
+        ImageSize original_image_size{encoded_image.original_image_size.height, encoded_image.original_image_size.width}; // [height, width]
 
         ov::Tensor packed_features = pack_image_features_llava_next(encoded_image, original_image_size, image_newline);
         for (size_t idx = 0; idx < packed_features.get_shape().at(1); ++idx) {

--- a/src/cpp/src/visual_language/llava_next/classes.hpp
+++ b/src/cpp/src/visual_language/llava_next/classes.hpp
@@ -22,7 +22,9 @@ class InputsEmbedderLLaVANext : public InputsEmbedderLLaVA {
 public:
     using InputsEmbedderLLaVA::InputsEmbedderLLaVA;
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
 };
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/minicpm/classes.hpp
+++ b/src/cpp/src/visual_language/minicpm/classes.hpp
@@ -45,7 +45,7 @@ public:
         const std::string& device,
         const ov::AnyMap device_config);
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
 
     void update_chat_history(const std::string& decoded_results, const ov::genai::GenerationStatus generation_finish_status) override;
 

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -515,11 +515,10 @@ InputsEmbedderPhi3V::InputsEmbedderPhi3V(
     m_hd_feature_transformer{create_hd_feature_transformer()},
     m_vision_projection{utils::singleton_core().compile_model(model_dir / "openvino_vision_projection_model.xml", device, {}).create_infer_request()} {}
 
-ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
+ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
     std::vector<ov::Tensor> images_features_proj;
     std::stringstream images_prompt;
-    for (const ov::Tensor& image : to_single_image_tensors(images)) {
-        EncodedImage encoded_image = m_vision_encoder->encode(image);
+    for (const ov::genai::EncodedImage& encoded_image : images) {
         images_features_proj.push_back(hd_feature_transform(encoded_image, m_hd_feature_transformer, m_vlm_config.sub_GN, m_vlm_config.glb_GN, m_vision_projection));
         m_tokens_per_images.push_back(images_features_proj.back().get_shape().at(1));
         images_prompt << "<|image_" << m_tokens_per_images.size() << "|>\n";

--- a/src/cpp/src/visual_language/phi3_vision/classes.hpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.hpp
@@ -28,7 +28,7 @@ public:
         const ov::AnyMap device_config
     );
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
 
     void update_chat_history(const std::string& decoded_results, const ov::genai::GenerationStatus generation_finish_status) override;
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -271,16 +271,14 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     m_vision_embeddings_merger = compiled_model.create_infer_request();
 }
 
-ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
-    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
-    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, single_images.size(), m_image_id);
+ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
+    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, images.size(), m_image_id);
     std::vector<ov::Tensor> image_embeds;
     std::vector<std::array<size_t, 3>> images_grid_thw;
-    image_embeds.reserve(single_images.size());
-    images_grid_thw.reserve(single_images.size());
+    image_embeds.reserve(images.size());
+    images_grid_thw.reserve(images.size());
     
-    for (const auto& image : single_images) {
-        EncodedImage encoded_image = m_vision_encoder->encode(image);
+    for (const auto& encoded_image : images) {
         ov::Tensor single_image_embeds = encoded_image.resized_source;
         image_embeds.push_back(std::move(single_image_embeds));
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.hpp
@@ -46,7 +46,7 @@ public:
         const std::string& device,
         const ov::AnyMap device_config);
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) override;
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) override;
 
     std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size) override;
 

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -41,6 +41,9 @@ struct EncodedImage {
     /// @brief Patches grid after llava_next preprocessing.
     /// Format: [num_patches_height, num_patches_width]
     std::pair<int, int> patches_grid;
+    
+    /// @brief Original size of the image
+    ImageSize original_image_size;
 };
 
 /// @brief A class used to infer embeddings of an image using


### PR DESCRIPTION
Storage of EncodedImage's in VLM CB chat history instead of original image allows to reduce generate() time by ~10% on 2nd and subsequent chat iterations.

Time measure for 3 CB chat iterations for MiniCPM-V-2_6 and [this image](https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11):
 
Master:
Generate 1 Time: 19625.116645 ms
Generate 2 Time: 58074.136806 ms
Generate 3 Time: 57504.088475 ms
 
This branch:
Generate 1 Time: 19716.716223 ms
Generate 2 Time: 51544.187465 ms
Generate 3 Time: 51619.265177 ms