### PR TITLE
[llm_bench] Add apply_chat_template for LLM

### DIFF
--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -194,6 +194,9 @@ def get_argprser():
     parser.add_argument("--embedding_normalize", action="store_true", help="Normalize embeddings. Applicable only for text embeddings")
     parser.add_argument("--embedding_max_length", type=int, default=None,
                         help="Max length for text embeddings. Input text will be padded or truncated to specified value")
+    parser.add_argument("--apply_chat_template", action="store_true",
+                        help="Apply chat template for LLM. By default chat template is not applied. It's better to use with --disable_prompt_permutation, \
+                              otherwise the prompt will be modified after applying the chat template, so the structure of chat template will not be kept.")
     return parser.parse_args()
 
 

--- a/tools/llm_bench/llm_bench_utils/model_utils.py
+++ b/tools/llm_bench/llm_bench_utils/model_utils.py
@@ -135,6 +135,7 @@ def analyze_args(args):
     model_args['emb_pooling_type'] = args.embedding_pooling
     model_args['emb_normalize'] = args.embedding_normalize
     model_args["emb_max_length"] = args.embedding_max_length
+    model_args["apply_chat_template"] = args.apply_chat_template
 
     optimum = args.optimum
 


### PR DESCRIPTION
[CVS-169182](https://jira.devtools.intel.com/browse/CVS-169182)

example of usage:
python ../tools/llm_bench/benchmark.py -m ./TinyLlama-1.1B-Chat-v1.0-int8-ov/ --disable_prompt_permutation  --apply_chat_template

By default chat template is not used as before. For GenAI cases it is better to use --apply_chat_template with disable_prompt_permutation  , otherwise after applying chat template prompt will be tokenized and mixed and chat template will not make sense