### PR TITLE
Complete GenAI Logger

### DIFF
--- a/src/cpp/src/logger.hpp
+++ b/src/cpp/src/logger.hpp
@@ -54,6 +54,9 @@ namespace detail {
 
 inline void log_message(ov::log::Level level, const char* file, int line, const std::string& msg) {
     auto& logger = Logger::get_instance();
+    if (!logger.should_log(level)) {
+        return;
+    }
     logger.do_log(level, file, line, msg);
 }
 
@@ -76,9 +79,9 @@ inline void log_message(ov::log::Level level, const char* file, int line, const 
 
 }  // namespace detail
 
-#define OPENVINO_DEBUG(...) ::ov::genai::detail::log_message(ov::log::Level::DEBUG, __FILE__, __LINE__, __VA_ARGS__)
-#define OPENVINO_INFO(...)  ::ov::genai::detail::log_message(ov::log::Level::INFO, __FILE__, __LINE__, __VA_ARGS__)
-#define OPENVINO_WARN(...)  ::ov::genai::detail::log_message(ov::log::Level::WARNING, __FILE__, __LINE__, __VA_ARGS__)
-#define OPENVINO_ERR(...)   ::ov::genai::detail::log_message(ov::log::Level::ERR, __FILE__, __LINE__, __VA_ARGS__)
+#define GENAI_DEBUG(...) ::ov::genai::detail::log_message(ov::log::Level::DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+#define GENAI_INFO(...)  ::ov::genai::detail::log_message(ov::log::Level::INFO, __FILE__, __LINE__, __VA_ARGS__)
+#define GENAI_WARN(...)  ::ov::genai::detail::log_message(ov::log::Level::WARNING, __FILE__, __LINE__, __VA_ARGS__)
+#define GENAI_ERR(...)   ::ov::genai::detail::log_message(ov::log::Level::ERR, __FILE__, __LINE__, __VA_ARGS__)
 
 }  // namespace ov::genai

--- a/src/cpp/src/rag/text_embedding_pipeline.cpp
+++ b/src/cpp/src/rag/text_embedding_pipeline.cpp
@@ -300,7 +300,7 @@ private:
                         << ")."
                         << " Some models may fail with such configuration."
                         << " Remove max_position_embeddings from config.json to silence this warning.";
-                OPENVINO_WARN(message.str());
+                GENAI_WARN(message.str());
             }
 
             if (m_config.pad_to_max_length.has_value() && *m_config.pad_to_max_length) {

--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
@@ -72,9 +72,9 @@ xgrammar::Grammar XGrammarStructuredOutput::create_grammar(const std::optional<S
             using ConfigType = std::decay_t<decltype(config)>;
             if constexpr (std::is_same_v<ConfigType, StructuralTagsConfig>) {
                 // Old format: StructuralTagsConfig
-                OPENVINO_WARN("The use of \"structural_tags_config\" with StructuralTagsConfig instance is "
-                              "deprecated and will be removed in future releases. "
-                              "Use TriggeredTags instead.");
+                GENAI_WARN("The use of \"structural_tags_config\" with StructuralTagsConfig instance is "
+                           "deprecated and will be removed in future releases. "
+                           "Use TriggeredTags instead.");
 
                 std::ostringstream oss;
                 oss << "{\"type\": \"structural_tag\", \"format\": " << config.to_json() << "}";
@@ -99,8 +99,8 @@ xgrammar::Grammar XGrammarStructuredOutput::create_grammar(const std::optional<S
             }
         }, structured_output_config.value().structural_tags_config.value());
     } else if (structured_output_config.value().compound_grammar.has_value()) {
-        OPENVINO_WARN("The use of \"compound_grammar\" is deprecated and will be removed in future releases.\n"
-                      "Pass the same input to \"structural_tags_config\" instead.");
+        GENAI_WARN("The use of \"compound_grammar\" is deprecated and will be removed in future releases.\n"
+                   "Pass the same input to \"structural_tags_config\" instead.");
         return parse_structural_tag(structured_output_config.value().compound_grammar.value());
     }
 

--- a/src/cpp/src/whisper/models/with_past_decoder.cpp
+++ b/src/cpp/src/whisper/models/with_past_decoder.cpp
@@ -82,10 +82,10 @@ namespace ov::genai {
 WhisperWithPastDecoder::WhisperWithPastDecoder(const std::filesystem::path& models_path,
                                                const std::string& device,
                                                const ov::AnyMap& properties) {
-    OPENVINO_WARN("Whisper decoder models with past is deprecated. Support will be removed in 2026.0.0 release.\n"
-                  "To obtain stateful decoder model use latest `optimum-intel` package:\n"
-                  "pip install optimum-intel@git+https://github.com/huggingface/optimum-intel.git@main\n"
-                  "optimum-cli export openvino --trust-remote-code --model openai/whisper-tiny whisper-tiny");
+    GENAI_WARN("Whisper decoder models with past is deprecated. Support will be removed in 2026.0.0 release.\n"
+               "To obtain stateful decoder model use latest `optimum-intel` package:\n"
+               "pip install optimum-intel@git+https://github.com/huggingface/optimum-intel.git@main\n"
+               "optimum-cli export openvino --trust-remote-code --model openai/whisper-tiny whisper-tiny");
 
     ov::Core core = utils::singleton_core();
 

--- a/tests/cpp/logger.cpp
+++ b/tests/cpp/logger.cpp
@@ -30,7 +30,7 @@ protected:
 
 TEST_F(LoggerTests, SupportsPrintfStyleFormatting) {
     testing::internal::CaptureStdout();
-    OPENVINO_INFO("The value of %s is %d", "alpha", 42);
+    GENAI_INFO("The value of %s is %d", "alpha", 42);
     std::string output = testing::internal::GetCapturedStdout();
 
     expect_contains(output, "[INFO] ");
@@ -41,7 +41,7 @@ TEST_F(LoggerTests, SupportsPrintfStyleFormatting) {
 
 TEST_F(LoggerTests, KeepsSingleTrailingNewline) {
     testing::internal::CaptureStdout();
-    OPENVINO_INFO("Message with newline\n");
+    GENAI_INFO("Message with newline\n");
     std::string output = testing::internal::GetCapturedStdout();
 
     expect_contains(output, "[INFO] ");
@@ -49,18 +49,18 @@ TEST_F(LoggerTests, KeepsSingleTrailingNewline) {
 }
 
 TEST_F(LoggerTests, ValidFormatDoesNotThrow) {
-    EXPECT_NO_THROW(OPENVINO_INFO("Hello, %s", "world"));
-    EXPECT_NO_THROW(OPENVINO_INFO("Hello, %s\n", "world"));
-    EXPECT_NO_THROW(OPENVINO_INFO("%d + %d = %d", 1, 2, 3));
-    EXPECT_NO_THROW(OPENVINO_INFO("Pi is approximately %.2f", 3.14159));
-    EXPECT_NO_THROW(OPENVINO_INFO("Hex: 0x%X", 255));
-    EXPECT_NO_THROW(OPENVINO_INFO("Pointer %p", static_cast<const void*>(this)));
+    EXPECT_NO_THROW(GENAI_INFO("Hello, %s", "world"));
+    EXPECT_NO_THROW(GENAI_INFO("Hello, %s\n", "world"));
+    EXPECT_NO_THROW(GENAI_INFO("%d + %d = %d", 1, 2, 3));
+    EXPECT_NO_THROW(GENAI_INFO("Pi is approximately %.2f", 3.14159));
+    EXPECT_NO_THROW(GENAI_INFO("Hex: 0x%X", 255));
+    EXPECT_NO_THROW(GENAI_INFO("Pointer %p", static_cast<const void*>(this)));
 }
 
 TEST_F(LoggerTests, NoOutputWhenLevelIsNo) {
     ov::genai::Logger::get_instance().set_log_level(ov::log::Level::NO);
     testing::internal::CaptureStdout();
-    OPENVINO_INFO("Should not appear");
+    GENAI_INFO("Should not appear");
     std::string output = testing::internal::GetCapturedStdout();
 
     EXPECT_TRUE(output.empty());
@@ -71,10 +71,10 @@ TEST_F(LoggerTests, RespectsLogLevelFiltering) {
     testing::internal::CaptureStderr();
 
     ov::genai::Logger::get_instance().set_log_level(ov::log::Level::WARNING);
-    OPENVINO_DEBUG("debug message");
-    OPENVINO_INFO("info message");
-    OPENVINO_WARN("warn message");
-    OPENVINO_ERR("error message");
+    GENAI_DEBUG("debug message");
+    GENAI_INFO("info message");
+    GENAI_WARN("warn message");
+    GENAI_ERR("error message");
 
     std::string output = testing::internal::GetCapturedStdout();
     std::string error_output = testing::internal::GetCapturedStderr();
@@ -90,21 +90,23 @@ TEST_F(LoggerTests, RespectsLogLevelFiltering) {
 
 TEST_F(LoggerTests, EmitsAllLogLevelsWithoutErrors) {
     ov::genai::Logger::get_instance().set_log_level(ov::log::Level::DEBUG);
-
     testing::internal::CaptureStdout();
     testing::internal::CaptureStderr();
 
-    OPENVINO_DEBUG("debug level message");
-    OPENVINO_INFO("info level message");
-    OPENVINO_WARN("warning level message");
-    OPENVINO_ERR("error level message");
+    GENAI_DEBUG("debug level message");
+    GENAI_INFO("info level message");
+    GENAI_WARN("warning level message");
+    GENAI_ERR("error level message");
 
     std::string std_output = testing::internal::GetCapturedStdout();
     std::string err_output = testing::internal::GetCapturedStderr();
 
-    expect_contains(std_output, "[DEBUG][");
+    // DEBUG output should contain timestamp and file:line
+    expect_contains(std_output, "[DEBUG] ");
+    expect_contains(std_output, "T");  // Timestamp contains 'T'
     expect_contains(std_output, ":");
     expect_contains(std_output, "debug level message");
+    // INFO and WARNING should not contain timestamp
     expect_contains(std_output, "[INFO] info level message");
     expect_contains(std_output, "[WARNING] warning level message");
 


### PR DESCRIPTION
Complete the logging mechanism with a thread-safe singleton Logger that honors OPENVINO_LOG_LEVEL before printing.
Added macros-based functions. (GENAI_DEBUG_LOG, GENAI_INFO_LOG, etc.)

Tickets: CVS-176017
