### PR TITLE
[Whisper]: Extend attention QKs operation types for word level timestamps

### DIFF
--- a/src/cpp/src/whisper/word_level_timestamps.cpp
+++ b/src/cpp/src/whisper/word_level_timestamps.cpp
@@ -707,6 +707,7 @@ void add_cross_attention_qk_scaled_scores_outputs_for_whisper(std::shared_ptr<ov
     size_t idx = 0;
     for (auto& op : model->get_ordered_ops()) {
         const auto op_type = op->get_type_info().name;
+        // SDPA decompose transformation can create different op types depending on the optimum-intel implementation
         if (op_type != std::string("Add") && op_type != std::string("MatMul")) {
             continue;
         }


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
SDPA decompose can create different operation types for scaled qks node depending on optimum-intel/transformers implementation. Extend op type with `MatMul`. This change supports model converted with:
```
<optimum_version value="1.25.3" />
<transformers_version value="4.51.3" />
```

I didn't add new tests as I don't want to test older versions of optimum-intel in CI. Manual tests passed.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-180780

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows GenAI Contributing guidelines. <!-- Always follow https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [NA] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
