### PR TITLE
[Continuous Batching] Fix multi-threads safety issue about variable sharing & avoid the denominator is 0 issue in statistic part

### DIFF
--- a/tools/continuous_batching/benchmark/continuous_batching_benchmark.cpp
+++ b/tools/continuous_batching/benchmark/continuous_batching_benchmark.cpp
@@ -300,7 +300,7 @@ public:
         mean_ttft /= generations_info.size();
         mean_tpot /= generations_info.size();
 
-        auto total_duration_second = total_duration.count() / 1000.0;
+        auto total_duration_second = std::chrono::duration<double>(total_duration).count();
         std::cout << "Benchmark duration: " << total_duration_second << " s" << std::endl;
         std::cout << "Total number of input tokens: " << total_input_len << std::endl;
         std::cout << "Total number of output tokens: " << total_output_len << std::endl;


### PR DESCRIPTION
1) For the thread control variable "finishThread", using the standard method change the value to keep the safety;
2) For the total duration time in second will be return 0, when the execution is very small, which will make some unexpected behaviors (hang in std::cout). So will get the ms duration and than transform to s and get the final statistic results.