### PR TITLE
create signature property

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -39,6 +39,17 @@ extract_prompt_lookup_from_config(ov::AnyMap& config) {
     return res;
 }
 
+void
+add_model_path_to_transform_signature(ov::AnyMap& properties, const std::filesystem::path& models_path) {
+    std::string model_path_signature = std::filesystem::absolute(models_path).string();
+    std::string existing_signature = "";
+    auto signature_it = properties.find(ov::hint::model_transform_signature.name());
+    if (signature_it != properties.end()) {
+        existing_signature = signature_it->second.as<std::string>() + "_";
+    }
+    properties[ov::hint::model_transform_signature.name()] = existing_signature + model_path_signature;
+}
+
 float get_load_time(std::chrono::steady_clock::time_point start_time) {
     auto stop_time = std::chrono::steady_clock::now();
     return std::chrono::duration_cast<std::chrono::milliseconds>(stop_time - start_time).count();
@@ -55,6 +66,9 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
     auto properties_without_draft_model = properties;
     auto draft_model_desr = extract_draft_model_from_config(properties_without_draft_model);
     auto is_prompt_lookup_enabled = extract_prompt_lookup_from_config(properties_without_draft_model);
+
+    // Add models_path to model_transform_signature
+    add_model_path_to_transform_signature(properties_without_draft_model, models_path);
 
     auto model = utils::read_model(models_path, properties);
     auto [properties_without_draft_model_without_gguf, enable_save_ov_model] = utils::extract_gguf_properties(properties_without_draft_model);
@@ -94,6 +108,9 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(
     auto properties_without_draft_model = properties;
     auto draft_model_desr = extract_draft_model_from_config(properties_without_draft_model);
     auto is_prompt_lookup_enabled = extract_prompt_lookup_from_config(properties_without_draft_model);
+
+    // Add models_path to model_transform_signature
+    add_model_path_to_transform_signature(properties_without_draft_model, models_path);
 
     auto model = utils::read_model(models_path, properties_without_draft_model);
     auto [properties_without_draft_model_without_gguf, enable_save_ov_model] = utils::extract_gguf_properties(properties_without_draft_model);


### PR DESCRIPTION
There's a [new PR in openvino for model_transform_signature](https://github.com/openvinotoolkit/openvino/pull/31761), which can be used to accelerate model hash computation and thus model loading time. #2526 
This PR will create this property based on transformation done in ContinuousBatchingPipeline and supply to compile_model call.