### PR TITLE
GGUF support load split files for Qwen2.5

### DIFF
--- a/src/cpp/src/gguf_utils/gguf.cpp
+++ b/src/cpp/src/gguf_utils/gguf.cpp
@@ -277,7 +277,7 @@ void check_file(std::string file){
     OPENVINO_ASSERT(exists, "[load_gguf] Failed to open '", file, "'");
 }
 
-std::vector<std::string> get_all_files(const std::string& file, int total_num) {
+std::vector<std::string> get_all_files(std::string file, int total_num) {
 
     std::vector<std::string> files;
     files.push_back(file);

--- a/src/cpp/src/gguf_utils/gguf.cpp
+++ b/src/cpp/src/gguf_utils/gguf.cpp
@@ -246,9 +246,6 @@ std::unordered_map<std::string, GGUFMetaData> load_metadata(gguf_ctx* ctx) {
 }
 
 void load_arrays(gguf_ctx* ctx, std::unordered_map<std::string, ov::Tensor>& array_map, std::unordered_map<std::string, gguf_tensor_type>& qtype_map) {
-// std::pair<std::unordered_map<std::string, ov::Tensor>, std::unordered_map<std::string, gguf_tensor_type>> load_arrays(gguf_ctx* ctx) {
-//   std::unordered_map<std::string, ov::Tensor> array_map;
-//   std::unordered_map<std::string, gguf_tensor_type> qtype_map;
   gguf_tensor tensor;
 
   auto check_insert = [](const auto& inserted) {
@@ -269,26 +266,7 @@ void load_arrays(gguf_ctx* ctx, std::unordered_map<std::string, ov::Tensor>& arr
       qtype_map.emplace(name_prefix + ".qtype", static_cast<gguf_tensor_type>(tensor.type));
     }
   }
-
-//   return {array_map, qtype_map};
 }
-
-// GGUFLoad get_gguf_data(const std::string& file) {
-//   bool exists;
-//   {
-//     std::ifstream f(file.c_str());
-//     exists = f.good();
-//   }
-//   OPENVINO_ASSERT(exists, "[load_gguf] Failed to open '", file, "'");
-
-//   std::unique_ptr<gguf_ctx, decltype(&gguf_close)> ctx(gguf_open(file.data()), gguf_close);
-//   OPENVINO_ASSERT(ctx, "Failed to open '", file, "' with gguf_open");
-
-//   auto metadata = load_metadata(ctx.get());
-//   auto [arrays, qtype] = load_arrays(ctx.get());
-
-//   return {metadata, arrays, qtype};
-// }
 
 void check_file(std::string file){
     bool exists;
@@ -340,14 +318,11 @@ GGUFLoad get_gguf_data(const std::string& file) {
 
     if(it == metadata.end()) // single GGUF file
     {
-        std::cout << "Debug: single" << std::endl;
         load_arrays(ctx.get(), arrays, qtype);
         return {metadata, arrays, qtype};
     } 
     else // multi GGUF files
-    {
-        std::cout << "Debug: multi" << std::endl;
-        
+    {     
         auto total_num_tensor = std::get<ov::Tensor>(metadata.at(split_flag));
         int total_num =  *(total_num_tensor.data<ov::element_type_traits<ov::element::u16>::value_type>());
 

--- a/src/cpp/src/gguf_utils/gguf.cpp
+++ b/src/cpp/src/gguf_utils/gguf.cpp
@@ -277,7 +277,7 @@ void check_file(std::string file){
     OPENVINO_ASSERT(exists, "[load_gguf] Failed to open '", file, "'");
 }
 
-std::vector<std::string> get_all_files(std::string file, int total_num){
+std::vector<std::string> get_all_files(const std::string& file, int total_num) {
 
     std::vector<std::string> files;
     files.push_back(file);

--- a/src/cpp/src/gguf_utils/gguf.cpp
+++ b/src/cpp/src/gguf_utils/gguf.cpp
@@ -301,7 +301,6 @@ std::vector<std::string> get_all_files(std::string file, int total_num){
 
 GGUFLoad get_gguf_data(const std::string& file) {
 
-    // std::unordered_map<std::string, GGUFMetaData> metadata;
     std::unordered_map<std::string, ov::Tensor> arrays;
     std::unordered_map<std::string, gguf_tensor_type> qtype;
    

--- a/src/cpp/src/gguf_utils/gguf_modeling.cpp
+++ b/src/cpp/src/gguf_utils/gguf_modeling.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<ov::Model> create_language_model(
     const std::map<std::string, GGUFMetaData>& configs,
     std::unordered_map<std::string, ov::Tensor>& consts,
     std::unordered_map<std::string, gguf_tensor_type>& qtypes,
-    bool shared_embedding = true) {
+    bool shared_embedding = false) {
     // Create input parameters
     auto input_ids = std::make_shared<ov::op::v0::Parameter>(
         ov::element::i64, ov::PartialShape{-1, -1});

--- a/src/cpp/src/gguf_utils/gguf_quants.cpp
+++ b/src/cpp/src/gguf_utils/gguf_quants.cpp
@@ -269,5 +269,5 @@ void gguf_load_quantized(std::unordered_map<std::string, ov::Tensor>& a,
     check_insert(a.emplace(name_prefix + ".scales", std::move(scales)));
     check_insert(a.emplace(name_prefix + ".biases", std::move(biases)));
 
-    qtype_map.insert({name_prefix + ".qtype", static_cast<gguf_tensor_type>(tensor.type)});
+    qtype_map.emplace(name_prefix + ".qtype", static_cast<gguf_tensor_type>(tensor.type));
 }


### PR DESCRIPTION
Base on https://github.com/openvinotoolkit/openvino.genai/pull/2110

Mainly features:
1. support splited gguf files loading such as [qwen2.5-7b-instruct-q4_0](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct-GGUF/tree/main?show_file_info=qwen2.5-7b-instruct-q4_0-00001-of-00002.gguf) by first file path.
2. change shared_embedding default value to false, because for some gguf model, it cause accuracy issue when GGUF token_embed.weights contains scales/biases with continuous 0 value. 

CVS-166026

