### PR TITLE
Add a note about VLM follow up iterations

### DIFF
--- a/samples/c/visual_language_chat/vlm_pipeline.c
+++ b/samples/c/visual_language_chat/vlm_pipeline.c
@@ -68,6 +68,7 @@ int main(int argc, char* argv[]) {
         if (strlen(prompt) == 0) {
             continue; 
         }
+        // New images and videos can be passed at each turn
         ov_genai_vlm_pipeline_generate(pipeline, prompt, NULL, 0, config, &callback, &results);
         printf("\n----------\nquestion:\n");
     }

--- a/samples/cpp/visual_language_chat/video_to_text_chat.cpp
+++ b/samples/cpp/visual_language_chat/video_to_text_chat.cpp
@@ -105,6 +105,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "\n----------\n"
         "question:\n";
     while (std::getline(std::cin, prompt)) {
+        // New images and videos can be passed at each turn
         pipe.generate(prompt,
                       ov::genai::generation_config(generation_config),
                       ov::genai::streamer(print_subword));

--- a/samples/cpp/visual_language_chat/visual_language_chat.cpp
+++ b/samples/cpp/visual_language_chat/visual_language_chat.cpp
@@ -43,6 +43,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "\n----------\n"
         "question:\n";
     while (std::getline(std::cin, prompt)) {
+        // New images and videos can be passed at each turn
         pipe.generate(prompt,
                       ov::genai::generation_config(generation_config),
                       ov::genai::streamer(print_subword));

--- a/samples/python/visual_language_chat/video_to_text_chat.py
+++ b/samples/python/visual_language_chat/video_to_text_chat.py
@@ -93,6 +93,7 @@ def main():
             prompt = input("\n----------\nquestion:\n")
         except EOFError:
             break
+        # New images and videos can be passed at each turn
         pipe.generate(prompt, generation_config=config, streamer=streamer)
     pipe.finish_chat()
 

--- a/samples/python/visual_language_chat/visual_language_chat.py
+++ b/samples/python/visual_language_chat/visual_language_chat.py
@@ -79,6 +79,7 @@ def main():
                 "question:\n")
         except EOFError:
             break
+        # New images and videos can be passed at each turn
         pipe.generate(prompt, generation_config=config, streamer=streamer)
     pipe.finish_chat()
 


### PR DESCRIPTION
I have a concern that someone could decide that images can be passed only on first iteration because we don't implement special chat commands to keep the samples short