### PR TITLE
VLM: fix image separators

### DIFF
--- a/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
@@ -109,7 +109,7 @@ public:
     /// images used in previous prompts isn't implemented.
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
-    /// MiniCPM-V-2_6: <image>./</image>
+    /// MiniCPM-V-2_6: (<image>./</image>)\n
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.
@@ -133,7 +133,7 @@ public:
     /// images used in previous prompts isn't implemented.
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
-    /// MiniCPM-V-2_6: <image>./</image>
+    /// MiniCPM-V-2_6: (<image>./</image>)\n
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.
@@ -158,7 +158,7 @@ public:
     /// images used in previous prompts isn't implemented.
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
-    /// MiniCPM-V-2_6: <image>./</image>
+    /// MiniCPM-V-2_6: (<image>./</image>)\n
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.

--- a/src/cpp/src/icontinuous_batching.cpp
+++ b/src/cpp/src/icontinuous_batching.cpp
@@ -7,7 +7,7 @@ namespace {
 std::string add_image_tags_to_prompt(const std::string& prompt, const std::vector<ov::Tensor>& rgbs, size_t history_images_size) {
     std::stringstream prompt_with_image_tags;
     for (size_t i = 0; i < rgbs.size(); i++) {
-        prompt_with_image_tags << "<ov_genai_image_" << i + history_images_size << ">\n";
+        prompt_with_image_tags << "<ov_genai_image_" << i + history_images_size << ">";
     }
     prompt_with_image_tags << prompt;
     return prompt_with_image_tags.str();

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -275,14 +275,20 @@ bool InputsEmbedder::prompt_has_image_tag(const std::string& prompt) const {
     return m_impl->prompt_has_image_tag(prompt);
 }
 
-std::pair<std::string, std::vector<size_t>> unify_prompt(const std::string& prompt, const std::string& native_tag, size_t n_new_images, size_t first_new_image_id) {
+std::pair<std::string, std::vector<size_t>> unify_prompt(
+    const std::string& prompt,
+    const std::string& native_tag,
+    const std::string& unified_tag_to_native_tag,
+    size_t n_new_images,
+    size_t first_new_image_id
+) {
     bool found_universal_tag = std::regex_search(prompt, UNIVERSAL_PATTERN);
     bool found_native_tag = prompt.find(native_tag) != std::string::npos;
     OPENVINO_ASSERT(!(found_universal_tag && found_native_tag), "Prompt can contain only one type of image tags.");
     std::stringstream images_prompt;
     if (!found_universal_tag && ! found_native_tag) {
         for (size_t i = first_new_image_id; i < n_new_images + first_new_image_id; ++i) {
-            images_prompt << "<ov_genai_image_" << i << ">\n";
+            images_prompt << "<ov_genai_image_" << i << ">";
         }
     }
     images_prompt << prompt;
@@ -305,7 +311,7 @@ std::pair<std::string, std::vector<size_t>> unify_prompt(const std::string& prom
                 images_sequence.push_back(std::stoi((*it)[1].str()));
                 OPENVINO_ASSERT(images_sequence.back() < n_new_images + first_new_image_id, "Missing image ", images_sequence.back());
                 OPENVINO_ASSERT(first_new_image_id <= images_sequence.back(), "Referring to older images isn't implemented");
-                unified_prompt.replace(it->position(), it->length(), native_tag);
+                unified_prompt.replace(it->position(), it->length(), unified_tag_to_native_tag);
                 found = true;
                 break;
             }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -165,6 +165,17 @@ private:
 /// If no any tag, prepend universal image tag.
 /// If native tag, assume incremental image order.
 /// Else replace universal tags with native tags and save image order.
-std::pair<std::string, std::vector<size_t>> unify_prompt(const std::string& prompt, const std::string& native_tag, size_t n_new_images, size_t first_new_image_id);
+/// @param unified_tag_to_native_tag MiniCPM-V-2_6 inserts
+/// (<image>./</image>)\n per image but it only replaces
+/// <image>./</image> leaving ()\n untouched.
+/// unified_tag_to_native_tag allows to handle this by being separated
+/// from native_tag param.
+std::pair<std::string, std::vector<size_t>> unify_prompt(
+    const std::string& prompt,
+    const std::string& native_tag,
+    const std::string& unified_tag_to_native_tag,
+    size_t n_new_images,
+    size_t first_new_image_id
+);
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -575,7 +575,13 @@ ov::Tensor InputsEmbedderMiniCPM::get_inputs_embeds(const std::string& prompt, c
     std::vector<EncodedImage> embeds;
 
     std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
-    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, single_images.size(), m_image_id);
+    auto [unified_prompt, images_sequence] = unify_prompt(
+        prompt,
+        NATIVE_TAG,
+        '(' + NATIVE_TAG + ")\n",
+        single_images.size(),
+        m_image_id
+    );
 
     for (const ov::Tensor& image : single_images) {
         embeds.push_back(m_vision_encoder->encode(image));

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -273,7 +273,7 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
 
 ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, const std::vector<ov::Tensor>& images, ov::genai::VLMPerfMetrics& metrics) {
     std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
-    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, single_images.size(), m_image_id);
+    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, NATIVE_TAG, single_images.size(), m_image_id);
     std::vector<ov::Tensor> image_embeds;
     std::vector<std::array<size_t, 3>> images_grid_thw;
     image_embeds.reserve(single_images.size());

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2114,7 +2114,7 @@ class VLMPipeline:
             images used in previous prompts isn't implemented.
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
-            MiniCPM-V-2_6: <image>./</image>
+            MiniCPM-V-2_6: (<image>./</image>)\\n
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.
@@ -2146,7 +2146,7 @@ class VLMPipeline:
             images used in previous prompts isn't implemented.
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
-            MiniCPM-V-2_6: <image>./</image>
+            MiniCPM-V-2_6: (<image>./</image>)\\n
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.
@@ -2177,7 +2177,7 @@ class VLMPipeline:
             images used in previous prompts isn't implemented.
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
-            MiniCPM-V-2_6: <image>./</image>
+            MiniCPM-V-2_6: (<image>./</image>)\\n
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -29,7 +29,7 @@ auto vlm_generate_docstring = R"(
     images used in previous prompts isn't implemented.
     A model's native image tag can be used instead of
     <ov_genai_image_i>. These tags are:
-    MiniCPM-V-2_6: <image>./</image>
+    MiniCPM-V-2_6: (<image>./</image>)\n
     Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     If the prompt doesn't contain image tags, but images are
     provided, the tags are prepended to the prompt.
@@ -59,7 +59,7 @@ auto vlm_generate_kwargs_docstring = R"(
     images used in previous prompts isn't implemented.
     A model's native image tag can be used instead of
     <ov_genai_image_i>. These tags are:
-    MiniCPM-V-2_6: <image>./</image>
+    MiniCPM-V-2_6: (<image>./</image>)\n
     Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     If the prompt doesn't contain image tags, but images are
     provided, the tags are prepended to the prompt.

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -494,7 +494,7 @@ image_id_ignorant = [
 
 models_to_tag = image_id_ignorant + [
     # minicpm tracks image number in expanded tags
-    ("katuni4ka/tiny-random-minicpmv-2_6", "<image>./</image>"),
+    ("katuni4ka/tiny-random-minicpmv-2_6", "(<image>./</image>)\n"),
 ]
 
 
@@ -541,10 +541,10 @@ class TestImageTags:
             answers = generate(vlm, requests)
 
             vlm.start_chat()
-            native_tag0 = vlm.generate("\n".join([model_to_tag[1], requests[0][0]]), images=requests[0][1])
+            native_tag0 = vlm.generate(model_to_tag[1] + requests[0][0], images=requests[0][1])
             assert native_tag0.texts == answers[0].texts
             assert native_tag0.scores == answers[0].scores
-            native_tags1 = vlm.generate("\n".join([model_to_tag[1]] * 2 + [requests[1][0]]), images=requests[1][1])
+            native_tags1 = vlm.generate(model_to_tag[1] * 2 + requests[1][0], images=requests[1][1])
             assert native_tags1.texts == answers[1].texts
             assert native_tags1.scores == answers[1].scores
             vlm.finish_chat()
@@ -557,10 +557,10 @@ class TestImageTags:
             answers = generate(vlm, requests)
 
             vlm.start_chat()
-            universal_tag0 = vlm.generate("<ov_genai_image_0>\n" + requests[0][0], images=requests[0][1])
+            universal_tag0 = vlm.generate("<ov_genai_image_0>" + requests[0][0], images=requests[0][1])
             assert universal_tag0.texts == answers[0].texts
             assert universal_tag0.scores == answers[0].scores
-            universal_tags1 = vlm.generate("<ov_genai_image_1>\n<ov_genai_image_2>\n" + requests[1][0], images=requests[1][1])
+            universal_tags1 = vlm.generate("<ov_genai_image_1><ov_genai_image_2>" + requests[1][0], images=requests[1][1])
             assert universal_tags1.texts == answers[1].texts
             assert universal_tags1.scores == answers[1].scores
             vlm.finish_chat()
@@ -575,15 +575,15 @@ class TestImageTags:
             vlm.set_generation_config(generation_config)
 
             vlm.start_chat()
-            native_tag0 = vlm.generate("\n".join([requests[0][0], model_to_tag[1]]), images=requests[0][1])
-            native_tags1 = vlm.generate("\n".join([requests[1][0]] + [model_to_tag[1]] * 2), images=requests[1][1])
+            native_tag0 = vlm.generate(requests[0][0] + model_to_tag[1], images=requests[0][1])
+            native_tags1 = vlm.generate(requests[1][0] + model_to_tag[1] * 2, images=requests[1][1])
             vlm.finish_chat()
 
             vlm.start_chat()
-            universal_tag0 = vlm.generate(requests[0][0] + "\n<ov_genai_image_0>" , images=requests[0][1])
+            universal_tag0 = vlm.generate(requests[0][0] + "<ov_genai_image_0>" , images=requests[0][1])
             assert universal_tag0.texts == native_tag0.texts
             assert universal_tag0.scores == native_tag0.scores
-            universal_tags1 = vlm.generate(requests[1][0] + "\n<ov_genai_image_1>\n<ov_genai_image_2>" , images=requests[1][1])
+            universal_tags1 = vlm.generate(requests[1][0] + "<ov_genai_image_1><ov_genai_image_2>" , images=requests[1][1])
             assert universal_tags1.texts == native_tags1.texts
             assert universal_tags1.scores == native_tags1.scores
             vlm.finish_chat()


### PR DESCRIPTION
Qwen2-VL doesnt use \n after an image. There is test_qwen2vl_representation() which was supposed to catch that but it didnt even after increasing max_new_tokens to 1000.

MiniCPM-V-2_6 inserts (<image>./</image>)\n per image but it only replaces <image>./</image> leaving ()\n untouched. There is no way to test the alinment because the insertion happens in MiniCPMV.chat() and it infers with PyTorch.