### PR TITLE
Update Whisper README.md as "--disable-stateful" is no longer required to export models for NPU

### DIFF
--- a/samples/cpp/whisper_speech_recognition/README.md
+++ b/samples/cpp/whisper_speech_recognition/README.md
@@ -13,8 +13,6 @@ pip install --upgrade-strategy eager -r ../../requirements.txt
 optimum-cli export openvino --trust-remote-code --model openai/whisper-base whisper-base
 ```
 
-If NPU is the inference device, an additional option `--disable-stateful` is required. See [NPU with OpenVINO GenAI](https://docs.openvino.ai/nightly/openvino-workflow-generative/inference-with-genai/inference-with-genai-on-npu.html) for the detail.
-
 ## Prepare audio file
 
 Prepare audio file in wav format with sampling rate 16k Hz.

--- a/samples/python/whisper_speech_recognition/README.md
+++ b/samples/python/whisper_speech_recognition/README.md
@@ -13,8 +13,6 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 optimum-cli export openvino --trust-remote-code --model openai/whisper-base whisper-base
 ```
 
-If NPU is the inference device, an additional option `--disable-stateful` is required. See [NPU with OpenVINO GenAI](https://docs.openvino.ai/nightly/openvino-workflow-generative/inference-with-genai/inference-with-genai-on-npu.html) for the detail.
-
 ## Prepare audio file
 
 Download example audio file: https://storage.openvinotoolkit.org/models_contrib/speech/2021.2/librispeech_s5/how_are_you_doing_today.wav


### PR DESCRIPTION
In OV2025.1, the option "--disable-stateful" to export model for NPU is not required as the stateful to stateless conversion is done inside the pipeline. https://github.com/openvinotoolkit/openvino.genai/blob/master/src/cpp/src/whisper/pipeline_static.cpp#L857