### PR TITLE
Log only if there is error

### DIFF
--- a/.github/actions/install_wheel/dist/index.js
+++ b/.github/actions/install_wheel/dist/index.js
@@ -35845,8 +35845,12 @@ async function installPackages(packages, localWheelDir, requirementsFiles) {
             stdio: 'inherit'
           }
         );
-        core.debug('stdout:', stdout);
-        core.error('stderr:', stderr);
+        if (stdout) {
+          core.debug('stdout:', stdout);
+        }
+        if (stderr) {
+          core.error('stderr:', stderr);
+        }
         break;
       } catch (error) {
         core.error(`Attempt ${attempt + 1} failed:`, error.message);

--- a/.github/actions/install_wheel/src/install_packages.js
+++ b/.github/actions/install_wheel/src/install_packages.js
@@ -77,8 +77,12 @@ async function installPackages(packages, localWheelDir, requirementsFiles) {
             stdio: 'inherit'
           }
         );
-        core.debug('stdout:', stdout);
-        core.error('stderr:', stderr);
+        if (stdout) {
+          core.debug('stdout:', stdout);
+        }
+        if (stderr) {
+          core.error('stderr:', stderr);
+        }
         break;
       } catch (error) {
         core.error(`Attempt ${attempt + 1} failed:`, error.message);


### PR DESCRIPTION
We now have "Error: stderr:" written in red which makes me think it crushed. Example https://github.com/openvinotoolkit/openvino.genai/actions/runs/16871994277/job/47789721463?pr=2583