### PR TITLE
[wwb] Fix num_inference_steps for inpainting and im2im

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/im2im_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/im2im_evaluator.py
@@ -35,8 +35,6 @@ def prepare_default_data(num_samples=None):
 
 @register_evaluator("image-to-image")
 class Image2ImageEvaluator(Text2ImageEvaluator):
-    DEF_NUM_INFERENCE_STEPS = 4
-
     def __init__(
         self,
         base_model: Any = None,
@@ -59,7 +57,7 @@ class Image2ImageEvaluator(Text2ImageEvaluator):
         self.metrics = metrics
         self.crop_prompt = crop_prompts
         self.num_samples = num_samples
-        self.num_inference_steps = num_inference_steps or self.DEF_NUM_INFERENCE_STEPS
+        self.num_inference_steps = num_inference_steps or self.DEFAULT_NUM_INFERENCE_STEPS
         self.seed = seed
         self.similarity = None
         self.similarity = ImageSimilarity(similarity_model_id)

--- a/tools/who_what_benchmark/whowhatbench/inpaint_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/inpaint_evaluator.py
@@ -51,8 +51,6 @@ def prepare_default_data(num_samples=None):
 
 @register_evaluator("image-inpainting")
 class InpaintingEvaluator(Text2ImageEvaluator):
-    DEF_NUM_INFERENCE_STEPS = 4
-
     def __init__(
         self,
         base_model: Any = None,
@@ -74,7 +72,7 @@ class InpaintingEvaluator(Text2ImageEvaluator):
         self.metrics = metrics
         self.crop_prompt = crop_prompts
         self.num_samples = num_samples
-        self.num_inference_steps = num_inference_steps or self.DEF_NUM_INFERENCE_STEPS
+        self.num_inference_steps = num_inference_steps or self.DEFAULT_NUM_INFERENCE_STEPS
         self.seed = seed
         self.similarity = None
         self.similarity = ImageSimilarity(similarity_model_id)

--- a/tools/who_what_benchmark/whowhatbench/text2image_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/text2image_evaluator.py
@@ -29,7 +29,7 @@ default_data = {
 
 @register_evaluator("text-to-image")
 class Text2ImageEvaluator(BaseEvaluator):
-    DEF_NUM_INFERENCE_STEPS = 4
+    DEFAULT_NUM_INFERENCE_STEPS = 4
 
     def __init__(
         self,
@@ -56,7 +56,7 @@ class Text2ImageEvaluator(BaseEvaluator):
         self.resolution = resolution
         self.crop_prompt = crop_prompts
         self.num_samples = num_samples
-        self.num_inference_steps = num_inference_steps or self.DEF_NUM_INFERENCE_STEPS
+        self.num_inference_steps = num_inference_steps or self.DEFAULT_NUM_INFERENCE_STEPS
         self.seed = seed
         self.similarity = None
         self.similarity = ImageSimilarity(similarity_model_id)


### PR DESCRIPTION
## Description
num_inference_steps was an option for the text2image/im2im/inpainting pipelines and had def value on the argument level. The option becomes shared for image and video in pr https://github.com/openvinotoolkit/openvino.genai/pull/3134. Image and video have differnet default values, so the default value in argument become None. But it's nessesary to set some number for the diffusers pipeline. This PR restores meaningful values ​​for im2im and inpainting.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-180367](https://jira.devtools.intel.com/browse/CVS-180367)

## Checklist:
- [x] This PR follows GenAI Contributing guidelines. <!-- Always follow https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
