### PR TITLE
Fix missing result_dir parameter in evaluator constructors

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/embeddings_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/embeddings_evaluator.py
@@ -82,7 +82,9 @@ class EmbeddingsEvaluator(BaseEvaluator):
         self.gt_dir = os.path.dirname(gt_data)
 
         if base_model:
-            self.gt_data = self._generate_data(base_model, gen_embeds_fn)
+            self.gt_data = self._generate_data(
+                base_model, gen_embeds_fn, os.path.join(self.gt_dir, "reference")
+            )
         else:
             self.gt_data = pd.read_csv(gt_data, keep_default_na=False)
 

--- a/tools/who_what_benchmark/whowhatbench/reranking_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/reranking_evaluator.py
@@ -64,7 +64,9 @@ class RerankingEvaluator(BaseEvaluator):
         self.gt_dir = os.path.dirname(gt_data)
 
         if base_model:
-            self.gt_data = self._generate_data(base_model, gen_rerank_fn)
+            self.gt_data = self._generate_data(
+                base_model, gen_rerank_fn, os.path.join(self.gt_dir, "reference")
+            )
         else:
             self.gt_data = pd.read_csv(gt_data, keep_default_na=False)
 


### PR DESCRIPTION
- Fix _generate_data call in RerankingEvaluator to include result_dir parameter
- Fix _generate_data call in EmbeddingsEvaluator to include result_dir parameter
- Both evaluators now properly pass reference directory path when generating ground truth data
- Ensures consistent behavior between constructor and score method data generation

## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!--- Jira ticket number (e.g., 123). Delete if there's no ticket. Don't include full link or project name. -->
Ticket: 

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation
