### PR TITLE
Removed inference and kv-cache precision hints for SD on NPU from tests

### DIFF
--- a/tests/python_tests/test_stateful_speculative_decoding.py
+++ b/tests/python_tests/test_stateful_speculative_decoding.py
@@ -14,7 +14,7 @@ from utils.comparation import compare_generation_results
 from utils.ov_genai_pipelines import convert_decoded_results_to_generation_result
 
 def get_npu_llm_properties_for_test():
-    config = get_default_llm_properties()
+    config = {}
     config["NPUW_DEVICES"] = "CPU"
     config["GENERATE_HINT"] = "BEST_PERF"
     return config


### PR DESCRIPTION
## Description
- *Removed inference and kv-cache precision hints in tests for Speculative Decoding on NPU*

## Checklist:
- [ ] Tests have been updated or added to cover the new code <!--- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation
