### PR TITLE
Added possibility to generate base text on GPU for text evaluation

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/text_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/text_evaluator.py
@@ -187,16 +187,22 @@ class TextEvaluator(BaseEvaluator):
 
     def _generate_data(self, model, gen_answer_fn=None, generation_config=None):
         def default_gen_answer(model, tokenizer, prompt, max_new_tokens, crop_question, use_chat_template=False):
+            device = "cpu"
+            if hasattr(model, "device"):
+                device = model.device
+
             if use_chat_template:
                 message = [{"role": "user", "content": prompt}]
-                inputs = tokenizer.apply_chat_template(message, tokenize=True, add_generation_prompt=True, return_tensors="pt")
+                inputs = tokenizer.apply_chat_template(
+                    message, tokenize=True, add_generation_prompt=True, return_tensors="pt"
+                ).to(device)
                 tokens = model.generate(inputs, do_sample=False, max_new_tokens=max_new_tokens)
                 if crop_question:
                     tokens = tokens[:, inputs.shape[-1]:]
                 res = self.tokenizer.decode(tokens[0], skip_special_tokens=True)
                 return res
             else:
-                inputs = self.tokenizer(prompt, return_tensors="pt")
+                inputs = self.tokenizer(prompt, return_tensors="pt").to(device)
                 tokens = model.generate(**inputs, do_sample=False, max_new_tokens=max_new_tokens)
                 if crop_question:
                     tokens = tokens[:, inputs["input_ids"].shape[-1] :]


### PR DESCRIPTION
Cherry-pick of #1945

Convert input device type according to device type of model for text evaluator.

It's needed for acceleration of new sample in NNCF with QAT + absorbable LoRA. 
Can use WWB for calculating references on GPU.

https://github.com/openvinotoolkit/nncf/pull/3351
epic ticket: 