### PR TITLE
Removed not needed code from apply_paged_attention_transformation().

### DIFF
--- a/src/cpp/src/continuous_batching/paged_attention_transformations.cpp
+++ b/src/cpp/src/continuous_batching/paged_attention_transformations.cpp
@@ -30,36 +30,6 @@ void apply_paged_attention_transformations(std::shared_ptr<ov::Model> model, boo
 
     OPENVINO_ASSERT(key_cache_params.size() == value_cache_params.size() && key_cache_params.size() > 0);
 
-    size_t num_decoder_layers = key_cache_params.size();
-    for (size_t idx = 0; idx < num_decoder_layers; idx++) {
-        auto k = key_cache_params[std::string("key_cache.") + std::to_string(idx)];
-        auto key_shape = k->get_partial_shape();
-        size_t num_k_heads = key_shape[1].get_length();
-        size_t k_head_size = key_shape[2].get_length();
-
-        auto v = value_cache_params[std::string("value_cache.") + std::to_string(idx)];
-        auto value_shape = v->get_partial_shape();
-        size_t num_v_heads = value_shape[1].get_length();
-        size_t v_head_size = value_shape[2].get_length();
-
-        // reset information in KV cache parameters and set PagedAttention's rt_info
-        // allow a plugin to automatically set KV cache precisions
-        k->set_element_type(ov::element::dynamic);
-        v->set_element_type(ov::element::dynamic);
-
-        // order of dimensions within shapes are not required for plugin during compilation
-        k->set_partial_shape(ov::PartialShape::dynamic(4));
-        v->set_partial_shape(ov::PartialShape::dynamic(4));
-
-        // set KV cache parameters as rt_info for PagedAttention op, so plugins can apply
-        // model compile-time optimizations based on them
-        auto pa_op = k->get_output_target_inputs(0).begin()->get_node();
-        pa_op->get_rt_info()["num_k_heads"] = num_k_heads;
-        pa_op->get_rt_info()["k_head_size"] = k_head_size;
-        pa_op->get_rt_info()["num_v_heads"] = num_v_heads;
-        pa_op->get_rt_info()["v_head_size"] = v_head_size;
-    }
-
     model->validate_nodes_and_infer_types();
 }
 


### PR DESCRIPTION
After this PR https://github.com/openvinotoolkit/openvino/pull/32570 `SDPAToPagedAttention` sets 4D dynamic shapes and dynamic element type for KV cache and sets required runtime info with k/v_head_size and num_k/v_head, so there's no need to do it in GenAI anymore.

Also after this PR PA pipeline fails with following error during the attempt to get shape from Parameter node with dynamic dimention:
```
Exception from src/core/src/dimension.cpp:227:
Cannot get length of dynamic dimension
```

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
