### PR TITLE
Update condition for enum value conflicting with windows headers

### DIFF
--- a/src/cpp/include/openvino/genai/cache_eviction.hpp
+++ b/src/cpp/include/openvino/genai/cache_eviction.hpp
@@ -31,8 +31,8 @@ enum class KVCrushAnchorPointMode {
     MEAN, /**<In this mode the anchor point is a random binary vector of 0s and 1s, where individual values are decided
              based on majority value */
     ALTERNATING, /**In this mode the anchor point is a vector of alternate 0s and 1s */
-#if !defined(_WIN32) || !defined(_MSC_VER) || _MSC_VER <= 1942
-    // KVCrushAnchorPointMode::ALTERNATE is conflicting with definitions in windows.h in newer MSVC versions
+#ifndef _WIN32
+    // KVCrushAnchorPointMode::ALTERNATE is conflicting with definitions in windows.h in MSVC versions (https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getpolyfillmode)
     ALTERNATE OPENVINO_ENUM_DEPRECATED("Please, use `KVCrushAnchorPointMode::ALTERNATING` instead of `KVCrushAnchorPointMode::ALTERNATE`.") = ALTERNATING /**In this mode the anchor point is a vector of alternate 0s and 1s */
 #endif
 };


### PR DESCRIPTION
## Description
This PR updates the preprocessor condition for the deprecated `ALTERNATE` enum value in `KVCrushAnchorPointMode` to avoid conflicts with Windows headers and exclude it on all Windows platforms

CVS-175618


## Checklist:
- [ ] Tests have been updated or added to cover the new code - N/A
- [x] This patch fully addresses the ticket
- [ ] I have made corresponding changes to the documentation - N/A
