### PR TITLE
Introduce JsonContainer for chat history

### DIFF
--- a/src/cpp/include/openvino/genai/json_container.hpp
+++ b/src/cpp/include/openvino/genai/json_container.hpp
@@ -169,13 +169,13 @@ public:
      * @brief Convert this container to an empty object.
      * @return Reference to this container for chaining
      */
-    JsonContainer& set_object();
+    JsonContainer& to_empty_object();
 
     /**
      * @brief Convert this container to an empty array.
      * @return Reference to this container for chaining
      */
-    JsonContainer& set_array();
+    JsonContainer& to_empty_array();
 
     /**
      * @brief Check if object contains a key.

--- a/src/cpp/include/openvino/genai/json_container.hpp
+++ b/src/cpp/include/openvino/genai/json_container.hpp
@@ -1,0 +1,249 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <initializer_list>
+
+#include <nlohmann/json.hpp>
+
+#include "openvino/core/any.hpp"
+#include "openvino/genai/visibility.hpp"
+
+namespace ov {
+namespace genai {
+
+class OPENVINO_GENAI_EXPORTS JsonContainer {
+private:
+    template<typename T>
+    struct is_json_primitive {
+        using type = typename std::decay<T>::type;
+        static constexpr bool value = 
+            std::is_same<type, bool>::value ||
+            std::is_same<type, int64_t>::value ||
+            std::is_same<type, int>::value ||
+            std::is_same<type, double>::value ||
+            std::is_same<type, float>::value ||
+            std::is_same<type, std::string>::value ||
+            std::is_same<type, const char*>::value ||
+            std::is_same<type, std::nullptr_t>::value;
+    };
+
+public:
+    /**
+     * @brief Default constructor creates an empty JSON object.
+     */
+    JsonContainer();
+
+    /**
+     * @brief Construct from JSON primitive types (bool, int64_t, double, string, etc.).
+     */
+    template<typename T>
+    JsonContainer(T&& value, typename std::enable_if<is_json_primitive<T>::value, int>::type = 0) :
+        JsonContainer(nlohmann::ordered_json(std::forward<T>(value))) {}
+
+    /**
+     * @brief Construct from initializer list of key-value pairs.
+     * 
+     * Example:
+     * JsonContainer({{"role", "user"}, {"content", "hello"}})
+     */
+    JsonContainer(std::initializer_list<std::pair<std::string, ov::Any>> init);
+
+    /**
+     * @brief Construct from AnyMap.
+     */
+    explicit JsonContainer(const ov::AnyMap& data);
+
+    /**
+     * @brief Construct from AnyMap (move version).
+     */
+    explicit JsonContainer(ov::AnyMap&& data);
+
+    /**
+     * @brief Copy constructor.
+     */
+    JsonContainer(const JsonContainer& other);
+
+    /**
+     * @brief Move constructor.
+     */
+    JsonContainer(JsonContainer&& other) noexcept;
+
+    ~JsonContainer();
+
+    /**
+     * @brief Create a shared copy of this JsonContainer.
+     */
+    JsonContainer share() const;
+
+    /**
+     * @brief Create a deep copy of this JsonContainer.
+     */
+    JsonContainer copy() const;
+
+    /**
+     * @brief Create JsonContainer from JSON string.
+     * @param json_str Valid JSON string
+     * @throw ov::Exception if parsing fails
+     */
+    static JsonContainer from_json_string(const std::string& json_str);
+
+    /**
+     * @brief Assignment operator for JSON primitive types (bool, int64_t, double, string, etc.).
+     */
+    template<typename T>
+    typename std::enable_if<is_json_primitive<T>::value, JsonContainer&>::type
+    operator=(T&& value) {
+        auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+        *json_value_ptr = nlohmann::ordered_json(std::forward<T>(value));
+        return *this;
+    }
+
+    /**
+     * @brief Copy assignment operator.
+     */
+    JsonContainer& operator=(const JsonContainer& other);
+
+    /**
+     * @brief Move assignment operator.
+     */
+    JsonContainer& operator=(JsonContainer&& other) noexcept;
+
+    bool operator==(const JsonContainer& other) const;
+    bool operator!=(const JsonContainer& other) const;
+
+    JsonContainer operator[](const std::string& key) const;
+    JsonContainer operator[](const char* key) const;
+    JsonContainer operator[](size_t index) const;
+    JsonContainer operator[](int index) const;
+
+    bool is_null() const;
+    bool is_boolean() const;
+    bool is_number() const;
+    bool is_number_integer() const;
+    bool is_number_float() const;
+    bool is_string() const;
+    bool is_array() const;
+    bool is_object() const;
+
+    std::optional<bool> as_bool() const;
+    std::optional<int64_t> as_int() const;
+    std::optional<double> as_double() const;
+    std::optional<std::string> as_string() const;
+
+    bool get_bool() const;
+    int64_t get_int() const;
+    double get_double() const;
+    std::string get_string() const;
+
+    /**
+     * @brief Add JsonContainer to end of array.
+     * If this container is not an array, it will be converted to an array.
+     * @param value JsonContainer to append
+     * @return Reference to this container for chaining
+     */
+    JsonContainer& push_back(const JsonContainer& value);
+
+    /**
+     * @brief Add JSON primitive to end of array.
+     * If this container is not an array, it will be converted to an array.
+     * @param value JSON primitive to append (bool, int64_t, double, string, etc.)
+     * @return Reference to this container for chaining
+     */
+    template<typename T>
+    typename std::enable_if<is_json_primitive<T>::value, JsonContainer&>::type
+    push_back(T&& value) {
+        auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+        if (!json_value_ptr->is_array()) {
+            *json_value_ptr = nlohmann::ordered_json::array();
+        }
+        json_value_ptr->push_back(nlohmann::ordered_json(std::forward<T>(value)));
+        return *this;
+    }
+
+    /**
+     * @brief Convert this container to an empty object.
+     * @return Reference to this container for chaining
+     */
+    JsonContainer& set_object();
+
+    /**
+     * @brief Convert this container to an empty array.
+     * @return Reference to this container for chaining
+     */
+    JsonContainer& set_array();
+
+    /**
+     * @brief Check if object contains a key.
+     * Returns false if container is not an object.
+     */
+    bool contains(const std::string& key) const;
+
+    /**
+     * @brief Get container size.
+     * @return Number of elements (object members or array elements), 1 for primitives, 0 for null
+     */
+    size_t size() const;
+
+    /**
+     * @brief Check if container is empty.
+     * @return true if container has no elements (or is null), false for primitives
+     */
+    bool empty() const;
+
+    /**
+     * @brief Erase a key from an object.
+     * @throw ov::Exception if container is not an object or key does not exist.
+     */
+    void erase(const std::string& key) const;
+
+    /**
+     * @brief Erase an element from an array by index with shifting.
+     * @throw ov::Exception if container is not an array or index is out of bounds.
+     */
+    void erase(size_t index) const;
+
+    /**
+     * @brief Clear all contents of the container (array or object).
+     * @throw ov::Exception if container is not an array or object.
+     */
+    void clear() const;
+
+    /**
+     * @brief Convert to JSON string.
+     * @param indent Indentation level (-1 for compact output)
+     * @return JSON string representation
+     */
+    std::string to_json_string(int indent = -1) const;
+
+    /**
+     * @brief Convert to nlohmann::ordered_json for internal use.
+     * @return nlohmann::ordered_json representation
+     */
+    nlohmann::ordered_json to_json() const;
+
+    /**
+     * @brief Get string representation of the JSON type.
+     * @return Type name: "null", "boolean", "number", "string", "array", "object" or "unknown"
+     */
+    std::string type_name() const;
+
+private:
+    JsonContainer(std::shared_ptr<nlohmann::ordered_json> json_ptr, const std::string& path);
+    JsonContainer(nlohmann::ordered_json json);
+
+    std::shared_ptr<nlohmann::ordered_json> m_json;
+
+    std::string m_path = "";
+
+    enum class AccessMode { Read, Write };
+    
+    nlohmann::ordered_json* get_json_value_ptr(AccessMode mode) const;
+};
+
+} // namespace genai
+} // namespace ov

--- a/src/cpp/include/openvino/genai/json_container.hpp
+++ b/src/cpp/include/openvino/genai/json_container.hpp
@@ -91,6 +91,16 @@ public:
      * @throw ov::Exception if parsing fails
      */
     static JsonContainer from_json_string(const std::string& json_str);
+    
+    /**
+     * @brief Create JsonContainer as an empty JSON object.
+     */
+    static JsonContainer object();
+
+    /**
+     * @brief Create JsonContainer as an empty JSON array.
+     */
+    static JsonContainer array();
 
     /**
      * @brief Assignment operator for JSON primitive types (bool, int64_t, double, string, etc.).

--- a/src/cpp/src/json_container.cpp
+++ b/src/cpp/src/json_container.cpp
@@ -66,25 +66,6 @@ nlohmann::ordered_json* JsonContainer::get_json_value_ptr(AccessMode mode) const
 }
 
 JsonContainer& JsonContainer::operator=(const JsonContainer& other) {
-    // if (this != &other) {
-    //     m_json = other.m_json;
-    //     m_path = other.m_path;
-    // }
-    // return *this;
-
-    // Hybrid approach
-    // if (this != &other) {
-    //     if (!m_path.empty()) {
-    //         // This is a path-based access - do value assignment
-    //         nlohmann::ordered_json other_value = other.to_json();
-    //         auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
-    //         *json_value_ptr = other_value;
-    //     } else {
-    //         // This is a root container - do standard assignment
-    //         m_json = other.m_json;
-    //         m_path = other.m_path;
-    //     }
-    // }
     if (this != &other) {
         auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
         *json_value_ptr = other.to_json();

--- a/src/cpp/src/json_container.cpp
+++ b/src/cpp/src/json_container.cpp
@@ -57,6 +57,14 @@ JsonContainer JsonContainer::from_json_string(const std::string& json_str) {
     }
 }
 
+JsonContainer JsonContainer::object() {
+    return JsonContainer(nlohmann::ordered_json::object());
+}
+
+JsonContainer JsonContainer::array() {
+    return JsonContainer(nlohmann::ordered_json::array());
+}
+
 nlohmann::ordered_json* JsonContainer::get_json_value_ptr(AccessMode mode) const {
     auto json_pointer = nlohmann::ordered_json::json_pointer(m_path);
     if (mode == AccessMode::Read && !m_json->contains(json_pointer)) {

--- a/src/cpp/src/json_container.cpp
+++ b/src/cpp/src/json_container.cpp
@@ -1,0 +1,320 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <regex>
+
+#include "openvino/core/except.hpp"
+
+#include "openvino/genai/json_container.hpp"
+#include "json_utils.hpp"
+
+
+namespace ov {
+namespace genai {
+
+JsonContainer::JsonContainer() :
+    JsonContainer(nlohmann::ordered_json::object()) {}
+
+JsonContainer::JsonContainer(std::initializer_list<std::pair<std::string, ov::Any>> init) :
+    JsonContainer(ov::genai::utils::any_map_to_json(ov::AnyMap{init.begin(), init.end()})) {}
+
+JsonContainer::JsonContainer(const ov::AnyMap& data) :
+    JsonContainer(ov::genai::utils::any_map_to_json(data)) {}
+
+JsonContainer::JsonContainer(ov::AnyMap&& data) :
+    JsonContainer(ov::genai::utils::any_map_to_json(std::move(data))) {}
+
+JsonContainer::JsonContainer(std::shared_ptr<nlohmann::ordered_json> json_ptr, const std::string& path) :
+    m_json(json_ptr),
+    m_path(path) {}
+
+JsonContainer::JsonContainer(nlohmann::ordered_json json) :
+    m_json(std::make_shared<nlohmann::ordered_json>(std::move(json))) {}
+
+JsonContainer::JsonContainer(const JsonContainer& other) :
+    m_json(std::make_shared<nlohmann::ordered_json>(*other.m_json)),
+    m_path(other.m_path) {}
+
+JsonContainer::JsonContainer(JsonContainer&& other) noexcept :
+    m_json(std::move(other.m_json)),
+    m_path(std::move(other.m_path)) {}
+
+JsonContainer::~JsonContainer() = default;
+
+JsonContainer JsonContainer::share() const {
+    return JsonContainer(m_json, m_path);
+}
+    
+JsonContainer JsonContainer::copy() const {
+    return JsonContainer(*this);
+}
+
+JsonContainer JsonContainer::from_json_string(const std::string& json_str) {
+    try {
+        return JsonContainer(nlohmann::ordered_json::parse(json_str));
+    } catch (const std::exception& e) {
+        OPENVINO_THROW("Failed to construct JsonContainer from JSON string: ", e.what());
+    }
+}
+
+nlohmann::ordered_json* JsonContainer::get_json_value_ptr(AccessMode mode) const {
+    auto json_pointer = nlohmann::ordered_json::json_pointer(m_path);
+    if (mode == AccessMode::Read && !m_json->contains(json_pointer)) {
+        OPENVINO_THROW("Path '", m_path, "' does not exist in the JsonContainer.");
+    }
+    return &(*m_json)[json_pointer];
+}
+
+JsonContainer& JsonContainer::operator=(const JsonContainer& other) {
+    // if (this != &other) {
+    //     m_json = other.m_json;
+    //     m_path = other.m_path;
+    // }
+    // return *this;
+
+    // Hybrid approach
+    // if (this != &other) {
+    //     if (!m_path.empty()) {
+    //         // This is a path-based access - do value assignment
+    //         nlohmann::ordered_json other_value = other.to_json();
+    //         auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+    //         *json_value_ptr = other_value;
+    //     } else {
+    //         // This is a root container - do standard assignment
+    //         m_json = other.m_json;
+    //         m_path = other.m_path;
+    //     }
+    // }
+    if (this != &other) {
+        auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+        *json_value_ptr = other.to_json();
+    }
+    return *this;
+}
+
+JsonContainer& JsonContainer::operator=(JsonContainer&& other) noexcept {
+    if (this != &other) {
+        auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+        if (m_json == other.m_json) {
+            *json_value_ptr = std::move(*other.get_json_value_ptr(AccessMode::Read));
+        } else {
+            *json_value_ptr = other.to_json();
+        }
+    }
+    return *this;
+}
+
+bool JsonContainer::operator==(const JsonContainer& other) const {
+    return to_json() == other.to_json();
+}
+
+bool JsonContainer::operator!=(const JsonContainer& other) const {
+    return !(*this == other);
+}
+
+JsonContainer JsonContainer::operator[](const std::string& key) const {
+    return JsonContainer(m_json, m_path + "/" + key);
+}
+
+JsonContainer JsonContainer::operator[](const char* key) const {
+    return operator[](std::string(key));
+}
+
+JsonContainer JsonContainer::operator[](size_t index) const {
+    return JsonContainer(m_json, m_path + "/" + std::to_string(index));
+}
+
+JsonContainer JsonContainer::operator[](int index) const {
+    return operator[](size_t(index));
+}
+
+nlohmann::ordered_json JsonContainer::to_json() const {
+    return *get_json_value_ptr(AccessMode::Read);
+}
+
+std::string JsonContainer::to_json_string(int indent) const {
+    return to_json().dump(indent);
+}
+
+bool JsonContainer::is_null() const {
+    return get_json_value_ptr(AccessMode::Read)->is_null();
+}
+
+bool JsonContainer::is_boolean() const {
+    return get_json_value_ptr(AccessMode::Read)->is_boolean();
+}
+
+bool JsonContainer::is_number() const {
+    return get_json_value_ptr(AccessMode::Read)->is_number();
+}
+
+bool JsonContainer::is_number_integer() const {
+    return get_json_value_ptr(AccessMode::Read)->is_number_integer();
+}
+
+bool JsonContainer::is_number_float() const {
+    return get_json_value_ptr(AccessMode::Read)->is_number_float();
+}
+
+bool JsonContainer::is_string() const {
+    return get_json_value_ptr(AccessMode::Read)->is_string();
+}
+
+bool JsonContainer::is_array() const {
+    return get_json_value_ptr(AccessMode::Read)->is_array();
+}
+
+bool JsonContainer::is_object() const {
+    return get_json_value_ptr(AccessMode::Read)->is_object();
+}
+
+std::optional<bool> JsonContainer::as_bool() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->is_boolean() ? std::make_optional(json_value_ptr->get<bool>()) : std::nullopt;
+}
+
+std::optional<int64_t> JsonContainer::as_int() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->is_number_integer() ? std::make_optional(json_value_ptr->get<int64_t>()) : std::nullopt;
+}
+
+std::optional<double> JsonContainer::as_double() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->is_number() ? std::make_optional(json_value_ptr->get<double>()) : std::nullopt;
+}
+
+std::optional<std::string> JsonContainer::as_string() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->is_string() ? std::make_optional(json_value_ptr->get<std::string>()) : std::nullopt;
+}
+
+bool JsonContainer::get_bool() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_boolean()) {
+        OPENVINO_THROW("JsonContainer expected boolean at path '", m_path, "' but found ",
+            json_value_ptr->type_name(), " with value: ", json_value_ptr->dump());
+    }
+    return json_value_ptr->get<bool>();
+}
+
+int64_t JsonContainer::get_int() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_number_integer()) {
+        OPENVINO_THROW("JsonContainer expected integer number at path '", m_path, "' but found ",
+            json_value_ptr->type_name(), " with value: ", json_value_ptr->dump());
+    }
+    return json_value_ptr->get<int64_t>();
+}
+
+double JsonContainer::get_double() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_number_float()) {
+        OPENVINO_THROW("JsonContainer expected floating-point number at path '", m_path, "' but found ",
+            json_value_ptr->type_name(), " with value: ", json_value_ptr->dump());
+    }
+    return json_value_ptr->get<double>();
+}
+
+std::string JsonContainer::get_string() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_string()) {
+        OPENVINO_THROW("JsonContainer expected string at path '", m_path, "' but found ",
+            json_value_ptr->type_name(), " with value: ", json_value_ptr->dump());
+    }
+    return json_value_ptr->get<std::string>();
+}
+
+JsonContainer& JsonContainer::set_object() {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+    *json_value_ptr = nlohmann::ordered_json::object();
+    return *this;
+}
+
+JsonContainer& JsonContainer::set_array() {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+    *json_value_ptr = nlohmann::ordered_json::array();
+    return *this;
+}
+
+JsonContainer& JsonContainer::push_back(const JsonContainer& item) {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
+    if (!json_value_ptr->is_array()) {
+        *json_value_ptr = nlohmann::ordered_json::array();
+    }
+    json_value_ptr->push_back(item.to_json());
+    return *this;
+}
+
+bool JsonContainer::contains(const std::string& key) const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_object()) {
+        return false;
+    }
+    return json_value_ptr->contains(key) && !(*json_value_ptr)[key].is_null();
+}
+
+size_t JsonContainer::size() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->size();
+}
+
+bool JsonContainer::empty() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    return json_value_ptr->empty();
+}
+
+void JsonContainer::erase(const std::string& key) const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_object()) {
+        OPENVINO_THROW("JsonContainer erase by key is only supported for objects, but found ",
+            json_value_ptr->type_name(), " at path '", m_path, "'");
+    }
+    auto erased_count = json_value_ptr->erase(key);
+    if (erased_count == 0) {
+        OPENVINO_THROW("JsonContainer erase key '", key, "' does not exist in the object at path '", m_path, "'");
+    }
+}
+
+void JsonContainer::erase(size_t index) const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_array()) {
+        OPENVINO_THROW("JsonContainer erase by index is only supported for arrays, but found ",
+            json_value_ptr->type_name(), " at path '", m_path, "'");
+    }
+    if (index >= json_value_ptr->size()) {
+        OPENVINO_THROW("JsonContainer erase index ", index, " is out of bounds for array of size ",
+            json_value_ptr->size(), " at path '", m_path, "'");
+    }
+    json_value_ptr->erase(json_value_ptr->begin() + index);
+}
+
+void JsonContainer::clear() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (!json_value_ptr->is_structured()) {
+        OPENVINO_THROW("JsonContainer clear is only supported for objects and arrays, but found ",
+            json_value_ptr->type_name(), " at path '", m_path, "'");
+    }
+    json_value_ptr->clear();
+}
+
+std::string JsonContainer::type_name() const {
+    auto json_value_ptr = get_json_value_ptr(AccessMode::Read);
+    if (json_value_ptr->is_null()) {
+        return "null";
+    } else if (json_value_ptr->is_boolean()) {
+        return "boolean";
+    } else if (json_value_ptr->is_number()) {
+        return "number";
+    } else if (json_value_ptr->is_string()) {
+        return "string";
+    } else if (json_value_ptr->is_array()) {
+        return "array";
+    } else if (json_value_ptr->is_object()) {
+        return "object";
+    } else {
+        return "unknown";
+    }
+}
+
+} // namespace genai
+} // namespace ov

--- a/src/cpp/src/json_container.cpp
+++ b/src/cpp/src/json_container.cpp
@@ -205,13 +205,13 @@ std::string JsonContainer::get_string() const {
     return json_value_ptr->get<std::string>();
 }
 
-JsonContainer& JsonContainer::set_object() {
+JsonContainer& JsonContainer::to_empty_object() {
     auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
     *json_value_ptr = nlohmann::ordered_json::object();
     return *this;
 }
 
-JsonContainer& JsonContainer::set_array() {
+JsonContainer& JsonContainer::to_empty_array() {
     auto json_value_ptr = get_json_value_ptr(AccessMode::Write);
     *json_value_ptr = nlohmann::ordered_json::array();
     return *this;

--- a/src/cpp/src/json_utils.hpp
+++ b/src/cpp/src/json_utils.hpp
@@ -13,6 +13,8 @@
 #include <openvino/core/except.hpp>
 #include <openvino/core/any.hpp>
 
+#include "openvino/genai/json_container.hpp"
+
 namespace ov {
 namespace genai {
 namespace utils {
@@ -70,6 +72,8 @@ inline nlohmann::ordered_json any_map_to_json(const ov::AnyMap& any_map);
 inline nlohmann::ordered_json any_to_json(const ov::Any& value) {
     if (value.is<std::string>()) {
         return value.as<std::string>();
+    } else if (value.is<int>()) {
+        return value.as<int>();
     } else if (value.is<int64_t>()) {
         return value.as<int64_t>();
     } else if (value.is<float>()) {
@@ -96,6 +100,8 @@ inline nlohmann::ordered_json any_to_json(const ov::Any& value) {
             array_json.push_back(any_map_to_json(map));
         }
         return array_json;
+    } else if (value.is<ov::genai::JsonContainer>()) {
+        return value.as<ov::genai::JsonContainer>().to_json();
     } else {
         OPENVINO_THROW("Failed to convert Any to JSON, unsupported type: ", value.type_info().name());
     }

--- a/tests/cpp/test_json_container.cpp
+++ b/tests/cpp/test_json_container.cpp
@@ -1,0 +1,399 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "openvino/genai/json_container.hpp"
+
+using namespace ov::genai;
+
+namespace {
+    constexpr bool BOOL_VALUE = true;
+    constexpr int INT_VALUE = 42;
+    constexpr int64_t INT64_VALUE = 10000000000;
+    constexpr double DOUBLE_VALUE = 3.14;
+    constexpr float FLOAT_VALUE = 2.71f;
+    const std::string TEST_STRING = "string";
+    const char* C_STRING_VALUE = "c_string";
+}
+
+TEST(JsonContainerTest, constructors) {
+    // Default constructor
+    JsonContainer empty_json;
+    EXPECT_TRUE(empty_json.is_object());
+    EXPECT_EQ(empty_json.size(), 0);
+    EXPECT_TRUE(empty_json.empty());
+
+    // Initializer list constructor
+    JsonContainer init_list_json({{"key1", TEST_STRING}, {"key2", INT_VALUE}, {"key3", BOOL_VALUE}});
+    EXPECT_TRUE(init_list_json.is_object());
+    EXPECT_EQ(init_list_json.size(), 3);
+    EXPECT_FALSE(init_list_json.empty());
+    EXPECT_TRUE(init_list_json.contains("key1"));
+    EXPECT_FALSE(init_list_json.contains("nonexistent"));
+    EXPECT_EQ(init_list_json["key1"].get_string(), TEST_STRING);
+    EXPECT_EQ(init_list_json["key2"].get_int(), INT_VALUE);
+    EXPECT_EQ(init_list_json["key3"].get_bool(), BOOL_VALUE);
+
+    // AnyMap constructor
+    ov::AnyMap any_map = {{"key1", TEST_STRING}, {"key2", DOUBLE_VALUE}};
+    JsonContainer any_map_json(any_map);
+    EXPECT_TRUE(any_map_json.is_object());
+    EXPECT_EQ(any_map_json.size(), 2);
+    EXPECT_EQ(any_map_json["key1"].get_string(), TEST_STRING);
+    EXPECT_DOUBLE_EQ(any_map_json["key2"].get_double(), DOUBLE_VALUE);
+
+    // From JSON string
+    std::string json_str = R"({"name": "test", "count": 10, "flag": false, "data": [1, 2, 3]})";
+    JsonContainer json_from_string = JsonContainer::from_json_string(json_str);
+    EXPECT_TRUE(json_from_string.is_object());
+    EXPECT_EQ(json_from_string.size(), 4);
+    EXPECT_EQ(json_from_string["name"].get_string(), "test");
+    EXPECT_EQ(json_from_string["count"].get_int(), 10);
+    EXPECT_EQ(json_from_string["flag"].get_bool(), false);
+    EXPECT_TRUE(json_from_string["data"].is_array());
+    EXPECT_EQ(json_from_string["data"].size(), 3);
+    EXPECT_EQ(json_from_string["data"][0].get_int(), 1);
+    EXPECT_EQ(json_from_string["data"][1].get_int(), 2);
+    EXPECT_EQ(json_from_string["data"][2].get_int(), 3);
+
+    EXPECT_THROW(JsonContainer::from_json_string("invalid json string"), ov::Exception);
+}
+
+TEST(JsonContainerTest, copy_move_equality) {
+    // Copy
+    JsonContainer original({{"key", "value"}});
+    
+    JsonContainer copied(original);
+    EXPECT_EQ(copied, original);
+    
+    original["key"] = "modified";
+    EXPECT_NE(copied, original);
+    EXPECT_EQ(copied["key"].get_string(), "value");
+    
+    // Move
+    JsonContainer source({{"temp", "data"}});
+    JsonContainer moved = std::move(source);
+    EXPECT_EQ(moved["temp"].get_string(), "data");
+    
+    // Equality
+    JsonContainer different({{"other", "value"}});
+    EXPECT_NE(original, different);
+    JsonContainer original_same_structure({{"key", "value"}});
+    EXPECT_EQ(original, original_same_structure);
+    JsonContainer nested = JsonContainer::from_json_string(R"({"nested": {"key": "value"}})");
+    JsonContainer original_same_structure_different_path = nested["nested"];
+    EXPECT_EQ(original, original_same_structure_different_path);
+}
+
+TEST(JsonContainerTest, primitive_values) {
+    JsonContainer bool_json = BOOL_VALUE;
+    JsonContainer int_json = INT_VALUE;
+    JsonContainer int64_json = INT64_VALUE;
+    JsonContainer double_json = DOUBLE_VALUE;
+    JsonContainer float_json = FLOAT_VALUE;
+    JsonContainer string_json = TEST_STRING;
+    JsonContainer c_string_json = C_STRING_VALUE;
+    JsonContainer null_json = nullptr;
+
+    EXPECT_TRUE(bool_json.is_boolean());
+    EXPECT_EQ(bool_json.type_name(), "boolean");
+    EXPECT_TRUE(bool_json.as_bool().has_value());
+    EXPECT_EQ(bool_json.as_bool().value(), BOOL_VALUE);
+    EXPECT_EQ(bool_json.get_bool(), BOOL_VALUE);
+    EXPECT_EQ(bool_json.to_json(), BOOL_VALUE);
+
+    EXPECT_TRUE(int_json.is_number());
+    EXPECT_TRUE(int_json.is_number_integer());
+    EXPECT_FALSE(int_json.is_number_float());
+    EXPECT_EQ(int_json.type_name(), "number");
+    EXPECT_TRUE(int_json.as_int().has_value());
+    EXPECT_EQ(int_json.as_int().value(), INT_VALUE);
+    EXPECT_EQ(int_json.get_int(), INT_VALUE);
+    EXPECT_EQ(int_json.to_json(), INT_VALUE);
+
+    EXPECT_TRUE(int64_json.is_number());
+    EXPECT_TRUE(int64_json.is_number_integer());
+    EXPECT_FALSE(int64_json.is_number_float());
+    EXPECT_EQ(int64_json.type_name(), "number");
+    EXPECT_TRUE(int64_json.as_int().has_value());
+    EXPECT_EQ(int64_json.as_int().value(), INT64_VALUE);
+    EXPECT_EQ(int64_json.get_int(), INT64_VALUE);
+    EXPECT_EQ(int64_json.to_json(), INT64_VALUE);
+
+    EXPECT_TRUE(double_json.is_number());
+    EXPECT_TRUE(double_json.is_number_float());
+    EXPECT_FALSE(double_json.is_number_integer());
+    EXPECT_EQ(double_json.type_name(), "number");
+    EXPECT_TRUE(double_json.as_double().has_value());
+    EXPECT_DOUBLE_EQ(double_json.as_double().value(), DOUBLE_VALUE);
+    EXPECT_DOUBLE_EQ(double_json.get_double(), DOUBLE_VALUE);
+    EXPECT_DOUBLE_EQ(double_json.to_json(), DOUBLE_VALUE);
+
+    EXPECT_TRUE(float_json.is_number());
+    EXPECT_TRUE(float_json.is_number_float());
+    EXPECT_FALSE(float_json.is_number_integer());
+    EXPECT_EQ(float_json.type_name(), "number");
+    EXPECT_TRUE(float_json.as_double().has_value());
+    EXPECT_FLOAT_EQ(static_cast<float>(float_json.as_double().value()), FLOAT_VALUE);
+    EXPECT_FLOAT_EQ(static_cast<float>(float_json.get_double()), FLOAT_VALUE);
+    EXPECT_FLOAT_EQ(static_cast<float>(float_json.to_json()), FLOAT_VALUE);
+
+    EXPECT_TRUE(string_json.is_string());
+    EXPECT_EQ(string_json.type_name(), "string");
+    EXPECT_TRUE(string_json.as_string().has_value());
+    EXPECT_EQ(string_json.as_string().value(), TEST_STRING);
+    EXPECT_EQ(string_json.get_string(), TEST_STRING);
+    EXPECT_EQ(string_json.to_json(), TEST_STRING);
+
+    EXPECT_TRUE(c_string_json.is_string());
+    EXPECT_EQ(c_string_json.type_name(), "string");
+    EXPECT_TRUE(c_string_json.as_string().has_value());
+    EXPECT_EQ(c_string_json.as_string().value(), C_STRING_VALUE);
+    EXPECT_EQ(c_string_json.get_string(), C_STRING_VALUE);
+    EXPECT_EQ(c_string_json.to_json(), C_STRING_VALUE);
+
+    EXPECT_TRUE(null_json.is_null());
+    EXPECT_EQ(null_json.type_name(), "null");
+    EXPECT_EQ(null_json.size(), 0);
+    EXPECT_EQ(null_json.empty(), true);
+    EXPECT_EQ(null_json.to_json(), nullptr);
+    null_json = "not null";
+    EXPECT_EQ(null_json.get_string(), "not null");
+    null_json = nullptr;
+    EXPECT_TRUE(null_json.is_null());
+
+    EXPECT_FALSE(string_json.as_bool().has_value());
+    EXPECT_FALSE(bool_json.as_int().has_value());
+    EXPECT_FALSE(int_json.as_string().has_value());
+
+    EXPECT_THROW(string_json.get_bool(), ov::Exception);
+    EXPECT_THROW(bool_json.get_int(), ov::Exception);
+    EXPECT_THROW(int_json.get_string(), ov::Exception);
+
+    // Primitives are considered as not empty
+    EXPECT_FALSE(string_json.empty());
+    EXPECT_FALSE(bool_json.empty());
+    EXPECT_FALSE(int_json.empty());
+    EXPECT_EQ(string_json.size(), 1);
+    EXPECT_EQ(bool_json.size(), 1);
+    EXPECT_EQ(int_json.size(), 1);
+    
+    // Null is considered as empty
+    EXPECT_TRUE(null_json.empty());
+    EXPECT_EQ(null_json.size(), 0);
+}
+
+TEST(JsonContainerTest, array_operations) {
+    JsonContainer jc;
+    jc.push_back(BOOL_VALUE)
+      .push_back(INT_VALUE)
+      .push_back(INT64_VALUE)
+      .push_back(DOUBLE_VALUE)
+      .push_back(FLOAT_VALUE)
+      .push_back(TEST_STRING)
+      .push_back(C_STRING_VALUE)
+      .push_back(JsonContainer({{"nested", "value"}}));
+      
+    EXPECT_TRUE(jc.is_array());
+    EXPECT_EQ(jc.type_name(), "array");
+    EXPECT_EQ(jc.size(), 8);
+    EXPECT_FALSE(jc.empty());
+
+    EXPECT_EQ(jc[size_t(0)].get_bool(), BOOL_VALUE);
+    EXPECT_EQ(jc["1"].get_int(), INT_VALUE);
+    EXPECT_EQ(jc[2].get_int(), INT64_VALUE);
+    EXPECT_DOUBLE_EQ(jc[3].get_double(), DOUBLE_VALUE);
+    EXPECT_FLOAT_EQ(static_cast<float>(jc[4].get_double()), FLOAT_VALUE);
+    EXPECT_EQ(jc[5].get_string(), TEST_STRING);
+    EXPECT_EQ(jc[6].get_string(), C_STRING_VALUE);
+    EXPECT_EQ(jc[7]["nested"].get_string(), "value");
+
+    // Test array append by index
+    jc[8] = "appended";
+    EXPECT_EQ(jc.size(), 9);
+    EXPECT_EQ(jc[8].get_string(), "appended");
+    
+    // Contains method checks object keys, should return false for arrays
+    EXPECT_FALSE(jc.contains("8"));
+
+    // Test erase by index with array shifting
+    jc.erase(7);
+    EXPECT_EQ(jc.size(), 8);
+    EXPECT_EQ(jc[7].get_string(), "appended");
+    EXPECT_THROW(jc.erase(100), ov::Exception);
+    EXPECT_THROW(jc[0].erase(0), ov::Exception); // test erase by index for primitives
+
+    // Test out-of-bounds access
+    EXPECT_THROW(jc[100].to_json(), ov::Exception);
+
+    // Test out-of-bounds assignment expands array with nulls
+    jc.set_array();
+    EXPECT_EQ(jc.size(), 0);
+    jc[2] = "value";  // Should create nulls at indices 0-1
+    EXPECT_TRUE(jc.is_array());
+    EXPECT_EQ(jc.size(), 3);
+    EXPECT_TRUE(jc[0].is_null());
+    EXPECT_TRUE(jc[1].is_null());
+    EXPECT_TRUE(jc[1].empty());
+    EXPECT_EQ(jc[1].type_name(), "null");
+    EXPECT_EQ(jc[2].get_string(), "value");
+
+    // Test clear array
+    EXPECT_THROW(jc[2].clear(), ov::Exception); // test clear for primitives
+    EXPECT_NO_THROW(jc.clear());
+    EXPECT_TRUE(jc.is_array());
+    EXPECT_EQ(jc.size(), 0);
+}
+
+TEST(JsonContainerTest, object_operations) {
+    JsonContainer jc;
+    jc["key1"] = "value";
+    jc[std::string("key2")] = true;
+    
+    EXPECT_TRUE(jc.is_object());
+    EXPECT_EQ(jc.type_name(), "object");
+    EXPECT_EQ(jc.size(), 2);
+    EXPECT_FALSE(jc.empty());
+    
+    // Test object contains and access
+    EXPECT_TRUE(jc.contains("key1"));
+    EXPECT_TRUE(jc.contains("key2"));
+    EXPECT_FALSE(jc.contains("nonexistent"));
+    EXPECT_NO_THROW(jc["key1"].get_string());
+    EXPECT_THROW(jc["nonexistent"].get_string(), ov::Exception);
+    EXPECT_THROW(jc["key1"]["nested"].get_string(), ov::Exception);
+
+    // Test erase by key in object
+    EXPECT_TRUE(jc.contains("key2"));
+    EXPECT_NO_THROW(jc.erase("key2"));
+    EXPECT_FALSE(jc.contains("key2"));
+    EXPECT_THROW(jc.erase("key2"), ov::Exception);
+    EXPECT_THROW(jc.erase("nonexistent"), ov::Exception);
+    EXPECT_THROW(jc["key1"].erase("something"), ov::Exception); // test erase by key for primitives
+
+    jc["key1"] = jc["key1"];
+    EXPECT_EQ(jc["key1"].get_string(), "value");
+
+    // Test object key assignment with integer (converted to string)
+    jc.set_object();
+    EXPECT_EQ(jc.size(), 0);
+    jc[5] = "value";
+    EXPECT_TRUE(jc.is_object());
+    EXPECT_EQ(jc.size(), 1);
+    EXPECT_EQ(jc["5"].get_string(), "value");
+    EXPECT_EQ(jc[5].get_string(), "value");
+
+    // Test nested object creation
+    EXPECT_NO_THROW(jc["new_path"]["deep"]["nested"] = "value");
+    EXPECT_EQ(jc["new_path"]["deep"]["nested"].get_string(), "value");
+
+    // Test clear object
+    jc["key"] = "value";
+    EXPECT_THROW(jc["key"].clear(), ov::Exception); // test clear for primitives
+    EXPECT_NO_THROW(jc.clear());
+    EXPECT_TRUE(jc.is_object());
+    EXPECT_EQ(jc.size(), 0);
+}
+
+TEST(JsonContainerTest, container_conversion) {
+    JsonContainer jc = "primitive";
+    EXPECT_TRUE(jc.is_string());
+    EXPECT_EQ(jc.get_string(), "primitive");
+
+    // Test primitive to array convertion
+    jc.set_array();
+    EXPECT_TRUE(jc.is_array());
+    EXPECT_EQ(jc.size(), 0);
+    jc.push_back("item1");
+    EXPECT_EQ(jc.size(), 1);
+    EXPECT_EQ(jc[0].get_string(), "item1");
+
+    // Test array to object convertion
+    jc.set_object();
+    EXPECT_TRUE(jc.is_object());
+    EXPECT_EQ(jc.size(), 0);
+    jc["key"] = "value";
+    EXPECT_EQ(jc.size(), 1);
+    EXPECT_EQ(jc["key"].get_string(), "value");
+}
+
+TEST(JsonContainerTest, nested_structures) {
+    JsonContainer jc;
+    jc["users"][0]["name"] = "Alice";
+    jc["users"][0]["age"] = 30;
+    jc["users"][0]["hobbies"].push_back("reading").push_back("coding");
+    
+    jc["users"][1]["name"] = "Bob";
+    jc["users"][1]["active"] = false;
+    
+    jc["metadata"]["counts"]["total"] = 2;
+    
+    EXPECT_TRUE(jc["users"].is_array());
+    EXPECT_TRUE(jc["users"][0].is_object());
+    EXPECT_EQ(jc["users"][0]["name"].get_string(), "Alice");
+    EXPECT_EQ(jc["users"][0]["age"].get_int(), 30);
+    EXPECT_TRUE(jc["users"][0]["hobbies"].is_array());
+    EXPECT_EQ(jc["users"][0]["hobbies"].size(), 2);
+    EXPECT_EQ(jc["users"][0]["hobbies"][1].get_string(), "coding");
+    EXPECT_TRUE(jc["users"][1].is_object());
+    EXPECT_EQ(jc["users"][1]["name"].get_string(), "Bob");
+    EXPECT_EQ(jc["users"][1]["active"].get_bool(), false);
+    EXPECT_TRUE(jc["metadata"].is_object());
+    EXPECT_EQ(jc["metadata"]["counts"]["total"].get_int(), 2);
+
+    JsonContainer root;
+    root["nested"] = jc;
+    EXPECT_EQ(root["nested"]["users"][0]["name"].get_string(), "Alice");
+}
+
+TEST(JsonContainerTest, json_string) {
+    JsonContainer any_map_json({
+        {"string", "test"},
+        {"number", 42},
+        {"boolean", true},
+        {"array", JsonContainer().set_array().push_back(1).push_back(2)},
+        {"object", JsonContainer({{"nested", "value"}})}
+    });
+    
+    std::string any_map_json_string = any_map_json.to_json_string();
+    // AnyMap sorts keys alphabetically
+    EXPECT_EQ(any_map_json_string, R"({"array":[1,2],"boolean":true,"number":42,"object":{"nested":"value"},"string":"test"})");
+
+    JsonContainer jc;
+    jc["string"] = "test";
+    jc["number"] = 42;
+    jc["boolean"] = true;
+    jc["array"].set_array().push_back(1).push_back(2);
+    jc["object"]["nested"] = "value";
+
+    std::string json_string = jc.to_json_string();
+    // Keys order should be preserved
+    EXPECT_EQ(json_string, R"({"string":"test","number":42,"boolean":true,"array":[1,2],"object":{"nested":"value"}})");
+    
+    std::string json_string_with_indent = jc.to_json_string(2);
+    EXPECT_GT(json_string_with_indent.length(), json_string.length());
+    
+    JsonContainer parsed = JsonContainer::from_json_string(json_string);
+    EXPECT_EQ(parsed, jc);
+    
+    EXPECT_EQ(parsed["string"].get_string(), "test");
+    EXPECT_EQ(parsed["number"].get_int(), 42);
+    EXPECT_EQ(parsed["boolean"].get_bool(), true);
+    EXPECT_EQ(parsed["array"].size(), 2);
+    EXPECT_EQ(parsed["object"]["nested"].get_string(), "value");
+}
+
+TEST(JsonContainerTest, nlohmann_json) {
+    nlohmann::ordered_json a = {{"key", "value1"}};
+    nlohmann::ordered_json a_same = {{"key", "value1"}};
+    EXPECT_EQ(a, a_same);
+    nlohmann::ordered_json b = {{"key", "value2"}};
+    a = b;
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(a["key"], "value2");
+    a["key"] = "changed";
+    EXPECT_NE(a, b);
+    EXPECT_EQ(a["key"], "changed");
+    EXPECT_EQ(b["key"], "value2");
+}

--- a/tests/cpp/test_json_container.cpp
+++ b/tests/cpp/test_json_container.cpp
@@ -383,7 +383,7 @@ TEST(JsonContainerTest, container_conversion) {
     EXPECT_TRUE(jc.is_string());
     EXPECT_EQ(jc.get_string(), "primitive");
 
-    // Test primitive to array convertion
+    // Test primitive to array conversion
     jc.to_empty_array();
     EXPECT_TRUE(jc.is_array());
     EXPECT_EQ(jc.size(), 0);
@@ -391,7 +391,7 @@ TEST(JsonContainerTest, container_conversion) {
     EXPECT_EQ(jc.size(), 1);
     EXPECT_EQ(jc[0].get_string(), "item1");
 
-    // Test array to object convertion
+    // Test array to object conversion
     jc.to_empty_object();
     EXPECT_TRUE(jc.is_object());
     EXPECT_EQ(jc.size(), 0);

--- a/tests/cpp/test_json_container.cpp
+++ b/tests/cpp/test_json_container.cpp
@@ -67,10 +67,11 @@ TEST(JsonContainerTest, copy_move_equality) {
     JsonContainer copied(original);
     EXPECT_EQ(copied, original);
     
-    original["key"] = "modified";
+    copied["key"] = "modified";
     EXPECT_NE(copied, original);
-    EXPECT_EQ(copied["key"].get_string(), "value");
-    
+    EXPECT_EQ(original["key"].get_string(), "value");
+    EXPECT_EQ(copied["key"].get_string(), "modified");
+
     // Move
     JsonContainer source({{"temp", "data"}});
     JsonContainer moved = std::move(source);
@@ -382,18 +383,4 @@ TEST(JsonContainerTest, json_string) {
     EXPECT_EQ(parsed["boolean"].get_bool(), true);
     EXPECT_EQ(parsed["array"].size(), 2);
     EXPECT_EQ(parsed["object"]["nested"].get_string(), "value");
-}
-
-TEST(JsonContainerTest, nlohmann_json) {
-    nlohmann::ordered_json a = {{"key", "value1"}};
-    nlohmann::ordered_json a_same = {{"key", "value1"}};
-    EXPECT_EQ(a, a_same);
-    nlohmann::ordered_json b = {{"key", "value2"}};
-    a = b;
-    EXPECT_EQ(a, b);
-    EXPECT_EQ(a["key"], "value2");
-    a["key"] = "changed";
-    EXPECT_NE(a, b);
-    EXPECT_EQ(a["key"], "changed");
-    EXPECT_EQ(b["key"], "value2");
 }

--- a/tests/cpp/test_json_container.cpp
+++ b/tests/cpp/test_json_container.cpp
@@ -310,7 +310,7 @@ TEST(JsonContainerTest, array_operations) {
     EXPECT_THROW(jc[100].to_json(), ov::Exception);
 
     // Test out-of-bounds assignment expands array with nulls
-    jc.set_array();
+    jc.to_empty_array();
     EXPECT_EQ(jc.size(), 0);
     jc[2] = "value";  // Should create nulls at indices 0-1
     EXPECT_TRUE(jc.is_array());
@@ -358,7 +358,7 @@ TEST(JsonContainerTest, object_operations) {
     EXPECT_EQ(jc["key1"].get_string(), "value");
 
     // Test object key assignment with integer (converted to string)
-    jc.set_object();
+    jc.to_empty_object();
     EXPECT_EQ(jc.size(), 0);
     jc[5] = "value";
     EXPECT_TRUE(jc.is_object());
@@ -384,7 +384,7 @@ TEST(JsonContainerTest, container_conversion) {
     EXPECT_EQ(jc.get_string(), "primitive");
 
     // Test primitive to array convertion
-    jc.set_array();
+    jc.to_empty_array();
     EXPECT_TRUE(jc.is_array());
     EXPECT_EQ(jc.size(), 0);
     jc.push_back("item1");
@@ -392,7 +392,7 @@ TEST(JsonContainerTest, container_conversion) {
     EXPECT_EQ(jc[0].get_string(), "item1");
 
     // Test array to object convertion
-    jc.set_object();
+    jc.to_empty_object();
     EXPECT_TRUE(jc.is_object());
     EXPECT_EQ(jc.size(), 0);
     jc["key"] = "value";
@@ -434,7 +434,7 @@ TEST(JsonContainerTest, json_string) {
         {"string", "test"},
         {"number", 42},
         {"boolean", true},
-        {"array", JsonContainer().set_array().push_back(1).push_back(2)},
+        {"array", JsonContainer().to_empty_array().push_back(1).push_back(2)},
         {"object", JsonContainer({{"nested", "value"}})}
     });
     
@@ -446,7 +446,7 @@ TEST(JsonContainerTest, json_string) {
     jc["string"] = "test";
     jc["number"] = 42;
     jc["boolean"] = true;
-    jc["array"].set_array().push_back(1).push_back(2);
+    jc["array"].to_empty_array().push_back(1).push_back(2);
     jc["object"]["nested"] = "value";
 
     std::string json_string = jc.to_json_string();


### PR DESCRIPTION
## Description
This PR introduces the `JsonContainer` class for handling chat history in a JSON format, providing a wrapper around `nlohmann::json` with type-safe accessors and path-based navigation.

Further PRs will integrate JsonContainer to chat history

Ticket: 170884

## Checklist:
- [x] Tests have been updated or added to cover the new code 
- [x] This patch fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**
