### PR TITLE
[C] Implement type conversion for the property values of MAX_PROMPT_LEN and MIN_RESPONSE_LEN

### DIFF
--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -88,6 +88,10 @@ typedef struct ov_genai_llm_pipeline_opaque ov_genai_llm_pipeline;
  * Example with properties:
  * ov_genai_llm_pipeline_create(model_path, "GPU", 2, &pipe,
  *                             "CACHE_DIR", "cache_dir");
+ * Note: If the property value is not a string, please pass it as a string
+ * Example:
+ * ov_genai_llm_pipeline_create(model_path, "NPU", 6, &pipeline, "MAX_PROMPT_LEN", "128", "MIN_RESPONSE_LEN",
+                                             "64", "CHACHE_DIR", "cache_dir")
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_create(const char* models_path,
                                                                   const char* device,

--- a/src/c/include/openvino/genai/c/llm_pipeline.h
+++ b/src/c/include/openvino/genai/c/llm_pipeline.h
@@ -91,7 +91,7 @@ typedef struct ov_genai_llm_pipeline_opaque ov_genai_llm_pipeline;
  * Note: If the property value is not a string, please pass it as a string
  * Example:
  * ov_genai_llm_pipeline_create(model_path, "NPU", 6, &pipeline, "MAX_PROMPT_LEN", "128", "MIN_RESPONSE_LEN",
-                                             "64", "CHACHE_DIR", "cache_dir")
+                                             "64", "CACHE_DIR", "cache_dir")
  */
 OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_llm_pipeline_create(const char* models_path,
                                                                   const char* device,

--- a/src/c/src/llm_pipeline.cpp
+++ b/src/c/src/llm_pipeline.cpp
@@ -81,7 +81,21 @@ ov_status_e ov_genai_llm_pipeline_create(const char* models_path, const char* de
             GET_PROPERTY_FROM_ARGS_LIST;
         }
         va_end(args_ptr);
-
+        // Check Property MAX_PROMPT_LEN and MIN_RESPONSE_LEN for NPU
+        // These two special properties, which only affect the genai level, should be manually converted to integers 
+        // before being passed to the constructor of LLMPipeline
+        if(std::string(device) == "NPU") {
+            if(property.find("MAX_PROMPT_LEN") != property.end()) {
+                std::string max_prompt_len = property["MAX_PROMPT_LEN"].as<std::string>();
+                property.erase("MAX_PROMPT_LEN");
+                property["MAX_PROMPT_LEN"] = std::stoi(max_prompt_len);
+            }
+            if(property.find("MIN_RESPONSE_LEN") != property.end()) {
+                std::string min_response_len = property["MIN_RESPONSE_LEN"].as<std::string>();
+                property.erase("MIN_RESPONSE_LEN");
+                property["MIN_RESPONSE_LEN"] = std::stoi(min_response_len);
+            }
+       }
         std::unique_ptr<ov_genai_llm_pipeline> _pipe = std::make_unique<ov_genai_llm_pipeline>();
         _pipe->object =
             std::make_shared<ov::genai::LLMPipeline>(std::filesystem::path(models_path), std::string(device), property);


### PR DESCRIPTION
These two unique properties, relevant only at the genai level for NPU https://github.com/openvinotoolkit/openvino.genai/blob/782109739f8a92fbad82819a6584912ace6f92ea/src/cpp/src/utils.cpp#L477-L478, need to be manually converted to integers before being provided to the `ov::genai::LLMPipeline` constructor.