### PR TITLE
Updated logic whether PA backend is explicitly required

### DIFF
--- a/src/cpp/src/llm_pipeline.cpp
+++ b/src/cpp/src/llm_pipeline.cpp
@@ -45,8 +45,10 @@ SchedulerConfig get_latency_oriented_scheduler_config() {
 }
 
 bool explicitly_requires_paged_attention(const ov::AnyMap& properties) {
+    auto attention_backend_it = properties.find("ATTENTION_BACKEND");
+
     if (properties.find(ov::genai::scheduler_config.name()) != properties.end() ||
-        properties.find("ATTENTION_BACKEND") != properties.end()) {
+        (attention_backend_it != properties.end() && attention_backend_it->second.as<std::string>() == PA_BACKEND)) {
         if (is_paged_attention_available()) {
             return true;
         } else {

--- a/src/cpp/src/llm_pipeline.cpp
+++ b/src/cpp/src/llm_pipeline.cpp
@@ -45,7 +45,8 @@ SchedulerConfig get_latency_oriented_scheduler_config() {
 }
 
 bool explicitly_requires_paged_attention(const ov::AnyMap& properties) {
-    if (properties.find(ov::genai::scheduler_config.name()) != properties.end()) {
+    if (properties.find(ov::genai::scheduler_config.name()) != properties.end() ||
+        properties.find("ATTENTION_BACKEND") != properties.end()) {
         if (is_paged_attention_available()) {
             return true;
         } else {


### PR DESCRIPTION
If user passed `LLMPipeline(model_path, device, ATTENTION_BACKEND=PA)`, then it should throw in case of PA backend cannot be used (either PA op is not available or model cannot be converted to PA representation)