### PR TITLE
add TensorArt SD3.5 models to supported list

### DIFF
--- a/site/docs/supported-models/_components/image-generation-models-table/models.ts
+++ b/site/docs/supported-models/_components/image-generation-models-table/models.ts
@@ -93,6 +93,8 @@ export const IMAGE_GENERATION_MODELS: ImageGenerationModelType[] = [
       'https://huggingface.co/stabilityai/stable-diffusion-3.5-medium',
       'https://huggingface.co/stabilityai/stable-diffusion-3.5-large',
       'https://huggingface.co/stabilityai/stable-diffusion-3.5-large-turbo',
+      'https://huggingface.co/tensorart/stable-diffusion-3.5-medium-turbo',
+      'https://huggingface.co/tensorart/stable-diffusion-3.5-large-TurboX'
     ],
   },
   {


### PR DESCRIPTION
CVS-163875

```
import PIL
import openvino_genai
model_dir = "table-diffusion-3.5-large-TurboX"

device = 'CPU' 
pipe = openvino_genai.Text2ImagePipeline(model_dir, device)
prompt = "A capybara wearing a suit holding a sign that reads SD3.5-TurboX"

image_tensor = pipe.generate(
        prompt,
        num_inference_steps=8,
        guidance_scale=1.5,
)

image = Image.fromarray(image_tensor.data[0])
```
![image](https://github.com/user-attachments/assets/c155d004-8e8f-49ad-b605-38e30bf90869)

