### PR TITLE
Fix reshape in heterogeneous SD samples

### DIFF
--- a/samples/cpp/image_generation/heterogeneous_stable_diffusion.cpp
+++ b/samples/cpp/image_generation/heterogeneous_stable_diffusion.cpp
@@ -41,9 +41,9 @@ int32_t main(int32_t argc, char* argv[]) try {
     ov::genai::Text2ImagePipeline pipe(models_path);
 
     //
-    // Step 2: Reshape the pipeline given number of images, width, height, and guidance scale.
+    // Step 2: Reshape the pipeline given number of images, height, width and guidance scale.
     //
-    pipe.reshape(1, width, height, pipe.get_generation_config().guidance_scale);
+    pipe.reshape(1, height, width, pipe.get_generation_config().guidance_scale);
 
     //
     // Step 3: Compile the pipeline with the specified devices, and properties (like cache dir)

--- a/samples/python/image_generation/heterogeneous_stable_diffusion.py
+++ b/samples/python/image_generation/heterogeneous_stable_diffusion.py
@@ -40,9 +40,9 @@ def main():
     pipe = openvino_genai.Text2ImagePipeline(args.model_dir)
 
     #
-    # Step 2: Reshape the pipeline given number of images, width, height, and guidance scale.
+    # Step 2: Reshape the pipeline given number of images, height, width, and guidance scale.
     #
-    pipe.reshape(1, width, height, pipe.get_generation_config().guidance_scale)
+    pipe.reshape(1, height, width, pipe.get_generation_config().guidance_scale)
 
     #
     # Step 3: Compile the pipeline given the specified devices, and properties (like cache dir)


### PR DESCRIPTION
`pipe.reshape` expects `(height, width)` not `(width, height)`