### PR TITLE
GGUF WA for GPU

### DIFF
--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -56,7 +56,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
     auto draft_model_desr = extract_draft_model_from_config(properties_without_draft_model);
     auto is_prompt_lookup_enabled = extract_prompt_lookup_from_config(properties_without_draft_model);
 
-    auto model = utils::read_model(models_path, properties);
+    auto model = utils::read_model(models_path / "qwen2.5-0.5b-instruct-q4_0.gguf", properties);
     auto tokenizer = ov::genai::Tokenizer(models_path, tokenizer_properties);
     auto generation_config = utils::from_config_json_if_exists(models_path);
 

--- a/src/cpp/src/continuous_batching_pipeline.cpp
+++ b/src/cpp/src/continuous_batching_pipeline.cpp
@@ -56,7 +56,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
     auto draft_model_desr = extract_draft_model_from_config(properties_without_draft_model);
     auto is_prompt_lookup_enabled = extract_prompt_lookup_from_config(properties_without_draft_model);
 
-    auto model = utils::read_model(models_path / "qwen2.5-0.5b-instruct-q4_0.gguf", properties);
+    auto model = utils::read_model(models_path, properties);
     auto tokenizer = ov::genai::Tokenizer(models_path, tokenizer_properties);
     auto generation_config = utils::from_config_json_if_exists(models_path);
 

--- a/src/cpp/src/gguf_utils/building_blocks.cpp
+++ b/src/cpp/src/gguf_utils/building_blocks.cpp
@@ -596,6 +596,11 @@ ov::Output<ov::Node> make_int4_weights(
         zero_point_data[i] = (bias2 << 4) | (bias1 & 0x0F);
     }
 
+    // CVS-166438: GGUF Q4_0 zp array (U4) with all same value (8) will be converted to single U4 scalar via ConvertU4WeightsZeroPointToScalar transformation.
+    // This corner case can be handled by CPU plugin properly, but will trigger compilation error on GPU plugin.
+    // Temporal WA by adding one small bias to keep zp array shape for GPU plugin, confirm no accuracy impact for final LLM generation results.
+    zero_point_data[0] += 1;
+
     auto zero_points_node = std::make_shared<ov::op::v0::Constant>(zero_point_tensor);
     auto zero_points_f16 = std::make_shared<ov::op::v0::Convert>(zero_points_node, ov::element::f16);
 
@@ -667,18 +672,23 @@ ov::Output<ov::Node> make_lm_head(
     const ov::Output<ov::Node>& input,
     const std::unordered_map<std::string, ov::Tensor>& consts,
     const ov::Output<ov::Node>& embeddings_node,
-    gguf_tensor_type qtype) {
+    gguf_tensor_type qtype,
+    bool shared_embedding) {
 
     ov::Output<ov::Node> w_f32;
-    
-    if (consts.count(key + ".weight")) {
-        gguf_tensor_type lm_qtype = qtype;
-        if (!consts.count(key + ".scales")) {
-            lm_qtype = gguf_tensor_type::GGUF_TYPE_F16;
-        }
-        w_f32 = make_weights_subgraph(key, consts, lm_qtype, false, -1);
-    } else {
+    if (shared_embedding){
         w_f32 = embeddings_node;
+    }
+    else {
+        if (consts.count(key + ".weight")) {
+            gguf_tensor_type lm_qtype = qtype;
+            if (!consts.count(key + ".scales")) {
+                lm_qtype = gguf_tensor_type::GGUF_TYPE_F16;
+            }
+            w_f32 = make_weights_subgraph(key, consts, lm_qtype, false, -1);
+        } else {
+            w_f32 = embeddings_node;
+        }
     }
     return std::make_shared<ov::op::v0::MatMul>(
         input, w_f32, false, true);

--- a/src/cpp/src/gguf_utils/building_blocks.hpp
+++ b/src/cpp/src/gguf_utils/building_blocks.hpp
@@ -18,7 +18,8 @@ ov::Output<ov::Node> make_lm_head(
     const ov::Output<ov::Node>& input,
     const std::unordered_map<std::string, ov::Tensor>& consts,
     const ov::Output<ov::Node>& embeddings_node,
-    gguf_tensor_type qtype);
+    gguf_tensor_type qtype,
+    bool shared_embedding);
 
 ov::Output<ov::Node> make_rms_norm(
     const std::string& key,

--- a/src/cpp/src/gguf_utils/gguf_modeling.cpp
+++ b/src/cpp/src/gguf_utils/gguf_modeling.cpp
@@ -28,11 +28,19 @@ auto set_name = [](auto node, const std::string& name) {
 };
 
 // Also valid for other models, e.g. SmolLMs
+// CVS-166108: Adding shared_embedding as true by default based on following two reason:
+// 1. For optimum-cli converted LLM OpenVINO IR, original input embedding weight will be reused for last make_lm_head layer
+//    Which can reduce both model size on disk and runtime memory usage via storing only single embeddding consts
+//    (e.g. Qwen2.5-7B-Instruct-Q4_0 token_embd.weight & output.weight shape [3584, 152064]
+// 2. For some GGUF model that contains both token_embd.weight & output.weight, e.g. Qwen2.5-3B-Instruct Q4_0
+//    meet accuracy issue on MTL/LNL GPU due to use both token_embd.weight & output.weight in OpenVINO IR.
+// WA Known issue: Qwen2.5-3B-Instruct-Q4_K_M meet accuracy issue on MTL/LNL CPU if only re-used token_embd.weight
+
 std::shared_ptr<ov::Model> create_language_model(
     const std::map<std::string, GGUFMetaData>& configs,
     std::unordered_map<std::string, ov::Tensor>& consts,
-    std::unordered_map<std::string, gguf_tensor_type>& qtypes) {
-
+    std::unordered_map<std::string, gguf_tensor_type>& qtypes,
+    bool shared_embedding = true) {
     // Create input parameters
     auto input_ids = std::make_shared<ov::op::v0::Parameter>(
         ov::element::i64, ov::PartialShape{-1, -1});
@@ -119,7 +127,8 @@ std::shared_ptr<ov::Model> create_language_model(
         final_norm,
         consts,
         embeddings,
-        qtypes.at("lm_head.qtype"));
+        qtypes.at("lm_head.qtype"),
+        shared_embedding);
 
     // Create results
     auto logits = std::make_shared<ov::op::v0::Result>(embed_out);
@@ -134,6 +143,9 @@ std::shared_ptr<ov::Model> create_language_model(
         model->set_rt_info(ov::element::f16, {"runtime_options", ov::hint::kv_cache_precision.name()});
     }
     model->set_rt_info(8.0f, {"runtime_options", ov::hint::activations_scale_factor.name()});
+    // CVS-166554: Dynamic quatnization enabled by default with gourp size 32 on MTL platfrom cause the runtime issue
+    // Apply WA to disable dynamic quantization with rt_info to fix GPU plugin issue on MTL
+    model->set_rt_info(0, {"runtime_options", ov::hint::dynamic_quantization_group_size.name()});
 
     return model;
 }


### PR DESCRIPTION
Follow up https://github.com/openvinotoolkit/openvino.genai/pull/2095
Temporal fix to address following issues on GPU, will be revert if issue fixed by GPU plugin.

- Add one small bias on Q4_0 zp array to keep array shape to avoid GPU compilation issue: CVS-166438
- Disable dynamic quantization by default to avoid Q8_0 issue: CVS-166554
- Re-use input embedding weights for make_lm_head by default to reduce model size & memory usage, temporal WA accuracy issue on GPU: CVS-166108

Validate/Supported scope:
Q4_0: Qwen2.5-0.5B, Qwen2.5-1.5B, Qwen2.5-3B (MTL/LNL/ARL)
Q4_K_M: Qwen2.5-3B (MTL)
Q8_0: Qwen2.5-0.5B, Qwen2.5-3B (MTL)