### PR TITLE
Update transformers to 4.53.3

### DIFF
--- a/samples/export-requirements.txt
+++ b/samples/export-requirements.txt
@@ -11,7 +11,7 @@ timm==1.0.19  # For exporting InternVL2
 # torchvision for visual language models
 torchvision==0.17.2; platform_system == "Darwin" and platform_machine == "x86_64"
 torchvision==0.23.0+cpu; platform_system != "Darwin" or platform_machine != "x86_64"
-transformers==4.52.4 # For Whisper
+transformers==4.53.3 # For Whisper
 hf_transfer==0.1.9  # for faster models download, should used with env var HF_HUB_ENABLE_HF_TRANSFER=1
 backoff==2.2.1  # for microsoft/Phi-3.5-vision-instruct
 peft==0.17.1  # For microsoft/Phi-4-multimodal-instruct

--- a/tests/python_tests/requirements.txt
+++ b/tests/python_tests/requirements.txt
@@ -4,7 +4,7 @@ optimum-intel==1.25.2
 numpy==1.26.4; platform_system == "Darwin" and platform_machine == "x86_64"
 safetensors==0.6.2; platform_system == "Darwin" and platform_machine == "x86_64"
 pytest==8.4.2
-transformers==4.52.4
+transformers==4.53.3
 hf_transfer==0.1.9
 gguf==0.17.1
 


### PR DESCRIPTION
PR for 4.53 transformers fix for static whisper pipeline merged: https://github.com/openvinotoolkit/openvino.genai/pull/2665
Latest supported by optimum-intel 1.25.2 transformers is 4.53.3: https://github.com/huggingface/optimum-intel/blob/v1.25.2-release/setup.py#L32