### PR TITLE
[StatefulLLMPipeline] Remove GenAI slicing in stateful pipeline

### DIFF
--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -49,7 +49,9 @@ StatefulLLMPipeline::StatefulLLMPipeline(
     const ov::AnyMap& properties,
     const ov::genai::GenerationConfig& generation_config)
     : LLMPipelineImplBase(tokenizer, generation_config), m_sampler(m_tokenizer) {
-    utils::apply_slice_before_matmul_transformation(model);
+    // FIXME: slicing produces incorrect results for some models.
+    // For now relying on NPUW slicing
+    // utils::apply_slice_before_matmul_transformation(model);
     auto kv_pos = ov::genai::utils::get_kv_axes_pos(model);
 
     if (device.find("NPU") != std::string::npos) {


### PR DESCRIPTION
apply_slice_before_matmul_transformation has incorrect indexes for some models. Removed it - will be relying on NPUW SLICE_OUT which is enabled in the common config by default