### PR TITLE
Add jinja2 in requirements for chat-template

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -16,3 +16,4 @@ timm
 tiktoken
 librosa # For Whisper
 matplotlib
+jinja2>=3.1.0

--- a/tools/who_what_benchmark/requirements.txt
+++ b/tools/who_what_benchmark/requirements.txt
@@ -11,3 +11,4 @@ datasets==3.6.0
 auto-gptq; sys_platform == "linux"
 autoawq<0.2.8; sys_platform == "linux"
 sentencepiece
+jinja2>=3.1.0


### PR DESCRIPTION
When chat-template is enabled, CI failed with the error message below:
```
..\..\tmp\llm_accuracy_venv\lib\site-packages\transformers\utils\chat_template_utils.py:458: in render_jinja_template
    compiled_template = _compile_jinja_template(chat_template)
..\..\tmp\llm_accuracy_venv\lib\site-packages\transformers\utils\chat_template_utils.py:418: in _compile_jinja_template
    raise ImportError(
E   ImportError: apply_chat_template requires jinja2>=3.1.0 to be installed. Your version is 3.0.1.
```