### PR TITLE
Increased VLM tests timeout.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -451,7 +451,7 @@ jobs:
           - name: 'LLM & VLM'
             cmd: 'tests/python_tests/test_llm_pipeline.py tests/python_tests/test_llm_pipeline_static.py tests/python_tests/test_vlm_pipeline.py'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
-            timeout: 60
+            timeout: 90
           - name: 'Tokenizer tests'
             cmd: 'tests/python_tests/test_tokenizer.py'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).tokenizers.test }}


### PR DESCRIPTION
After this [PR](https://github.com/openvinotoolkit/openvino.genai/pull/2129) most of VLM tests are executed for both SDPA and PA, so VLM tests time increased which leads to sporadic kills by timeout on windows, for this reason timeout for this test group was increased.