### PR TITLE
[GHA] Fix samples dependabot duplicated PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,39 +29,12 @@ updates:
   # Python dependencies
   #
   - package-ecosystem: "pip"
-    directory: "./tests/python_tests/"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/Dublin"
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: "pip"
-    directory: "./tools/llm_bench/"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/Dublin"
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: "pip"
-    directory: "./tools/who_what_benchmark/"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/Dublin"
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: "pip"
-    directory: "./samples/"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/Dublin"
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "./samples/"
+      - "./tests/python_tests/"
+      - "./tools/llm_bench/"
+      - "./tools/who_what_benchmark/"
     schedule:
       interval: "daily"
       time: "09:00"


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Duplicated PR: https://github.com/openvinotoolkit/openvino.genai/pull/3014 https://github.com/openvinotoolkit/openvino.genai/pull/3015
There is some inconsistency how `/samples` and `/tests` scanned. This is a fix attempt. Group directories and prefix samples with `.`

