### PR TITLE
wwb/visualtext_evaluator: try to set processor.chat_template from tokenizer if it's not already set

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
@@ -122,7 +122,10 @@ class VisualTextEvaluator(TextEvaluator):
             # OV GenAI will use the chat_template from tokenizer.
             # Optimum (within preprocess_inputs) will use the chat_template only if it has been defined for processor.
             # So, if the chat_template hasn't been set for processor, try to set it from the tokenizer.
-            if getattr(processor, "chat_template", None) is None and getattr(tokenizer, "chat_template", None) is not None:
+            if (
+                getattr(processor, "chat_template", None) is None
+                and getattr(tokenizer, "chat_template", None) is not None
+            ):
                 processor.chat_template = tokenizer.chat_template
             inputs = preprocess_inputs(prompt, image, processor, tokenizer, config=model.config, video=video)
             tokens = model.generate(


### PR DESCRIPTION

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

There seems to be some differences in applying chat templates between optimum & OV GenAI cases.

For example, running wwb with optimum, using `MiniCPM-V-2_6`:
With current version of wwb, `preprocess_inputs` will manually apply the chat template here: [modeling_visual_language.py#L2108](https://github.com/huggingface/optimum-intel/blob/v1.27.0/optimum/intel/openvino/modeling_visual_language.py#L2108) 

This is because processor.chat_template hasn't been set.

When running OV GenAI, it will use the chat_template from the tokenizer config.

For `MiniCPM-V-2_6`, this is a problem as the chat_template defined by the tokenizer config will add a default system prompt -- so this gets added for OV GenAI case, but not when running optimum.

To better align chat_templating, I've added some logic to set processor.chat_template (if it isn't already set, and if it's defined for the tokenizer).

With this change, we get much better similarity scores for `MiniCPM-V-2_6` (and perhaps others).

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
Related / found while working this ticket:
CVS-178941

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
