### PR TITLE
Fix for cloning NPU Image Generation pipelines (#2376)

### DIFF
--- a/samples/cpp/image_generation/image2image_concurrency.cpp
+++ b/samples/cpp/image_generation/image2image_concurrency.cpp
@@ -14,7 +14,7 @@ int32_t main(int32_t argc, char* argv[]) try {
     OPENVINO_ASSERT(argc >= 4, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' '<PROMPT>' ... <IMAGE>");
 
     const std::string models_path = argv[1];
-    const std::string device = "CPU";  // GPU can be used as well
+    const std::string device = "CPU";  // GPU and NPU can be used as well
     const std::string image_path = argv[argc - 1];
     ov::Tensor image = utils::load_image(image_path);
 
@@ -25,8 +25,28 @@ int32_t main(int32_t argc, char* argv[]) try {
     for (int32_t i = 2; i < argc - 1; ++i)
         prompts.push_back(argv[i]);
 
-    // Prepare initial pipeline and compiled models into device
-    pipelines.emplace_back(models_path, device);
+    ov::AnyMap properties;
+    if (device == "NPU") {
+        // Define static shape and guidance scale for NPU
+        const int num_images_per_prompt = 1;
+        const int height = 512;
+        const int width = 512;
+        const float guidance_scale = 7.5f;
+
+        pipelines.emplace_back(models_path);
+        pipelines.back().reshape(num_images_per_prompt, height, width, guidance_scale);
+        pipelines.back().compile(device);  // All models are compiled for NPU
+        //pipelines.back().compile("NPU", "NPU", "GPU");  // Compile for NPU and GPU, if needed
+
+        // Don't specify N, H, W, and guidance_scale in the properties map because they were made static
+        properties = ov::AnyMap{ov::genai::strength(0.8f),
+                                ov::genai::num_inference_steps(4)};
+    } else {
+        pipelines.emplace_back(models_path, device);
+
+        properties = ov::AnyMap{ov::genai::strength(0.8f),  // controls how initial image is noised after being converted to latent space. `1` means initial image is fully noised
+                                ov::genai::num_inference_steps(4)};
+    }
 
     // Clone pipeline for concurrent usage
     for (size_t i = 1; i < prompts.size(); ++i)
@@ -38,12 +58,9 @@ int32_t main(int32_t argc, char* argv[]) try {
 
         std::cout << "Starting to generate with prompt: '" << prompt << "'..." << std::endl;
 
-        threads.emplace_back([i, &pipe, prompt, image] () {
+        threads.emplace_back([i, &pipe, prompt, image, &properties] () {
 
-            ov::Tensor generated_image = pipe.generate(prompt, image,
-                // controls how initial image is noised after being converted to latent space. `1` means initial image is fully noised
-                ov::genai::strength(0.8f),
-                ov::genai::num_inference_steps(4));
+            ov::Tensor generated_image = pipe.generate(prompt, image, properties);
 
             // writes `num_images_per_prompt` images by pattern name
             imwrite("image_" + std::to_string(i) + "_%d.bmp", generated_image, true);

--- a/samples/cpp/image_generation/text2image_concurrency.cpp
+++ b/samples/cpp/image_generation/text2image_concurrency.cpp
@@ -12,7 +12,7 @@ int32_t main(int32_t argc, char* argv[]) try {
     OPENVINO_ASSERT(argc >= 3, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' '<PROMPT>' ...");
 
     const std::string models_path = argv[1];
-    const std::string device = "CPU";  // GPU can be used as well
+    const std::string device = "CPU";  // GPU and NPU can be used as well
 
     std::vector<std::thread> threads;
     std::vector<std::string> prompts;
@@ -22,7 +22,29 @@ int32_t main(int32_t argc, char* argv[]) try {
         prompts.push_back(argv[i]);
 
     // Prepare initial pipeline and compiled models into device
-    pipelines.emplace_back(models_path, device);
+    ov::AnyMap properties;
+    if (device == "NPU") {
+        // Define static shape and guidance scale for NPU
+        const int num_images_per_prompt = 1;
+        const int height = 512;
+        const int width = 512;
+        const float guidance_scale = 7.5f;
+
+        pipelines.emplace_back(models_path);
+        pipelines.back().reshape(num_images_per_prompt, height, width, guidance_scale);
+        pipelines.back().compile(device);  // All models are compiled for NPU
+        // pipelines.back().compile("NPU", "NPU", "GPU");  // Compile for NPU and GPU, if needed
+
+        // Don't specify N, H, W, and guidance_scale in the properties map because they were made static
+        properties = ov::AnyMap{ov::genai::num_inference_steps(2)};
+    } else {
+        pipelines.emplace_back(models_path, device);
+
+        properties = ov::AnyMap{ov::genai::width(512),
+                                ov::genai::height(512),
+                                ov::genai::num_inference_steps(2),
+                                ov::genai::num_images_per_prompt(1)};
+    }
 
     // Clone pipeline for concurrent usage
     for (size_t i = 1; i < prompts.size(); ++i)
@@ -34,14 +56,8 @@ int32_t main(int32_t argc, char* argv[]) try {
 
         std::cout << "Starting to generate with prompt: '" << prompt << "'..." << std::endl;
 
-        threads.emplace_back([i, &pipe, prompt] () {
-
-            ov::Tensor image = pipe.generate(prompt,
-                ov::AnyMap{
-                    ov::genai::width(512),
-                    ov::genai::height(512),
-                    ov::genai::num_inference_steps(2),
-                    ov::genai::num_images_per_prompt(1)});
+        threads.emplace_back([i, &pipe, prompt, &properties] () {
+            ov::Tensor image = pipe.generate(prompt, properties);
 
             imwrite("image_" + std::to_string(i) + "_%d.bmp", image, true);
         });

--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -286,6 +286,7 @@ public:
 
         pipeline->m_root_dir = m_root_dir;
         pipeline->set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
+        pipeline->set_generation_config(m_generation_config);
         return pipeline;
     }
 

--- a/src/cpp/src/image_generation/models/sd3transformer_2d_inference_static_bs1.hpp
+++ b/src/cpp/src/image_generation/models/sd3transformer_2d_inference_static_bs1.hpp
@@ -13,15 +13,23 @@ namespace genai {
 
 // Static Batch-Size 1 variant of SD3Transformer2DModel::Inference
 class SD3Transformer2DModel::InferenceStaticBS1 : public SD3Transformer2DModel::Inference {
+
+    InferenceStaticBS1(const InferenceStaticBS1&) = delete;
+    InferenceStaticBS1(InferenceStaticBS1&&) = delete;
+    InferenceStaticBS1(InferenceStaticBS1& other) = delete;
+
 public:
+    InferenceStaticBS1() : Inference(), m_native_batch_size(0) {}
+
     virtual std::shared_ptr<Inference> clone() override {
         OPENVINO_ASSERT(m_requests.size(), "SD3Transformer2DModel must have m_requests initialized");
-        InferenceStaticBS1 cloned(*this);
-        cloned.m_requests.reserve(m_requests.size());
+        auto clone = std::make_shared<InferenceStaticBS1>();
+        clone->m_native_batch_size = m_native_batch_size;
+        clone->m_requests.reserve(m_requests.size());
         for (auto& request : m_requests) {
-            cloned.m_requests.push_back(request.get_compiled_model().create_infer_request());
+            clone->m_requests.push_back(request.get_compiled_model().create_infer_request());
         }
-        return std::make_shared<InferenceStaticBS1>(cloned);
+        return clone;
     }
 
     virtual void compile(std::shared_ptr<ov::Model> model,

--- a/src/cpp/src/image_generation/models/unet_inference_static_bs1.hpp
+++ b/src/cpp/src/image_generation/models/unet_inference_static_bs1.hpp
@@ -14,15 +14,23 @@ namespace genai {
 
 // Static Batch-Size 1 variant of UNetInference
 class UNet2DConditionModel::UNetInferenceStaticBS1 : public UNet2DConditionModel::UNetInference {
+
+    UNetInferenceStaticBS1(const UNetInferenceStaticBS1&) = delete;
+    UNetInferenceStaticBS1(UNetInferenceStaticBS1&&) = delete;
+    UNetInferenceStaticBS1(UNetInferenceStaticBS1& other) = delete;
+
 public:
+    UNetInferenceStaticBS1() : UNetInference(), m_native_batch_size(0) {}
+
     virtual std::shared_ptr<UNetInference> clone() override {
         OPENVINO_ASSERT(m_requests.size(), "UNet2DConditionModel must have m_requests initialized");
-        UNetInferenceStaticBS1 cloned(*this);
-        cloned.m_requests.reserve(m_requests.size());
+        auto clone = std::make_shared<UNetInferenceStaticBS1>();
+        clone->m_native_batch_size = m_native_batch_size;
+        clone->m_requests.reserve(m_requests.size());
         for (auto& request : m_requests) {
-            cloned.m_requests.push_back(request.get_compiled_model().create_infer_request());
+            clone->m_requests.push_back(request.get_compiled_model().create_infer_request());
         }
-        return std::make_shared<UNetInferenceStaticBS1>(cloned);
+        return clone;
     }
 
     virtual void compile(std::shared_ptr<ov::Model> model,

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -292,6 +292,7 @@ public:
 
         pipeline->m_root_dir = m_root_dir;
         pipeline->set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
+        pipeline->set_generation_config(m_generation_config);
         return pipeline;
     }
 

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -180,6 +180,7 @@ public:
 
         pipeline->m_root_dir = m_root_dir;
         pipeline->set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
+        pipeline->set_generation_config(m_generation_config);
         return pipeline;
     }
 

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -203,6 +203,7 @@ public:
 
         pipeline->m_root_dir = m_root_dir;
         pipeline->set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
+        pipeline->set_generation_config(m_generation_config);
         return pipeline;
     }
 


### PR DESCRIPTION
This is cherry-pick from release branch.

Pipeline cloning for multi-threaded usage had a few bugs:
- generation config was not copied to newly cloned instances, causing n/h/w/guidance_scale to not propagate further
- BS1 inference classes clone/copy had issue with default constructors which caused m_requests to duplicate and grow over time

This change was tested with SD v1.5 with `text2image_concurrent` sample, and this change will enable OpenVINO Model Server with NPU enablement for Image Generation use cases.

CVS-168932

---------