### PR TITLE
vlm benchmarking multi images support for both python and cpp

### DIFF
--- a/samples/cpp/visual_language_chat/benchmark_vlm.cpp
+++ b/samples/cpp/visual_language_chat/benchmark_vlm.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) try {
     options.add_options()
     ("m,model", "Path to model and tokenizers base directory", cxxopts::value<std::string>()->default_value("."))
     ("p,prompt", "Prompt", cxxopts::value<std::string>()->default_value("What is on the image?"))
-    ("i,image", "Image", cxxopts::value<std::string>()->default_value("image.jpg"))
+    ("i,image", "Image file or dir with images", cxxopts::value<std::string>()->default_value("image.jpg"))
     ("nw,num_warmup", "Number of warmup iterations", cxxopts::value<size_t>()->default_value(std::to_string(1)))
     ("n,num_iter", "Number of iterations", cxxopts::value<size_t>()->default_value(std::to_string(3)))
     ("mt,max_new_tokens", "Maximal number of new tokens", cxxopts::value<size_t>()->default_value(std::to_string(20)))
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) try {
     std::string device = result["device"].as<std::string>();
     size_t num_warmup = result["num_warmup"].as<size_t>();
     size_t num_iter = result["num_iter"].as<size_t>();
-    ov::Tensor image = utils::load_image(image_path);
+    std::vector<ov::Tensor> image = utils::load_images(image_path);
   
     ov::genai::GenerationConfig config;
     config.max_new_tokens = result["max_new_tokens"].as<size_t>();
@@ -49,12 +49,12 @@ int main(int argc, char* argv[]) try {
     ov::genai::VLMPipeline pipe(models_path, device);
     
     for (size_t i = 0; i < num_warmup; i++)
-        pipe.generate(prompt, ov::genai::image(image), ov::genai::generation_config(config));
+        pipe.generate(prompt, ov::genai::images(image), ov::genai::generation_config(config));
     
-    auto res = pipe.generate(prompt, ov::genai::image(image), ov::genai::generation_config(config));
+    auto res = pipe.generate(prompt, ov::genai::images(image), ov::genai::generation_config(config));
     auto metrics = res.perf_metrics;
     for (size_t i = 0; i < num_iter - 1; i++) {
-        res = pipe.generate(prompt, ov::genai::image(image), ov::genai::generation_config(config));
+        res = pipe.generate(prompt, ov::genai::images(image), ov::genai::generation_config(config));
         metrics = metrics + res.perf_metrics;
     }
 

--- a/samples/python/visual_language_chat/benchmark_vlm.py
+++ b/samples/python/visual_language_chat/benchmark_vlm.py
@@ -7,6 +7,7 @@ import openvino_genai as ov_genai
 from PIL import Image
 from openvino import Tensor
 import numpy as np
+from pathlib import Path
 
 
 def read_image(path: str) -> Tensor:
@@ -22,6 +23,11 @@ def read_image(path: str) -> Tensor:
     image_data = np.array(pic)
     return Tensor(image_data)
 
+def read_images(path: str) -> list[Tensor]:
+    entry = Path(path)
+    if entry.is_dir():
+        return [read_image(str(file)) for file in sorted(entry.iterdir())]
+    return [read_image(path)]
 
 def main():
     parser = argparse.ArgumentParser(description="Help command")
@@ -39,7 +45,7 @@ def main():
     # In order to get VLMDecodedResults instead of a string input should be a list.
     prompt = args.prompt
     models_path = args.model
-    image = read_image(args.image)
+    image = read_images(args.image)
     device = args.device
     num_warmup = args.num_warmup
     num_iter = args.num_iter

--- a/samples/python/visual_language_chat/benchmark_vlm.py
+++ b/samples/python/visual_language_chat/benchmark_vlm.py
@@ -33,7 +33,7 @@ def main():
     parser = argparse.ArgumentParser(description="Help command")
     parser.add_argument("-m", "--model", type=str, help="Path to model and tokenizers base directory")
     parser.add_argument("-p", "--prompt", type=str, default="The Sky is blue because", help="Prompt")
-    parser.add_argument("-i", "--image", type=str, default="image.jpg", help="Image")
+    parser.add_argument("-i", "--image", type=str, default="image.jpg", help="Image file or dir with images")
     parser.add_argument("-nw", "--num_warmup", type=int, default=1, help="Number of warmup iterations")
     parser.add_argument("-n", "--num_iter", type=int, default=2, help="Number of iterations")
     parser.add_argument("-mt", "--max_new_tokens", type=int, default=20, help="Maximal number of new tokens")

--- a/samples/python/visual_language_chat/encrypted_model_vlm.py
+++ b/samples/python/visual_language_chat/encrypted_model_vlm.py
@@ -96,7 +96,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('model_dir')
     parser.add_argument('image_dir', help="Image file or dir with images")
-    parser.add_argument('prompt', help="Image file or dir with images")
+    parser.add_argument('prompt', help="Prompt")
     args = parser.parse_args()
 
     model_name_to_file_map = {


### PR DESCRIPTION
Add multi images input support for benchmark_vlm.py and benchmark_vlm.cpp, which is based on the existing implementation in visual_language_chat.py and visual_language_chat.cpp. 