### PR TITLE
Fix SnapKV scoring

### DIFF
--- a/src/cpp/include/openvino/genai/cache_eviction.hpp
+++ b/src/cpp/include/openvino/genai/cache_eviction.hpp
@@ -30,7 +30,6 @@ public:
         OPENVINO_ASSERT(start_size, "CacheEvictionConfig.start_size must be non-zero");
         OPENVINO_ASSERT(recent_size, "CacheEvictionConfig.recent_size must be non-zero");
         OPENVINO_ASSERT(max_cache_size, "CacheEvictionConfig.max_cache_size must be non-zero");
-        OPENVINO_ASSERT(snapkv_window_size, "CacheEvictionConfig.snapkv_window_size must be non-zero");
 
         OPENVINO_ASSERT(max_cache_size > (start_size + recent_size),
                         "CacheEvictionConfig.max_cache_size must be larger than CacheEvictionConfig.start_size + CacheEvictionConfig.recent_size");
@@ -73,7 +72,8 @@ public:
 
     /** The size of the importance score aggregation window (in token positions from the end of the prompt) for
      * computing initial importance scores at the beginning of the generation phase for purposes of eviction,
-     * following the SnapKV article approach (https://arxiv.org/abs/2404.14469). **/
+     * following the SnapKV article approach (https://arxiv.org/abs/2404.14469). Setting this to 0 disables the SnapKV
+     * score aggregation. **/
     size_t snapkv_window_size = 8;
 
 private:

--- a/src/cpp/src/continuous_batching/cache_eviction.hpp
+++ b/src/cpp/src/continuous_batching/cache_eviction.hpp
@@ -29,9 +29,17 @@ public:
      * @param num_decoder_layers Number of independent KV caches (each corresponding to a single attention layer) in the underlying LLM.
      * @param max_pool_window_size Window size for the max pooling step applied to the newly registered scores before aggregation.
      * @param aggregation_mode Aggregation mode for the scores across register calls.
-     * @param ignore_first_n_blocks Number of blocks from the beginning of the per-token score vector, the scores for which will be disregarded and never aggregated.
+     * @param ignore_first_n_blocks Number of blocks from the beginning of the per-token score vector, the scores for which will
+     * be disregarded and never aggregated.
+     * @param snapkv_window_size Window size for the SnapKV algorithm in effect. If non-zero, then by the start of the generation phase
+     * for the tracked sequence (when the total number of `num_snapkv_scores` passed to each `register_new_token_scores` call reaches
+     * the `snapkv_window_size`) the internal occurence counters will be:
+     * `| S | S | ... | S | S - 1 | S - 2 | ... | 2 | 1 |`,
+     * where `S` is equal to `snapkv_window_size`. In contrast, if this is set to 0, then the initial counter state would be
+     * `| L | L - 1 | ... | 2 | 1 |`,
+     * where L is the prompt size of the sequence in tokens.
      */
-    explicit EvictionScoreManager(size_t block_size, size_t num_decoder_layers, size_t max_pool_window_size, AggregationMode aggregation_mode, size_t ignore_first_n_blocks = 0) : m_block_size(block_size), m_num_decoder_layers(num_decoder_layers), m_scores(num_decoder_layers), m_cache_counter(num_decoder_layers), m_max_pool_window_size(max_pool_window_size), m_aggregation_mode(aggregation_mode), m_ignore_first_n_blocks(ignore_first_n_blocks) {}
+    explicit EvictionScoreManager(size_t block_size, size_t num_decoder_layers, size_t max_pool_window_size, AggregationMode aggregation_mode, size_t ignore_first_n_blocks = 0, size_t snapkv_window_size = 0) : m_block_size(block_size), m_num_decoder_layers(num_decoder_layers), m_scores(num_decoder_layers), m_cache_counter(num_decoder_layers), m_max_pool_window_size(max_pool_window_size), m_aggregation_mode(aggregation_mode), m_ignore_first_n_blocks(ignore_first_n_blocks), m_snapkv_window_size(snapkv_window_size), m_num_registered_snapkv_aggregated_scores(0) {}
 
     /**
      * Registers new token scores and aggregates them internally as necessary. The token scores provided may be corresponding not to all
@@ -42,8 +50,9 @@ public:
      * scores in a corresponding decoder layer.
      * @param skipped_logical_block_ids Logical block indices which had been skipped during inference call that produced the new scores, and
      * which are missing from the new scores.
+     * @param num_snapkv_scores Number of latest token scores that were aggregated together when computing the registered score. If SnapKV is not used, this should be set to 0.
      */
-    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_for_all_decoder_layers, const std::set<size_t>& skipped_logical_block_ids);
+    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_for_all_decoder_layers, const std::set<size_t>& skipped_logical_block_ids, size_t num_snapkv_scores = 0);
 
     /**
      * Removes the scores from tracking for given block indices and given decoder layer.
@@ -88,6 +97,22 @@ private:
     std::size_t m_max_pool_window_size;
     AggregationMode m_aggregation_mode;
     std::size_t m_ignore_first_n_blocks;
+    std::size_t m_snapkv_window_size;
+    std::size_t m_num_registered_snapkv_aggregated_scores;
+};
+
+class SnapKVScoreAggregationCalculator {
+public:
+    SnapKVScoreAggregationCalculator() = default;
+    SnapKVScoreAggregationCalculator(const SnapKVScoreAggregationCalculator& rhs) = default;
+    SnapKVScoreAggregationCalculator& operator=(const SnapKVScoreAggregationCalculator& rhs) = default;
+    SnapKVScoreAggregationCalculator(size_t snapkv_window_size) : m_snapkv_window_size(snapkv_window_size) {}
+
+    size_t get_num_token_scores_to_aggregate(size_t prompt_len, size_t num_scheduled_tokens, size_t num_processed_tokens);
+
+private:
+    size_t m_snapkv_window_size;
+
 };
 
 /**
@@ -160,10 +185,12 @@ public:
      * @param attention_scores_for_all_decoder_layers A vector with a size equal to the configured num_decoder_layers, where each entry is a
      * vector of per-token attention scores calculated within this layer.
      * @param skipped_logical_block_ids The set of logical indices that have been skipped from the scores as part of the sparse attention prefill process
+     * @param num_snapkv_scores The number of SnapKV-aggregated scores in this score chunk. Set to 0 if SnapKV is not used
+     * (i.e. eviction_config.snapkv_window_size == 0)
      */
-    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_for_all_decoder_layers, const std::set<size_t>& skipped_logical_block_ids);
+    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_for_all_decoder_layers, const std::set<size_t>& skipped_logical_block_ids, size_t num_snapkv_scores = 0);
 
-    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_across_decoder_layers_for_current_sequence);
+    void register_new_token_scores(const AttentionScoresForEachDecoderLayer& attention_scores_across_decoder_layers_for_current_sequence, size_t num_snapkv_scores = 0);
     /**
      * Returns the per-layer sets of logical block indices that should be evicted according to the internally computed importance scores
      * and removes the corresponding blocks from the internal algorithm tracking.

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -665,7 +665,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_maybe_evict_cache_bloc
 
         if (skip_set.empty()) {
             // For now, will only register token scores from the dense attention stages
-            cache_eviction_algo.register_new_token_scores(attention_scores_for_all_decoder_layers, skip_set);
+            cache_eviction_algo.register_new_token_scores(attention_scores_for_all_decoder_layers, skip_set, scheduler_output.m_score_aggregation_windows.at(seq_id));
         }
 
         auto seq_group_ptr_it = std::find_if(m_requests.begin(), m_requests.end(), [seq_id](const SequenceGroup::Ptr& val) { return val->has_sequence_with_id(seq_id); });

--- a/src/cpp/src/continuous_batching/scheduler.hpp
+++ b/src/cpp/src/continuous_batching/scheduler.hpp
@@ -15,6 +15,7 @@
 #include "continuous_batching/timer.hpp"
 #include "continuous_batching/sparse_attention.hpp"
 #include "utils.hpp"
+#include "continuous_batching/cache_eviction.hpp"
 
 namespace ov::genai {
 class Scheduler {
@@ -394,10 +395,7 @@ private:
                         // block tables for each running sequence within a group
                         scheduler_output.m_block_tables[seq_id] = m_block_manager->get_block_tables(seq_id);
 
-                        if (seq->get_generated_len() == 0) {
-                            // full prompt or its remaining tail part fit completely into the next inference
-                            scheduler_output.m_score_aggregation_windows[seq_id] = _schedule_scores_to_aggregate(sequence_group);
-                        }
+                        scheduler_output.m_score_aggregation_windows[seq_id] = _schedule_scores_to_aggregate(sequence_group);
                         scheduler_output.m_xattention_block_size = m_config.sparse_attention_config.xattention_block_size;
                         scheduler_output.m_xattention_stride = m_config.sparse_attention_config.xattention_stride;
                     }
@@ -585,22 +583,13 @@ private:
     }
 
     size_t _schedule_scores_to_aggregate(SequenceGroup::Ptr sequence_group) {
-        size_t prompt_len = sequence_group->get_prompt_len();
-        size_t first_scored_token_position = m_snapkv_window_size > prompt_len ? 0 : prompt_len - m_snapkv_window_size;
-        size_t num_scored_token_positions_in_this_chunk = 0;
-        size_t num_processed_tokens_before_this_chunk = sequence_group->get_num_processed_tokens();
-        size_t num_scheduled_tokens = sequence_group->get_num_scheduled_tokens();
-        size_t num_processed_tokens_after_this_chunk = num_processed_tokens_before_this_chunk + num_scheduled_tokens;
-        if (num_processed_tokens_after_this_chunk > first_scored_token_position) {
-            if (num_processed_tokens_before_this_chunk > first_scored_token_position) {
-                num_scored_token_positions_in_this_chunk = num_scheduled_tokens;
-            }
-            else {
-                num_scored_token_positions_in_this_chunk = num_processed_tokens_after_this_chunk - first_scored_token_position;
-            }
+        auto calculator = SnapKVScoreAggregationCalculator(m_snapkv_window_size);
 
-        }
-        return num_scored_token_positions_in_this_chunk;
+        size_t num_scheduled_tokens = sequence_group->get_num_scheduled_tokens();
+        size_t num_processed_tokens = sequence_group->get_num_processed_tokens();
+        size_t prompt_len = sequence_group->get_prompt_len();
+
+        return calculator.get_num_token_scores_to_aggregate(prompt_len, num_scheduled_tokens, num_processed_tokens);
     }
 
     float _schedule_xattention_threshold(SequenceGroup::Ptr sequence_group) {


### PR DESCRIPTION
Adds an option to disable SnapKV entirely and fixes token occurence counts in the SnapKV case. Also adds unit tests for the associated logic.