### PR TITLE
Fix license filter

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -8,7 +8,7 @@ allow-licenses:
   - 'BlueOak-1.0.0'
   - '0BSD'
   - 'Python-2.0'
-  - 'MIT-CMU'  # Pillow's license
+  - 'LicenseRef-scancode-secret-labs-2011 AND MIT-CMU'  # Pillow's license
 fail-on-scopes:
   - 'runtime'
   - 'development'


### PR DESCRIPTION
The reason we dont see the error about this license is that they scan diff instead of repo state: https://github.com/actions/dependency-review-action/issues/922. MIT-CMU was my attempt to please it, but it seems that the reviewer uses .github/dependency_review.yml from the target branch only which is another their issue. The license in this commit feels to be more correct because it is the license printed in the error message https://github.com/openvinotoolkit/openvino.genai/actions/runs/14531018031/job/40770651373