### PR TITLE
phi3_v: add universal tag

### DIFF
--- a/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
@@ -110,6 +110,7 @@ public:
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
     /// MiniCPM-V-2_6: (<image>./</image>)\n
+    /// Phi-3-vision: <|image_i|>\n - the index starts with one
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.
@@ -134,6 +135,7 @@ public:
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
     /// MiniCPM-V-2_6: (<image>./</image>)\n
+    /// Phi-3-vision: <|image_i|>\n - the index starts with one
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.
@@ -159,6 +161,7 @@ public:
     /// A model's native image tag can be used instead of
     /// <ov_genai_image_i>. These tags are:
     /// MiniCPM-V-2_6: (<image>./</image>)\n
+    /// Phi-3-vision: <|image_i|>\n - the index starts with one
     /// Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     /// If the prompt doesn't contain image tags, but images are
     /// provided, the tags are prepended to the prompt.

--- a/src/cpp/src/llm_pipeline_static.cpp
+++ b/src/cpp/src/llm_pipeline_static.cpp
@@ -7,7 +7,6 @@
 #include "utils.hpp"
 
 #include <fstream>
-#include <regex>
 
 #include "openvino/runtime/core.hpp"
 #include "openvino/core/parallel.hpp"

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <numeric>
 #include <random>
-#include <regex>
 #include <vector>
 
 #include "utils.hpp"

--- a/src/cpp/src/lora_adapter.cpp
+++ b/src/cpp/src/lora_adapter.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 #include <fstream>
-#include <regex>
 #include <optional>
 #include <numeric>
 #include <iostream>

--- a/src/cpp/src/lora_common.hpp
+++ b/src/cpp/src/lora_common.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include <optional>
-#include <regex>
 #include <vector>
 
 #include "openvino/op/constant.hpp"

--- a/src/cpp/src/lora_names_mapping.hpp
+++ b/src/cpp/src/lora_names_mapping.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include <set>
+#include <regex>
 
 #include <openvino/genai/lora_adapter.hpp>
 

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -581,12 +581,12 @@ InputsEmbedderMiniCPM::InputsEmbedderMiniCPM(
 }
 
 ov::Tensor InputsEmbedderMiniCPM::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
-    auto [unified_prompt, images_sequence] = unify_prompt(
+    auto [unified_prompt, images_sequence] = normalize_prompt(
         prompt,
         NATIVE_TAG,
         '(' + NATIVE_TAG + ")\n",
-        images.size(),
-        m_image_id
+        m_image_id,
+        images.size()
     );
 
     std::string unk64;

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -9,13 +9,58 @@
 
 #include "utils.hpp"
 
-#include <regex>
-
 namespace ov::genai {
 
 namespace {
 
 constexpr size_t INPUT_IMAGE_SIZE = 336;
+static const std::regex NATIVE_PATTERN{R"(<\|image_(\d+)\|>)"};
+
+void write_native(std::ostream& os, size_t idx) {
+    os << "<|image_" << idx + 1 << "|>\n";
+}
+
+std::pair<std::string, std::vector<size_t>> normalize_prompt(
+    const std::string& prompt, size_t base_id, size_t n_images
+) {
+    std::smatch match;
+    std::regex_search(prompt, match, NATIVE_PATTERN);
+    auto [image_prompt, image_sequence] = universal_to_native(prompt, write_native);
+    if (!image_sequence.empty()) {
+        OPENVINO_ASSERT(match.empty(), "Prompt can contain only one type of image tags.");
+        verify_ids(image_sequence, base_id, n_images);
+        return {std::move(image_prompt), std::move(image_sequence)};
+    }
+    // Restore ids from native tags
+    if (!match.empty()) {
+        size_t image_id = std::stoul(match.str(1));
+        OPENVINO_ASSERT(image_id != 0, "Image tags must be greater than 0");
+        image_sequence.push_back(image_id - 1);
+        constexpr int submatch_id_to_return = 1;
+        for (std::sregex_token_iterator iter{
+            match.suffix().first,
+            prompt.end(),
+            NATIVE_PATTERN,
+            submatch_id_to_return
+        }; iter != std::sregex_token_iterator{}; ++iter) {
+            size_t image_id = std::stoul(*iter);
+            OPENVINO_ASSERT(image_id != 0, "Image tags must be greater than 0");
+            image_sequence.push_back(image_id - 1);
+        }
+        if (!image_sequence.empty()) {
+            verify_ids(image_sequence, base_id, n_images);
+            return {std::move(image_prompt), std::move(image_sequence)};
+        }
+    }
+    // Prepend native tags
+    std::stringstream stream;
+    for (size_t relative_id = 0; relative_id < n_images; relative_id++) {
+        image_sequence.push_back(base_id + relative_id);
+        write_native(stream, image_sequence.back());
+    }
+    stream << prompt;
+    return {stream.str(), image_sequence};
+}
 
 ov::Tensor padding_336(const ov::Tensor& unpadded) {
     ov::Shape _1ss3 = unpadded.get_shape();
@@ -439,71 +484,97 @@ ov::Tensor hd_feature_transform(const EncodedImage& image_features, InferRequest
     return res;
 }
 
+/// @brief Empty Tensor denotes image placeholder
 std::vector<ov::Tensor> split_tokenize(const std::string& text, ov::genai::Tokenizer& tokenizer) {
-    constexpr int make_suffix_iterator = -1;
-    std::regex rgx{R"(<\|image_\d+\|>)"};
-    std::sregex_token_iterator iter{
-        text.begin(),
-        text.end(),
-        rgx,
-        make_suffix_iterator
-    };
     std::vector<ov::Tensor> tokenized;
-    for ( ; iter != std::sregex_token_iterator{}; ++iter) {
-        if (iter->str().empty()) {
-            continue;
+    auto prefix_begin = text.begin();
+    for (std::sregex_token_iterator iter{
+        prefix_begin,
+        text.end(),
+        NATIVE_PATTERN
+    }; iter != std::sregex_token_iterator{}; ++iter) {
+        std::string regular_text{prefix_begin, iter->first};
+        if (!regular_text.empty()) {
+            tokenized.push_back(tokenizer.encode(regular_text, ov::genai::add_special_tokens(true)).input_ids);
         }
-        std::string substr = *iter;
-        tokenized.push_back(tokenizer.encode(substr, ov::genai::add_special_tokens(true)).input_ids);
+        tokenized.push_back({});
+        prefix_begin = iter->second;
+    }
+    std::string regular_text{prefix_begin, text.end()};
+    if (!regular_text.empty()) {
+        tokenized.push_back(tokenizer.encode(regular_text, ov::genai::add_special_tokens(true)).input_ids);
     }
     return tokenized;
 }
 
-ov::Tensor insert_image_placeholders(const std::vector<ov::Tensor>& chunks, const std::vector<size_t>& tokens_per_images) {
+ov::Tensor insert_image_placeholders(
+    const std::vector<ov::Tensor>& chunks,
+    const std::vector<size_t>& image_sequence,
+    const std::vector<size_t>& tokens_per_images
+) {
     size_t merged_length = 0;
     for (const ov::Tensor& chunk : chunks) {
-        merged_length += chunk.get_shape().at(1);
+        if (chunk) {  // Images are represented with empty tensors
+            merged_length += chunk.get_shape().at(1);
+        }
     }
-    merged_length += std::accumulate(tokens_per_images.begin(), tokens_per_images.end(), 0);
+    for (size_t image_id : image_sequence) {
+        merged_length += tokens_per_images.at(image_id);
+    }
     ov::Tensor merged{ov::element::i64, {1, merged_length}};
     size_t offset = 0;
-    int64_t image_id = 0;
+    size_t image_count = 0;
     for (const ov::Tensor& chunk : chunks) {
-        size_t length = chunk.get_shape().at(1);
-        std::copy_n(
-            chunk.data<int64_t>(),
-            length,
-            merged.data<int64_t>() + offset
-        );
-        if (tokens_per_images.empty())
-            continue;
-        offset += length;
-        if (offset < merged_length) {
+        if (chunk) {
+            size_t length = chunk.get_shape().at(1);
+            std::copy_n(
+                chunk.data<int64_t>(),
+                length,
+                merged.data<int64_t>() + offset
+            );
+            offset += length;
+        } else {
+            size_t image_id = image_sequence.at(image_count);
             std::fill_n(
                 merged.data<int64_t>() + offset,
                 tokens_per_images.at(image_id),
-                -image_id - 1  // It could be just -image_id. -1 is for consistency with the original implementation.
+                -image_id - 1  // -1 to distinguish 0 token and 0 image id.
             );
             offset += tokens_per_images.at(image_id);
-            ++image_id;
+            ++image_count;
         }
     }
+    OPENVINO_ASSERT(image_count == image_sequence.size());
     return merged;
 }
 
 std::vector<ov::Tensor> drop_image_placeholders(const ov::Tensor& tokens) {
     std::vector<ov::Tensor> chunks;
-    size_t offset = 0;
-    while (offset < tokens.get_shape().at(1)) {
-        size_t length = 0;
-        while (offset + length < tokens.get_shape().at(1) && tokens.data<int64_t>()[offset + length] >= 0) {
-            ++length;
+    int64_t last_token = tokens.data<int64_t>()[0];
+    size_t text_start = 0;
+    for (size_t offset = 1; offset < tokens.get_shape().at(1); ++offset) {
+        // If last_token and next_token are not negative, it's continuation of the current chunk text - skip
+        // If last_token is negative and next_token is not negative, it's a start of text - save the offset, add image placeholder
+        // If last token is not negative and next_token is negative, it's an end of text - push_back a chunk
+        // If last_token and next_token are negative, it's continuation of an image placeholder - skip
+        // if last_token and next_token are negative but different, it's a start of a new image placeholder - save the previous image placeholder
+        int64_t next_token = tokens.data<int64_t>()[offset];
+        if (last_token < 0 && next_token >= 0) {
+            text_start = offset;
+            chunks.push_back({});
+        } else if (last_token >= 0 && next_token < 0) {
+            chunks.emplace_back(ov::element::i64, ov::Shape{1, offset - text_start}, tokens.data<int64_t>() + text_start);
+        } else if (last_token < 0 && next_token < 0 && last_token != next_token) {
+            chunks.push_back({});
         }
-        chunks.emplace_back(ov::element::i64, ov::Shape{1, length}, tokens.data<int64_t>() + offset);
-        offset += length;
-        while (offset < tokens.get_shape().at(1) && tokens.data<int64_t>()[offset] < 0) {
-            ++offset;
-        }
+        last_token = next_token;
+    }
+    // Add the last chunk
+    size_t full_length = tokens.get_shape().at(1);
+    if (last_token >= 0) {
+        chunks.emplace_back(ov::element::i64, ov::Shape{1, full_length - text_start}, tokens.data<int64_t>() + text_start);
+    } else {
+        chunks.push_back({});
     }
     return chunks;
 }
@@ -532,8 +603,10 @@ InputsEmbedderPhi3V::InputsEmbedderPhi3V(
     }
 
 ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
+    size_t base_id = m_tokens_per_images.size();
+    auto [image_prompt, image_sequence] = normalize_prompt(prompt, base_id, images.size());
+    m_image_sequence.insert(m_image_sequence.end(), image_sequence.begin(), image_sequence.end());
     std::vector<ov::Tensor> images_features_proj;
-    std::stringstream images_prompt;
     CircularBufferQueueElementGuard<ov::InferRequest> hd_feature_transformer_ireq_guard(this->m_ireq_queue_hd_feature_transformer.get());
     CircularBufferQueueElementGuard<ov::InferRequest> vision_projection_ireq_guard(this->m_ireq_queue_vision_projection.get());
     ov::InferRequest& hd_feature_transformer = hd_feature_transformer_ireq_guard.get();
@@ -541,12 +614,10 @@ ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, con
     for (const ov::genai::EncodedImage& encoded_image : images) {
         images_features_proj.push_back(hd_feature_transform(encoded_image, hd_feature_transformer, m_vlm_config.sub_GN, m_vlm_config.glb_GN, vision_projection));
         m_tokens_per_images.push_back(images_features_proj.back().get_shape().at(1));
-        images_prompt << "<|image_" << m_tokens_per_images.size() << "|>\n";
     }
-    images_prompt << prompt;
     std::vector<ov::Tensor> new_chat_tokens;
     if (m_is_chat_conversation) {
-        m_history.push_back({{"role", "user"}, {"content", images_prompt.str()}});
+        m_history.push_back({{"role", "user"}, {"content", std::move(image_prompt)}});
         constexpr bool add_generation_prompt = true;
         std::string new_templated_chat_history = m_tokenizer.apply_chat_template(m_history, add_generation_prompt);
         auto start_tokenizer_time = std::chrono::steady_clock::now();
@@ -556,69 +627,53 @@ ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& prompt, con
     } else {
         std::string templated_prompt;
         if (m_apply_chat_template) {
-            ChatHistory history({{{"role", "user"}, {"content", images_prompt.str()}}});
+            ChatHistory history({{{"role", "user"}, {"content", std::move(image_prompt)}}});
             constexpr bool add_generation_prompt = true;
             templated_prompt = m_tokenizer.apply_chat_template(history, add_generation_prompt);
         } else {
-            templated_prompt = images_prompt.str();
+            templated_prompt = std::move(image_prompt);
         }
         auto start_tokenizer_time = std::chrono::steady_clock::now();
         new_chat_tokens = split_tokenize(templated_prompt, m_tokenizer);
         auto end_tokenizer_time = std::chrono::steady_clock::now();
         metrics.raw_metrics.tokenization_durations.emplace_back(PerfMetrics::get_microsec(end_tokenizer_time - start_tokenizer_time));
     }
-    ov::Tensor new_merged_tokens = insert_image_placeholders(new_chat_tokens, m_tokens_per_images);
+    ov::Tensor new_merged_tokens = insert_image_placeholders(new_chat_tokens, m_image_sequence, m_tokens_per_images);
     ov::Tensor new_tokens = update_history(new_merged_tokens);
     m_prev_hist_length = m_kv_cache_state.get_state().size();
     m_kv_cache_state.add_inputs(new_tokens);
 
     std::vector<ov::Tensor> tokens = drop_image_placeholders(new_tokens);
-    // if <|image_i|> tag is in the begining, it doesn't split tokes into separate sequences and tokens.size() == images_features_proj.size().
-    OPENVINO_ASSERT(tokens.size() == images_features_proj.size() + 1 || tokens.size() == images_features_proj.size());
-    size_t features_length = 0;
-    for (size_t im_id = 0; im_id < images_features_proj.size(); ++im_id) {
-        size_t text_length = tokens.at(im_id).get_shape().at(1);
-        size_t im_length = images_features_proj.at(im_id).get_shape().at(1);
-        features_length += text_length + im_length;
-    }
-    if (tokens.size() > images_features_proj.size()) {
-        features_length += tokens.back().get_shape().at(1);
-    }
-    OPENVINO_ASSERT(features_length == new_tokens.get_shape().at(1));
-    ov::Tensor inputs_embeds{ov::element::f32, {1, features_length, m_vlm_config.hidden_size}};
+    ov::Tensor inputs_embeds{ov::element::f32, {1, new_tokens.get_shape().at(1), m_vlm_config.hidden_size}};
+    size_t image_count = 0;
     size_t offset = 0;
-    if (tokens.size() > images_features_proj.size()) {
-        const ov::Tensor& text_embeds = m_embedding->infer(tokens.at(0));
-        size_t text_length = text_embeds.get_shape().at(1);
-        std::copy_n(
-            text_embeds.data<float>(),
-            text_embeds.get_size(),
-            inputs_embeds.data<float>()
-        );
-        offset = text_length;
-        tokens.erase(tokens.begin());
-    }
-    for (size_t im_id = 0; im_id < images_features_proj.size(); ++im_id) {
-        const ov::Tensor& image_embeds = images_features_proj.at(im_id);
-        size_t im_length = image_embeds.get_shape().at(1);
-        std::copy_n(
-            image_embeds.data<float>(),
-            image_embeds.get_size(),
-            inputs_embeds.data<float>() + offset * m_vlm_config.hidden_size
-        );
-        offset += im_length;
-        const ov::Tensor& text_embeds = m_embedding->infer(tokens.at(im_id));
-        size_t text_length = text_embeds.get_shape().at(1);
-        std::copy_n(
-            text_embeds.data<float>(),
-            text_embeds.get_size(),
-            inputs_embeds.data<float>() + offset * m_vlm_config.hidden_size
-        );
-        offset += text_length;
+    for (const ov::Tensor& chunk : tokens) {
+        if (chunk) {
+            const ov::Tensor& text_embeds = m_embedding->infer(chunk);
+            size_t text_length = text_embeds.get_shape().at(1);
+            std::copy_n(
+                text_embeds.data<float>(),
+                text_embeds.get_size(),
+                inputs_embeds.data<float>() + offset * m_vlm_config.hidden_size
+            );
+            offset += text_length;
+        } else {
+            size_t image_id = image_sequence.at(image_count) - base_id;
+            const ov::Tensor& image_embeds = images_features_proj.at(image_id);
+            size_t im_length = image_embeds.get_shape().at(1);
+            std::copy_n(
+                image_embeds.data<float>(),
+                image_embeds.get_size(),
+                inputs_embeds.data<float>() + offset * m_vlm_config.hidden_size
+            );
+            offset += im_length;
+            ++image_count;
+        }
     }
 
     if (!m_is_chat_conversation) {
         m_tokens_per_images.clear();
+        m_image_sequence.clear();
     }
 
     return inputs_embeds;
@@ -635,11 +690,17 @@ void InputsEmbedderPhi3V::update_chat_history(const std::string& decoded_results
 void InputsEmbedderPhi3V::start_chat(const std::string& system_message) {
     IInputsEmbedder::start_chat(system_message);
     m_tokens_per_images.clear();
+    m_image_sequence.clear();
 }
 
 void InputsEmbedderPhi3V::finish_chat() {
     IInputsEmbedder::finish_chat();
     m_tokens_per_images.clear();
+    m_image_sequence.clear();
+}
+
+bool InputsEmbedderPhi3V::prompt_has_image_tag(const std::string& prompt) const {
+    return IInputsEmbedder::prompt_has_image_tag(prompt) || std::regex_search(prompt, NATIVE_PATTERN);
 }
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/phi3_vision/classes.hpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.hpp
@@ -36,11 +36,14 @@ public:
 
     void finish_chat() override;
 
+    bool prompt_has_image_tag(const std::string& prompt) const override;
+
 private:
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_hd_feature_transformer;
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_projection;
     std::vector<size_t> m_tokens_per_images;
     std::vector<size_t> m_prev_tokens_per_images;
+    std::vector<size_t> m_image_sequence;
 };
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -282,7 +282,7 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
 }
 
 ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics) {
-    auto [unified_prompt, images_sequence] = unify_prompt(prompt, NATIVE_TAG, NATIVE_TAG, images.size(), m_image_id);
+    auto [unified_prompt, images_sequence] = normalize_prompt(prompt, NATIVE_TAG, NATIVE_TAG, m_image_id, images.size());
     std::vector<ov::Tensor> image_embeds;
     std::vector<std::array<size_t, 3>> images_grid_thw;
     image_embeds.reserve(images.size());

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -5,7 +5,6 @@
 
 #include <iostream>
 #include <openvino/openvino.hpp>
-#include <regex>
 #include <thread>
 
 #include "context_tokens.hpp"

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2115,6 +2115,7 @@ class VLMPipeline:
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
             MiniCPM-V-2_6: (<image>./</image>)\\n
+            Phi-3-vision: <|image_i|>\\n - the index starts with one
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.
@@ -2147,6 +2148,7 @@ class VLMPipeline:
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
             MiniCPM-V-2_6: (<image>./</image>)\\n
+            Phi-3-vision: <|image_i|>\\n - the index starts with one
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.
@@ -2178,6 +2180,7 @@ class VLMPipeline:
             A model's native image tag can be used instead of
             <ov_genai_image_i>. These tags are:
             MiniCPM-V-2_6: (<image>./</image>)\\n
+            Phi-3-vision: <|image_i|>\\n - the index starts with one
             Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
             If the prompt doesn't contain image tags, but images are
             provided, the tags are prepended to the prompt.

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -30,6 +30,7 @@ auto vlm_generate_docstring = R"(
     A model's native image tag can be used instead of
     <ov_genai_image_i>. These tags are:
     MiniCPM-V-2_6: (<image>./</image>)\n
+    Phi-3-vision: <|image_i|>\n - the index starts with one
     Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     If the prompt doesn't contain image tags, but images are
     provided, the tags are prepended to the prompt.
@@ -60,6 +61,7 @@ auto vlm_generate_kwargs_docstring = R"(
     A model's native image tag can be used instead of
     <ov_genai_image_i>. These tags are:
     MiniCPM-V-2_6: (<image>./</image>)\n
+    Phi-3-vision: <|image_i|>\n - the index starts with one
     Qwen2-VL: <|vision_start|><|image_pad|><|vision_end|>
     If the prompt doesn't contain image tags, but images are
     provided, the tags are prepended to the prompt.


### PR DESCRIPTION
Replace unify_prompt() with normalize_prompt(). The new function doesn't insert/replace image tags multiple times. It doesn't search the same place multiple times for the same tag. phi3_v is able to reuse its parts.

Ticket 164259