### PR TITLE
[llm_bench] Add possibility to find stablelm model by model_type

### DIFF
--- a/tools/llm_bench/llm_bench_utils/config_class.py
+++ b/tools/llm_bench/llm_bench_utils/config_class.py
@@ -100,6 +100,7 @@ USE_CASES = {
         'opt-',
         'pythia-',
         'stablelm-',
+        'stablelm',
         'stable-zephyr-',
         'rocket-',
         'blenderbot',


### PR DESCRIPTION
[CVS-170990](https://jira.devtools.intel.com/browse/CVS-170990)

fix `no use_case found`:
use_cases can be extracted by path or by config.json for text gen models, path doesn't always include the model name and model_type includes only `stablelm`