### PR TITLE
[StructuredOutput] Update XGrammar

### DIFF
--- a/samples/cpp/text_generation/benchmark_genai.cpp
+++ b/samples/cpp/text_generation/benchmark_genai.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[]) try {
 
     ov::genai::GenerationConfig config;
     config.max_new_tokens = result["max_new_tokens"].as<size_t>();
+    config.apply_chat_template = false;
 
     ov::genai::SchedulerConfig scheduler_config;
     scheduler_config.enable_prefix_caching = false;

--- a/samples/python/text_generation/benchmark_genai.py
+++ b/samples/python/text_generation/benchmark_genai.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import argparse
+import sys
+
 import openvino_genai as ov_genai
 from openvino import get_version
 
@@ -20,19 +21,19 @@ def main():
     args = parser.parse_args()
 
     if args.prompt is not None and args.prompt_file is not None:
-        raise RuntimeError(f'Prompt and prompt file should not exist together!')
+        raise RuntimeError("Prompt and prompt file should not exist together!")
     else:
         if args.prompt_file is not None:
-            with open(args.prompt_file, 'r', encoding='utf-8') as f:
+            with open(args.prompt_file, "r", encoding="utf-8") as f:
                 prompt = [f.read()]
         else:
-            prompt = ['The Sky is blue because'] if args.prompt is None else [args.prompt]
+            prompt = ["The Sky is blue because"] if args.prompt is None else [args.prompt]
     if len(prompt) == 0:
-        raise RuntimeError(f'Prompt is empty!')
+        raise RuntimeError("Prompt is empty!")
 
-    print(f'openvino runtime version: {get_version()}, genai version: {ov_genai.__version__}')
+    print(f"openvino runtime version: {get_version()}, genai version: {ov_genai.__version__}")
 
-    # Perf metrics is stored in DecodedResults. 
+    # Perf metrics is stored in DecodedResults.
     # In order to get DecodedResults instead of a string input should be a list.
     models_path = args.model
     device = args.device
@@ -63,15 +64,22 @@ def main():
     for _ in range(num_iter - 1):
         res = pipe.generate(prompt, config)
         perf_metrics += res.perf_metrics
-    
+
     print(f"Output token size: {res.perf_metrics.get_num_generated_tokens()}")
     print(f"Load time: {perf_metrics.get_load_time():.2f} ms")
-    print(f"Generate time: {perf_metrics.get_generate_duration().mean:.2f} ± {perf_metrics.get_generate_duration().std:.2f} ms")
-    print(f"Tokenization time: {perf_metrics.get_tokenization_duration().mean:.2f} ± {perf_metrics.get_tokenization_duration().std:.2f} ms")
-    print(f"Detokenization time: {perf_metrics.get_detokenization_duration().mean:.2f} ± {perf_metrics.get_detokenization_duration().std:.2f} ms")
+    print(
+        f"Generate time: {perf_metrics.get_generate_duration().mean:.2f} ± {perf_metrics.get_generate_duration().std:.2f} ms"
+    )
+    print(
+        f"Tokenization time: {perf_metrics.get_tokenization_duration().mean:.2f} ± {perf_metrics.get_tokenization_duration().std:.2f} ms"
+    )
+    print(
+        f"Detokenization time: {perf_metrics.get_detokenization_duration().mean:.2f} ± {perf_metrics.get_detokenization_duration().std:.2f} ms"
+    )
     print(f"TTFT: {perf_metrics.get_ttft().mean:.2f} ± {perf_metrics.get_ttft().std:.2f} ms")
     print(f"TPOT: {perf_metrics.get_tpot().mean:.2f} ± {perf_metrics.get_tpot().std:.2f} ms")
     print(f"Throughput : {perf_metrics.get_throughput().mean:.2f} ± {perf_metrics.get_throughput().std:.2f} tokens/s")
+
 
 if __name__ == "__main__":
     main()

--- a/samples/python/text_generation/benchmark_genai.py
+++ b/samples/python/text_generation/benchmark_genai.py
@@ -6,6 +6,7 @@ import argparse
 import openvino_genai as ov_genai
 from openvino import get_version
 
+
 def main():
     parser = argparse.ArgumentParser(description="Help command")
     parser.add_argument("-m", "--model", type=str, required=True, help="Path to model and tokenizers base directory")
@@ -15,7 +16,7 @@ def main():
     parser.add_argument("-n", "--num_iter", type=int, default=2, help="Number of iterations")
     parser.add_argument("-mt", "--max_new_tokens", type=int, default=20, help="Maximal number of new tokens")
     parser.add_argument("-d", "--device", type=str, default="CPU", help="Device")
-    
+
     args = parser.parse_args()
 
     if args.prompt is not None and args.prompt_file is not None:
@@ -37,9 +38,10 @@ def main():
     device = args.device
     num_warmup = args.num_warmup
     num_iter = args.num_iter
-    
+
     config = ov_genai.GenerationConfig()
     config.max_new_tokens = args.max_new_tokens
+    config.apply_chat_template = False
 
     if device == "NPU":
         pipe = ov_genai.LLMPipeline(models_path, device)
@@ -55,7 +57,7 @@ def main():
 
     for _ in range(num_warmup):
         pipe.generate(prompt, config)
-    
+
     res = pipe.generate(prompt, config)
     perf_metrics = res.perf_metrics
     for _ in range(num_iter - 1):

--- a/samples/python/text_generation/compound_grammar_generation.py
+++ b/samples/python/text_generation/compound_grammar_generation.py
@@ -7,12 +7,13 @@ import json
 from typing import Any
 
 from openvino_genai import (
-    LLMPipeline,
     GenerationConfig,
-    StructuredOutputConfig as SOC,
+    LLMPipeline,
     StreamingStatus,
 )
-
+from openvino_genai import (
+    StructuredOutputConfig as SOC,
+)
 from pydantic import BaseModel, Field
 
 
@@ -25,9 +26,7 @@ class booking_flight_tickets(BaseModel):
     """booking flights"""
 
     origin_airport_code: str = Field(description="The name of Departure airport code")
-    destination_airport_code: str = Field(
-        description="The name of Destination airport code"
-    )
+    destination_airport_code: str = Field(description="The name of Destination airport code")
     departure_date: str = Field(description="The date of outbound flight")
     return_date: str = Field(description="The date of return flight")
 
@@ -74,11 +73,10 @@ def tools_to_array_schema(*tools: BaseModel) -> str:
     return json.dumps(
         {
             "type": "array",
-            "items": {
-                "anyOf": [tool_to_dict(tool, with_description=False) for tool in tools]
-            },
+            "items": {"anyOf": [tool_to_dict(tool, with_description=False) for tool in tools]},
         }
     )
+
 
 # modified system message from:
 # https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_phi4_mini.jinja
@@ -88,7 +86,7 @@ You can answer yes or no to questions, or you can chose to call one or more of t
 Use the following rule to decide when to call a function:
     * if the response can be generated from your internal knowledge, do so, but use only yes or no as the response
     * if you need external information that can be obtained by calling one or more of the provided functions, generate function calls
-    
+
 If you decide to call functions:
     * prefix function calls with functools marker (no closing marker required)
     * all function calls should be generated in a single JSON list formatted as functools[{"name": [function name], "arguments": [function arguments as JSON]}, ...]
@@ -118,9 +116,7 @@ def main():
     user_text_1 = "Do dolphins have fingers?"
     print("User: ", user_text_1)
     chat_history.append({"role": "user", "content": user_text_1})
-    model_input = tokenizer.apply_chat_template(
-        chat_history, add_generation_prompt=True
-    )
+    model_input = tokenizer.apply_chat_template(chat_history, add_generation_prompt=True)
     # same as SOC.Union(SOC.ConstString("yes"), SOC.ConstString("no"))
     yes_or_no_grammar = SOC.ConstString("yes") | SOC.ConstString("no")
     generation_config.structured_output_config = SOC(structural_tags_config=yes_or_no_grammar)
@@ -135,17 +131,11 @@ def main():
     )
     print("User: ", user_text_2)
     chat_history.append({"role": "user", "content": user_text_2})
-    model_input = tokenizer.apply_chat_template(
-        chat_history, add_generation_prompt=True
-    )
+    model_input = tokenizer.apply_chat_template(chat_history, add_generation_prompt=True)
 
     start_tool_call_tag = SOC.ConstString(r"functools")
-    tools_json = SOC.JSONSchema(
-        tools_to_array_schema(booking_flight_tickets, booking_hotels)
-    )
-    tool_call_grammar = (
-        start_tool_call_tag + tools_json
-    )  # SOC.Concat(start_tool_call_tag, tools_json)
+    tools_json = SOC.JSONSchema(tools_to_array_schema(booking_flight_tickets, booking_hotels))
+    tool_call_grammar = start_tool_call_tag + tools_json  # SOC.Concat(start_tool_call_tag, tools_json)
     generation_config.structured_output_config.structural_tags_config = tool_call_grammar
 
     print("Assistant: ", end="")

--- a/samples/python/text_generation/structural_tags_generation.py
+++ b/samples/python/text_generation/structural_tags_generation.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+from json import tool
 import re
 import json
 from datetime import datetime
@@ -11,9 +12,7 @@ from pprint import pprint
 from openvino_genai import (
     LLMPipeline,
     GenerationConfig,
-    StructuredOutputConfig,
-    StructuralTagsConfig,
-    StructuralTagItem,
+    StructuredOutputConfig as SOC,
     StreamingStatus,
 )
 from typing import ClassVar
@@ -125,17 +124,17 @@ def main():
 
         pipe.start_chat(sys_message)
         if use_structural_tags:
-            config.structured_output_config = StructuredOutputConfig(
-                structural_tags_config=StructuralTagsConfig(
-                    structural_tags=[
-                        StructuralTagItem(
+            config.structured_output_config = SOC(
+                structural_tags_config=SOC.TriggeredTags(
+                    triggers=["<function="],
+                    tags=[
+                        SOC.Tag(
                             begin=f'<function="{name}">',
-                            schema=json.dumps(tool.model_json_schema()),
+                            content=SOC.JSONSchema(json.dumps(tool.model_json_schema())),
                             end="</function>",
                         )
                         for name, tool in tools.items()
-                    ],
-                    triggers=["<function="],
+                    ]
                 )
             )
             config.do_sample = True

--- a/samples/python/text_generation/structural_tags_generation.py
+++ b/samples/python/text_generation/structural_tags_generation.py
@@ -3,19 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-from json import tool
-import re
 import json
+import re
 from datetime import datetime
 from pprint import pprint
+from typing import ClassVar
 
 from openvino_genai import (
-    LLMPipeline,
     GenerationConfig,
-    StructuredOutputConfig as SOC,
+    LLMPipeline,
     StreamingStatus,
 )
-from typing import ClassVar
+from openvino_genai import (
+    StructuredOutputConfig as SOC,
+)
 from pydantic import BaseModel, Field
 
 
@@ -34,9 +35,7 @@ class WeatherRequest(ToolRequest):
 
     city: str = Field(description="City name")
     country: str = Field(description="Country name")
-    date: str = Field(
-        pattern=r"2\d\d\d-[0-1]\d-[0-3]\d", description="Date in YYYY-MM-DD format"
-    )
+    date: str = Field(pattern=r"2\d\d\d-[0-1]\d-[0-3]\d", description="Date in YYYY-MM-DD format")
 
 
 class CurrencyExchangeRequest(ToolRequest):
@@ -58,8 +57,8 @@ sys_message = (
     "You can use the following tools:\n"
     f"{new_line.join([tool.string_representation() for tool in tools.values()])}\n"
     "Please, only use the following format for tool calling in your responses:\n"
-    "<function=\"function_name\">"
-    "{\"argument1\": \"value1\", ...}"
+    '<function="function_name">'
+    '{"argument1": "value1", ...}'
     "</function>\n"
     "Use the tool name and arguments as defined in the tool schema.\n"
     "If you don't know the answer, just say that you don't know, but try to call the tool if it helps to answer the question.\n"
@@ -76,10 +75,7 @@ def parse_tools_from_response(response: str) -> list[ToolRequest]:
     <function="function_name">{"argument1": "value1", ...}</function>
     """
     matches = re.finditer(function_pattern, response)
-    return [
-        tools.get(match.group(1)).model_validate_json(match.group(2))
-        for match in matches
-    ]
+    return [tools.get(match.group(1)).model_validate_json(match.group(2)) for match in matches]
 
 
 def streamer(subword):
@@ -88,7 +84,9 @@ def streamer(subword):
 
 
 def main():
-    default_prompt = "What is the weather in London today and in Paris yesterday, and how many pounds can I get for 100 euros?"
+    default_prompt = (
+        "What is the weather in London today and in Paris yesterday, and how many pounds can I get for 100 euros?"
+    )
 
     description = (
         "This script demonstrates how to use OpenVINO GenAI with structured tags to generate responses "
@@ -115,9 +113,7 @@ def main():
 
     for use_structural_tags in [False, True]:
         print("=" * 80)
-        print(
-            f"{'Using structural tags' if use_structural_tags else 'Using no structural tags':^80}"
-        )
+        print(f"{'Using structural tags' if use_structural_tags else 'Using no structural tags':^80}")
         print("=" * 80)
         config = GenerationConfig()
         config.max_new_tokens = 300
@@ -134,7 +130,7 @@ def main():
                             end="</function>",
                         )
                         for name, tool in tools.items()
-                    ]
+                    ],
                 )
             )
             config.do_sample = True

--- a/samples/python/text_generation/structured_output_generation.py
+++ b/samples/python/text_generation/structured_output_generation.py
@@ -70,7 +70,7 @@ def main():
         except EOFError:
             break
         pipe.start_chat(sys_message)
-        config.structured_output_config = StructuredOutputConfig(json_schema = json.dumps(ItemQuantities.model_json_schema()))
+        config.structured_output_config = StructuredOutputConfig(json_schema=json.dumps(ItemQuantities.model_json_schema()))
         config.do_sample = False
         res = json.loads(pipe.generate(prompt, config))
         pipe.finish_chat()
@@ -82,7 +82,7 @@ def main():
         pipe.start_chat(sys_message_for_items)
         generate_has_run = False
         for item, quantity in res.items():
-            config.structured_output_config = StructuredOutputConfig(json_schema = json.dumps(items_map[item].model_json_schema()))
+            config.structured_output_config = StructuredOutputConfig(json_schema=json.dumps(items_map[item].model_json_schema()))
             for _ in range(quantity):
                 generate_has_run = True
                 json_strs = pipe.generate(prompt, config)

--- a/samples/python/text_generation/structured_output_generation.py
+++ b/samples/python/text_generation/structured_output_generation.py
@@ -4,8 +4,9 @@
 
 import argparse
 import json
-from openvino_genai import LLMPipeline, GenerationConfig, StructuredOutputConfig
 from typing import Literal
+
+from openvino_genai import GenerationConfig, LLMPipeline, StructuredOutputConfig
 from pydantic import BaseModel, Field
 
 
@@ -14,7 +15,7 @@ class Person(BaseModel):
     surname: str = Field(pattern=r"^[A-Z][a-z]{1,20}$")
     age: int
     city: Literal["Dublin", "Dubai", "Munich"]
-    
+
 
 class Car(BaseModel):
     model: str = Field(pattern=r"^[A-Z][a-z]{1,20} ?[A-Z][a-z]{0,20} ?.?$")
@@ -40,8 +41,8 @@ sys_message = (
     "You generate JSON objects based on the user's request. You can generate JSON objects with different types of objects: person, car, transaction. "
     "If the user requested a different type, the JSON fields should remain zero. "
     "Please note that the words 'individual', 'person', 'people', 'man', 'human', 'woman', 'inhabitant', 'citizen' are synonyms and can be used interchangeably. "
-    "E.g. if the user wants 5 houses, then the JSON must be {\"person\": 0, \"car\": 0, \"transaction\": 0}. "
-    "If the user wants 3 people and 1 house, then the JSON must be {\"person\": 3, \"car\": 0, \"transaction\": 0}. "
+    'E.g. if the user wants 5 houses, then the JSON must be {"person": 0, "car": 0, "transaction": 0}. '
+    'If the user wants 3 people and 1 house, then the JSON must be {"person": 3, "car": 0, "transaction": 0}. '
     "Make sure that the JSON contains the numbers that the user requested. If the user asks for specific attributes, like 'surname', 'model', etc., "
     "ignore this information and generate JSON objects with the same fields as in the schema. "
     "Please use double quotes for JSON keys and values. "
@@ -49,28 +50,33 @@ sys_message = (
 
 sys_message_for_items = "Please try to avoid generating the same JSON objects multiple times."
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('model_dir', help="Path to the model directory. It should contain the OpenVINO model files.")
+    parser.add_argument("model_dir", help="Path to the model directory. It should contain the OpenVINO model files.")
     args = parser.parse_args()
 
-    device = 'CPU'  # GPU can be used as well
+    device = "CPU"  # GPU can be used as well
     pipe = LLMPipeline(args.model_dir, device)
 
     config = GenerationConfig()
     config.max_new_tokens = 300
 
-    print("This is a smart assistant that generates structured output in JSON format. "
-          "You can ask to generate information about a person, car, or bank transaction. "
-          'For example, you can ask: "Please generate jsons for 3 persons and 1 transaction."')
+    print(
+        "This is a smart assistant that generates structured output in JSON format. "
+        "You can ask to generate information about a person, car, or bank transaction. "
+        'For example, you can ask: "Please generate jsons for 3 persons and 1 transaction."'
+    )
 
     while True:
         try:
-            prompt = input('> ')
+            prompt = input("> ")
         except EOFError:
             break
         pipe.start_chat(sys_message)
-        config.structured_output_config = StructuredOutputConfig(json_schema=json.dumps(ItemQuantities.model_json_schema()))
+        config.structured_output_config = StructuredOutputConfig(
+            json_schema=json.dumps(ItemQuantities.model_json_schema())
+        )
         config.do_sample = False
         res = json.loads(pipe.generate(prompt, config))
         pipe.finish_chat()
@@ -82,7 +88,9 @@ def main():
         pipe.start_chat(sys_message_for_items)
         generate_has_run = False
         for item, quantity in res.items():
-            config.structured_output_config = StructuredOutputConfig(json_schema=json.dumps(items_map[item].model_json_schema()))
+            config.structured_output_config = StructuredOutputConfig(
+                json_schema=json.dumps(items_map[item].model_json_schema())
+            )
             for _ in range(quantity):
                 generate_has_run = True
                 json_strs = pipe.generate(prompt, config)
@@ -92,5 +100,5 @@ def main():
             print("No items generated. Please try again with a different request.")
 
 
-if '__main__' == __name__:
+if "__main__" == __name__:
     main()

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -59,7 +59,7 @@ if(ANDROID)
 endif()
 
 if(ENABLE_XGRAMMAR)
-    set(XGRAMMAR_VERSION v0.1.18)
+    set(XGRAMMAR_VERSION v0.1.25)
     set(XGRAMMAR_DIR ${CMAKE_BINARY_DIR}/xgrammar)
 
     FetchContent_Declare(

--- a/src/cpp/include/openvino/genai/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/generation_config.hpp
@@ -403,8 +403,7 @@ public:
      * @brief Tag defines a begin/end wrapper with constrained inner content.
      *
      * The generator will output `begin`, then the `content` (a StructuralTag),
-     * and finally `end`. Useful for embedding structured fragments inside free
-     * text using explicit markers.
+     * and finally `end`.
      *
      * Example: Tag("<think>", AnyText(), "</think>") represents thinking portion of the model output.
      */

--- a/src/cpp/include/openvino/genai/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/generation_config.hpp
@@ -261,7 +261,7 @@ public:
                              std::is_same_v<T, std::shared_ptr<ov::genai::StructuredOutputConfig::TagsWithSeparator>>) {
             return g ? g->to_string() : std::string("null");
         } else {
-            return std::string("unsupported_structural_tag");
+            OPENVINO_THROW("Unsupported structural tag, cannot convert to string:" + std::string(typeid(g).name()));
         }
     }
 
@@ -283,7 +283,7 @@ public:
                              std::is_same_v<T, std::shared_ptr<ov::genai::StructuredOutputConfig::TagsWithSeparator>>) {
             return g ? g->to_json() : std::string("null");
         } else {
-            return std::string("unsupported_structural_tag");
+            OPENVINO_THROW("Unsupported structural tag, cannot convert to json:" + std::string(typeid(g).name()));
         }
     }
 
@@ -369,9 +369,9 @@ public:
         Tag(const std::string& begin, StructuralTag content, const std::string& end) : begin(begin), content(std::move(content)), end(end) {};
         std::string to_json() const {
             std::ostringstream oss;
-            oss << "{\"type\": \"tag\", \"begin\": \"" << begin << "\", \"content\": " <<
+            oss << "{\"type\": \"tag\", \"begin\": " << format_for_json(begin) << ", \"content\": " <<
                    std::visit([](const auto& g) -> std::string { return structural_tag_to_json(g); }, content) <<
-                   ", \"end\": \"" << end << "\"}";
+                   ", \"end\": " << format_for_json(end) << "}";
             return oss.str();
         };
         std::string to_string() const {
@@ -402,7 +402,7 @@ public:
             std::ostringstream oss;
             oss << "{\"type\": \"triggered_tags\", \"triggers\": [";
             for (size_t i = 0; i < triggers.size(); ++i) {
-                oss << "\"" << triggers[i] << "\"";
+                oss << format_for_json(triggers[i]);
                 if (i != triggers.size() - 1) {
                     oss << ", ";
                 }

--- a/src/cpp/src/generation_config.cpp
+++ b/src/cpp/src/generation_config.cpp
@@ -210,6 +210,15 @@ std::string StructuralTagsConfig::to_string() const {
            ", triggers=" + triggers_repr.str() + ")";
 }
 
+std::string StructuralTagsConfig::to_json() const {
+    std::vector<StructuredOutputConfig::Tag> tags;
+    tags.reserve(structural_tags.size());
+    for (const auto& tag : structural_tags) {
+        tags.emplace_back(tag.begin, StructuredOutputConfig::JSONSchema{tag.schema}, tag.end);
+    }
+    return StructuredOutputConfig::TriggeredTags(triggers, tags, false, false).to_json();
+}
+
 StructuredOutputConfig::StructuredOutputConfig(const ov::AnyMap& properties) {
     update_config(properties);
     validate();
@@ -367,16 +376,15 @@ void StructuredOutputConfig::validate() const {
         (json_schema.has_value() ? "json=" + *json_schema +", " : ""),
         (regex.has_value() ? "regex=" + *regex + ", " : ""),
         (grammar.has_value() ? "grammar=" + *grammar : ""),
-        (structural_tags_config.has_value() ? "structural_tags_config=" + structural_tags_config->to_string() : ""),
-        (compound_grammar.has_value() ? "compound_grammar=" + std::visit([](const auto& g) -> std::string {
-            if constexpr (
-                std::is_same_v<std::decay_t<decltype(g)>, std::shared_ptr<ov::genai::StructuredOutputConfig::Concat>> ||
-                std::is_same_v<std::decay_t<decltype(g)>, std::shared_ptr<ov::genai::StructuredOutputConfig::Union>>
-            ) {
-                return g ? g->to_string() : "null";
+        (structural_tags_config.has_value() ? "structural_tags_config=" + std::visit([](const auto& config) -> std::string {
+            if constexpr (std::is_same_v<std::decay_t<decltype(config)>, StructuralTagsConfig>) {
+                return config.to_string();
             } else {
-                return g.to_string();
+                return StructuredOutputConfig::structural_tag_to_string(config);
             }
+        }, *structural_tags_config) : ""),
+        (compound_grammar.has_value() ? "compound_grammar=" + std::visit([](const auto& g) -> std::string {
+            return StructuredOutputConfig::structural_tag_to_string(g);
         }, *compound_grammar) : "")
     );
 }
@@ -389,15 +397,66 @@ void StructuredOutputConfig::validate(Tokenizer& tokenizer) const {
 
 
 std::shared_ptr<ov::genai::StructuredOutputConfig::Concat>
-operator+(const ov::genai::StructuredOutputConfig::CompoundGrammar& lhs,
-          const ov::genai::StructuredOutputConfig::CompoundGrammar& rhs) {
-    return std::make_shared<ov::genai::StructuredOutputConfig::Concat>(lhs, rhs);
+operator+(const ov::genai::StructuredOutputConfig::StructuralTag& lhs,
+          const ov::genai::StructuredOutputConfig::StructuralTag& rhs) {
+    using SOC = ov::genai::StructuredOutputConfig;
+    const auto lhs_concat = std::get_if<std::shared_ptr<SOC::Concat>>(&lhs);
+    const auto rhs_concat = std::get_if<std::shared_ptr<SOC::Concat>>(&rhs);
+
+    if (lhs_concat && *lhs_concat) {
+        // lhs is a Concat
+        if (rhs_concat && *rhs_concat) {
+            // both are Concat: combine elements
+            std::vector<SOC::StructuralTag> elems = (*lhs_concat)->elements;
+            elems.insert(elems.end(), (*rhs_concat)->elements.begin(), (*rhs_concat)->elements.end());
+            return std::make_shared<SOC::Concat>(elems);
+        } else {
+            // only lhs is Concat: append rhs
+            std::vector<SOC::StructuralTag> elems = (*lhs_concat)->elements;
+            elems.push_back(rhs);
+            return std::make_shared<SOC::Concat>(elems);
+        }
+    } else if (rhs_concat && *rhs_concat) {
+        // only rhs is Concat: prepend lhs
+        std::vector<SOC::StructuralTag> elems;
+        elems.push_back(lhs);
+        elems.insert(elems.end(), (*rhs_concat)->elements.begin(), (*rhs_concat)->elements.end());
+        return std::make_shared<SOC::Concat>(elems);
+    } else {
+        // neither is Concat: create binary Concat
+        return std::make_shared<SOC::Concat>(lhs, rhs);
+    }
 }
 
 std::shared_ptr<ov::genai::StructuredOutputConfig::Union>
-operator|(const ov::genai::StructuredOutputConfig::CompoundGrammar& lhs,
-          const ov::genai::StructuredOutputConfig::CompoundGrammar& rhs) {
-    return std::make_shared<ov::genai::StructuredOutputConfig::Union>(lhs, rhs);
+operator|(const ov::genai::StructuredOutputConfig::StructuralTag& lhs,
+          const ov::genai::StructuredOutputConfig::StructuralTag& rhs) {
+    using SOC = ov::genai::StructuredOutputConfig;
+    const auto lhs_union = std::get_if<std::shared_ptr<SOC::Union>>(&lhs);
+    const auto rhs_union = std::get_if<std::shared_ptr<SOC::Union>>(&rhs);
+
+    if (lhs_union && *lhs_union) {
+        if (rhs_union && *rhs_union) {
+            // both are Union: combine elements
+            std::vector<SOC::StructuralTag> elems = (*lhs_union)->elements;
+            elems.insert(elems.end(), (*rhs_union)->elements.begin(), (*rhs_union)->elements.end());
+            return std::make_shared<SOC::Union>(elems);
+        } else {
+            // only lhs is Union: append rhs
+            std::vector<SOC::StructuralTag> elems = (*lhs_union)->elements;
+            elems.push_back(rhs);
+            return std::make_shared<SOC::Union>(elems);
+        }
+    } else if (rhs_union && *rhs_union) {
+        // only rhs is Union: prepend lhs
+        std::vector<SOC::StructuralTag> elems;
+        elems.push_back(lhs);
+        elems.insert(elems.end(), (*rhs_union)->elements.begin(), (*rhs_union)->elements.end());
+        return std::make_shared<SOC::Union>(elems);
+    } else {
+        // neither is Union: create binary Union
+        return std::make_shared<SOC::Union>(lhs, rhs);
+    }
 }
 
 GenerationConfig beam_search() {

--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "xgrammar_backend.hpp"
+#include "logger.hpp"
 #include <iostream>
 
 namespace ov {
@@ -71,6 +72,11 @@ xgrammar::Grammar XGrammarStructuredOutput::create_grammar(const std::optional<S
             using ConfigType = std::decay_t<decltype(config)>;
             if constexpr (std::is_same_v<ConfigType, StructuralTagsConfig>) {
                 // Old format: StructuralTagsConfig
+                Logger::warn(
+                    "The use of \"structural_tags_config\" with StructuralTagsConfig instance is deprecated and will be removed in future releases. "
+                    "Use TriggeredTags instead."
+                );
+                
                 std::ostringstream oss;
                 oss << "{\"type\": \"structural_tag\", \"format\": " << config.to_json() << "}";
                 auto result = xgrammar::Grammar::FromStructuralTag(oss.str());
@@ -94,6 +100,10 @@ xgrammar::Grammar XGrammarStructuredOutput::create_grammar(const std::optional<S
             }
         }, structured_output_config.value().structural_tags_config.value());
     } else if (structured_output_config.value().compound_grammar.has_value()) {
+        Logger::warn(
+            "The use of \"compound_grammar\" is deprecated and will be removed in future releases.\n" 
+            "Pass the same input to \"structural_tags_config\" instead."
+        );
         return parse_structural_tag(structured_output_config.value().compound_grammar.value());
     }
 

--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.hpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.hpp
@@ -84,7 +84,7 @@ public:
 private:
     std::unique_ptr<xgrammar::GrammarCompiler> m_grammar_compiler;
 
-    static xgrammar::Grammar parse_compound_grammar(const StructuredOutputConfig::CompoundGrammar& compound_grammar);
+    static xgrammar::Grammar parse_structural_tag(const StructuredOutputConfig::CompoundGrammar& compound_grammar);
     xgrammar::Grammar create_grammar(const std::optional<StructuredOutputConfig>& structured_output_config);
 };
 

--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.hpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.hpp
@@ -43,7 +43,9 @@ protected:
     std::shared_ptr<DLTensor> m_token_bitmask;
     std::shared_ptr<DLTensor> m_next_token_logits;
     std::vector<int64_t> m_logits_shape;
+    std::vector<int64_t> m_logits_strides = {1};
     std::vector<int64_t> m_bitmask_shape;
+    std::vector<int64_t> m_bitmask_strides = {1};
     int m_vocab_size;
 };
 

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2618,13 +2618,18 @@ class StructuredOutputConfig:
         def __repr__(self) -> str:
             ...
     class Concat:
-        @staticmethod
-        def __new__(arg0: typing.Any, arg1: typing.Any, arg2: typing.Any) -> StructuredOutputConfig.Concat:
-            """
-            Concat combines two grammars sequentially, e.g. "A B" means A followed by B
-            """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
+        @typing.overload
+        def __init__(self, elements: collections.abc.Iterable) -> None:
+            """
+            Concat combines grammar elements from an iterable sequentially, e.g. [A, B, C] means A followed by B followed by C.
+            """
+        @typing.overload
+        def __init__(self, *args) -> None:
+            """
+            Concat combines positional grammar elements sequentially, e.g. Concat(A, B, C).
+            """
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2755,13 +2760,18 @@ class StructuredOutputConfig:
         def triggers(self, arg0: collections.abc.Sequence[str]) -> None:
             ...
     class Union:
-        @staticmethod
-        def __new__(arg0: typing.Any, arg1: typing.Any, arg2: typing.Any) -> StructuredOutputConfig.Union:
-            """
-            Union combines two grammars in parallel, e.g. "A | B" means either A or B
-            """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
+        @typing.overload
+        def __init__(self, elements: collections.abc.Iterable) -> None:
+            """
+            Union combines grammar elements from an iterable in parallel, e.g. [A, B, C] means A or B or C.
+            """
+        @typing.overload
+        def __init__(self, *args) -> None:
+            """
+            Union combines positional grammar elements in parallel, e.g. Union(A, B, C).
+            """
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2606,9 +2606,18 @@ class StructuredOutputConfig:
             It allows for more complex and flexible structured output generation.
             The compound grammar a Union or Concat of several grammars, where each grammar can be a JSON schema, regex, EBNF, Union or Concat.
     """
+    class AnyText:
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self) -> None:
+            """
+            Any text building block for compound grammar configuration.
+            """
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
     class Concat:
-        left: openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union
-        right: openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union
         @staticmethod
         def __new__(arg0: typing.Any, arg1: typing.Any, arg2: typing.Any) -> StructuredOutputConfig.Concat:
             """
@@ -2616,6 +2625,24 @@ class StructuredOutputConfig:
             """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
+        @property
+        def elements(self) -> list[str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator]:
+            ...
+        @elements.setter
+        def elements(self, arg0: collections.abc.Sequence[str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator]) -> None:
+            ...
+    class ConstString:
+        value: str
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self, arg0: str) -> None:
+            """
+            Constant string building block for compound grammar configuration.
+            """
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2644,6 +2671,18 @@ class StructuredOutputConfig:
             ...
         def __repr__(self) -> str:
             ...
+    class QwenXMLParametersFormat:
+        json_schema: str
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self, arg0: str) -> None:
+            """
+            Qwen XML parameters format building block for compound grammar configuration.
+            """
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
     class Regex:
         value: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
@@ -2656,9 +2695,66 @@ class StructuredOutputConfig:
             ...
         def __repr__(self) -> str:
             ...
+    class Tag:
+        begin: str
+        content: str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator
+        end: str
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self, begin: str, content: str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator, end: str) -> None:
+            """
+            Tag wraps content with begin and end strings
+            """
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
+    class TagsWithSeparator:
+        at_least_one: bool
+        separator: str
+        stop_after_first: bool
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self, tags: collections.abc.Sequence[StructuredOutputConfig.Tag], separator: str, at_least_one: bool = False, stop_after_first: bool = False) -> None:
+            """
+            TagsWithSeparator generates multiple tags separated by a separator string
+            """
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
+        @property
+        def tags(self) -> list[StructuredOutputConfig.Tag]:
+            ...
+        @tags.setter
+        def tags(self, arg0: collections.abc.Sequence[StructuredOutputConfig.Tag]) -> None:
+            ...
+    class TriggeredTags:
+        at_least_one: bool
+        stop_after_first: bool
+        def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
+            ...
+        def __init__(self, triggers: collections.abc.Sequence[str], tags: collections.abc.Sequence[StructuredOutputConfig.Tag], at_least_one: bool = False, stop_after_first: bool = False) -> None:
+            """
+            TriggeredTags generates structured tags when trigger strings are encountered
+            """
+        def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
+            ...
+        def __repr__(self) -> str:
+            ...
+        @property
+        def tags(self) -> list[StructuredOutputConfig.Tag]:
+            ...
+        @tags.setter
+        def tags(self, arg0: collections.abc.Sequence[StructuredOutputConfig.Tag]) -> None:
+            ...
+        @property
+        def triggers(self) -> list[str]:
+            ...
+        @triggers.setter
+        def triggers(self, arg0: collections.abc.Sequence[str]) -> None:
+            ...
     class Union:
-        left: openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union
-        right: openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union
         @staticmethod
         def __new__(arg0: typing.Any, arg1: typing.Any, arg2: typing.Any) -> StructuredOutputConfig.Union:
             """
@@ -2669,6 +2765,12 @@ class StructuredOutputConfig:
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
+            ...
+        @property
+        def elements(self) -> list[str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator]:
+            ...
+        @elements.setter
+        def elements(self, arg0: collections.abc.Sequence[str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator]) -> None:
             ...
     @typing.overload
     def __init__(self) -> None:
@@ -2683,12 +2785,12 @@ class StructuredOutputConfig:
     def __repr__(self) -> str:
         ...
     @property
-    def compound_grammar(self) -> openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | None:
+    def compound_grammar(self) -> str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator | None:
         """
         Compound grammar for structured output generation
         """
     @compound_grammar.setter
-    def compound_grammar(self, arg0: openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | None) -> None:
+    def compound_grammar(self, arg0: str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator | None) -> None:
         ...
     @property
     def grammar(self) -> str | None:
@@ -2715,12 +2817,12 @@ class StructuredOutputConfig:
     def regex(self, arg0: str | None) -> None:
         ...
     @property
-    def structural_tags_config(self) -> openvino_genai.py_openvino_genai.StructuralTagsConfig | None:
+    def structural_tags_config(self) -> typing.Any:
         """
-        Configuration for structural tags in structured output generation
+        Configuration for structural tags in structured output generation (can be StructuralTagsConfig or StructuralTag)
         """
     @structural_tags_config.setter
-    def structural_tags_config(self, arg0: openvino_genai.py_openvino_genai.StructuralTagsConfig | None) -> None:
+    def structural_tags_config(self, arg1: typing.Any) -> None:
         ...
 class SummaryStats:
     def __init__(self) -> None:

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2505,14 +2505,10 @@ class StructuralTagItem:
     """
     @typing.overload
     def __init__(self) -> None:
-        """
-        Default constructor for StructuralTagItem
-        """
+        ...
     @typing.overload
     def __init__(self, **kwargs) -> None:
-        """
-        Constructor that initializes the structured tags configuration with kwargs.
-        """
+        ...
     def __repr__(self) -> str:
         ...
     @property
@@ -2562,14 +2558,10 @@ class StructuralTagsConfig:
     """
     @typing.overload
     def __init__(self) -> None:
-        """
-        Default constructor for StructuralTagsConfig
-        """
+        ...
     @typing.overload
     def __init__(self, **kwargs) -> None:
-        """
-        Constructor that initializes the structured tags configuration with kwargs.
-        """
+        ...
     def __repr__(self) -> str:
         ...
     @property
@@ -2607,29 +2599,36 @@ class StructuredOutputConfig:
             The compound grammar a Union or Concat of several grammars, where each grammar can be a JSON schema, regex, EBNF, Union or Concat.
     """
     class AnyText:
+        """
+        
+            AnyText structural tag allows any text for the portion of output
+            covered by this tag.
+        """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self) -> None:
-            """
-            Any text building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class Concat:
+        """
+        
+            Concat composes multiple structural tags in sequence. Each element
+            must be produced in the given order. Can be used indirectly with + operator.
+        
+            Example: Concat(ConstString("a"), ConstString("b")) produces "ab".
+            ConstString("a") + ConstString("b") is equivalent.
+        """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         @typing.overload
         def __init__(self, elements: collections.abc.Iterable) -> None:
-            """
-            Concat combines grammar elements from an iterable sequentially, e.g. [A, B, C] means A followed by B followed by C.
-            """
+            ...
         @typing.overload
         def __init__(self, *args) -> None:
-            """
-            Concat combines positional grammar elements sequentially, e.g. Concat(A, B, C).
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2641,89 +2640,116 @@ class StructuredOutputConfig:
         def elements(self, arg0: collections.abc.Sequence[str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator]) -> None:
             ...
     class ConstString:
+        """
+        
+            ConstString structural tag forces the generator to produce exactly
+            the provided constant string value.
+        """
         value: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, arg0: str) -> None:
-            """
-            Constant string building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class EBNF:
+        """
+        
+            EBNF structural tag constrains output using an EBNF grammar.
+        """
         value: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, arg0: str) -> None:
-            """
-            EBNF grammar building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class JSONSchema:
+        """
+        
+            JSONSchema structural tag constrains output to a JSON document that
+            must conform to the provided JSON Schema string.
+        """
         value: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, arg0: str) -> None:
-            """
-            JSON schema building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class QwenXMLParametersFormat:
+        """
+        
+            QwenXMLParametersFormat instructs the generator to output an XML
+            parameters block derived from the provided JSON schema. This is a
+            specialized helper for Qwen-style XML parameter formatting.
+        """
         json_schema: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, arg0: str) -> None:
-            """
-            Qwen XML parameters format building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class Regex:
+        """
+        
+            Regex structural tag constrains output using a regular expression.
+        """
         value: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, arg0: str) -> None:
-            """
-            Regex building block for compound grammar configuration.
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class Tag:
+        """
+        
+            Tag defines a begin/end wrapper with constrained inner content.
+        
+            The generator will output `begin`, then the `content` (a StructuralTag),
+            and finally `end`.
+        
+            Example: Tag("<think>", AnyText(), "</think>") represents thinking portion of the model output.
+        """
         begin: str
         content: str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator
         end: str
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, begin: str, content: str | openvino_genai.py_openvino_genai.StructuredOutputConfig.Regex | openvino_genai.py_openvino_genai.StructuredOutputConfig.JSONSchema | openvino_genai.py_openvino_genai.StructuredOutputConfig.EBNF | openvino_genai.py_openvino_genai.StructuredOutputConfig.ConstString | openvino_genai.py_openvino_genai.StructuredOutputConfig.AnyText | openvino_genai.py_openvino_genai.StructuredOutputConfig.QwenXMLParametersFormat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Concat | openvino_genai.py_openvino_genai.StructuredOutputConfig.Union | openvino_genai.py_openvino_genai.StructuredOutputConfig.Tag | openvino_genai.py_openvino_genai.StructuredOutputConfig.TriggeredTags | openvino_genai.py_openvino_genai.StructuredOutputConfig.TagsWithSeparator, end: str) -> None:
-            """
-            Tag wraps content with begin and end strings
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
             ...
     class TagsWithSeparator:
+        """
+        
+            TagsWithSeparator configures generation of a sequence of tags
+            separated by a fixed separator string.
+        
+            Can be used to produce repeated tagged elements like "<f>A</f>;<f>B</f>"
+            where `separator`=";".
+        """
         at_least_one: bool
         separator: str
         stop_after_first: bool
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, tags: collections.abc.Sequence[StructuredOutputConfig.Tag], separator: str, at_least_one: bool = False, stop_after_first: bool = False) -> None:
-            """
-            TagsWithSeparator generates multiple tags separated by a separator string
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2735,14 +2761,20 @@ class StructuredOutputConfig:
         def tags(self, arg0: collections.abc.Sequence[StructuredOutputConfig.Tag]) -> None:
             ...
     class TriggeredTags:
+        """
+        
+            TriggeredTags associates a set of `triggers` with multiple `tags`.
+        
+            When the model generates any of the trigger strings the structured
+            generation activates to produce configured tags. Flags allow requiring
+            at least one tag and stopping structured generation after the first tag.
+        """
         at_least_one: bool
         stop_after_first: bool
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         def __init__(self, triggers: collections.abc.Sequence[str], tags: collections.abc.Sequence[StructuredOutputConfig.Tag], at_least_one: bool = False, stop_after_first: bool = False) -> None:
-            """
-            TriggeredTags generates structured tags when trigger strings are encountered
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2760,18 +2792,20 @@ class StructuredOutputConfig:
         def triggers(self, arg0: collections.abc.Sequence[str]) -> None:
             ...
     class Union:
+        """
+        
+            Union composes multiple structural tags as alternatives. The
+            model may produce any one of the provided elements. Can be used indirectly
+            with | operator.
+        """
         def __add__(self, arg0: typing.Any) -> StructuredOutputConfig.Concat:
             ...
         @typing.overload
         def __init__(self, elements: collections.abc.Iterable) -> None:
-            """
-            Union combines grammar elements from an iterable in parallel, e.g. [A, B, C] means A or B or C.
-            """
+            ...
         @typing.overload
         def __init__(self, *args) -> None:
-            """
-            Union combines positional grammar elements in parallel, e.g. Union(A, B, C).
-            """
+            ...
         def __or__(self, arg0: typing.Any) -> StructuredOutputConfig.Union:
             ...
         def __repr__(self) -> str:
@@ -2784,14 +2818,10 @@ class StructuredOutputConfig:
             ...
     @typing.overload
     def __init__(self) -> None:
-        """
-        Default constructor for StructuredOutputConfig
-        """
+        ...
     @typing.overload
     def __init__(self, **kwargs) -> None:
-        """
-        Constructor that initializes the structured output configuration with kwargs.
-        """
+        ...
     def __repr__(self) -> str:
         ...
     @property

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -47,6 +47,75 @@ auto structured_output_config_docstring = R"(
         The compound grammar a Union or Concat of several grammars, where each grammar can be a JSON schema, regex, EBNF, Union or Concat.
 )";
 
+// Docstrings for structural tag building blocks
+auto regex_docstring = R"(
+    Regex structural tag constrains output using a regular expression.
+)";
+
+auto jsonschema_docstring = R"(
+    JSONSchema structural tag constrains output to a JSON document that
+    must conform to the provided JSON Schema string.
+)";
+
+auto ebnf_docstring = R"(
+    EBNF structural tag constrains output using an EBNF grammar.
+)";
+
+auto conststring_docstring = R"(
+    ConstString structural tag forces the generator to produce exactly
+    the provided constant string value.
+)";
+
+auto anytext_docstring = R"(
+    AnyText structural tag allows any text for the portion of output
+    covered by this tag.
+)";
+
+auto qwenxml_docstring = R"(
+    QwenXMLParametersFormat instructs the generator to output an XML
+    parameters block derived from the provided JSON schema. This is a
+    specialized helper for Qwen-style XML parameter formatting.
+)";
+
+auto concat_docstring = R"(
+    Concat composes multiple structural tags in sequence. Each element
+    must be produced in the given order. Can be used indirectly with + operator.
+
+    Example: Concat(ConstString("a"), ConstString("b")) produces "ab".
+    ConstString("a") + ConstString("b") is equivalent.
+)";
+
+auto union_docstring = R"(
+    Union composes multiple structural tags as alternatives. The
+    model may produce any one of the provided elements. Can be used indirectly
+    with | operator.
+)";
+
+auto tag_docstring = R"(
+    Tag defines a begin/end wrapper with constrained inner content.
+
+    The generator will output `begin`, then the `content` (a StructuralTag),
+    and finally `end`.
+
+    Example: Tag("<think>", AnyText(), "</think>") represents thinking portion of the model output.
+)";
+
+auto triggered_tags_docstring = R"(
+    TriggeredTags associates a set of `triggers` with multiple `tags`.
+
+    When the model generates any of the trigger strings the structured
+    generation activates to produce configured tags. Flags allow requiring
+    at least one tag and stopping structured generation after the first tag.
+)";
+
+auto tags_with_separator_docstring = R"(
+    TagsWithSeparator configures generation of a sequence of tags
+    separated by a fixed separator string.
+
+    Can be used to produce repeated tagged elements like "<f>A</f>;<f>B</f>"
+    where `separator`=";".
+)";
+
 auto structured_tags_config_docstring = R"(
     Configures structured output generation by combining regular sampling with structural tags.
 
@@ -195,42 +264,42 @@ void init_generation_config(py::module_& m) {
     // pybind11-stubgen generates not accurate signatures and shows warning/errors
     // because Concat/Union/StructuredOutputConfig use EBNF/JSONSchema/etc. which are not defined yet.
     auto structured_output_config = py::class_<StructuredOutputConfig>(m, "StructuredOutputConfig", structured_output_config_docstring);
-    auto concat = py::class_<StructuredOutputConfig::Concat, std::shared_ptr<StructuredOutputConfig::Concat>>(structured_output_config, "Concat");
-    auto union_ = py::class_<StructuredOutputConfig::Union, std::shared_ptr<StructuredOutputConfig::Union>>(structured_output_config, "Union");
-    auto tag = py::class_<StructuredOutputConfig::Tag, std::shared_ptr<StructuredOutputConfig::Tag>>(structured_output_config, "Tag");
-    auto triggered_tags = py::class_<StructuredOutputConfig::TriggeredTags, std::shared_ptr<StructuredOutputConfig::TriggeredTags>>(structured_output_config, "TriggeredTags");
-    auto tags_with_separator = py::class_<StructuredOutputConfig::TagsWithSeparator, std::shared_ptr<StructuredOutputConfig::TagsWithSeparator>>(structured_output_config, "TagsWithSeparator");
+    auto concat = py::class_<StructuredOutputConfig::Concat, std::shared_ptr<StructuredOutputConfig::Concat>>(structured_output_config, "Concat", concat_docstring);
+    auto union_ = py::class_<StructuredOutputConfig::Union, std::shared_ptr<StructuredOutputConfig::Union>>(structured_output_config, "Union", union_docstring);
+    auto tag = py::class_<StructuredOutputConfig::Tag, std::shared_ptr<StructuredOutputConfig::Tag>>(structured_output_config, "Tag", tag_docstring);
+    auto triggered_tags = py::class_<StructuredOutputConfig::TriggeredTags, std::shared_ptr<StructuredOutputConfig::TriggeredTags>>(structured_output_config, "TriggeredTags", triggered_tags_docstring);
+    auto tags_with_separator = py::class_<StructuredOutputConfig::TagsWithSeparator, std::shared_ptr<StructuredOutputConfig::TagsWithSeparator>>(structured_output_config, "TagsWithSeparator", tags_with_separator_docstring);
 
-    auto regex = py::class_<StructuredOutputConfig::Regex>(structured_output_config, "Regex")
+    auto regex = py::class_<StructuredOutputConfig::Regex>(structured_output_config, "Regex", regex_docstring)
         .def(py::init<const std::string&>(), "Regex building block for compound grammar configuration.")
         .def_readwrite("value", &StructuredOutputConfig::Regex::value)
         .def("__repr__", [](const StructuredOutputConfig::Regex& self) { return self.to_string(); });
     add_grammar_operators(regex);
 
-    auto json_schema = py::class_<StructuredOutputConfig::JSONSchema>(structured_output_config, "JSONSchema")
+    auto json_schema = py::class_<StructuredOutputConfig::JSONSchema>(structured_output_config, "JSONSchema", jsonschema_docstring)
         .def(py::init<const std::string&>(), "JSON schema building block for compound grammar configuration.")
         .def_readwrite("value", &StructuredOutputConfig::JSONSchema::value)
         .def("__repr__", [](const StructuredOutputConfig::JSONSchema& self) { return self.to_string(); });
     add_grammar_operators(json_schema);
 
-    auto ebnf = py::class_<StructuredOutputConfig::EBNF>(structured_output_config, "EBNF")
+    auto ebnf = py::class_<StructuredOutputConfig::EBNF>(structured_output_config, "EBNF", ebnf_docstring)
         .def(py::init<const std::string&>(), "EBNF grammar building block for compound grammar configuration.")
         .def_readwrite("value", &StructuredOutputConfig::EBNF::value)
         .def("__repr__", [](const StructuredOutputConfig::EBNF& self) { return self.to_string(); });
     add_grammar_operators(ebnf);
 
-    auto const_string = py::class_<StructuredOutputConfig::ConstString>(structured_output_config, "ConstString")
+    auto const_string = py::class_<StructuredOutputConfig::ConstString>(structured_output_config, "ConstString", conststring_docstring)
         .def(py::init<const std::string&>(), "Constant string building block for compound grammar configuration.")
         .def_readwrite("value", &StructuredOutputConfig::ConstString::value)
         .def("__repr__", [](const StructuredOutputConfig::ConstString& self) { return self.to_string(); });
     add_grammar_operators(const_string);
 
-    auto any_text = py::class_<StructuredOutputConfig::AnyText>(structured_output_config, "AnyText")
+    auto any_text = py::class_<StructuredOutputConfig::AnyText>(structured_output_config, "AnyText", anytext_docstring)
         .def(py::init<>(), "Any text building block for compound grammar configuration.")
         .def("__repr__", [](const StructuredOutputConfig::AnyText& self) { return self.to_string(); });
     add_grammar_operators(any_text);
 
-    auto qwen_xml = py::class_<StructuredOutputConfig::QwenXMLParametersFormat>(structured_output_config, "QwenXMLParametersFormat")
+    auto qwen_xml = py::class_<StructuredOutputConfig::QwenXMLParametersFormat>(structured_output_config, "QwenXMLParametersFormat", qwenxml_docstring)
         .def(py::init<const std::string&>(), "Qwen XML parameters format building block for compound grammar configuration.")
         .def_readwrite("json_schema", &StructuredOutputConfig::QwenXMLParametersFormat::json_schema)
         .def("__repr__", [](const StructuredOutputConfig::QwenXMLParametersFormat& self) { return self.to_string(); });
@@ -241,8 +310,7 @@ void init_generation_config(py::module_& m) {
             return std::make_shared<StructuredOutputConfig::Concat>(
                 collect_structural_tags(elements, "StructuredOutputConfig.Concat"));
         }), py::arg("elements"),
-        "Concat combines grammar elements from an iterable sequentially, e.g. "
-        "[A, B, C] means A followed by B followed by C.")
+        "Concat combines grammar elements from an iterable sequentially, e.g. [A, B, C] means A followed by B followed by C.")
         .def(py::init([](py::args args) {
             return std::make_shared<StructuredOutputConfig::Concat>(
                 collect_structural_tags(py::reinterpret_borrow<py::iterable>(args),
@@ -258,8 +326,7 @@ void init_generation_config(py::module_& m) {
             return std::make_shared<StructuredOutputConfig::Union>(
                 collect_structural_tags(elements, "StructuredOutputConfig.Union"));
         }), py::arg("elements"),
-        "Union combines grammar elements from an iterable in parallel, e.g. "
-        "[A, B, C] means A or B or C.")
+        "Union combines grammar elements from an iterable in parallel, e.g. [A, B, C] means A or B or C.")
         .def(py::init([](py::args args) {
             return std::make_shared<StructuredOutputConfig::Union>(
                 collect_structural_tags(py::reinterpret_borrow<py::iterable>(args),

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -229,10 +229,10 @@ void init_generation_config(py::module_& m) {
 
 
     py::class_<StructuralTagItem>(m, "StructuralTagItem", structured_tags_item_docstring)
-        .def(py::init<>(), "Default constructor for StructuralTagItem")
+        .def(py::init<>())
         .def(py::init([](py::kwargs kwargs) {
             return StructuralTagItem(pyutils::kwargs_to_any_map(kwargs));
-        }), "Constructor that initializes the structured tags configuration with kwargs.")
+        }))
         .def_readwrite("begin", &StructuralTagItem::begin, "Begin string for Structural Tag Item")
         .def_readwrite("schema", &StructuralTagItem::schema, "Json schema for Structural Tag Item")
         .def_readwrite("end", &StructuralTagItem::end, "End string for Structural Tag Item")
@@ -246,10 +246,10 @@ void init_generation_config(py::module_& m) {
 
 
     py::class_<StructuralTagsConfig>(m, "StructuralTagsConfig", structured_tags_config_docstring)
-        .def(py::init<>(), "Default constructor for StructuralTagsConfig")
+        .def(py::init<>())
         .def(py::init([](py::kwargs kwargs) {
             return StructuralTagsConfig(pyutils::kwargs_to_any_map(kwargs));
-        }), "Constructor that initializes the structured tags configuration with kwargs.")
+        }))
         .def_readwrite("structural_tags", &StructuralTagsConfig::structural_tags, "List of structural tag items for structured output generation")
         .def_readwrite("triggers", &StructuralTagsConfig::triggers, "List of strings that will trigger generation of structured output")
         .def("__repr__",
@@ -270,36 +270,36 @@ void init_generation_config(py::module_& m) {
     auto tags_with_separator = py::class_<StructuredOutputConfig::TagsWithSeparator, std::shared_ptr<StructuredOutputConfig::TagsWithSeparator>>(structured_output_config, "TagsWithSeparator", tags_with_separator_docstring);
 
     auto regex = py::class_<StructuredOutputConfig::Regex>(structured_output_config, "Regex", regex_docstring)
-        .def(py::init<const std::string&>(), "Regex building block for compound grammar configuration.")
+        .def(py::init<const std::string&>())
         .def_readwrite("value", &StructuredOutputConfig::Regex::value)
         .def("__repr__", [](const StructuredOutputConfig::Regex& self) { return self.to_string(); });
     add_grammar_operators(regex);
 
     auto json_schema = py::class_<StructuredOutputConfig::JSONSchema>(structured_output_config, "JSONSchema", jsonschema_docstring)
-        .def(py::init<const std::string&>(), "JSON schema building block for compound grammar configuration.")
+        .def(py::init<const std::string&>())
         .def_readwrite("value", &StructuredOutputConfig::JSONSchema::value)
         .def("__repr__", [](const StructuredOutputConfig::JSONSchema& self) { return self.to_string(); });
     add_grammar_operators(json_schema);
 
     auto ebnf = py::class_<StructuredOutputConfig::EBNF>(structured_output_config, "EBNF", ebnf_docstring)
-        .def(py::init<const std::string&>(), "EBNF grammar building block for compound grammar configuration.")
+        .def(py::init<const std::string&>())
         .def_readwrite("value", &StructuredOutputConfig::EBNF::value)
         .def("__repr__", [](const StructuredOutputConfig::EBNF& self) { return self.to_string(); });
     add_grammar_operators(ebnf);
 
     auto const_string = py::class_<StructuredOutputConfig::ConstString>(structured_output_config, "ConstString", conststring_docstring)
-        .def(py::init<const std::string&>(), "Constant string building block for compound grammar configuration.")
+        .def(py::init<const std::string&>())
         .def_readwrite("value", &StructuredOutputConfig::ConstString::value)
         .def("__repr__", [](const StructuredOutputConfig::ConstString& self) { return self.to_string(); });
     add_grammar_operators(const_string);
 
     auto any_text = py::class_<StructuredOutputConfig::AnyText>(structured_output_config, "AnyText", anytext_docstring)
-        .def(py::init<>(), "Any text building block for compound grammar configuration.")
+        .def(py::init<>())
         .def("__repr__", [](const StructuredOutputConfig::AnyText& self) { return self.to_string(); });
     add_grammar_operators(any_text);
 
     auto qwen_xml = py::class_<StructuredOutputConfig::QwenXMLParametersFormat>(structured_output_config, "QwenXMLParametersFormat", qwenxml_docstring)
-        .def(py::init<const std::string&>(), "Qwen XML parameters format building block for compound grammar configuration.")
+        .def(py::init<const std::string&>())
         .def_readwrite("json_schema", &StructuredOutputConfig::QwenXMLParametersFormat::json_schema)
         .def("__repr__", [](const StructuredOutputConfig::QwenXMLParametersFormat& self) { return self.to_string(); });
     add_grammar_operators(qwen_xml);
@@ -308,14 +308,12 @@ void init_generation_config(py::module_& m) {
         .def(py::init([](py::iterable elements) {
             return std::make_shared<StructuredOutputConfig::Concat>(
                 collect_structural_tags(elements, "StructuredOutputConfig.Concat"));
-        }), py::arg("elements"),
-        "Concat combines grammar elements from an iterable sequentially, e.g. [A, B, C] means A followed by B followed by C.")
+        }), py::arg("elements"))
         .def(py::init([](py::args args) {
             return std::make_shared<StructuredOutputConfig::Concat>(
                 collect_structural_tags(py::reinterpret_borrow<py::iterable>(args),
                                         "StructuredOutputConfig.Concat"));
-        }),
-        "Concat combines positional grammar elements sequentially, e.g. Concat(A, B, C).")
+        }))
         .def_readwrite("elements", &StructuredOutputConfig::Concat::elements)
         .def("__repr__", [](const StructuredOutputConfig::Concat& self) { return self.to_string(); });
     add_grammar_operators(concat);
@@ -324,22 +322,19 @@ void init_generation_config(py::module_& m) {
         .def(py::init([](py::iterable elements) {
             return std::make_shared<StructuredOutputConfig::Union>(
                 collect_structural_tags(elements, "StructuredOutputConfig.Union"));
-        }), py::arg("elements"),
-        "Union combines grammar elements from an iterable in parallel, e.g. [A, B, C] means A or B or C.")
+        }), py::arg("elements"))
         .def(py::init([](py::args args) {
             return std::make_shared<StructuredOutputConfig::Union>(
                 collect_structural_tags(py::reinterpret_borrow<py::iterable>(args),
                                         "StructuredOutputConfig.Union"));
-        }),
-        "Union combines positional grammar elements in parallel, e.g. Union(A, B, C).")
+        }))
         .def_readwrite("elements", &StructuredOutputConfig::Union::elements)
         .def("__repr__", [](const StructuredOutputConfig::Union& self) { return self.to_string(); });
     add_grammar_operators(union_);
 
     tag
         .def(py::init<const std::string&, StructuredOutputConfig::StructuralTag, const std::string&>(),
-             py::arg("begin"), py::arg("content"), py::arg("end"),
-             "Tag wraps content with begin and end strings")
+             py::arg("begin"), py::arg("content"), py::arg("end"))
         .def_readwrite("begin", &StructuredOutputConfig::Tag::begin)
         .def_readwrite("content", &StructuredOutputConfig::Tag::content)
         .def_readwrite("end", &StructuredOutputConfig::Tag::end)
@@ -348,8 +343,7 @@ void init_generation_config(py::module_& m) {
 
     triggered_tags
         .def(py::init<const std::vector<std::string>&, const std::vector<StructuredOutputConfig::Tag>&, bool, bool>(),
-             py::arg("triggers"), py::arg("tags"), py::arg("at_least_one") = false, py::arg("stop_after_first") = false,
-             "TriggeredTags generates structured tags when trigger strings are encountered")
+             py::arg("triggers"), py::arg("tags"), py::arg("at_least_one") = false, py::arg("stop_after_first") = false)
         .def_readwrite("triggers", &StructuredOutputConfig::TriggeredTags::triggers)
         .def_readwrite("tags", &StructuredOutputConfig::TriggeredTags::tags)
         .def_readwrite("at_least_one", &StructuredOutputConfig::TriggeredTags::at_least_one)
@@ -359,8 +353,7 @@ void init_generation_config(py::module_& m) {
 
     tags_with_separator
         .def(py::init<const std::vector<StructuredOutputConfig::Tag>&, const std::string&, bool, bool>(),
-             py::arg("tags"), py::arg("separator"), py::arg("at_least_one") = false, py::arg("stop_after_first") = false,
-             "TagsWithSeparator generates multiple tags separated by a separator string")
+             py::arg("tags"), py::arg("separator"), py::arg("at_least_one") = false, py::arg("stop_after_first") = false)
         .def_readwrite("tags", &StructuredOutputConfig::TagsWithSeparator::tags)
         .def_readwrite("separator", &StructuredOutputConfig::TagsWithSeparator::separator)
         .def_readwrite("at_least_one", &StructuredOutputConfig::TagsWithSeparator::at_least_one)
@@ -369,10 +362,10 @@ void init_generation_config(py::module_& m) {
     add_grammar_operators(tags_with_separator);
 
     structured_output_config
-        .def(py::init<>(), "Default constructor for StructuredOutputConfig")
+        .def(py::init<>())
         .def(py::init([](py::kwargs kwargs) {
             return StructuredOutputConfig(pyutils::kwargs_to_any_map(kwargs));
-        }), "Constructor that initializes the structured output configuration with kwargs.")
+        }))
         .def_readwrite("json_schema", &StructuredOutputConfig::json_schema, "JSON schema for structured output generation")
         .def_readwrite("regex", &StructuredOutputConfig::regex, "Regular expression for structured output generation")
         .def_readwrite("grammar", &StructuredOutputConfig::grammar, "Grammar for structured output generation")

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -47,7 +47,6 @@ auto structured_output_config_docstring = R"(
         The compound grammar a Union or Concat of several grammars, where each grammar can be a JSON schema, regex, EBNF, Union or Concat.
 )";
 
-// Docstrings for structural tag building blocks
 auto regex_docstring = R"(
     Regex structural tag constrains output using a regular expression.
 )";

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -132,10 +132,10 @@ template <typename PyClass>
 void add_grammar_operators(PyClass& py_cls) {
     py_cls
         .def("__add__", [](py::object self, py::object other) {
-            return pyutils::py_obj_to_compound_grammar(self) + pyutils::py_obj_to_compound_grammar(other);
+            return pyutils::py_obj_to_structural_tag(self) + pyutils::py_obj_to_structural_tag(other);
         })
         .def("__or__", [](py::object self, py::object other) {
-            return pyutils::py_obj_to_compound_grammar(self) | pyutils::py_obj_to_compound_grammar(other);
+            return pyutils::py_obj_to_structural_tag(self) | pyutils::py_obj_to_structural_tag(other);
         });
 };
 
@@ -143,7 +143,7 @@ std::vector<StructuredOutputConfig::StructuralTag> collect_structural_tags(py::i
                                                                            const char* context) {
     std::vector<StructuredOutputConfig::StructuralTag> tags;
     for (py::handle element : elements) {
-        tags.emplace_back(pyutils::py_obj_to_compound_grammar(
+        tags.emplace_back(pyutils::py_obj_to_structural_tag(
             py::reinterpret_borrow<py::object>(element)));
     }
     if (tags.size() < 2) {
@@ -336,7 +336,7 @@ void init_generation_config(py::module_& m) {
                            || py::isinstance<StructuredOutputConfig::Tag>(value)
                            || py::isinstance<StructuredOutputConfig::TriggeredTags>(value)
                            || py::isinstance<StructuredOutputConfig::TagsWithSeparator>(value)) {
-                    self.structural_tags_config = pyutils::py_obj_to_compound_grammar(value);
+                    self.structural_tags_config = pyutils::py_obj_to_structural_tag(value);
                 } else {
                     throw py::type_error("structural_tags_config must be either StructuralTagsConfig or a StructuralTag (Regex, JSONSchema, EBNF, ConstString, AnyText, QwenXMLParametersFormat, Union, Concat, Tag, TriggeredTags, TagsWithSeparator or plain str)");
                 }

--- a/src/python/py_utils.cpp
+++ b/src/python/py_utils.cpp
@@ -336,10 +336,10 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
         // For structural_tags_config property, wrap in variant
         if (property_name == "structural_tags_config") {
             std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value = 
-                py_obj_to_compound_grammar(py_obj);
+                py_obj_to_structural_tag(py_obj);
             return variant_value;
         }
-        return py_obj_to_compound_grammar(py_obj);
+        return py_obj_to_structural_tag(py_obj);
     } else if (py::isinstance<ov::genai::GenerationConfig>(py_obj)) {
         return py::cast<ov::genai::GenerationConfig>(py_obj);
     } else if (py::isinstance<ov::genai::ImageGenerationConfig>(py_obj)) {
@@ -444,7 +444,7 @@ ov::genai::StreamerVariant pystreamer_to_streamer(const PyBindStreamerVariant& p
     return streamer;
 }
 
-StructuredOutputConfig::StructuralTag py_obj_to_compound_grammar(const py::object& py_obj) {
+StructuredOutputConfig::StructuralTag py_obj_to_structural_tag(const py::object& py_obj) {
     if (py::isinstance<ov::genai::StructuredOutputConfig::Regex>(py_obj)) {
         return py::cast<ov::genai::StructuredOutputConfig::Regex>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj)) {

--- a/src/python/py_utils.cpp
+++ b/src/python/py_utils.cpp
@@ -90,6 +90,11 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
 
     py::object float_32_type = py::module_::import("numpy").attr("float32");
     if (py::isinstance<py::str>(py_obj)) {
+        if (property_name == "structural_tags_config") {
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value =
+                py_obj.cast<std::string>();
+            return variant_value;
+        }
         return py_obj.cast<std::string>();
     } else if (py::isinstance<py::bool_>(py_obj)) {
         return py_obj.cast<bool>();
@@ -309,13 +314,31 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
     } else if (py::isinstance<ov::genai::StructuralTagItem>(py_obj)) {
         return py::cast<ov::genai::StructuralTagItem>(py_obj);
     } else if (py::isinstance<ov::genai::StructuralTagsConfig>(py_obj)) {
+        // For structural_tags_config property, wrap in variant
+        if (property_name == "structural_tags_config") {
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value = 
+                py::cast<ov::genai::StructuralTagsConfig>(py_obj);
+            return variant_value;
+        }
         return py::cast<ov::genai::StructuralTagsConfig>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::Regex>(py_obj)
                || py::isinstance<ov::genai::StructuredOutputConfig::EBNF>(py_obj)
                || py::isinstance<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::ConstString>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::AnyText>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::QwenXMLParametersFormat>(py_obj)
                // python does not use std::shared_ptr to obj
                || py::isinstance<ov::genai::StructuredOutputConfig::Union>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::Concat>(py_obj)) {
+               || py::isinstance<ov::genai::StructuredOutputConfig::Concat>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::Tag>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::TriggeredTags>(py_obj)
+               || py::isinstance<ov::genai::StructuredOutputConfig::TagsWithSeparator>(py_obj)) {
+        // For structural_tags_config property, wrap in variant
+        if (property_name == "structural_tags_config") {
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value = 
+                py_obj_to_compound_grammar(py_obj);
+            return variant_value;
+        }
         return py_obj_to_compound_grammar(py_obj);
     } else if (py::isinstance<ov::genai::GenerationConfig>(py_obj)) {
         return py::cast<ov::genai::GenerationConfig>(py_obj);
@@ -421,19 +444,33 @@ ov::genai::StreamerVariant pystreamer_to_streamer(const PyBindStreamerVariant& p
     return streamer;
 }
 
-StructuredOutputConfig::CompoundGrammar py_obj_to_compound_grammar(const py::object& py_obj) {
+StructuredOutputConfig::StructuralTag py_obj_to_compound_grammar(const py::object& py_obj) {
     if (py::isinstance<ov::genai::StructuredOutputConfig::Regex>(py_obj)) {
         return py::cast<ov::genai::StructuredOutputConfig::Regex>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj)) {
         return py::cast<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::EBNF>(py_obj)) {
         return py::cast<ov::genai::StructuredOutputConfig::EBNF>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::ConstString>(py_obj)) {
+        return py::cast<ov::genai::StructuredOutputConfig::ConstString>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::AnyText>(py_obj)) {
+        return py::cast<ov::genai::StructuredOutputConfig::AnyText>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::QwenXMLParametersFormat>(py_obj)) {
+        return py::cast<ov::genai::StructuredOutputConfig::QwenXMLParametersFormat>(py_obj);
+    } else if (py::isinstance<py::str>(py_obj)) {
+        return py::cast<std::string>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::Concat>(py_obj)) {
         return py::cast<std::shared_ptr<ov::genai::StructuredOutputConfig::Concat>>(py_obj);
     } else if (py::isinstance<ov::genai::StructuredOutputConfig::Union>(py_obj)) {
         return py::cast<std::shared_ptr<ov::genai::StructuredOutputConfig::Union>>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::Tag>(py_obj)) {
+        return py::cast<std::shared_ptr<ov::genai::StructuredOutputConfig::Tag>>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::TriggeredTags>(py_obj)) {
+        return py::cast<std::shared_ptr<ov::genai::StructuredOutputConfig::TriggeredTags>>(py_obj);
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::TagsWithSeparator>(py_obj)) {
+        return py::cast<std::shared_ptr<ov::genai::StructuredOutputConfig::TagsWithSeparator>>(py_obj);
     } else {
-        OPENVINO_THROW(py_obj.get_type(), " type isn't supported for StructuredOutputConfig compound grammar: ", py::str(py_obj));
+        OPENVINO_THROW(py_obj.get_type(), " type isn't supported for StructuralTag: ", py::str(py_obj));
     }
 }
 

--- a/src/python/py_utils.hpp
+++ b/src/python/py_utils.hpp
@@ -22,7 +22,7 @@ using PyBindStreamerVariant = std::variant<
     std::shared_ptr<StreamerBase>,
     std::monostate>;
 
-ov::genai::StructuredOutputConfig::CompoundGrammar py_obj_to_compound_grammar(const py::object& py_obj);
+ov::genai::StructuredOutputConfig::CompoundGrammar py_obj_to_structural_tag(const py::object& py_obj);
 
 template <class... Ts>
 struct overloaded : Ts... {

--- a/tests/python_tests/test_structured_output.py
+++ b/tests/python_tests/test_structured_output.py
@@ -174,9 +174,8 @@ def test_structural_tags_old(ov_pipe, prompt_and_structural_tag):
 
 
 @pytest.mark.precommit
-@pytest.mark.parametrize(
-    "ov_pipe", [model_id for model_id in structured_id_models if "random" not in model_id], indirect=True
-)
+# use only non-random model for stable output in TriggeredTags test
+@pytest.mark.parametrize("ov_pipe", ["TinyLlama/TinyLlama-1.1B-Chat-v1.0"], indirect=True)
 @pytest.mark.parametrize(
     "prompt,tag,validate",
     [

--- a/tests/python_tests/test_structured_output.py
+++ b/tests/python_tests/test_structured_output.py
@@ -233,7 +233,7 @@ def test_structural_tags_old(ov_pipe, prompt_and_structural_tag):
             id="Union",
         ),
         pytest.param(
-            "QwenXMLParametersFormat",
+            "",
             SOC.QwenXMLParametersFormat(json.dumps(RESTAPIResponse.model_json_schema())),
             lambda x: (
                 # enum values are placed in double quotes for some reason
@@ -257,7 +257,7 @@ def test_structural_tags_old(ov_pipe, prompt_and_structural_tag):
             id="TriggeredTags",
         ),
         pytest.param(
-            "TagsWithSeparator",
+            "",
             SOC.TagsWithSeparator(
                 tags=[
                     SOC.Tag(begin="<f>", content=SOC.ConstString("A"), end="</f>"),


### PR DESCRIPTION
## Description
Update XGrammar to 0.1.25 version.
- New version reduces grammar compile time
- Support new structural tags that work similarly to compound grammar
- Deprecate compound grammar and old structural tags
- Update samples with new structural tags API
- Fix python benchmark sample - the actual number of tokens was different to the reported number of tokens
- Update python formatting with ruff.

OVMS StructuralTags compilation benchmark results:
0.1.18:   2613.6 ms
0.1.19:  10242.3 ms
0.1.20:  15852.5 ms
0.1.21:  17536.1 ms
0.1.22: 205489.0 ms
0.1.23:    703.5 ms
0.1.24:    692.8 ms 
0.1.25      86.4 ms

Ticket: CVS-173972

## Checklist:
- [x] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation
