### PR TITLE
[Test] Skip gguf test on MacOS due to sporadic failure

### DIFF
--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -4,6 +4,7 @@
 
 import pytest
 import torch
+import sys
 import os
 import json
 import numpy as np
@@ -813,6 +814,8 @@ def test_pipelines_generate_with_streaming(pipeline_type, stop_str):
 @pytest.mark.parametrize("model_ids", get_gguf_model_list())
 @pytest.mark.precommit
 def test_pipelines_with_gguf_generate(pipeline_type, model_ids):
+    if sys.platform == 'darwin':
+        pytest.skip(reason="168882: Sporadic segmentation fault failure on MacOS.")
     gguf_model_id = model_ids["gguf_model_id"]
     gguf_filename = model_ids["gguf_filename"]
     prompt = 'Why is the Sun yellow?'
@@ -848,6 +851,8 @@ def test_pipelines_with_gguf_generate(pipeline_type, model_ids):
 @pytest.mark.parametrize("model_ids", get_gguf_model_list())
 @pytest.mark.precommit
 def test_full_gguf_pipeline(pipeline_type, model_ids):
+    if sys.platform == 'darwin':
+        pytest.skip(reason="168882: Sporadic segmentation fault failure on MacOS.")
     gguf_model_id = model_ids["gguf_model_id"]
     gguf_filename = model_ids["gguf_filename"]
     prompt = 'Why is the Sun yellow?'


### PR DESCRIPTION
**Details:** 
- Temporarily skip GGUF test in `test_llm_pipeline.py` on MacOS due to sporadic failure to unblock other PRs. 
- Will follow up to investigate the root cause for MacOS w/ help from validation team. 

**Tickets**
- CVS-168882