### PR TITLE
Add thread control and verbose performance stats to chat_sample.py

### DIFF
--- a/samples/python/text_generation/chat_sample.py
+++ b/samples/python/text_generation/chat_sample.py
@@ -3,36 +3,99 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import time
+
 import openvino_genai
 
 
 def streamer(subword):
-    print(subword, end='', flush=True)
+    print(subword, end="", flush=True)
     # Return flag corresponds whether generation should be stopped.
     return openvino_genai.StreamingStatus.RUNNING
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('model_dir', help='Path to the model directory')
-    parser.add_argument('device', nargs='?', default='CPU', help='Device to run the model on (default: CPU)')
+    parser.add_argument("model_dir", help="Path to the model directory")
+    parser.add_argument(
+        "device",
+        nargs="?",
+        default="CPU",
+        help="Device to run the model on (default: CPU)",
+    )
+    parser.add_argument(
+        "-mt",
+        "--max_new_tokens",
+        type=int,
+        default=100,
+        help="Maximum number of new tokens to generate (default: 100)",
+    )
+    parser.add_argument(
+        "-t",
+        "--num_threads",
+        type=int,
+        default=None,
+        help="Number of threads to use for inference (CPU only, ignored for GPU/NPU)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Display performance stats after each generation",
+    )
     args = parser.parse_args()
 
     device = args.device
-    pipe = openvino_genai.LLMPipeline(args.model_dir, device)
+
+    # Configure properties for the pipeline
+    properties = {}
+    # Only apply thread count for CPU devices
+    if device.upper() == "CPU" and args.num_threads is not None:
+        properties["INFERENCE_NUM_THREADS"] = args.num_threads
+
+    pipe = openvino_genai.LLMPipeline(args.model_dir, device, **properties)
 
     config = openvino_genai.GenerationConfig()
-    config.max_new_tokens = 100
+
+    config.max_new_tokens = args.max_new_tokens
 
     pipe.start_chat()
     while True:
         try:
-            prompt = input('question:\n')
+            prompt = input("question:\n")
         except EOFError:
             break
-        pipe.generate(prompt, config, streamer)
-        print('\n----------')
+
+        # Track generation time if verbose mode is enabled
+        if args.verbose:
+            start_time = time.time()
+            # Pass prompt as a list to get DecodedResults with performance metrics
+            result = pipe.generate([prompt], config, streamer)
+            end_time = time.time()
+
+            generation_time = end_time - start_time
+
+            # Get accurate token count and performance metrics
+            perf_metrics = result.perf_metrics
+            tokens_generated = perf_metrics.get_num_generated_tokens()
+            ttft = perf_metrics.get_ttft().mean  # Time to first token
+            tpot = perf_metrics.get_tpot().mean  # Time per output token
+            throughput = perf_metrics.get_throughput().mean  # Tokens per second
+
+            print(f"\n----------")
+            print(f"Performance Stats:")
+            print(f"  Generation time: {generation_time:.2f} seconds")
+            print(f"  Tokens generated: {tokens_generated}")
+            print(f"  Time to first token (TTFT): {ttft:.2f} ms")
+            print(f"  Time per output token (TPOT): {tpot:.2f} ms")
+            print(f"  Throughput: {throughput:.2f} tokens/s")
+            print(f"----------")
+        else:
+            pipe.generate(prompt, config, streamer)
+            print("\n----------")
+
     pipe.finish_chat()
 
 
-if '__main__' == __name__:
+if "__main__" == __name__:
     main()


### PR DESCRIPTION
Hi OpenVINO team,

This makes it easier to get a quick sense of performance for chat applications, similar to llama-cli.

- Add -t/--num_threads argument for CPU thread control (CPU only)
- Add -v/--verbose flag to display performance statistics
- Implement accurate token counting using perf_metrics
- Add TTFT, TPOT, and throughput measurements
- Display warning when thread count is specified for non-CPU devices