### PR TITLE
[C] Add ov::Property as arguments to the ov_genai_llm_pipeline_create function

### DIFF
--- a/samples/c/text_generation/benchmark_genai_c.c
+++ b/samples/c/text_generation/benchmark_genai_c.c
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
     ov_genai_perf_metrics* metrics = NULL;
     ov_genai_perf_metrics* cumulative_metrics = NULL;
 
-    CHECK_STATUS(ov_genai_llm_pipeline_create(options.model, options.device, &pipe));
+    CHECK_STATUS(ov_genai_llm_pipeline_create(options.model, options.device, 0, &pipe));
 
     CHECK_STATUS(ov_genai_generation_config_create(&config));
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, options.max_new_tokens));

--- a/samples/c/text_generation/chat_sample_c.c
+++ b/samples/c/text_generation/chat_sample_c.c
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
     streamer.callback_func = print_callback;
     char prompt[MAX_PROMPT_LENGTH];
 
-    CHECK_STATUS(ov_genai_llm_pipeline_create(models_path, device, &pipeline));
+    CHECK_STATUS(ov_genai_llm_pipeline_create(models_path, device, 0, &pipeline));
     CHECK_STATUS(ov_genai_generation_config_create(&config));
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, 100));
 

--- a/samples/c/text_generation/greedy_causal_lm_c.c
+++ b/samples/c/text_generation/greedy_causal_lm_c.c
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
                           // the memory.
     size_t output_size = 0;  // Used to store the required size of the output buffer.
 
-    CHECK_STATUS(ov_genai_llm_pipeline_create(model_dir, device, &pipeline));
+    CHECK_STATUS(ov_genai_llm_pipeline_create(model_dir, device, 0, &pipeline));
     CHECK_STATUS(ov_genai_generation_config_create(&config));
     CHECK_STATUS(ov_genai_generation_config_set_max_new_tokens(config, 100));
     CHECK_STATUS(ov_genai_llm_pipeline_generate(pipeline, prompt, config, NULL, &results));

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -70,19 +70,30 @@ typedef struct ov_genai_llm_pipeline_opaque ov_genai_llm_pipeline;
 
 /**
  * @brief Construct ov_genai_llm_pipeline.
+ *
+ * Initializes a ov_genai_llm_pipeline instance from the specified model directory and device. Optional property
+ * parameters can be passed as key-value pairs.
+ *
  * @param models_path Path to the directory containing the model files.
  * @param device Name of a device to load a model to.
  * @param property_args_size How many properties args will be passed, each property contains 2 args: key and value.
  * @param ov_genai_llm_pipeline A pointer to the newly created ov_genai_llm_pipeline.
  * @param ... property paramater: Optional pack of pairs: <char* property_key, char* property_value> relevant only
  * @return ov_status_e A status code, return OK(0) if successful.
+ *
+ * @example
+ * Example with no properties:
+ * ov_genai_llm_pipeline_create(model_path, "CPU", 0, &pipe);
+ *
+ * Example with properties:
+ * ov_genai_llm_pipeline_create(model_path, "GPU", 2, &pipe,
+ *                             "CACHE_DIR", "cache_dir");
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_create(const char* models_path,
                                                                   const char* device,
                                                                   const size_t property_args_size,
                                                                   ov_genai_llm_pipeline** pipe,
                                                                   ...);
-
 
 /**
  * @brief Release the memory allocated by ov_genai_llm_pipeline.

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -83,7 +83,6 @@ OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_create(const char* mo
                                                                   ov_genai_llm_pipeline** pipe,
                                                                   ...);
 
-// TODO: Add 'const ov::AnyMap& properties' as an input argument when creating ov_genai_llm_pipeline.
 
 /**
  * @brief Release the memory allocated by ov_genai_llm_pipeline.

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -72,12 +72,16 @@ typedef struct ov_genai_llm_pipeline_opaque ov_genai_llm_pipeline;
  * @brief Construct ov_genai_llm_pipeline.
  * @param models_path Path to the directory containing the model files.
  * @param device Name of a device to load a model to.
+ * @param property_args_size How many properties args will be passed, each property contains 2 args: key and value.
  * @param ov_genai_llm_pipeline A pointer to the newly created ov_genai_llm_pipeline.
+ * @param ... property paramater: Optional pack of pairs: <char* property_key, char* property_value> relevant only
  * @return ov_status_e A status code, return OK(0) if successful.
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_create(const char* models_path,
                                                                   const char* device,
-                                                                  ov_genai_llm_pipeline** pipe);
+                                                                  const size_t property_args_size,
+                                                                  ov_genai_llm_pipeline** pipe,
+                                                                  ...);
 
 // TODO: Add 'const ov::AnyMap& properties' as an input argument when creating ov_genai_llm_pipeline.
 

--- a/src/c/src/llm_pipeline.cpp
+++ b/src/c/src/llm_pipeline.cpp
@@ -6,6 +6,7 @@
 #include "openvino/genai/generation_config.hpp"
 #include "openvino/genai/llm_pipeline.hpp"
 #include "types_c.h"
+#include <stdarg.h>
 
 ov_status_e ov_genai_decoded_results_create(ov_genai_decoded_results** results) {
     if (!results) {
@@ -67,14 +68,23 @@ ov_status_e ov_genai_decoded_results_get_string(const ov_genai_decoded_results* 
     }
     return ov_status_e::OK;
 }
-ov_status_e ov_genai_llm_pipeline_create(const char* models_path, const char* device, ov_genai_llm_pipeline** pipe) {
-    if (!models_path || !device || !pipe) {
+ov_status_e ov_genai_llm_pipeline_create(const char* models_path, const char* device, const size_t property_args_size, ov_genai_llm_pipeline** pipe, ...) {
+    if (!models_path || !device || !pipe || property_args_size % 2 != 0) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
+        ov::AnyMap property = {};
+        va_list args_ptr;
+        va_start(args_ptr, pipe);
+        size_t property_size = property_args_size / 2;
+        for (size_t i = 0; i < property_size; i++) {
+            GET_PROPERTY_FROM_ARGS_LIST;
+        }
+        va_end(args_ptr);
+
         std::unique_ptr<ov_genai_llm_pipeline> _pipe = std::make_unique<ov_genai_llm_pipeline>();
         _pipe->object =
-            std::make_shared<ov::genai::LLMPipeline>(std::filesystem::path(models_path), std::string(device));
+            std::make_shared<ov::genai::LLMPipeline>(std::filesystem::path(models_path), std::string(device),property);
         *pipe = _pipe.release();
     } catch (...) {
         return ov_status_e::UNKNOW_EXCEPTION;

--- a/src/c/src/llm_pipeline.cpp
+++ b/src/c/src/llm_pipeline.cpp
@@ -84,7 +84,7 @@ ov_status_e ov_genai_llm_pipeline_create(const char* models_path, const char* de
 
         std::unique_ptr<ov_genai_llm_pipeline> _pipe = std::make_unique<ov_genai_llm_pipeline>();
         _pipe->object =
-            std::make_shared<ov::genai::LLMPipeline>(std::filesystem::path(models_path), std::string(device),property);
+            std::make_shared<ov::genai::LLMPipeline>(std::filesystem::path(models_path), std::string(device), property);
         *pipe = _pipe.release();
     } catch (...) {
         return ov_status_e::UNKNOW_EXCEPTION;

--- a/src/c/src/types_c.h
+++ b/src/c/src/types_c.h
@@ -17,7 +17,7 @@
             std::string out_str;                                                                               \
             encrypt_func(in.c_str(), in.length(), nullptr, &out_size);                                         \
             if (out_size > 0) {                                                                                \
-                std::unique_ptr<char[]> output_ptr(new char[out_size]);                                        \
+                std::unique_ptr<char[]> output_ptr = std::make_unique<char[]>(out_size);                       \
                 if (output_ptr) {                                                                              \
                     char* output = output_ptr.get();                                                           \
                     encrypt_func(in.c_str(), in.length(), output, &out_size);                                  \
@@ -31,7 +31,7 @@
             std::string out_str;                                                                               \
             decrypt_func(in.c_str(), in.length(), nullptr, &out_size);                                         \
             if (out_size > 0) {                                                                                \
-                std::unique_ptr<char[]> output_ptr(new char[out_size]);                                        \
+                std::unique_ptr<char[]> output_ptr = std::make_unique<char[]>(out_size);                       \
                 if (output_ptr) {                                                                              \
                     char* output = output_ptr.get();                                                           \
                     decrypt_func(in.c_str(), in.length(), output, &out_size);                                  \

--- a/src/c/src/types_c.h
+++ b/src/c/src/types_c.h
@@ -6,6 +6,48 @@
 #include "openvino/genai/llm_pipeline.hpp"
 #include "openvino/genai/visibility.hpp"
 
+#define GET_PROPERTY_FROM_ARGS_LIST                                                                            \
+    std::string property_key = va_arg(args_ptr, char*);                                                        \
+    if (property_key == ov::cache_encryption_callbacks.name()) {                                               \
+        ov_encryption_callbacks* _value = va_arg(args_ptr, ov_encryption_callbacks*);                          \
+        auto encrypt_func = _value->encrypt_func;                                                              \
+        auto decrypt_func = _value->decrypt_func;                                                              \
+        std::function<std::string(const std::string&)> encrypt_value = [encrypt_func](const std::string& in) { \
+            size_t out_size = 0;                                                                               \
+            std::string out_str;                                                                               \
+            encrypt_func(in.c_str(), in.length(), nullptr, &out_size);                                         \
+            if (out_size > 0) {                                                                                \
+                std::unique_ptr<char[]> output_ptr(new char[out_size]);                                        \
+                if (output_ptr) {                                                                              \
+                    char* output = output_ptr.get();                                                           \
+                    encrypt_func(in.c_str(), in.length(), output, &out_size);                                  \
+                    out_str.assign(output, out_size);                                                          \
+                }                                                                                              \
+            }                                                                                                  \
+            return out_str;                                                                                    \
+        };                                                                                                     \
+        std::function<std::string(const std::string&)> decrypt_value = [decrypt_func](const std::string& in) { \
+            size_t out_size = 0;                                                                               \
+            std::string out_str;                                                                               \
+            decrypt_func(in.c_str(), in.length(), nullptr, &out_size);                                         \
+            if (out_size > 0) {                                                                                \
+                std::unique_ptr<char[]> output_ptr(new char[out_size]);                                        \
+                if (output_ptr) {                                                                              \
+                    char* output = output_ptr.get();                                                           \
+                    decrypt_func(in.c_str(), in.length(), output, &out_size);                                  \
+                    out_str.assign(output, out_size);                                                          \
+                }                                                                                              \
+            }                                                                                                  \
+            return out_str;                                                                                    \
+        };                                                                                                     \
+        ov::EncryptionCallbacks encryption_callbacks{std::move(encrypt_value), std::move(decrypt_value)};      \
+        property[property_key] = encryption_callbacks;                                                         \
+    } else {                                                                                                   \
+        std::string _value = va_arg(args_ptr, char*);                                                          \
+        ov::Any value = _value;                                                                                \
+        property[property_key] = value;                                                                        \
+    }
+
 /**
  * @struct ov_genai_generation_config_opaque
  * @brief This is an interface of ov::genai::GenerationConfig


### PR DESCRIPTION
In order to enhance the functionality of the `ov_genai_llm_pipeline_create` function, I've included `ov::Property` as arguments. This will allow user to pass additional properties when compiling the model.