### PR TITLE
[VLM] Optimize vision preprocessing for LLaVA-NeXT-Video

### DIFF
--- a/src/cpp/src/visual_language/llava_next_video/classes.hpp
+++ b/src/cpp/src/visual_language/llava_next_video/classes.hpp
@@ -15,9 +15,7 @@ public:
 
     EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
 
-    std::pair<ov::Tensor, size_t> preprocess_frames_cpp(const std::vector<ov::Tensor>& frames);
-
-    std::pair<ov::Tensor, size_t> preprocess_frames_ov(const std::vector<ov::Tensor>& frames);
+    ov::Tensor preprocess_frames_cpp(const std::vector<ov::Tensor>& frames);
 
     VisionEncoderLLaVANextVideo(const std::filesystem::path& model_dir, const std::string& device, const ov::AnyMap properties);
 
@@ -38,15 +36,19 @@ public:
         return m_ireq_queue_vision_resampler.get();
     }
 
-    bool get_use_ov_preprocess() const {
-        return use_ov_preprocess;
+    bool get_use_ov_vision_preprocess() const {
+        return use_ov_vision_preprocess;
+    }
+
+    size_t get_patch_size() const {
+        return m_patch_size;
     }
 
 private:
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_multi_modal_projector;
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_resampler;
     size_t m_patch_size;
-    bool use_ov_preprocess = true;
+    bool use_ov_vision_preprocess = true; // default use ov vision preprocessing, control by env VISION_PREPROCESS=CPP to use CPU vision preprocessing
 };
 
 class InputsEmbedderLLaVANextVideo : public InputsEmbedderLLaVANext {

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -888,7 +888,7 @@ EncodedImage VisionEncoderPhi3V::encode(const ov::Tensor& image, const ov::AnyMa
 
     ImageSize image_size;
 
-    if (use_ov_image_preprocess) {
+    if (use_ov_vision_preprocess) {
         ov::Tensor hd_image = HD_transform(image, config.phi3_v.num_crops);
         image_size = ImageSize{hd_image.get_shape().at(2), hd_image.get_shape().at(1)};
 
@@ -921,8 +921,8 @@ EncodedImage VisionEncoderPhi3V::encode(const ov::Tensor& image, const ov::AnyMa
     return encoded_image;
 }
 
-bool can_use_ov_image_preprocess() {
-    const char* env = std::getenv("IMAGE_PREPROCESS");
+bool can_use_ov_vision_preprocess() {
+    const char* env = std::getenv("VISION_PREPROCESS");
     return !(env && std::string(env) == "CPP");
 }
 
@@ -930,8 +930,8 @@ VisionEncoderPhi3V::VisionEncoderPhi3V(const std::filesystem::path& model_dir,
                                        const std::string& device,
                                        const ov::AnyMap properties)
     : VisionEncoder(model_dir, device, properties),
-      use_ov_image_preprocess(can_use_ov_image_preprocess()) {
-    if (use_ov_image_preprocess) {
+      use_ov_vision_preprocess(can_use_ov_vision_preprocess()) {
+    if (use_ov_vision_preprocess) {
         auto vision_encoder_model = utils::singleton_core().read_model(model_dir / "openvino_vision_embeddings_model.xml");
         auto model = patch_image_preprocess_into_vision_encoder_model(vision_encoder_model, m_processor_config);
         auto compiled_model = utils::singleton_core().compile_model(model, device, properties);
@@ -963,8 +963,8 @@ VisionEncoderPhi3V::VisionEncoderPhi3V(const ModelsMap& models_map,
                                        const std::string& device,
                                        const ov::AnyMap properties)
     : VisionEncoder(models_map, config_dir_path, device, properties),
-      use_ov_image_preprocess(can_use_ov_image_preprocess()) {
-    if (use_ov_image_preprocess) {
+      use_ov_vision_preprocess(can_use_ov_vision_preprocess()) {
+    if (use_ov_vision_preprocess) {
         const auto& [vision_encoder_model, vision_encoder_weights] = utils::get_model_weights_pair(models_map, "vision_embeddings");
         auto model_org = utils::singleton_core().read_model(vision_encoder_model, vision_encoder_weights);
         auto model = patch_image_preprocess_into_vision_encoder_model(model_org, m_processor_config);

--- a/src/cpp/src/visual_language/phi3_vision/classes.hpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.hpp
@@ -42,7 +42,7 @@ public:
     EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
 
 private:
-    bool use_ov_image_preprocess = true; // default use ov image preprocessing, control by env IMAGE_PREPROCESS=CPP to use CPU image preprocessing
+    bool use_ov_vision_preprocess = true; // default use ov vision preprocessing, control by env VISION_PREPROCESS=CPP to use CPU vision preprocessing
 
 };
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -649,8 +649,8 @@ std::unique_ptr<CircularBufferQueue<ov::InferRequest>> create_vision_encoder_ire
         });
 }
 
-bool check_image_preprocess_env() {
-    const char* env = std::getenv("IMAGE_PREPROCESS");
+bool check_vision_preprocess_env() {
+    const char* env = std::getenv("VISION_PREPROCESS");
     return !(env && std::string(env) == "CPP");
 }
 
@@ -658,8 +658,8 @@ VisionEncoderQwen2VL::VisionEncoderQwen2VL(const std::filesystem::path& model_di
                                            const std::string& device,
                                            const ov::AnyMap properties)
     : VisionEncoder(model_dir, device, properties),
-      use_ov_image_preprocess(check_image_preprocess_env()) {
-    if (use_ov_image_preprocess) {
+      use_ov_vision_preprocess(check_vision_preprocess_env()) {
+    if (use_ov_vision_preprocess) {
         auto model_org = utils::singleton_core().read_model(model_dir / "openvino_vision_embeddings_model.xml");
         m_ireq_queue_vision_encoder = create_vision_encoder_ireq(model_org, m_processor_config, device, properties);
     }
@@ -670,8 +670,8 @@ VisionEncoderQwen2VL::VisionEncoderQwen2VL(const ModelsMap& models_map,
                                            const std::string& device,
                                            const ov::AnyMap properties)
     : VisionEncoder(models_map, config_dir_path, device, properties),
-      use_ov_image_preprocess(check_image_preprocess_env()) {
-    if (use_ov_image_preprocess) {
+      use_ov_vision_preprocess(check_vision_preprocess_env()) {
+    if (use_ov_vision_preprocess) {
         const auto& [vision_encoder_model, vision_encoder_weights] =
             utils::get_model_weights_pair(models_map, "vision_embeddings");
         auto model_org = utils::singleton_core().read_model(vision_encoder_model, vision_encoder_weights);
@@ -880,7 +880,7 @@ void VisionEncoderQwen2VL::encode_with_imagepreprocess_ov(const std::vector<ov::
 
 EncodedImage VisionEncoderQwen2VL::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
     EncodedImage encoded_img;
-    if (use_ov_image_preprocess == false) {
+    if (use_ov_vision_preprocess == false) {
         encode_with_imagepreprocess_cpp({image}, config_map, encoded_img.resized_source, encoded_img.resized_source_size);
         return encoded_img;
     }
@@ -899,7 +899,7 @@ EncodedVideo VisionEncoderQwen2VL::encode_frames(const std::vector<ov::Tensor>& 
 
     using EncodeFunc = std::function<void(const std::vector<ov::Tensor>&, const ov::AnyMap&, ov::genai::EncodedVideo&, size_t, size_t)>;
     EncodeFunc encode_func;
-    if (use_ov_image_preprocess == false) {
+    if (use_ov_vision_preprocess == false) {
         encode_func = [this](const std::vector<ov::Tensor>& image, const ov::AnyMap& config_map, ov::genai::EncodedVideo& encoded_video, size_t frm_num, size_t frm_id) {
             this->encode_with_imagepreprocess_cpp(image, config_map, encoded_video.video_features, encoded_video.resized_source_size, frm_num, frm_id);
         };

--- a/src/cpp/src/visual_language/qwen2vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.hpp
@@ -34,7 +34,7 @@ private:
                                         size_t frame_num = 1,
                                         size_t frame_id = 0);
 
-    bool use_ov_image_preprocess = true; // default use ov image preprocess, control by env IMAGE_PREPROCESS=CPP to use cpp image preprocess
+    bool use_ov_vision_preprocess = true; // default use ov vision preprocess, control by env VISION_PREPROCESS=CPP to use cpp vision preprocess
 };
 
 class InputsEmbedderQwen2VL : public InputsEmbedder::IInputsEmbedder {


### PR DESCRIPTION
## Description
Optimize video frame preprocessing for LLaVA-NeXT-Video-7B model on GPU by creating an OpenVINO preprocessing model to move preprocessing operations from CPU to GPU

Ticket: [CVS-177558](https://jira.devtools.intel.com/browse/CVS-177558)

Average 1st token latency (1280x720 5s video (32 frames) + 100 input tokens -> generate 128 tokens)
```
CPP preprocessing (GPU)  2906.118 ms
OV preprocessing (GPU)   845.6711 ms
CPP preprocessing (CPU)  15321.59 ms
OV preprocessing (CPU)   14327.6  ms
```

WWB results with video input (--model-type visual-video-text):
```
CPP preprocessing (GPU)  0.880806
OV preprocessing (GPU)   0.860603
CPP preprocessing (CPU)  0.918247
OV preprocessing (CPU)   0.906167
```

WWB results with image input (--model-type visual-text):
```
CPP preprocessing (GPU)  0.899575
OV preprocessing (GPU)   0.881532
CPP preprocessing (CPU)  0.903088
OV preprocessing (CPU)   0.902678
```

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
