### PR TITLE
[llm_bench] Fix typos for 1st token info and names of memory monitoring phase

### DIFF
--- a/tools/llm_bench/llm_bench_utils/hook_forward_whisper.py
+++ b/tools/llm_bench/llm_bench_utils/hook_forward_whisper.py
@@ -63,12 +63,12 @@ class WhisperHook:
                     f"encoder infers latency: {data['enc_infer_time']:.2f} ms/infer"
             if 'dec_1st_token_time' and 'dec_2nd_tokens_time' in data:
                 str += \
-                    f"\n{title} decoder first token latency: {data['dec_1st_token_time']} ms/token, " \
+                    f"\n{title} decoder first token latency: {data['dec_1st_token_time']} ms, " \
                     f"decoder other tokens latency: {data['dec_2nd_tokens_time']} ms/token, " \
                     f"decoder tokens count: {data['dec_token_count']}\n"
             if 'dec_1st_infer_time' and 'dec_2nd_infers_time' in data:
                 str += \
-                    f"{title} decoder first infer latency: {data['dec_1st_infer_time']} ms/infer, " \
+                    f"{title} decoder first infer latency: {data['dec_1st_infer_time']} ms, " \
                     f"decoder other infers latency: {data['dec_2nd_infers_time']} ms/infer, " \
                     f"decoder infers count: {data['dec_infer_count']}"
             if idx < len(self.latency_list) - 1:

--- a/tools/llm_bench/llm_bench_utils/metrics_print.py
+++ b/tools/llm_bench/llm_bench_utils/metrics_print.py
@@ -40,7 +40,7 @@ def print_metrics(
     if tms is not None:
         iter_data['first_token_latency'] = tms[0] * 1000 if len(tms) > 0 else -1
         iter_data['other_tokens_avg_latency'] = sum(tms[1:]) / (len(tms) - 1) * 1000 if len(tms) > 1 else -1
-        first_token_latency = 'NA' if iter_data['first_token_latency'] == -1 else f"{iter_data['first_token_latency']:.2f} ms/{latency_unit}"
+        first_token_latency = 'NA' if iter_data['first_token_latency'] == -1 else f"{iter_data['first_token_latency']:.2f} ms"
         other_token_latency = 'NA' if iter_data['other_tokens_avg_latency'] == -1 else f"{iter_data['other_tokens_avg_latency']:.2f} ms/{latency_unit}"
         if text_emb is None:
             log.info(
@@ -57,7 +57,7 @@ def print_metrics(
     if tms_infer is not None:
         iter_data['first_token_infer_latency'] = tms_infer[0] * 1000 if len(tms_infer) > 0 else -1
         iter_data['other_tokens_infer_avg_latency'] = sum(tms_infer[1:]) / (len(tms_infer) - 1) * 1000 if len(tms_infer) > 1 else -1
-        first_infer_latency = 'NA' if iter_data['first_token_infer_latency'] == -1 else f"{iter_data['first_token_infer_latency']:.2f} ms/infer"
+        first_infer_latency = 'NA' if iter_data['first_token_infer_latency'] == -1 else f"{iter_data['first_token_infer_latency']:.2f} ms"
         other_infer_latency = 'NA' if iter_data['other_tokens_infer_avg_latency'] == -1 else f"{iter_data['other_tokens_infer_avg_latency']:.2f} ms/infer"
         log.info(
             f'{prefix} First infer latency: {first_infer_latency}, '
@@ -119,7 +119,7 @@ def print_stable_diffusion_infer_latency(iter_str, iter_data, stable_diffusion=N
     iter_data['other_tokens_infer_avg_latency'] = iter_data['other_tokens_avg_latency']
 
     prefix = f'[{iter_str}][P{prompt_idx}]'
-    log.info(f"{prefix} First step of {main_model_name} latency: {iter_data['first_token_latency']:.2f} ms/step, "
+    log.info(f"{prefix} First step of {main_model_name} latency: {iter_data['first_token_latency']:.2f} ms, "
              f"other steps of {main_model_name} latency: {iter_data['other_tokens_avg_latency']:.2f} ms/step",)
 
     log_str = f"{prefix} "
@@ -157,7 +157,7 @@ def print_ldm_unet_vqvae_infer_latency(iter_num, iter_data, tms=None, warm_up=Fa
     iter_data['first_token_infer_latency'] = iter_data['first_token_latency']
     iter_data['other_tokens_infer_avg_latency'] = iter_data['other_tokens_avg_latency']
 
-    first_token_latency = 'NA' if iter_data['first_token_latency'] == -1 else f"{iter_data['first_token_latency']:.2f} ms/step"
+    first_token_latency = 'NA' if iter_data['first_token_latency'] == -1 else f"{iter_data['first_token_latency']:.2f} ms"
     other_token_latency = 'NA' if iter_data['other_tokens_avg_latency'] == -1 else f"{iter_data['other_tokens_avg_latency']:.2f} ms/step"
     prefix = f'[{iter_str}][P{prompt_idx}]'
     log.info(f"{prefix} First step of unet latency: {first_token_latency}, "
@@ -197,7 +197,7 @@ def output_avg_statis_tokens(prompt_dict, prompt_idx_list, iter_data_list, batch
             tput_unit = latency_unit
             if batch_size > 1:
                 latency_unit = '{}{}s'.format(batch_size, latency_unit)
-            avg_1st_token_latency = 'NA' if avg_1st_token_latency < 0 else f'{avg_1st_token_latency:.2f} ms/{latency_unit}'
+            avg_1st_token_latency = 'NA' if avg_1st_token_latency < 0 else f'{avg_1st_token_latency:.2f} ms'
             avg_2nd_tokens_latency = 'NA' if avg_2nd_tokens_latency < 0 else f'{avg_2nd_tokens_latency:.2f} ms/{latency_unit}'
             avg_2nd_token_tput = 'NA' if avg_2nd_tokens_latency == 'NA' else f'{avg_2nd_token_tput:.2f} {tput_unit}s/s'
             prefix = f'[ INFO ] [Average] P[{p_idx}]L[{loop_idx}]' if loop_idx != -1 else f'[ INFO ] [Average] P[{p_idx}]'

--- a/tools/llm_bench/llm_bench_utils/ov_utils.py
+++ b/tools/llm_bench/llm_bench_utils/ov_utils.py
@@ -155,7 +155,7 @@ def create_text_gen_model(model_path, device, memory_monitor, **kwargs):
         end = time.perf_counter()
         if kwargs.get("mem_consumption"):
             memory_monitor.stop_and_collect_data('compilation_phase')
-            memory_monitor.log_data('for copmpilation phase')
+            memory_monitor.log_data('for compilation phase')
     bench_hook = get_bench_hook(kwargs['num_beams'], ov_model)
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
@@ -225,7 +225,7 @@ def create_genai_text_gen_model(model_path, device, ov_config, memory_monitor, *
     log.info(f'Pipeline initialization time: {end - start:.2f}s')
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
 
     class TokenStreamer(openvino_genai.StreamerBase):
         def __init__(self, tokenizer):
@@ -306,7 +306,7 @@ def create_image_gen_model(model_path, device, memory_monitor, **kwargs):
         end = time.perf_counter()
         if kwargs.get("mem_consumption"):
             memory_monitor.stop_and_collect_data('compilation_phase')
-            memory_monitor.log_data('for copmpilation phase')
+            memory_monitor.log_data('for compilation phase')
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
     return ov_model, from_pretrained_time, False, None
@@ -472,7 +472,7 @@ def create_genai_image_gen_model(model_path, device, ov_config, model_index_data
     end = time.perf_counter()
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     log.info(f'Pipeline initialization time: {end - start:.2f}s')
     return image_gen_pipe, end - start, True, callback
 
@@ -492,7 +492,7 @@ def create_ldm_super_resolution_model(model_path, device, memory_monitor, **kwar
     end = time.perf_counter()
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
     return ov_model, from_pretrained_time
@@ -511,7 +511,7 @@ def create_genai_speech_2_txt_model(model_path, device, memory_monitor, **kwargs
     end = time.perf_counter()
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
     processor = AutoProcessor.from_pretrained(model_path)
@@ -552,7 +552,7 @@ def create_speech_2_txt_model(model_path, device, memory_monitor, **kwargs):
         end = time.perf_counter()
         if kwargs.get("mem_consumption"):
             memory_monitor.stop_and_collect_data('compilation_phase')
-            memory_monitor.log_data('for copmpilation phase')
+            memory_monitor.log_data('for compilation phase')
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
     if is_transformers_version(">=", "4.51.0"):
@@ -609,7 +609,7 @@ def create_genai_image_text_gen_model(model_path, device, ov_config, memory_moni
     log.info("Selected OpenVINO GenAI for benchmarking")
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     log.info(f'Pipeline initialization time: {end - start:.2f}s')
 
     return llm_pipe, processor_config, end - start, None, True
@@ -645,7 +645,7 @@ def create_genai_text_embed_model(model_path, device, memory_monitor, **kwargs):
     log.info("Selected OpenVINO GenAI for benchmarking")
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     log.info(f'Pipeline initialization time: {end - start:.2f}s')
     try:
         tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -724,7 +724,7 @@ def create_text_embeddings_model(model_path, device, memory_monitor, **kwargs):
 
     if kwargs.get("mem_consumption"):
         memory_monitor.stop_and_collect_data('compilation_phase')
-        memory_monitor.log_data('for copmpilation phase')
+        memory_monitor.log_data('for compilation phase')
     bench_hook = get_bench_hook(1, ov_model, embed=True)
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')
@@ -776,7 +776,7 @@ def create_image_text_gen_model(model_path, device, memory_monitor, **kwargs):
         end = time.perf_counter()
         if kwargs.get("mem_consumption"):
             memory_monitor.stop_and_collect_data('compilation_phase')
-            memory_monitor.log_data('for copmpilation phase')
+            memory_monitor.log_data('for compilation phase')
     bench_hook = get_bench_hook(kwargs['num_beams'], ov_model)
     from_pretrained_time = end - start
     log.info(f'From pretrained time: {from_pretrained_time:.2f}s')


### PR DESCRIPTION
memory monitoring phase naming: `for copmpilation phase` -> `for compilation phase`
1st token info: removed `ms/token`/`ms/step`/`ms/infer` -> `ms`