### PR TITLE
[VLM] Fix disabling `apply_chat_template` in generation config

### DIFF
--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -194,7 +194,7 @@ public:
                 image_sequence[idx] -= m_image_id;
             }
         }
-        else if (generation_config.apply_chat_template) {
+        else {
             m_inputs_embedder->set_apply_chat_template_status(generation_config.apply_chat_template);
         }
 


### PR DESCRIPTION
The issue is related to VLM pipeline.
If user set `apply_chat_template=False` in `.generate()` method, it will not take effect (as flag was not switched to false) and chat template still will be applied.
