### PR TITLE
[2025.1] Aligned python version on mac

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,4 +1,4 @@
-name: macOS (13, Python 3.10)
+name: macOS (13, Python 3.11)
 on:
   workflow_dispatch:
   pull_request:
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   MACOSX_DEPLOYMENT_TARGET: '11.0'
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.11'
   TARGET_BRANCH: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref }}
   CCACHE_MAXSIZE: 500Mi
   


### PR DESCRIPTION
OV provider uses build with python 3.11 now, need to align this versions on mac to be able to use post-commit artifacts 