### PR TITLE
[wwb] Add text embeddings pipeline

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_embeddings.py
+++ b/tools/who_what_benchmark/tests/test_cli_embeddings.py
@@ -1,0 +1,91 @@
+import subprocess  # nosec B404
+import pytest
+import logging
+from test_cli_image import run_wwb
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    ("model_id", "model_type"),
+    [
+        ("BAAI/bge-small-en-v1.5", "text-embedding"),
+        ("Qwen/Qwen3-Embedding-0.6B", "text-embedding"),
+    ],
+)
+def test_embeddings_basic(model_id, model_type, tmp_path):
+    GT_FILE = tmp_path / "gt.csv"
+    MODEL_PATH = tmp_path / model_id.replace("/", "--")
+
+    result = subprocess.run(["optimum-cli", "export",
+                             "openvino", "-m", model_id,
+                             MODEL_PATH, "--task",
+                             "feature-extraction",
+                             "--trust-remote-code"],
+                            capture_output=True,
+                            text=True,
+                            )
+    assert result.returncode == 0
+
+    # Collect reference with HF model
+    run_wwb([
+        "--base-model",
+        model_id,
+        "--num-samples",
+        "1",
+        "--gt-data",
+        GT_FILE,
+        "--device",
+        "CPU",
+        "--model-type",
+        model_type,
+        "--hf",
+    ])
+
+    # test Optimum
+    run_wwb([
+        "--target-model",
+        MODEL_PATH,
+        "--num-samples",
+        "1",
+        "--gt-data",
+        GT_FILE,
+        "--device",
+        "CPU",
+        "--model-type",
+        model_type,
+    ])
+
+    # test GenAI
+    run_wwb([
+        "--target-model",
+        MODEL_PATH,
+        "--num-samples",
+        "1",
+        "--gt-data",
+        GT_FILE,
+        "--device",
+        "CPU",
+        "--model-type",
+        model_type,
+        "--genai",
+        "--output",
+        tmp_path,
+    ])
+
+    # test w/o models
+    run_wwb([
+        "--target-data",
+        tmp_path / "target.csv",
+        "--num-samples",
+        "1",
+        "--gt-data",
+        GT_FILE,
+        "--device",
+        "CPU",
+        "--model-type",
+        model_type,
+        "--genai",
+    ])

--- a/tools/who_what_benchmark/whowhatbench/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/__init__.py
@@ -5,6 +5,7 @@ from .text2image_evaluator import Text2ImageEvaluator
 from .visualtext_evaluator import VisualTextEvaluator
 from .im2im_evaluator import Image2ImageEvaluator
 from .inpaint_evaluator import InpaintingEvaluator
+from .embeddings_evaluator import EmbeddingsEvaluator
 
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "VisualTextEvaluator",
     "Image2ImageEvaluator",
     "InpaintingEvaluator",
+    "EmbeddingsEvaluator",
     "EVALUATOR_REGISTRY",
 ]

--- a/tools/who_what_benchmark/whowhatbench/embeddings_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/embeddings_evaluator.py
@@ -1,0 +1,189 @@
+from typing import Any, Union
+
+import os
+import torch
+import numpy as np
+import pandas as pd
+import datasets
+
+from tqdm import tqdm
+from torch import Tensor
+from transformers import set_seed
+
+from .registry import register_evaluator, BaseEvaluator
+from .whowhat_metrics import EmbedsSimilarity
+
+
+DEF_MAX_LENGTH = 100
+
+
+def prepare_default_data(num_samples=None):
+    DATASET_NAME = "microsoft/ms_marco"
+    NUM_SAMPLES = num_samples if num_samples else 24
+    set_seed(42)
+    default_dataset = datasets.load_dataset(
+        DATASET_NAME, 'v2.1', split="test", streaming=True
+    ).shuffle(42).take(NUM_SAMPLES)
+    return default_dataset.map(
+        lambda x: {'passages': x['passages']['passage_text']}, remove_columns=default_dataset.column_names
+    )
+
+
+def last_token_pool(last_hidden_states: Tensor, attention_mask: Tensor) -> Tensor:
+    left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+    if left_padding:
+        return last_hidden_states[:, -1]
+    else:
+        sequence_lengths = attention_mask.sum(dim=1) - 1
+        batch_size = last_hidden_states.shape[0]
+        batch_dim = torch.arange(batch_size, device=last_hidden_states.device)
+        result = last_hidden_states[batch_dim, sequence_lengths]
+        return result
+
+
+def mean_pooling(last_hidden_states: Tensor, attention_mask: Tensor) -> Tensor:
+    input_mask_expanded = (
+        attention_mask.unsqueeze(-1).expand(last_hidden_states.size()).to(last_hidden_states.dtype)
+    )
+    sum_embeddings = torch.sum(last_hidden_states * input_mask_expanded, 1)
+    sum_mask = input_mask_expanded.sum(1)
+    sum_mask = torch.clamp(sum_mask, min=1e-9)
+
+    return sum_embeddings / sum_mask
+
+
+@register_evaluator(
+    "text-embedding"
+)
+class EmbeddingsEvaluator(BaseEvaluator):
+    def __init__(
+        self,
+        base_model: Any = None,
+        tokenizer: Any = None,
+        gt_data: str = None,
+        test_data: Union[str, list] = None,
+        num_samples=None,
+        gen_embeds_fn=None,
+        pooling_type=None,
+        normalize=None,
+        padding_side=None
+    ) -> None:
+        assert (
+            base_model is not None or gt_data is not None
+        ), "Text generation pipeline for evaluation or ground trush data must be defined"
+
+        self.test_data = test_data
+        self.tokenizer = tokenizer
+        self.num_samples = num_samples
+        self.generation_fn = gen_embeds_fn
+        self.pooling_type = pooling_type or 'cls'
+        self.normalize = normalize or False
+        self.padding_side = padding_side or 'right'
+        self.gt_dir = os.path.dirname(gt_data)
+
+        if base_model:
+            self.gt_data = self._generate_data(base_model, gen_embeds_fn)
+        else:
+            self.gt_data = pd.read_csv(gt_data, keep_default_na=False)
+
+        self.similarity = EmbedsSimilarity()
+        self.last_cmp = None
+
+    def get_generation_fn(self):
+        return self.generation_fn
+
+    def score(self, model_or_data, gen_answer_fn=None, output_dir=None, **kwargs):
+        if output_dir is None:
+            result_folder = os.path.join(self.gt_dir, "target")
+        else:
+            result_folder = os.path.join(output_dir, "target")
+
+        if isinstance(model_or_data, str) and os.path.exists(model_or_data):
+            predictions = pd.read_csv(model_or_data, keep_default_na=False)
+        else:
+            predictions = self._generate_data(model_or_data, gen_answer_fn, result_folder)
+        self.predictions = predictions
+
+        all_metrics_per_prompt = {}
+        all_metrics = {}
+        all_metrics, all_metrics_per_prompt = self.similarity.evaluate(
+            self.gt_data, predictions
+        )
+
+        self.last_cmp = all_metrics_per_prompt
+        self.last_cmp["passages"] = predictions["passages"].values
+        self.last_cmp["source_model"] = self.gt_data["embeds_path"].values
+        self.last_cmp["optimized_model"] = predictions["embeds_path"].values
+        self.last_cmp = pd.DataFrame(self.last_cmp)
+
+        return pd.DataFrame(all_metrics_per_prompt), pd.DataFrame([all_metrics])
+
+    def worst_examples(self, top_k: int = 5, metric="similarity"):
+        assert self.last_cmp is not None
+        res = self.last_cmp.nsmallest(top_k, metric)
+        return list(row for idx, row in res.iterrows())
+
+    def _generate_data(self, model, gen_answer_fn=None, result_dir="reference"):
+        def default_gen_answer(model, tokenizer, passages, **kwargs):
+            device = "cpu"
+            if hasattr(model, "device"):
+                device = model.device
+            tokenizer_kwargs = {'padding': 'max_length', 'max_length': DEF_MAX_LENGTH,
+                                'truncation': True, 'padding_side': kwargs.get('padding_side', 'right')}
+            inputs = self.tokenizer(passages, return_tensors="pt", **tokenizer_kwargs).to(device)
+
+            with torch.no_grad():
+                outputs = model(**inputs)
+
+            if model.config.model_type == "qwen3" or kwargs.get("pooling_type", "last_token"):
+                embeddings = last_token_pool(outputs.last_hidden_state, inputs["attention_mask"])
+            elif kwargs.get("pooling_type", "mean"):
+                embeddings = mean_pooling(outputs.last_hidden_state, inputs["attention_mask"])
+            else:
+                embeddings = outputs.last_hidden_state[:, 0]
+
+            if kwargs.get("normalize", False):
+                embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+            return embeddings
+
+        gen_answer_fn = gen_answer_fn or default_gen_answer
+
+        if self.test_data:
+            if isinstance(self.test_data, str):
+                data = pd.read_csv(self.test_data)
+            else:
+                if isinstance(self.test_data, dict):
+                    assert "prompts" in self.test_data
+                    data = dict(self.test_data)
+                else:
+                    data = {"prompts": list(self.test_data)}
+                data = pd.DataFrame.from_dict(data)
+        else:
+            data = pd.DataFrame.from_dict(prepare_default_data(self.num_samples))
+
+        embeds_paths = []
+        passages = []
+        inptus = (
+            data.values
+            if self.num_samples is None
+            else data.values[: self.num_samples]
+        )
+
+        if not os.path.exists(result_dir):
+            os.makedirs(result_dir)
+
+        for i, data in tqdm(enumerate(inptus), desc="Evaluate pipeline"):
+            kwargs = {'padding_side': self.padding_side,
+                      'pooling_type': self.pooling_type,
+                      'normalize': self.normalize}
+            result = gen_answer_fn(model, self.tokenizer, data[0], **kwargs)
+            passages.append(data[0])
+            result_path = os.path.join(result_dir, f"embeds_{i}.npy")
+            with open(result_path, 'wb') as f:
+                np.save(f, result)
+            embeds_paths.append(result_path)
+
+        res_data = {"passages": passages, "embeds_path": embeds_paths}
+        df = pd.DataFrame(res_data)
+
+        return df

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -4,6 +4,7 @@ import torch
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModel, AutoModelForVision2Seq, AutoTokenizer
 
+from .embeddings_evaluator import DEF_MAX_LENGTH
 from .utils import mock_torch_cuda_is_available, mock_AwqQuantizer_validate_environment
 
 
@@ -20,7 +21,7 @@ class GenAIModelWrapper:
         self.model = model
         self.model_type = model_type
 
-        if model_type == "text" or model_type == "visual-text":
+        if model_type in ["text", "visual-text", "text-embedding"]:
             try:
                 self.config = AutoConfig.from_pretrained(model_dir)
             except Exception:
@@ -428,6 +429,63 @@ def load_inpainting_model(
     return model
 
 
+def load_embedding_genai_pipeline(model_dir, device="CPU", ov_config=None, **kwargs):
+    try:
+        import openvino_genai
+    except ImportError as e:
+        logger.error("Failed to import openvino_genai package. Please install it. Details:\n", e)
+        exit(-1)
+
+    config = openvino_genai.TextEmbeddingPipeline.Config()
+    if kwargs.get("pooling_type"):
+        if kwargs.get("pooling_type") == "mean":
+            config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.MEAN
+        elif kwargs.get("pooling_type") == "last_token":
+            config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.LAST_TOKEN
+        else:
+            config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.CLS
+    config.max_length = DEF_MAX_LENGTH
+    config.normalize = kwargs.get("normalize", False)
+    config.pad_to_max_length = True
+
+    logger.info("Using OpenVINO GenAI TextEmbeddingPipeline API")
+    pipeline = openvino_genai.TextEmbeddingPipeline(model_dir, device.upper(), config, **ov_config)
+
+    return GenAIModelWrapper(
+        pipeline,
+        model_dir,
+        "text-embedding"
+    )
+
+
+def load_embedding_model(model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False, **kwargs):
+    if use_hf:
+        from transformers import AutoModel
+        logger.info("Using HF Transformers API")
+        model = AutoModel.from_pretrained(model_id, trust_remote_code=True)
+    elif use_genai:
+        logger.info("Using OpenVINO GenAI API")
+        model = load_embedding_genai_pipeline(model_id, device, ov_config, **kwargs)
+    else:
+        logger.info("Using Optimum API")
+        from optimum.intel.openvino import OVModelForFeatureExtraction
+        try:
+            model = OVModelForFeatureExtraction.from_pretrained(
+                model_id, device=device, ov_config=ov_config, safety_checker=None,
+            )
+        except ValueError as e:
+            logger.error("Failed to load inpaiting pipeline. Details:\n", e)
+            model = OVModelForFeatureExtraction.from_pretrained(
+                model_id,
+                trust_remote_code=True,
+                use_cache=True,
+                device=device,
+                ov_config=ov_config,
+                safety_checker=None
+            )
+    return model
+
+
 def load_model(
     model_type, model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False, use_llamacpp=False, **kwargs
 ):
@@ -452,5 +510,7 @@ def load_model(
         return load_imagetext2image_model(model_id, device, ov_options, use_hf, use_genai)
     elif model_type == "image-inpainting":
         return load_inpainting_model(model_id, device, ov_options, use_hf, use_genai)
+    elif model_type == "text-embedding":
+        return load_embedding_model(model_id, device, ov_options, use_hf, use_genai, **kwargs)
     else:
         raise ValueError(f"Unsupported model type: {model_type}")

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -4,7 +4,7 @@ import torch
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModel, AutoModelForVision2Seq, AutoTokenizer
 
-from .embeddings_evaluator import DEF_MAX_LENGTH
+from .embeddings_evaluator import DEFAULT_MAX_LENGTH
 from .utils import mock_torch_cuda_is_available, mock_AwqQuantizer_validate_environment
 
 
@@ -437,15 +437,15 @@ def load_embedding_genai_pipeline(model_dir, device="CPU", ov_config=None, **kwa
         exit(-1)
 
     config = openvino_genai.TextEmbeddingPipeline.Config()
-    if kwargs.get("pooling_type"):
-        if kwargs.get("pooling_type") == "mean":
+    if kwargs.get("embeds_pooling"):
+        if kwargs.get("embeds_pooling") == "mean":
             config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.MEAN
-        elif kwargs.get("pooling_type") == "last_token":
+        elif kwargs.get("embeds_pooling") == "last_token":
             config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.LAST_TOKEN
         else:
             config.pooling_type = openvino_genai.TextEmbeddingPipeline.PoolingType.CLS
-    config.max_length = DEF_MAX_LENGTH
-    config.normalize = kwargs.get("normalize", False)
+    config.max_length = DEFAULT_MAX_LENGTH
+    config.normalize = kwargs.get("embeds_normalize", False)
     config.pad_to_max_length = True
 
     logger.info("Using OpenVINO GenAI TextEmbeddingPipeline API")
@@ -474,7 +474,7 @@ def load_embedding_model(model_id, device="CPU", ov_config=None, use_hf=False, u
                 model_id, device=device, ov_config=ov_config, safety_checker=None,
             )
         except ValueError as e:
-            logger.error("Failed to load inpaiting pipeline. Details:\n", e)
+            logger.error("Failed to load embedding pipeline. Details:\n", e)
             model = OVModelForFeatureExtraction.from_pretrained(
                 model_id,
                 trust_remote_code=True,

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -204,10 +204,11 @@ def parse_args():
         help="Inference with empty adapters. Applicable for GenAI only.",
     )
     parser.add_argument(
-        "--embeds_pooling",
+        "--embeds_pooling_type",
         choices=["cls", "mean", "last_token"],
         default=None,
-        help="Pooling type CLS or MEAN. Applicable only for text embeddings")
+        help="Pooling type CLS or MEAN for encoders, LAST_TOKEN for decoders. "
+             "Different post-processing is applied depending on the padding side. Applicable only for text embeddings")
     parser.add_argument(
         "--embeds_normalize",
         action="store_true",
@@ -533,7 +534,7 @@ def create_evaluator(base_model, args):
                 test_data=prompts,
                 num_samples=args.num_samples,
                 gen_embeds_fn=genai_gen_embedding if args.genai else None,
-                pooling_type=args.embeds_pooling,
+                pooling_type=args.embeds_pooling_type,
                 normalize=args.embeds_normalize,
                 padding_side=args.embeds_padding_side,
             )
@@ -643,7 +644,7 @@ def main():
         else:
             kwargs["alphas"] = [1.0] * len(args.adapters)
     kwargs["empty_adapters"] = args.empty_adapters
-    kwargs["embeds_pooling"] = args.embeds_pooling
+    kwargs["embeds_pooling"] = args.embeds_pooling_type
     kwargs["embeds_normalize"] = args.embeds_normalize
     kwargs["embeds_padding_side"] = args.embeds_padding_side
 


### PR DESCRIPTION
## Description

Added possibility to run text embeddings pipeline via wwb. Also was added some logic for Qwen/Qwen3-Embedding-0.6B model.
similarity is calculated with torch.nn.functional.cosine_similarity.
embeddings are saving to separate folder as file.npy per generation.
options `--embeds_pooling_type`, `--embeds_normalize`, `--embeds_padding_side` were added.

example to run for BAAI/bge-small-en-v1.5:
`wwb.py --base-model BAAI/bge-small-en-v1.5 --model-type text-embedding --gt-data gt_embedds.csv  -v --output ./output_embeds/ --embeds_pooling_type mean --embeds_normalize --embeds_padding_side left`

example to run for Qwen/Qwen3-Embedding-0.6B (**--embeds_pooling_type last_token** is important):
`wwb.py --base-model Qwen/Qwen3-Embedding-0.6B --model-type text-embedding --gt-data gt_embedds.csv  -v --output ./output_embeds/ --embeds_pooling_type last_token --embeds_normalize --embeds_padding_side left`

Ticket: CVS-173900

## Checklist:
- [x] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation
