### PR TITLE
[CI][GHA] Increase Python (Cacheopt E2E) timeout for manylinux_2_28

### DIFF
--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -376,7 +376,7 @@ jobs:
           - name: 'Cacheopt E2E'
             cmd: 'tests/python_tests/test_kv_cache_eviction.py'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).continuous_batching.test }}
-            timeout: 60
+            timeout: 180
           - name: 'LLM & VLM'
             cmd: 'tests/python_tests/test_llm_pipeline.py tests/python_tests/test_llm_pipeline_static.py tests/python_tests/test_vlm_pipeline.py tests/python_tests/test_structured_output.py'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test || fromJSON(needs.smart_ci.outputs.affected_components).LLM.test }}


### PR DESCRIPTION
**Details:** 
- https://github.com/openvinotoolkit/openvino.genai/commit/21693ffbe0f62467435e3eb15cd03b723f365d21 introduce manylinux_2_28 GHA CI with only 60 minutes timeout for Python (Cacheopt E2E) test, which cause following CI timeout issue: 
- https://github.com/openvinotoolkit/openvino.genai/actions/runs/16289735787/job/45999102256?pr=2433
- https://github.com/openvinotoolkit/openvino.genai/actions/runs/16285960689/job/45986489423?pr=2340


This PR aim to increase Python (Cacheopt E2E) timeout to 180 minutes for manylinux_2_28 to align with linux test: 
https://github.com/openvinotoolkit/openvino.genai/blob/21693ffbe0f62467435e3eb15cd03b723f365d21/.github/workflows/linux.yml#L512-L515


