### PR TITLE
Fixed VLMpipeline sample failure on NPU

### DIFF
--- a/samples/cpp/visual_language_chat/visual_language_chat.cpp
+++ b/samples/cpp/visual_language_chat/visual_language_chat.cpp
@@ -32,7 +32,11 @@ int main(int argc, char* argv[]) try {
 
     std::string prompt;
 
-    pipe.start_chat();
+    if (device != "NPU") {
+        // Start the chat session only for CPU and GPU.
+        // NPU does not support chat mode.
+        pipe.start_chat();
+    }
     std::cout << "question:\n";
 
     std::getline(std::cin, prompt);

--- a/samples/cpp/visual_language_chat/visual_language_chat.cpp
+++ b/samples/cpp/visual_language_chat/visual_language_chat.cpp
@@ -43,9 +43,16 @@ int main(int argc, char* argv[]) try {
     std::cout << "\n----------\n"
         "question:\n";
     while (std::getline(std::cin, prompt)) {
-        pipe.generate(prompt,
-                      ov::genai::generation_config(generation_config),
-                      ov::genai::streamer(print_subword));
+        if (device == "NPU") {
+            pipe.generate(prompt,
+                          ov::genai::images(rgbs),
+                          ov::genai::generation_config(generation_config),
+                          ov::genai::streamer(print_subword));
+        } else {
+            pipe.generate(prompt,
+                          ov::genai::generation_config(generation_config),
+                          ov::genai::streamer(print_subword));
+        }
         std::cout << "\n----------\n"
             "question:\n";
     }

--- a/samples/python/visual_language_chat/visual_language_chat.py
+++ b/samples/python/visual_language_chat/visual_language_chat.py
@@ -79,7 +79,10 @@ def main():
                 "question:\n")
         except EOFError:
             break
-        pipe.generate(prompt, generation_config=config, streamer=streamer)
+        if args.device == "NPU":
+            pipe.generate(prompt, images=rgbs, generation_config=config, streamer=streamer)
+        else:
+            pipe.generate(prompt, generation_config=config, streamer=streamer)
     pipe.finish_chat()
 
 

--- a/samples/python/visual_language_chat/visual_language_chat.py
+++ b/samples/python/visual_language_chat/visual_language_chat.py
@@ -69,7 +69,10 @@ def main():
     config = openvino_genai.GenerationConfig()
     config.max_new_tokens = 100
 
-    pipe.start_chat()
+    if args.device != "NPU":
+        # Start the chat session only for CPU and GPU.
+        # NPU does not support chat mode.
+        pipe.start_chat()
     prompt = input('question:\n')
     pipe.generate(prompt, images=rgbs, generation_config=config, streamer=streamer)
 


### PR DESCRIPTION
Fixed issues when running VLMpipeline sample on NPU.
When run on NPU, it will provide image tensor even it already processes it to avoid below issue. 

```sh
Check 'rgbs.size() == 1u' failed at C:\Jenkins\workspace\private-ci\ie\build-windows-vs2022\b\repos\openvino.genai\src\cpp\src\visual_language\pipeline.cpp:179:
Currently only batch size equal to 1 is supported for NPU device!
```