### PR TITLE
Reduce structured output controller mutex locking scope

### DIFF
--- a/src/cpp/src/sampling/structured_output/structured_output_controller.cpp
+++ b/src/cpp/src/sampling/structured_output/structured_output_controller.cpp
@@ -33,32 +33,7 @@ StructuredOutputController::StructuredOutputController(const ov::genai::Tokenize
                                                        std::optional<int> vocab_size)
     : m_tokenizer_impl(tokenizer_impl), m_vocab_size(vocab_size) {}
 
-void StructuredOutputController::validate_grammar(const std::optional<StructuredOutputConfig>& structured_output_config) {
-    OPENVINO_ASSERT(structured_output_config.has_value());
-    std::string backend_name = structured_output_config.value().backend.value_or(get_default_backend_name());
-
-    std::unique_lock<std::mutex> lock(m_mutex);
-
-    // Check if backend already instantiated
-    auto impl_it = m_impls.find(backend_name);
-    if (impl_it == m_impls.end()) {
-        // Backend not instantiated yet, create it
-        auto& registry = get_backend_registry();
-        auto factory_it = registry.find(backend_name);
-        if (factory_it == registry.end()) {
-            OPENVINO_THROW("Structured output backend not found: " + backend_name);
-        }
-        // Create the backend instance and store it
-        m_impls[backend_name] = factory_it->second(m_tokenizer_impl, m_vocab_size);
-        impl_it = m_impls.find(backend_name);
-    }
-    lock.unlock();
-    impl_it->second->validate_grammar(structured_output_config);
-}
-
-std::shared_ptr<LogitTransformers::ILogitTransformer> StructuredOutputController::get_logits_transformer(const ov::genai::GenerationConfig& sampling_parameters) {
-    OPENVINO_ASSERT(sampling_parameters.structured_output_config.has_value());
-    std::string backend_name = sampling_parameters.structured_output_config.value().backend.value_or(get_default_backend_name());
+const std::unique_ptr<IStructuredOutputImpl>& StructuredOutputController::get_backend(const std::string& backend_name) {
     std::unique_lock<std::mutex> lock(m_mutex);
     auto impl_it = m_impls.find(backend_name);
     if (impl_it == m_impls.end()) {
@@ -76,13 +51,24 @@ std::shared_ptr<LogitTransformers::ILogitTransformer> StructuredOutputController
         const auto end = std::chrono::steady_clock::now();
         m_init_grammar_compiler_times[backend_name] = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
     }
+    return impl_it->second;
+}
 
-    lock.unlock();
+void StructuredOutputController::validate_grammar(const std::optional<StructuredOutputConfig>& structured_output_config) {
+    OPENVINO_ASSERT(structured_output_config.has_value());
+    std::string backend_name = structured_output_config.value().backend.value_or(get_default_backend_name());
+    const auto& backend = get_backend(backend_name);
+    backend->validate_grammar(structured_output_config);
+}
+
+std::shared_ptr<LogitTransformers::ILogitTransformer> StructuredOutputController::get_logits_transformer(const ov::genai::GenerationConfig& sampling_parameters) {
+    OPENVINO_ASSERT(sampling_parameters.structured_output_config.has_value());
+    std::string backend_name = sampling_parameters.structured_output_config.value().backend.value_or(get_default_backend_name());
+    const auto& backend = get_backend(backend_name);
     // Use the instantiated backend
     const auto start = std::chrono::steady_clock::now();
-    auto logit_transformer = impl_it->second->get_logits_transformer(sampling_parameters);
+    auto logit_transformer = backend->get_logits_transformer(sampling_parameters);
     const auto end = std::chrono::steady_clock::now();
-    lock.lock();
     m_grammar_compile_times.emplace_back(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
     return logit_transformer;
 }

--- a/src/cpp/src/sampling/structured_output/structured_output_controller.hpp
+++ b/src/cpp/src/sampling/structured_output/structured_output_controller.hpp
@@ -62,6 +62,8 @@ public:
  */
 class StructuredOutputController {
     std::shared_ptr<ov::genai::LogitTransformers::ILogitTransformer> m_logits_transformer;
+    
+    const std::unique_ptr<IStructuredOutputImpl>& get_backend(const std::string& backend_name);
 public:
     using BackendFactory = std::function<std::unique_ptr<ov::genai::IStructuredOutputImpl>(
         const ov::genai::Tokenizer::TokenizerImpl&, std::optional<int>)>;


### PR DESCRIPTION
Improve concurrent requests handling by reducing duration of mutex lock. We don't need to lock it for entire grammar creation and loading time.