### PR TITLE
Info ignored LoRA tensor regularly

### DIFF
--- a/src/cpp/src/lora_adapter.cpp
+++ b/src/cpp/src/lora_adapter.cpp
@@ -172,7 +172,7 @@ LoRATensors group_lora_tensors(const ConstantMap& tensors, const LoRAPartsParser
         } else if(auto parsed = parts_parser.alpha(named_tensor.first)) {
             result[*parsed].alpha = named_tensor.second;
         } else {
-            DEBUG_PRINT("Ignored LoRA tensor \"" << named_tensor.first << "\" because couldn't recognize expected name pattern." );
+            std::cerr << "[ WARNING ] Ignored LoRA tensor \"" << named_tensor.first << "\" because couldn't recognize expected name pattern.\n";
         }
     }
 


### PR DESCRIPTION
Recently, customer reported an issue which related to their customized LoRA and it shows the LoRA tensor is unused during runtime.

`    Unused LoRA tensor: lora_unet.unet.down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_k`

During debug we noticed this is cause by LoRA name pattern. After further deep dive, I noticed that most of LoRA tensor is ignored but not report regularly. For example, `text_encoder_2.text_model.encoder.layers.5.self_attn.k_proj.lora_linear_layer.down.weight` is ignored as name pattern doesn't match current GenAI supported pattern. Therefore, I will recommend show the Ignored tensor during runtime to notice end users. 