### PR TITLE
[speculative decoding] Move from ManualTimer to pure metrics

### DIFF
--- a/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching_for_speculative_decoding_impl.cpp
@@ -310,15 +310,14 @@ void ContinuousBatchingPipeline::ContinuousBatchingForSpeculativeDecodingImpl::m
     while (to_generate) {
         generated_tokens_cnt++;
 
-        ManualTimer multistep_timer("speculative_decoding: multistep()");
-        multistep_timer.start();
+        const auto step_start = std::chrono::steady_clock::now();
         step();
-        multistep_timer.end();
+        const auto step_end = std::chrono::steady_clock::now();
+        const auto generation_duration = PerfMetrics::get_microsec(step_end - step_start);
 
         const auto num_generated_tokens = get_processed_tokens_per_iteration();
         auto pipeline_metrics = get_metrics();
         if (num_generated_tokens > 0) {
-            auto generation_duration = multistep_timer.get_duration_microsec();
             raw_perf_metrics.m_durations.emplace_back(generation_duration);
             raw_perf_metrics.m_inference_durations[0] = MicroSeconds(pipeline_metrics.inference_duration);
             raw_perf_metrics.m_batch_sizes.emplace_back(num_generated_tokens);

--- a/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
+++ b/src/cpp/src/speculative_decoding/speculative_decoding_impl.cpp
@@ -152,18 +152,16 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
     auto& raw_perf_counters = m_perf_metrics.raw_metrics;
     auto& main_raw_perf_counters = m_perf_metrics.main_model_metrics.raw_metrics;
 
-    ManualTimer step_timer("speculative_decoding: step()");
-    step_timer.start();
+    const auto step_start = std::chrono::steady_clock::now();
 
     m_draft_pipeline->pull_awaiting_requests(true);
     m_main_pipeline->pull_awaiting_requests();
 
     // generate candidates by draft model
-    ManualTimer draft_timer("speculative_decoding: draft_model: multistep()");
-    draft_timer.start();
+    const auto draft_start = std::chrono::steady_clock::now();
     m_draft_pipeline->multistep();
-    draft_timer.end();
-    m_sd_metrics.draft_duration += draft_timer.get_duration();
+    const auto draft_end = std::chrono::steady_clock::now();
+    m_sd_metrics.draft_duration += PerfMetrics::get_microsec(draft_end - draft_start) / 1e6;
     m_pipeline_metrics = m_main_pipeline->get_metrics();
 
     // to generate num_matches statistic
@@ -175,11 +173,11 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
         update_sequence_info.insert({{candidate.first, update_result}});
     }
 
-    ManualTimer main_timer("speculative_decoding: main_model: step()");
-    main_timer.start();
+    const auto main_start = std::chrono::steady_clock::now();
     m_main_pipeline->step();
-    main_timer.end();
-    m_sd_metrics.main_duration += main_timer.get_duration();
+    const auto main_end = std::chrono::steady_clock::now();
+    const auto main_duration = PerfMetrics::get_microsec(main_end - main_start);
+    m_sd_metrics.main_duration += main_duration / 1e6;
     m_pipeline_metrics = m_main_pipeline->get_metrics();
 
     auto main_generated_requests = m_main_pipeline->get_generated_requests();
@@ -208,20 +206,19 @@ void ContinuousBatchingPipeline::SpeculativeDecodingImpl::step() {
         m_sd_metrics.update_draft_accepted_tokens(request_id, (updated_seq_info.inserted_tokens_cnt - updated_seq_info.removed_tokens_cnt));
     }
 
-    step_timer.end();
+    const auto step_end = std::chrono::steady_clock::now();
+    const auto step_microsec_duration = PerfMetrics::get_microsec(step_end - step_start);
 
     // update perf metrics
     const auto num_generated_tokens = m_main_pipeline->get_processed_tokens_per_iteration();
     if (num_generated_tokens > 0) {
-        auto infer_duration = step_timer.get_duration_microsec();
-        raw_perf_counters.m_token_infer_durations.emplace_back(infer_duration);
-        raw_perf_counters.m_inference_durations[0] += MicroSeconds(infer_duration);
-        raw_perf_counters.m_new_token_times.emplace_back(main_timer.get_end_time());
+        raw_perf_counters.m_token_infer_durations.emplace_back(step_microsec_duration);
+        raw_perf_counters.m_inference_durations[0] += MicroSeconds(step_microsec_duration);
+        raw_perf_counters.m_new_token_times.emplace_back(main_end);
         raw_perf_counters.m_batch_sizes.emplace_back(num_generated_tokens);
 
-        auto main_model_gen_duration = main_timer.get_duration_microsec();
         auto m_main_pipeline_metrics = m_main_pipeline->get_metrics();
-        main_raw_perf_counters.m_durations.push_back(MicroSeconds(main_model_gen_duration));
+        main_raw_perf_counters.m_durations.push_back(MicroSeconds(main_duration));
         main_raw_perf_counters.m_inference_durations[0] = MicroSeconds(m_main_pipeline_metrics.inference_duration);
         main_raw_perf_counters.m_batch_sizes.push_back(num_generated_tokens); // or should be processed + generated
         m_sd_metrics.update_generated_len(num_generated_tokens);
@@ -247,8 +244,7 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
     OPENVINO_ASSERT(!has_non_finished_requests(), "Generate cannot be called while ContinuousBatchingPipeline is already in running state. Use ContinuousBatchingPipeline::add_request");
     OPENVINO_ASSERT(input_ids.size() == sampling_params.size());
 
-    ManualTimer generate_timer("speculative_decoding: generate()");
-    generate_timer.start();
+    const auto generate_start = std::chrono::steady_clock::now();
 
     // checks that all requests has the same LoRA adapters property value
     for (size_t i = 1; i < sampling_params.size(); ++i) {
@@ -302,7 +298,8 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
 
     m_perf_metrics.draft_model_metrics.raw_metrics = m_draft_pipeline->raw_perf_metrics;
 
-    generate_timer.end();
+    const auto generate_end = std::chrono::steady_clock::now();
+    const auto generate_duration = PerfMetrics::get_microsec(generate_end - generate_start);
 
     for (size_t request_id = 0; request_id < all_requests.size(); ++request_id) {
         const auto& request = all_requests[request_id];
@@ -332,9 +329,9 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         m_perf_metrics.raw_metrics.generate_durations.clear();
-        m_perf_metrics.raw_metrics.generate_durations.emplace_back(generate_timer.get_duration_microsec());
+        m_perf_metrics.raw_metrics.generate_durations.emplace_back(generate_duration);
         m_perf_metrics.num_input_tokens = request->get_prompt_len();
-        m_perf_metrics.evaluate_statistics(generate_timer.get_start_time());
+        m_perf_metrics.evaluate_statistics(generate_start);
 
         result.perf_metrics = m_perf_metrics;
         result.extended_perf_metrics = std::make_shared<SDPerModelsPerfMetrics>(m_perf_metrics);


### PR DESCRIPTION
ManualTimer takes about 4 extra microseconds per each creation , let's avoid to create it for each main/draft/collective steps and for generate as well