### PR TITLE
[llm_bench] Remove unused processor for genAI vlm pipeline

### DIFF
--- a/tools/llm_bench/llm_bench_utils/ov_utils.py
+++ b/tools/llm_bench/llm_bench_utils/ov_utils.py
@@ -595,8 +595,6 @@ def create_genai_image_text_gen_model(model_path, device, ov_config, memory_moni
     if not (model_path / "openvino_tokenizer.xml").exists() or not (model_path / "openvino_detokenizer.xml").exists():
         convert_ov_tokenizer(model_path)
 
-    processor_config = get_vlm_processor(model_path)
-
     cb_config = kwargs.get("cb_config")
     if cb_config is not None:
         ov_config["scheduler_config"] = get_scheduler_config_genai(cb_config)
@@ -612,7 +610,7 @@ def create_genai_image_text_gen_model(model_path, device, ov_config, memory_moni
         memory_monitor.log_data('for compilation phase')
     log.info(f'Pipeline initialization time: {end - start:.2f}s')
 
-    return llm_pipe, processor_config, end - start, None, True
+    return llm_pipe, None, end - start, None, True
 
 
 def create_genai_text_embed_model(model_path, device, memory_monitor, **kwargs):


### PR DESCRIPTION
Fix was caused by failing of run phi-3.5-vision-instruct and phi-4-multimodal-instruct with GenAI, but anyway processor config is not used in case of GenAI.

Note:
Converted to IR format versions of these models from hf master will still fails in runs via optimum.
Why runs are fails ?
Converted to IR format versions of phi-3.5-vision-instruct and phi-4-multimodal-instruct models from hf master includes chat_template.json/chat_template.jinja ,  AutoTokenizer take into account chat_template as extra processor config args, but processing_phi3_v.py/processing_phi4mm.py is not allows to do that. 
How these models can be run with optimum ?
1. phi-3.5 - take converted model from OpenVINO repo on hf: https://huggingface.co/OpenVINO/Phi-3.5-vision-instruct-fp16-ov
2. convert model based on special revision, where processing.py files was updated, it is `--revision  refs/pr/78` for phi-3.5 and `--revision  refs/pr/35` for phi-3.5