### PR TITLE
Downgrade transformers

### DIFF
--- a/samples/export-requirements.txt
+++ b/samples/export-requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 openvino-tokenizers[transformers]~=2025.3.0.0.dev
-optimum-intel[nncf] @ git+https://github.com/huggingface/optimum-intel.git@3fe7559101d3ba85ac597fe5d7ee5c7669397d7c
+optimum-intel[nncf]==1.25.1
 numpy==1.26.4; platform_system == "Darwin" and platform_machine == "x86_64"
 safetensors==0.5.3; platform_system == "Darwin" and platform_machine == "x86_64"
 einops==0.8.1  # For Qwen
@@ -11,7 +11,7 @@ timm==1.0.19  # For exporting InternVL2
 # torchvision for visual language models
 torchvision==0.17.2; platform_system == "Darwin" and platform_machine == "x86_64"
 torchvision==0.23.0; platform_system != "Darwin" or platform_machine != "x86_64"
-transformers==4.52.4 # For Whisper
+transformers==4.51.3 # For Whisper
 hf_transfer==0.1.9  # for faster models download, should used with env var HF_HUB_ENABLE_HF_TRANSFER=1
 backoff==2.2.1  # for microsoft/Phi-3.5-vision-instruct
 peft==0.17.0  # For microsoft/Phi-4-multimodal-instruct

--- a/tests/python_tests/requirements.txt
+++ b/tests/python_tests/requirements.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 diffusers==0.34.0
-optimum-intel @ git+https://github.com/huggingface/optimum-intel.git@3fe7559101d3ba85ac597fe5d7ee5c7669397d7c  # latest
+optimum-intel==1.25.1
 numpy==1.26.4; platform_system == "Darwin" and platform_machine == "x86_64"
 safetensors==0.5.3; platform_system == "Darwin" and platform_machine == "x86_64"
 pytest==8.4.1
-transformers==4.52.4
+transformers==4.51.3
 hf_transfer==0.1.9
 gguf==0.17.1
 


### PR DESCRIPTION
MiniCPM-V-2_6 should work with 4.51.3 as mentioned in ticket 170987. Since we do not use the latest transformers allowed by the latest optimum-intel, optimum-intel can be used from PyPI