### PR TITLE
[CI][GHA]Fix RAG sample pytest import error

### DIFF
--- a/tests/python_tests/samples/test_rag_sample.py
+++ b/tests/python_tests/samples/test_rag_sample.py
@@ -10,7 +10,7 @@ from test_utils import run_sample
 
 
 class TestTextEmbeddingPipeline:
-    @pytest.mark.rag
+    #@pytest.mark.rag
     @pytest.mark.samples
     @pytest.mark.parametrize("convert_model", ["bge-small-en-v1.5"], indirect=True)
     def test_sample_text_embedding_pipeline(self, convert_model):
@@ -35,7 +35,7 @@ class TestTextEmbeddingPipeline:
 
 
 class TestTextRerankPipeline:
-    @pytest.mark.rag
+    #@pytest.mark.rag
     @pytest.mark.samples
     @pytest.mark.parametrize("convert_model", ["ms-marco-TinyBERT-L2-v2"], indirect=True)
     def test_sample_text_rerank_pipeline(self, convert_model):

--- a/tests/python_tests/samples/test_rag_sample.py
+++ b/tests/python_tests/samples/test_rag_sample.py
@@ -10,7 +10,7 @@ from test_utils import run_sample
 
 
 class TestTextEmbeddingPipeline:
-    #@pytest.mark.rag
+    @pytest.mark.rag
     @pytest.mark.samples
     @pytest.mark.parametrize("convert_model", ["bge-small-en-v1.5"], indirect=True)
     def test_sample_text_embedding_pipeline(self, convert_model):
@@ -35,7 +35,7 @@ class TestTextEmbeddingPipeline:
 
 
 class TestTextRerankPipeline:
-    #@pytest.mark.rag
+    @pytest.mark.rag
     @pytest.mark.samples
     @pytest.mark.parametrize("convert_model", ["ms-marco-TinyBERT-L2-v2"], indirect=True)
     def test_sample_text_rerank_pipeline(self, convert_model):


### PR DESCRIPTION
**Details**: 
After https://github.com/openvinotoolkit/openvino.genai/pull/2436 merged, there are two test_rag.py as follow:  
- [pytests/samples/test_rag.py](https://github.com/openvinotoolkit/openvino.genai/blob/master/tests/python_tests/samples/test_rag.py)
- [pytests/test_rag.py](https://github.com/openvinotoolkit/openvino.genai/blob/master/tests/python_tests/test_rag.py)
 
Which introduced following issue in CI precommit test locally: 
```
__________________________ERROR collecting test_rag.py__________________________
import file mismatch:
imported module 'test_rag' has this __file__ attribute:
  C:\xsun\openvino.genai\tests\python_tests\samples\test_rag.py
which is not the same as the test file we want to collect:
  C:\xsun\openvino.genai\tests\python_tests\test_rag.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```
This PR aim to rename `pytests/samples/test_rag.py` to `pytests/samples/test_rag_sample.py` to avoid ambiguous name conflict with [pytests/test_rag.py](https://github.com/openvinotoolkit/openvino.genai/blob/master/tests/python_tests/test_rag.py), therefore fix the pytest import issue in CI precommit test.