### PR TITLE
Disable XGrammar on Android

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -72,6 +72,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND WIN32)
     set(ENABLE_XGRAMMAR OFF CACHE BOOL "Enable XGrammar" FORCE)
 endif()
 
+# Disable XGrammar for Android platform, causes issues in CI
+if(ANDROID)
+    set(ENABLE_XGRAMMAR OFF CACHE BOOL "Enable XGrammar" FORCE)
+endif()
+
 if(ENABLE_XGRAMMAR)
     set(XGRAMMAR_VERSION v0.1.18)
     set(XGRAMMAR_DIR ${CMAKE_BINARY_DIR}/xgrammar)


### PR DESCRIPTION
Disable android build because of OV CI issues: https://github.com/openvinotoolkit/openvino/actions/runs/15904034593/job/44857058265?pr=31125