### PR TITLE
downgrade xgrammar version in master

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -59,7 +59,7 @@ if(ANDROID)
 endif()
 
 if(ENABLE_XGRAMMAR)
-    set(XGRAMMAR_VERSION v0.1.22)
+    set(XGRAMMAR_VERSION v0.1.18)
     set(XGRAMMAR_DIR ${CMAKE_BINARY_DIR}/xgrammar)
 
     FetchContent_Declare(


### PR DESCRIPTION
Cherry-pick of https://github.com/openvinotoolkit/openvino.genai/pull/2664/files

New version of xgrammar introduced perf regression. We don't use features of the newer versions. Let's downgrade version to have no performance loss.

Ticket: CVS-172605