### PR TITLE
sdxl: Fix accuracy issues for running VAE on NPU

### DIFF
--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -210,9 +210,7 @@ public:
         m_clip_text_encoder_with_projection->compile(text_encode_device, *updated_properties);
         m_unet->compile(denoise_device, *updated_properties);
 
-        // Workaround for EISW-176450: SDXL VAE may produce all-zero outputs on NPU due to
-        // precision issues in internal MVN normalization. Increase precision for
-        // internal_MvnNormalize via NPU_COMPILATION_MODE_PARAMS; scope is SDXL VAE on NPU only.
+        // EISW-176450
         if (vae_device.find("NPU") != std::string::npos) {
             updated_properties.fork()["NPU_COMPILATION_MODE_PARAMS"] =
                 "compute-layers-with-higher-precision=internal_MvnNormalize";


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
For SDXL, when VAE decoder runs on NPU it produces blank output (i.e. all zeros). This is the fix.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
EISW-176450

## Checklist:
- [x] This PR follows GenAI Contributing guidelines. <!-- Always follow https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
