### PR TITLE
Enable model caching for Whisper pipeline on GPU and NPU

### DIFF
--- a/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
+++ b/samples/cpp/whisper_speech_recognition/whisper_speech_recognition.cpp
@@ -4,6 +4,12 @@
 #include "audio_utils.hpp"
 #include "openvino/genai/whisper_pipeline.hpp"
 
+auto get_config_for_cache() {
+    ov::AnyMap config;
+    config.insert({ov::cache_dir("whisper_cache")});
+    return config;
+}
+
 int main(int argc, char* argv[]) try {
     if (argc < 3 || argc > 4) {
         throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR> \"<WAV_FILE_PATH>\" <DEVICE>");
@@ -13,7 +19,14 @@ int main(int argc, char* argv[]) try {
     std::string wav_file_path = argv[2];
     std::string device = (argc == 4) ? argv[3] : "CPU";  // Default to CPU if no device is provided
 
-    ov::genai::WhisperPipeline pipeline(models_path, device);
+    ov::AnyMap ov_config;
+    if (device == "NPU" || device.find("GPU") != std::string::npos) {  // need to handle cases like "GPU", "GPU.0" and "GPU.1"
+        // Cache compiled models on disk for GPU and NPU to save time on the
+        // next run. It's not beneficial for CPU.
+        ov_config = get_config_for_cache();
+    }
+
+    ov::genai::WhisperPipeline pipeline(models_path, device, ov_config);
 
     ov::genai::WhisperGenerationConfig config = pipeline.get_generation_config();
     // 'task' and 'language' parameters are supported for multilingual models only


### PR DESCRIPTION
Whisper sample code to enable model caching on GPU and NPU

This is https://github.com/openvinotoolkit/openvino.genai/pull/2751 follow up

Sample Code Reference: 
https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/python/visual_language_chat/encrypted_model_vlm.py#L87
https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/cpp/text_generation/encrypted_model_causal_lm.cpp#L52

OPTIMIZE_SIZE and encryption are not included. The main performance concern for Whisper is pipeline speed. Since Whisper is much smaller than LLMs, size optimization offers only very little savings while potentially adding latency. Similarly, model encryption can also introduce additional latency.

