### PR TITLE
[llm_bench] Add start memory info

### DIFF
--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -276,6 +276,7 @@ def main():
         memory_monitor.create_monitors()
         if args.memory_consumption_dir:
             memory_monitor.set_dir(args.memory_consumption_dir)
+        memory_monitor.log_curent_memory_data(prefix="Start")
     try:
         if model_args['use_case'] in ['text_gen', 'code_gen']:
             iter_data_list, pretrain_time, iter_timestamp = CASE_TO_BENCH[model_args['use_case']](


### PR DESCRIPTION
[CVS-171619](https://jira.devtools.intel.com/browse/CVS-171619)

added print of start memory condition

Example:
`[ INFO ] Start  RSS memory 571.18MiB, Start  system memory 8771.15MiB`

Memory for compilation phase already exists:
`[ INFO ] Max rss memory cost for compilation phase: 642.86MiB, rss memory increase for compilation phase: 0.00MiB, max system memory cost for compilation phase: 8814.46MiB, system memory increase for compilation phase: 0.00MiB`