### PR TITLE
[JS] Fix error when LLMPipeline.stream() is broken.

### DIFF
--- a/src/js/lib/addon.ts
+++ b/src/js/lib/addon.ts
@@ -29,7 +29,7 @@ export type TextEmbeddingConfig = {
 };
 
 export interface TextEmbeddingPipelineWrapper {
-  new (): TextEmbeddingPipelineWrapper;
+  new(): TextEmbeddingPipelineWrapper;
   init(
     modelPath: string,
     device: string,

--- a/src/js/tests/module.test.js
+++ b/src/js/tests/module.test.js
@@ -25,7 +25,7 @@ describe('module', async () => {
       'Type something in English',
       // eslint-disable-next-line camelcase
       { temperature: '0', max_new_tokens: '4' },
-      () => {},
+      () => { },
     );
 
     assert.ok(result.length > 0);
@@ -115,7 +115,7 @@ describe('generation parameters validation', () => {
     'should throw an error if options specified but not an object',
     async () => {
       await assert.rejects(
-        async () => await pipeline.generate('prompt', 'options', () => {}),
+        async () => await pipeline.generate('prompt', 'options', () => { }),
         {
           name: 'Error',
           message: 'Options must be an object',
@@ -156,5 +156,54 @@ describe('generation parameters validation', () => {
     };
     const result = await pipeline.generate('continue: 1 2 3', generationConfig);
     assert.strictEqual(typeof result, 'string');
+  });
+});
+
+describe('stream()', () => {
+  let pipeline = null;
+
+  before(async () => {
+    pipeline = await LLMPipeline(MODEL_PATH, 'CPU');
+  });
+
+  it('stream() with max_new_tokens', async () => {
+    const streamer = pipeline.stream(
+      'Print hello world',
+      {
+        'max_new_tokens': 5,
+      },
+    );
+    const chunks = [];
+    for await (const chunk of streamer) {
+      chunks.push(chunk);
+    }
+    assert.ok(chunks.length < 5);
+  });
+
+  it('stream() with stop_strings', async () => {
+    const streamer = pipeline.stream(
+      'Print hello world',
+      {
+        'stop_strings': new Set(['world']),
+        'include_stop_str_in_output': true,
+      },
+    );
+    const chunks = [];
+    for await (const chunk of streamer) {
+      chunks.push(chunk);
+    }
+    assert.ok(chunks[chunks.length - 1].includes('world'));
+  });
+
+  it('early break of stream', async () => {
+    const streamer = pipeline.stream('Print hello world');
+    const chunks = [];
+    for await (const chunk of streamer) {
+      chunks.push(chunk);
+      if (chunks.length >= 5) {
+        break;
+      }
+    }
+    assert.equal(chunks.length, 5);
   });
 });


### PR DESCRIPTION
## Detais:
- Fix the error that occurs when `LLMPipeline.stream()` is broken.
- Fix eslint errors
- Added tests for `LLMPipeline.stream()`
## Tasks:
- CVS-168626