### PR TITLE
Fixed system message in chat mode.

### DIFF
--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -312,6 +312,9 @@ public:
             m_history.clear();
         }
         m_inputs_embedder->start_chat(system_message);
+        if (system_message.empty()) {
+            return;
+        }
         m_history = {{{"role", "system"}, {"content", system_message}}};
     }
 


### PR DESCRIPTION
When system message is not in the history tokenizer inserts default system message during applying of chat template. 
Adding to the history empty system message breaks this logic which leads to empty system message in the resulting model input.
This affects chat accuracy.