### PR TITLE
[WWB] Remove use_flash_attention_2 argument for phi4mm

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -275,14 +275,13 @@ def load_visual_text_model(
                     model_id, trust_remote_code=trust_remote_code, device_map=device.lower()
                 )
             except ValueError:
-                from_pretrained_kwargs = {"_attn_implementation": "eager", "use_flash_attention_2": False}
                 if config.model_type == "phi4mm":
                     if "activation_checkpointing" in config.audio_processor["config"]:
                         config.audio_processor["config"]["activation_checkpointing"] = ""
-                    del from_pretrained_kwargs["_attn_implementation"]
-                    del from_pretrained_kwargs["use_flash_attention_2"]
                     config._attn_implementation = "sdpa"
-                    from_pretrained_kwargs["config"] = config
+                    from_pretrained_kwargs = {"config": config}
+                else:
+                    from_pretrained_kwargs = {"_attn_implementation": "eager", "use_flash_attention_2": False}
 
                 model = AutoModelForCausalLM.from_pretrained(
                     model_id,


### PR DESCRIPTION
### Reason for changes

After update to transformers 4.53 WWB on phi4 multimodal started to fail with:
```
TypeError: Phi4MMForCausalLM.__init__() got an unexpected keyword argument 'use_flash_attention_2'
```

In this PR this argument is removed for this model. SDPA implementation is manually set through config to "sdpa" anyway.