### PR TITLE
[WWB] friendly error message for wrong model type

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -259,9 +259,13 @@ def load_tokenizer(args):
                 args.target_model, trust_remote_code=False
             )
         except Exception:
-            tokenizer = AutoTokenizer.from_pretrained(
-                args.target_model, trust_remote_code=True
-            )
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.target_model, trust_remote_code=True
+                )
+            except Exception:
+                logger.error(f"Cannot load the tokenizer for model type \"{args.model_type}\" from {args.target_model}")
+                raise
 
     return tokenizer
 


### PR DESCRIPTION
* If "text" model-type was chosen by mistake for image-to-text model, it generated error message that is difficult to understand.
* Improved the error message to be more friendly.