### PR TITLE
[OV JS} Add perfMetrics grammar getters & update docstrings

### DIFF
--- a/src/cpp/include/openvino/genai/perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/perf_metrics.hpp
@@ -87,7 +87,9 @@ struct OPENVINO_GENAI_EXPORTS SummaryStats {
  * @param get_num_input_tokens Returns the number of tokens in the input prompt.
  * @param get_ttft Returns the mean and standard deviation of TTFT.
  * @param get_tpot Returns the mean and standard deviation of TPOT.
+ * @param get_ipot Returns the mean and standard deviation of IPOT.
  * @param get_throughput Returns the mean and standard deviation of throughput.
+ * @param get_inference_duration Returns the mean and standard deviation of inference duration.
  * @param get_generate_duration Returns the mean and standard deviation of generate duration.
  * @param get_tokenization_duration Returns the mean and standard deviation of tokenization duration.
  * @param get_detokenization_duration Returns the mean and standard deviation of detokenization duration.
@@ -106,7 +108,9 @@ struct OPENVINO_GENAI_EXPORTS SummaryStats {
  * Cached mean and standard deviations.
  * @param ttft Mean and standard deviation of Time to the First Token (TTFT) in milliseconds.
  * @param tpot Mean and standard deviation of Time per Output Token (TPOT) in milliseconds per token.
+ * @param ipot Mean and standard deviation of Inference Time per Output Token (IPOT) in milliseconds per token.
  * @param throughput Mean and standard deviation of tokens per second.
+ * @param inference_duration Mean and standard deviation of the time spent on model inference during generate call in milliseconds.
  * @param generate_duration Mean and standard deviation of the total duration of generate calls in milliseconds.
  * @param tokenization_duration Mean and standard deviation of the tokenization duration in milliseconds.
  * @param detokenization_duration Mean and standard deviation of the detokenization duration in milliseconds.

--- a/src/js/include/helper.hpp
+++ b/src/js/include/helper.hpp
@@ -82,6 +82,18 @@ Napi::Value cpp_to_js<std::vector<double>, Napi::Value>(const Napi::Env& env, co
 
 template <>
 Napi::Value cpp_to_js<std::vector<size_t>, Napi::Value>(const Napi::Env& env, const std::vector<size_t> value);
-                                                                  
-bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num);
 
+/**
+ * @brief  Template function to convert C++ map into Javascript Object. Map key must be std::string.
+ * @tparam MapElementType C++ data type of map elements.
+ */
+template <typename MapElementType>
+Napi::Object cpp_map_to_js_object(const Napi::Env& env, const std::map<std::string, MapElementType>& map) {
+    Napi::Object obj = Napi::Object::New(env);
+    for (const auto& [k, v] : map) {
+        obj.Set(k, v);
+    }
+    return obj;
+}
+
+bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num);

--- a/src/js/include/perf_metrics.hpp
+++ b/src/js/include/perf_metrics.hpp
@@ -24,6 +24,9 @@ public:
     Napi::Value get_tokenization_duration(const Napi::CallbackInfo& info);
     Napi::Value get_detokenization_duration(const Napi::CallbackInfo& info);
 
+    Napi::Value get_grammar_compiler_init_times(const Napi::CallbackInfo& info);
+    Napi::Value get_grammar_compile_time(const Napi::CallbackInfo& info);
+
     Napi::Value get_raw_metrics(const Napi::CallbackInfo& info);
 
 private:

--- a/src/js/lib/pipelines/llmPipeline.ts
+++ b/src/js/lib/pipelines/llmPipeline.ts
@@ -47,25 +47,39 @@ export type RawMetrics = {
   grammarCompileTimes: number[];
 };
 
+/** Structure holding mean and standard deviation values. */
 export type MeanStdPair = {
   mean: number;
   std: number;
 };
 
+/** Structure holding summary of statistical values */
+export type SummaryStats = {
+  mean: number;
+  std: number;
+  min: number;
+  max: number;
+};
+
 /**
  * Holds performance metrics for each generate call.
  *
- * PerfMetrics holds fields with mean and standard deviations for the following metrics:
+ * PerfMetrics holds the following metrics with mean and standard deviations:
     - Time To the First Token (TTFT), ms
     - Time per Output Token (TPOT), ms/token
+    - Inference time per Output Token (IPOT), ms/token
     - Generate total duration, ms
+    - Inference duration, ms
     - Tokenization duration, ms
     - Detokenization duration, ms
     - Throughput, tokens/s
- * Additional fields include:
     - Load time, ms
     - Number of generated tokens
     - Number of tokens in the input prompt
+    - Time to initialize grammar compiler for each backend, ms
+    - Time to compile grammar, ms
+ * Preferable way to access metrics is via get functions. Getters calculate mean and std values from raw_metrics and return pairs.
+ * If mean and std were already calculated getters return cached values.
  */
 export interface PerfMetrics {
   /** Returns the load time in milliseconds. */
@@ -82,7 +96,7 @@ export interface PerfMetrics {
   getIPOT(): MeanStdPair;
   /** Returns the mean and standard deviation of throughput in tokens per second. */
   getThroughput(): MeanStdPair;
-  /** Returns the mean and standard deviation of inference durations in milliseconds. */
+  /** Returns the mean and standard deviation of the time spent on model inference during generate call in milliseconds. */
   getInferenceDuration(): MeanStdPair;
   /** Returns the mean and standard deviation of generate durations in milliseconds. */
   getGenerateDuration(): MeanStdPair;
@@ -90,6 +104,10 @@ export interface PerfMetrics {
   getTokenizationDuration(): MeanStdPair;
   /** Returns the mean and standard deviation of detokenization durations in milliseconds. */
   getDetokenizationDuration(): MeanStdPair;
+  /** Returns a map with the time to initialize the grammar compiler for each backend in milliseconds. */
+  getGrammarCompilerInitTimes(): { [key: string]: number };
+  /** Returns the mean, standard deviation, min, and max of grammar compile times in milliseconds. */
+  getGrammarCompileTime(): SummaryStats;
   /** A structure of RawPerfMetrics type that holds raw metrics. */
   rawMetrics: RawMetrics;
 }

--- a/src/js/src/perf_metrics.cpp
+++ b/src/js/src/perf_metrics.cpp
@@ -1,8 +1,8 @@
 #include "include/perf_metrics.hpp"
 
+#include "bindings_utils.hpp"
 #include "include/addon.hpp"
 #include "include/helper.hpp"
-#include "bindings_utils.hpp"
 
 using ov::genai::common_bindings::utils::get_ms;
 using ov::genai::common_bindings::utils::timestamp_to_ms;
@@ -27,6 +27,8 @@ Napi::Function PerfMetricsWrapper::get_class(Napi::Env env) {
             InstanceMethod("getGenerateDuration", &PerfMetricsWrapper::get_generate_duration),
             InstanceMethod("getTokenizationDuration", &PerfMetricsWrapper::get_tokenization_duration),
             InstanceMethod("getDetokenizationDuration", &PerfMetricsWrapper::get_detokenization_duration),
+            InstanceMethod("getGrammarCompilerInitTimes", &PerfMetricsWrapper::get_grammar_compiler_init_times),
+            InstanceMethod("getGrammarCompileTime", &PerfMetricsWrapper::get_grammar_compile_time),
             InstanceAccessor<&PerfMetricsWrapper::get_raw_metrics>("rawMetrics"),
         });
 }
@@ -59,6 +61,15 @@ Napi::Object create_mean_std_pair(Napi::Env env, const ov::genai::MeanStdPair& p
     Napi::Object obj = Napi::Object::New(env);
     obj.Set("mean", Napi::Number::New(env, pair.mean));
     obj.Set("std", Napi::Number::New(env, pair.std));
+    return obj;
+}
+
+Napi::Object create_summary_stats(Napi::Env env, const ov::genai::SummaryStats& stats) {
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("mean", Napi::Number::New(env, stats.mean));
+    obj.Set("std", Napi::Number::New(env, stats.std));
+    obj.Set("min", Napi::Number::New(env, stats.min));
+    obj.Set("max", Napi::Number::New(env, stats.max));
     return obj;
 }
 
@@ -96,6 +107,16 @@ Napi::Value PerfMetricsWrapper::get_tokenization_duration(const Napi::CallbackIn
     VALIDATE_ARGS_COUNT(info, 0, "getTokenizationDuration()");
     return create_mean_std_pair(info.Env(), _metrics.get_tokenization_duration());
 }
+
+Napi::Value PerfMetricsWrapper::get_grammar_compiler_init_times(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getGrammarCompilerInitTimes()");
+    return cpp_map_to_js_object(info.Env(), _metrics.get_grammar_compiler_init_times());
+}
+
+Napi::Value PerfMetricsWrapper::get_grammar_compile_time(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getGrammarCompileTime()");
+    return create_summary_stats(info.Env(), _metrics.get_grammar_compile_time());
+};
 
 Napi::Value PerfMetricsWrapper::get_detokenization_duration(const Napi::CallbackInfo& info) {
     VALIDATE_ARGS_COUNT(info, 0, "getDetokenizationDuration()");

--- a/src/js/tests/module.test.js
+++ b/src/js/tests/module.test.js
@@ -224,6 +224,13 @@ describe("LLMPipeline.generate()", () => {
     );
     assert.strictEqual(detokenizationDuration.std, 0);
 
+    assert.ok(typeof perfMetrics.getGrammarCompilerInitTimes() === "object");
+    const grammarCompileTime = perfMetrics.getGrammarCompileTime();
+    assert.ok(typeof grammarCompileTime.mean === "number");
+    assert.ok(typeof grammarCompileTime.std === "number");
+    assert.ok(typeof grammarCompileTime.min === "number");
+    assert.ok(typeof grammarCompileTime.max === "number");
+
     // assert that calculating statistics manually from the raw counters
     // we get the same restults as from PerfMetrics
     assert.strictEqual(
@@ -247,6 +254,7 @@ describe("LLMPipeline.generate()", () => {
     assert.ok(perfMetrics.rawMetrics.batchSizes.length > 0);
     assert.ok(perfMetrics.rawMetrics.durations.length > 0);
     assert.ok(perfMetrics.rawMetrics.inferenceDurations.length > 0);
+    assert.ok(perfMetrics.rawMetrics.grammarCompileTimes.length === 0);
   });
 });
 

--- a/src/python/py_perf_metrics.cpp
+++ b/src/python/py_perf_metrics.cpp
@@ -64,18 +64,22 @@ auto raw_perf_metrics_docstring = R"(
 auto perf_metrics_docstring = R"(
     Holds performance metrics for each generate call.
 
-    PerfMetrics holds fields with mean and standard deviations for the following metrics:
+    PerfMetrics holds the following metrics with mean and standard deviations:
     - Time To the First Token (TTFT), ms
     - Time per Output Token (TPOT), ms/token
+    - Inference time per Output Token (IPOT), ms/token
     - Generate total duration, ms
+    - Inference duration, ms
     - Tokenization duration, ms
     - Detokenization duration, ms
     - Throughput, tokens/s
 
-    Additional fields include:
+    Additional metrics include:
     - Load time, ms
     - Number of generated tokens
     - Number of tokens in the input prompt
+    - Time to initialize grammar compiler for each backend, ms
+    - Time to compile grammar, ms
 
     Preferable way to access values is via get functions. Getters calculate mean and std values from raw_metrics and return pairs.
     If mean and std were already calculated, getters return cached values.
@@ -95,8 +99,14 @@ auto perf_metrics_docstring = R"(
     :param get_tpot: Returns the mean and standard deviation of TPOT in milliseconds.
     :type get_tpot: MeanStdPair
 
+    :param get_ipot: Returns the mean and standard deviation of IPOT in milliseconds.
+    :type get_ipot: MeanStdPair
+
     :param get_throughput: Returns the mean and standard deviation of throughput in tokens per second.
     :type get_throughput: MeanStdPair
+
+    :param get_inference_duration: Returns the mean and standard deviation of the time spent on model inference during generate call in milliseconds.
+    :type get_inference_duration: MeanStdPair
 
     :param get_generate_duration: Returns the mean and standard deviation of generate durations in milliseconds.
     :type get_generate_duration: MeanStdPair


### PR DESCRIPTION
- Add `PerfMetrics.getGrammarCompilerInitTimes()` and `perfMetrics.getGrammarCompileTime()`
- Add simple test for those properties
- Update docstrings in _src/cpp/include/openvino/genai/perf_metrics.hpp_ and _src/python/py_perf_metrics.cpp_
