### PR TITLE
[WWB]: move diffusers imports closer to usage

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -3,7 +3,6 @@ import json
 import torch
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModel, AutoModelForVision2Seq, AutoTokenizer
-from diffusers import DiffusionPipeline, AutoPipelineForImage2Image, AutoPipelineForInpainting
 
 from .utils import mock_torch_cuda_is_available
 
@@ -27,6 +26,7 @@ class GenAIModelWrapper:
             except Exception:
                 self.config = AutoConfig.from_pretrained(model_dir)
         elif model_type == "text-to-image":
+            from diffusers import DiffusionPipeline
             self.config = DiffusionPipeline.load_config(
                 model_dir, trust_remote_code=True)
 
@@ -175,6 +175,7 @@ def load_text2image_model(
         logger.info("Using OpenvINO GenAI API")
         model = load_text2image_genai_pipeline(model_id, device, ov_config)
     elif use_hf:
+        from diffusers import DiffusionPipeline
         logger.info("Using HF Transformers API")
         model = DiffusionPipeline.from_pretrained(
             model_id, trust_remote_code=True)
@@ -287,6 +288,7 @@ def load_imagetext2image_model(
     model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False
 ):
     if use_hf:
+        from diffusers import AutoPipelineForImage2Image
         logger.info("Using HF Transformers API")
         model = AutoPipelineForImage2Image.from_pretrained(
             model_id, trust_remote_code=True
@@ -333,6 +335,7 @@ def load_inpainting_model(
     model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False
 ):
     if use_hf:
+        from diffusers import AutoPipelineForInpainting
         logger.info("Using HF Transformers API")
         model = AutoPipelineForInpainting.from_pretrained(
             model_id, trust_remote_code=True

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -26,6 +26,11 @@ def patch_diffusers():
 
 @contextmanager
 def mock_torch_cuda_is_available(to_patch):
+    try:
+        # import bnb before patching for avoid attempt to load cuda extension during first import
+        import bitsandbytes as bnb # noqa: F401 
+    except ImportError:
+        pass
     original_is_available = torch.cuda.is_available
     if to_patch:
         torch.cuda.is_available = lambda: True

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -2,8 +2,6 @@ from typing import Union, Tuple, List, Optional
 import torch
 from contextlib import contextmanager
 
-from diffusers.utils import torch_utils
-
 
 def new_randn_tensor(
     shape: Union[Tuple, List],
@@ -22,6 +20,7 @@ def new_randn_tensor(
 
 
 def patch_diffusers():
+    from diffusers.utils import torch_utils
     torch_utils.randn_tensor = new_randn_tensor
 
 

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -28,7 +28,7 @@ def patch_diffusers():
 def mock_torch_cuda_is_available(to_patch):
     try:
         # import bnb before patching for avoid attempt to load cuda extension during first import
-        import bitsandbytes as bnb # noqa: F401
+        import bitsandbytes as bnb  # noqa: F401
     except ImportError:
         pass
     original_is_available = torch.cuda.is_available

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -28,7 +28,7 @@ def patch_diffusers():
 def mock_torch_cuda_is_available(to_patch):
     try:
         # import bnb before patching for avoid attempt to load cuda extension during first import
-        import bitsandbytes as bnb # noqa: F401 
+        import bitsandbytes as bnb # noqa: F401
     except ImportError:
         pass
     original_is_available = torch.cuda.is_available

--- a/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
@@ -3,7 +3,7 @@ from typing import Any, Union
 import os
 import datasets
 import pandas as pd
-from diffusers.utils.loading_utils import load_image
+from transformers.image_utils import load_image
 from tqdm import tqdm
 from transformers import set_seed
 


### PR DESCRIPTION
CVS-165875

in some cases diffusers import may breaks transformers models loading, however that should not be used at all.
Moved diffusers closer to their usage for avoid possible issues