### PR TITLE
Keep original chat template for OVMS

### DIFF
--- a/src/cpp/include/openvino/genai/tokenizer.hpp
+++ b/src/cpp/include/openvino/genai/tokenizer.hpp
@@ -262,6 +262,7 @@ public:
 
     // get information about a chat template to check its status, for example whether it is empty
     std::string get_chat_template() const;
+    std::string get_original_chat_template() const;
 
     // information about <bos>, <eos> tokens should be public,
     // they are used at least in StreamerBase descendants


### PR DESCRIPTION
In python enabled version of OVMS we are not limited with chat template application. It does not make sense to load GGUF second time just to extract chat template but GenAI modifies chat template.