### PR TITLE
Creating image generation pipeline type from another type fix

### DIFF
--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -242,8 +242,25 @@ public:
         OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
             pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
 
+        m_root_dir = pipe.m_root_dir;
+        const std::filesystem::path model_index_path = m_root_dir / "model_index.json";
+        std::ifstream file(model_index_path);
+        OPENVINO_ASSERT(file.is_open(), "Failed to open ", model_index_path);
+
+        nlohmann::json data = nlohmann::json::parse(file);
+        using utils::read_json_param;
+
+        set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
+
+        m_clip_text_encoder = std::make_shared<CLIPTextModel>(*pipe.m_clip_text_encoder);
+        m_t5_text_encoder = std::make_shared<T5EncoderModel>(*pipe.m_t5_text_encoder);
+        m_vae = std::make_shared<AutoencoderKL>(*pipe.m_vae);
+        m_transformer = std::make_shared<FluxTransformer2DModel>(*pipe.m_transformer);
+
         m_pipeline_type = pipeline_type;
         initialize_generation_config("FluxPipeline");
+
+        OPENVINO_ASSERT(!is_inpainting_model(), "inpainting model is not currently supported by Flux InpaintingPipeline. Please, contact OpenVINO GenAI developers.");
     }
 
     void reshape(const int num_images_per_prompt,

--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -243,14 +243,6 @@ public:
             pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
 
         m_root_dir = pipe.m_root_dir;
-        const std::filesystem::path model_index_path = m_root_dir / "model_index.json";
-        std::ifstream file(model_index_path);
-        OPENVINO_ASSERT(file.is_open(), "Failed to open ", model_index_path);
-
-        nlohmann::json data = nlohmann::json::parse(file);
-        using utils::read_json_param;
-
-        set_scheduler(Scheduler::from_config(m_root_dir / "scheduler/scheduler_config.json"));
 
         m_clip_text_encoder = std::make_shared<CLIPTextModel>(*pipe.m_clip_text_encoder);
         m_t5_text_encoder = std::make_shared<T5EncoderModel>(*pipe.m_t5_text_encoder);

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -219,6 +219,19 @@ public:
         OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
             pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
 
+        m_root_dir = pipe.m_root_dir;
+
+        if (pipe.m_t5_text_encoder) {
+            m_t5_text_encoder = std::make_shared<T5EncoderModel>(*pipe.m_t5_text_encoder);
+        }
+
+        m_clip_text_encoder_1 = std::make_shared<CLIPTextModelWithProjection>(*pipe.m_clip_text_encoder_1);
+        m_clip_text_encoder_2 = std::make_shared<CLIPTextModelWithProjection>(*pipe.m_clip_text_encoder_2);
+        m_transformer = std::make_shared<SD3Transformer2DModel>(*pipe.m_transformer);
+        m_vae = std::make_shared<AutoencoderKL>(*pipe.m_vae);
+
+        // initialize generation config
+
         m_pipeline_type = pipeline_type;
         initialize_generation_config("StableDiffusion3Pipeline");
     }

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -138,6 +138,12 @@ public:
         OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
             pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
 
+        m_root_dir = pipe.m_root_dir;
+
+        m_clip_text_encoder = std::make_shared<CLIPTextModel>(*pipe.m_clip_text_encoder);
+        m_unet = std::make_shared<UNet2DConditionModel>(*pipe.m_unet);
+        m_vae = std::make_shared<AutoencoderKL>(*pipe.m_vae);
+
         m_pipeline_type = pipeline_type;
 
         const bool is_lcm = m_unet->get_config().time_cond_proj_dim > 0;

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -159,6 +159,13 @@ public:
         OPENVINO_ASSERT(!pipe.is_inpainting_model(), "Cannot create ",
             pipeline_type == PipelineType::TEXT_2_IMAGE ? "'Text2ImagePipeline'" : "'Image2ImagePipeline'", " from InpaintingPipeline with inpainting model");
 
+        m_root_dir = pipe.m_root_dir;
+
+        m_clip_text_encoder = std::make_shared<CLIPTextModel>(*pipe.m_clip_text_encoder);
+        m_clip_text_encoder_with_projection = std::make_shared<CLIPTextModelWithProjection>(*pipe.m_clip_text_encoder_with_projection);
+        m_unet = std::make_shared<UNet2DConditionModel>(*pipe.m_unet);
+        m_vae = std::make_shared<AutoencoderKL>(*pipe.m_vae);
+
         m_pipeline_type = pipeline_type;
         initialize_generation_config("StableDiffusionXLPipeline");
     }


### PR DESCRIPTION
There was no support for that after compilation

Example usage:
```
    ov::genai::Image2ImagePipeline pipe(models_path);
    pipe.compile(device, ov::AnyMap{});
    ov::genai::Text2ImagePipeline new_pipe(pipe);
    auto cloned_new_pipe = new_pipe.clone();
    ov::Tensor image = cloned_new_pipe.generate(prompt,
        ov::genai::width(512),
        ov::genai::height(512),
        ov::genai::num_inference_steps(3),
        ov::genai::num_images_per_prompt(1),
        ov::genai::callback(progress_bar));
```