### PR TITLE
Support One Element Vector in Chat Scenario

### DIFF
--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -121,20 +121,17 @@ DecodedResults StatefulLLMPipeline::generate(
 
     if (auto input_vector = std::get_if<std::vector<std::string>>(&inputs)) {
         if (is_chat_conversation) {
-            if (input_vector->size() == 1) {
-                m_history.push_back({{"role", "user"}, {"content", (*input_vector)[0]}});
-                constexpr bool add_generation_prompt = true;
-                auto new_templated_chat_history = m_tokenizer.apply_chat_template(m_history, add_generation_prompt);
-                auto new_chat_tokens = m_tokenizer.encode(new_templated_chat_history, ov::genai::add_special_tokens(false));
+            OPENVINO_ASSERT(input_vector->size() == 1, "Can't chat with multiple prompts");
+            m_history.push_back({{"role", "user"}, {"content", (*input_vector)[0]}});
+            constexpr bool add_generation_prompt = true;
+            auto new_templated_chat_history = m_tokenizer.apply_chat_template(m_history, add_generation_prompt);
+            auto new_chat_tokens = m_tokenizer.encode(new_templated_chat_history, ov::genai::add_special_tokens(false));
 
-                if (m_use_full_chat_history) {
-                    encoded_input = new_chat_tokens;
-                } else {
-                    ov::genai::align_kv_cache_and_history(new_chat_tokens.input_ids, m_kv_cache_state);
-                    encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_kv_cache_state);
-                }
+            if (m_use_full_chat_history) {
+                encoded_input = new_chat_tokens;
             } else {
-                OPENVINO_ASSERT(!is_chat_conversation, "Can't chat with multiple prompts");
+                ov::genai::align_kv_cache_and_history(new_chat_tokens.input_ids, m_kv_cache_state);
+                encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_kv_cache_state);
             }
         } else if (config.apply_chat_template && !m_tokenizer.get_chat_template().empty()) {
             std::vector<std::string> templated_input_vector;


### PR DESCRIPTION
## Description
Quick patch to support vector of strings (size=1) in chat scenario, so it returns `DecodedResults` and not a string object.
```python
pipe.start_chat()
res = pipe.generate([prompt], config, streamer)
```

Ticket: -

## Checklist:
- [ ] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation
