### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,7 +179,7 @@ jobs:
           # Need to remove the default Python 3.11 in /venv from the Path so that CMake uses the correct one from newly created venv$py_version
           export PATH=${PATH/:\/venv\/bin/}
 
-          for py_version in "3.9" "3.10" "3.11" "3.12" "3.13"
+          for py_version in "3.10" "3.11" "3.12" "3.13"
           do
             rm -rf ${{ env.BUILD_DIR }}/CMakeCache.txt
             
@@ -301,7 +301,7 @@ jobs:
       
       - name: Build GenAI Wheel
         run: |
-          for py_version in "3.9" "3.10" "3.11" "3.12" "3.13"
+          for py_version in "3.10" "3.11" "3.12" "3.13"
           do
             python_exec_path=$(python$py_version -c "import sys; print(sys.executable)")
             $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -170,7 +170,7 @@ jobs:
                 -S ${{ env.SRC_DIR }} \
                 -B ${{ env.BUILD_DIR }}
           /usr/bin/cmake --build ${{ env.BUILD_DIR }} --config ${{ matrix.build-type }} --parallel $(nproc) --verbose
-          for py_version in "3.9" "3.10" "3.11" "3.12" "3.13"
+          for py_version in "3.10" "3.11" "3.12" "3.13"
           do
             rm -rf ${{ env.BUILD_DIR }}/CMakeCache.txt
             
@@ -287,7 +287,7 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          for py_version in "3.9" "3.10" "3.11" "3.12" "3.13"
+          for py_version in "3.10" "3.11" "3.12" "3.13"
           do
             python_exec_path=$(python$py_version -c "import sys; print(sys.executable)")
             $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,12 +123,6 @@ jobs:
           submodules: recursive
           path: ${{ env.SRC_DIR }}
 
-      - name: Setup Python 3.9
-        if: ${{ matrix.build-type != 'Debug' }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        with:
-          python-version: '3.9'
-      
       - name: Setup Python 3.10
         if: ${{ matrix.build-type != 'Debug' }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -209,7 +203,7 @@ jobs:
         run: |
           ${{ env.OV_INSTALL_DIR }}/setupvars.ps1
           if ( "${{ matrix.build-type }}" -ne "Debug" ) {
-            $pyVersions = '3.9', '3.10', '3.11', '3.12', '3.13'
+            $pyVersions = '3.10', '3.11', '3.12', '3.13'
           } else {
             $pyVersions = '3.11'
           }
@@ -383,12 +377,6 @@ jobs:
         run: python -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} ${{ env.SRC_DIR }}/tools/who_what_benchmark
         working-directory: ${{ env.OV_INSTALL_DIR }}
       
-      - name: Setup Python 3.9
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        with:
-          python-version: '3.9'
-          cache: 'pip'
-      
       - name: Setup Python 3.10
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -409,7 +397,7 @@ jobs:
       
       - name: Build genai wheel
         run: |
-          $pyVersions = '3.9', '3.10', '3.11', '3.12', '3.13'
+          $pyVersions = '3.10', '3.11', '3.12', '3.13'
           foreach ($pyVersion in $pyVersions) {
             $pythonCommand = "py -$pyVersion -c `"import sys; print(f'{sys.executable}')`""
             $pythonExecutablePath = & cmd /c $pythonCommand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "openvino-genai"
 version = "2025.4.0.0"
 description = "Library of the most popular Generative AI model pipelines, optimized execution methods, and samples"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = { file = "src/README.md", content-type="text/markdown" }
 license = { "file" = "LICENSE" }
 authors = [
@@ -15,7 +15,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/docs/BUILD.md
+++ b/src/docs/BUILD.md
@@ -9,14 +9,14 @@ The preferred approach is to build both OpenVINO and OpenVINO GenAI from sources
 
 - [CMake](https://cmake.org/download/) 3.23 or higher
 - GCC 7.5 or higher
-- Python 3.9 or higher
+- Python 3.10 or higher
 - Git
 
 ### Windows
 
 - [CMake](https://cmake.org/download/) 3.23 or higher
 - Microsoft Visual Studio 2019 or higher, version 16.3 or later
-- Python 3.9 or higher
+- Python 3.10 or higher
 - Git for Windows
 
 ### macOS
@@ -30,7 +30,7 @@ The preferred approach is to build both OpenVINO and OpenVINO GenAI from sources
     ```sh
     xcode-select --install
     ```
-- Python 3.9 or higher
+- Python 3.10 or higher
 - Git
 
 


### PR DESCRIPTION
## Description
No longer supported. You can verify by inspecting nightly packages: https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly/

Linux runners no longer have it so pre-commit fails.

CVS-170716

## Checklist:
- [x] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [x] I have made corresponding changes to the documentation
