### PR TITLE
Disable MSVC debug assertions, addressing false positives in iterator checking

### DIFF
--- a/src/cpp/src/sequence_group.cpp
+++ b/src/cpp/src/sequence_group.cpp
@@ -32,7 +32,8 @@ size_t Sequence::_make_hash(size_t content_length) {
             }
             if (content_length > prompt_ids.size()) {
                 size_t start = block_start_idx < prompt_ids.size() ? 0 : block_start_idx - prompt_ids.size();
-                content.insert(content.end(), m_generated_ids.begin() + start, m_generated_ids.begin() + content_length - prompt_ids.size());
+                // Use parentheses around (content_length - prompt_ids.size()) to suppress MSVC debug assert: "cannot seek vector iterator after end"
+                content.insert(content.end(), m_generated_ids.begin() + start, m_generated_ids.begin() + (content_length - prompt_ids.size()));
             }
         }
         else if (sequence_group->get_sequence_group_type() == SequenceGroupType::EMBEDDINGS) {


### PR DESCRIPTION
This PR aims to suppress an msvc debug assertion that has been identified as a false positive. The debug scenario is illustrated in the image below
<img src="https://github.com/user-attachments/assets/b12fdf10-f4a6-4010-a73b-20ff0a2bbf14" alt="debug_assert" width="300"/>
<img src="https://github.com/user-attachments/assets/c499e33d-630e-4e0d-855e-9e9799fc6ba8" alt="genai_debug" width="500"/>

This line of code triggered an MSVC false positive assertion. Please refer to https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/inc/vector#L122

The simplest reproducer: The following code triggers the assertion when debugging in Visual Studio 2022
```C++
// command line : cl.exe /Zi /EHsc /std:c++17 /Od  /MDd main.cpp
#include <iostream>
#include <vector>

int main()
{
	std::vector<int64_t> content, m_generated_ids{ 1 }, prompt_ids(24);
	size_t start = 0, content_length = 25;
	content.insert(content.end(), m_generated_ids.begin() + start, m_generated_ids.begin() + content_length - prompt_ids.size());
	std::cout << "Succeed!";
}
```

Another way to suppress the assertion is by adding `/D_ITERATOR_DEBUG_LEVEL=0`. I'm not sure whether modifying the code or adjusting the compiler option is better.
