### PR TITLE
Fix Generated tokens in sd debug metrics

### DIFF
--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -107,7 +107,6 @@ GenerationHandle
 ContinuousBatchingPipeline::SpeculativeDecodingImpl::add_request(uint64_t request_id,
                                                                  const ov::Tensor& input_ids,
                                                                  ov::genai::GenerationConfig sampling_params) {
-    m_sd_metrics.set_generated_len(request_id, sampling_params.get_max_new_tokens(input_ids.get_size()));
     std::lock_guard<std::mutex> lock(m_draft_generations_mutex);
     auto draft_sampling_params = sampling_params;
     draft_sampling_params.ignore_eos = true;
@@ -120,7 +119,6 @@ GenerationHandle
 ContinuousBatchingPipeline::SpeculativeDecodingImpl::add_request(uint64_t request_id,
                                                                  const std::string& prompt,
                                                                  ov::genai::GenerationConfig sampling_params) {
-    m_sd_metrics.set_generated_len(request_id, sampling_params.get_max_new_tokens(prompt.length()));
     std::lock_guard<std::mutex> lock(m_draft_generations_mutex);
     auto draft_sampling_params = sampling_params;
     draft_sampling_params.ignore_eos = true;
@@ -198,8 +196,10 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
             m_draft_generations.erase(request_id);
         }
         auto updated_seq_info = update_sequence_info[request_id];
+        m_sd_metrics.update_draft_generated_len(request_id, updated_seq_info.inserted_tokens_cnt);
+
         // several prompt phase
-        if (updated_seq_info.inserted_tokens_cnt == 0) {
+        if (updated_seq_info.inserted_tokens_cnt == 0 || main_generated_requests.empty()) {
             continue;
         }
         float acceptance_rate = 1 - static_cast<float>(updated_seq_info.removed_tokens_cnt) / updated_seq_info.inserted_tokens_cnt;
@@ -223,6 +223,7 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
         main_raw_perf_counters.m_durations.push_back(MicroSeconds(main_model_gen_duration));
         main_raw_perf_counters.m_inference_durations[0] = MicroSeconds(m_main_pipeline_metrics.inference_duration);
         main_raw_perf_counters.m_batch_sizes.push_back(num_generated_tokens); // or should be processed + generated
+        m_sd_metrics.update_generated_len(num_generated_tokens);
     }
 
     if (main_generated_requests.empty() && utils::env_setup_for_print_debug_info()) {
@@ -261,7 +262,6 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
 
     std::vector<GenerationHandle> main_generations;
     for (size_t request_id = 0; request_id < input_ids.size(); ++request_id) {
-        m_sd_metrics.set_generated_len(request_id, sampling_params[request_id].get_max_new_tokens(input_ids[request_id].get_size()));
         OPENVINO_ASSERT(1 == input_ids[request_id].get_shape().at(0), "Use multiple tensors to pass a batch.");
         main_generations.push_back(m_main_pipeline->add_request(request_id, input_ids[request_id], sampling_params[request_id]));
 

--- a/src/cpp/src/speculative_decoding/speculative_decoding_metrics.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_metrics.cpp
@@ -59,15 +59,15 @@ float SpeculativeDecodingMetrics::get_draft_accepted_tokens_percentage(int64_t r
         size_t total_iteration_cnt = 0;
         for (const auto& accepten_token_cnt : m_draft_accepted_tokens) {
             avg_acceptance_rate += accepten_token_cnt.second;
-            total_iteration_cnt += m_generated_len[request_id];
+            total_iteration_cnt += m_draft_generated_len[request_id];
         }
         OPENVINO_ASSERT(total_iteration_cnt > 0);
         avg_acceptance_rate /= total_iteration_cnt;
     } else {
         OPENVINO_ASSERT(m_draft_accepted_tokens.count(request_id));
         avg_acceptance_rate = m_draft_accepted_tokens[request_id];
-        OPENVINO_ASSERT(m_generated_len[request_id] > 0);
-        avg_acceptance_rate /= m_generated_len[request_id];
+        OPENVINO_ASSERT(m_draft_generated_len[request_id] > 0);
+        avg_acceptance_rate /= m_draft_generated_len[request_id];
     }
     return avg_acceptance_rate * 100;
 }
@@ -88,24 +88,24 @@ size_t SpeculativeDecodingMetrics::get_draft_accepted_tokens_counter(int64_t req
 }
 
 void SpeculativeDecodingMetrics::update_draft_accepted_tokens(int64_t request_id, size_t num_matches) {
-    if (m_draft_accepted_tokens.count(request_id)) {
-        m_draft_accepted_tokens[request_id] += num_matches;
-    } else {
-        m_draft_accepted_tokens.insert({request_id, num_matches});
-    }
+    m_draft_accepted_tokens[request_id] += num_matches;
 }
 
-void SpeculativeDecodingMetrics::set_generated_len(int64_t request_id, size_t generated_len) {
-    m_generated_len.insert({ request_id, generated_len });
+void SpeculativeDecodingMetrics::update_draft_generated_len(int64_t request_id, size_t generated_len) {
+    m_draft_generated_len[request_id] += generated_len;
 }
 
-size_t SpeculativeDecodingMetrics::get_generated_len(int64_t request_id) {
-    return m_generated_len.at(request_id);
+size_t SpeculativeDecodingMetrics::get_draft_generated_len(int64_t request_id) {
+    return m_draft_generated_len.at(request_id);
+}
+
+void SpeculativeDecodingMetrics::update_generated_len(size_t generated_len) {
+    m_generated_len += generated_len;
 }
 
 std::vector<int64_t> SpeculativeDecodingMetrics::get_requests_id() {
     std::vector<int64_t> result;
-    for (const auto& req : m_generated_len) {
+    for (const auto& req : m_draft_generated_len) {
         result.push_back(req.first);
     }
     return result;
@@ -126,21 +126,21 @@ void SpeculativeDecodingMetrics::print(bool is_printing_per_request) {
         total_duration = draft_duration + main_duration;
     }
     std::cout << "\n=============================== " << std::endl;
+    std::cout << "Generated tokens: " << m_generated_len << std::endl;
     std::cout << "Total duration, sec: " << total_duration << std::endl;
     std::cout << "Draft model duration, sec: " << draft_duration << std::endl;
     std::cout << "Main model duration, sec: " << main_duration << std::endl;
     std::cout << "Draft model duration, %: " << get_draft_duration_percentage() << std::endl;
     std::cout << "Main model duration, %: " << get_main_duration_percentage() << std::endl;
+    std::cout << "Token per sec: " << float(m_generated_len) / total_duration << std::endl;
     std::cout << "AVG acceptance rate, %: " << get_avg_acceptance_rate(-1) << std::endl;
     std::cout << "=============================== " << std::endl;
     if (is_printing_per_request) {
         for (const auto& i : get_requests_id()) {
             std::cout << "REQUEST_ID: " << i << std::endl;
             std::cout << "Main model iterations: " << get_iteration_number(i) << std::endl;
-            std::cout << "Token per sec: " << float(get_generated_len(i)) / total_duration << std::endl;
             std::cout << "AVG acceptance rate, %: " << get_avg_acceptance_rate(i) << std::endl;
-            std::cout << "Accepted tokens by draft model: " << get_draft_accepted_tokens_counter(i) << std::endl;
-            std::cout << "Generated tokens: " << get_generated_len(i) << std::endl;
+            std::cout << "Generated tokens by draft model: " << get_draft_generated_len(i) << std::endl;
             std::cout << "Accepted token rate, %: " << get_draft_accepted_tokens_percentage(i) << std::endl;
             std::cout << "=============================== " << std::endl;
         }
@@ -152,7 +152,8 @@ void SpeculativeDecodingMetrics::print(bool is_printing_per_request) {
 void SpeculativeDecodingMetrics::clean_up() {
     m_acceptance_rate.clear();
     m_draft_accepted_tokens.clear();
-    m_generated_len.clear();
+    m_draft_generated_len.clear();
+    m_generated_len = 0;
     draft_duration = 0;
     main_duration = 0;
     total_duration = 0;

--- a/src/cpp/src/speculative_decoding/speculative_decoding_metrics.hpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_metrics.hpp
@@ -15,10 +15,11 @@ class SpeculativeDecodingMetrics {
     std::map<int64_t, AcceptanceRate> m_acceptance_rate;
 
     std::map<int64_t, size_t> m_draft_accepted_tokens;
-    std::map<int64_t, size_t> m_generated_len;
+    std::map<int64_t, size_t> m_draft_generated_len;
 
 public:
     float draft_duration = 0, main_duration = 0, total_duration = 0;
+    size_t m_generated_len = 0;
 
     float get_avg_acceptance_rate(int64_t request_id);
     void update_acceptance_rate(int64_t request_id, float acceptance_rate);
@@ -27,8 +28,9 @@ public:
     size_t get_draft_accepted_tokens_counter(int64_t request_id);
     void update_draft_accepted_tokens(int64_t request_id, size_t num_matches);
 
-    void set_generated_len(int64_t request_id, size_t generated_len);
-    size_t get_generated_len(int64_t request_id);
+    void update_draft_generated_len(int64_t request_id, size_t generated_len);
+    void update_generated_len(size_t generated_len);
+    size_t get_draft_generated_len(int64_t request_id);
 
     size_t get_iteration_number(int64_t request_id);
 


### PR DESCRIPTION
[CVS-167754](https://jira.devtools.intel.com/browse/CVS-167754)

removed `Generated tokens` per requests, as we can't keep accurate numbers for last step, when requests for main model have removed
added common `Generated tokens` 
added `generated token by draft model`