### PR TITLE
Fix Text2VideoPipeline crash with guidance_scale=1 when using default constructor

### DIFF
--- a/src/cpp/src/video_generation/ltx_pipeline.hpp
+++ b/src/cpp/src/video_generation/ltx_pipeline.hpp
@@ -410,8 +410,6 @@ public:
         m_vae_device = device;
         m_compile_properties = properties;
         m_is_compiled = true;
-        m_reshape_batch_size_multiplier = do_classifier_free_guidance(m_generation_config.guidance_scale) ? 2 : 1;
-        m_compiled_batch_size_multiplier = m_reshape_batch_size_multiplier;
         const std::filesystem::path model_index_path = models_dir / "model_index.json";
         std::ifstream file(model_index_path);
         OPENVINO_ASSERT(file.is_open(), "Failed to open ", model_index_path);

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -232,6 +232,19 @@ class TestText2VideoPipelineAdvanced:
         result = pipe.generate("test prompt", num_inference_steps=2)
         assert result.video is not None
 
+    def test_generate_without_cfg_default_compile(self, video_generation_model):
+        """Regression test: direct-compile constructor should work with guidance_scale <= 1."""
+        pipe = ov_genai.Text2VideoPipeline(video_generation_model, "CPU")
+        result = pipe.generate(
+            "test prompt",
+            guidance_scale=1.0,
+            height=32,
+            width=32,
+            num_frames=9,
+            num_inference_steps=2,
+        )
+        assert result.video is not None
+
     def test_generate_without_cfg_after_reshape_with_cfg(self, video_generation_model):
         """Test: reshape with CFG then generate without CFG should raise error."""
         pipe = ov_genai.Text2VideoPipeline(video_generation_model)


### PR DESCRIPTION
Fixed regression where Text2VideoPipeline(model_dir, device) followed by generate(guidance_scale=1.0) crashes with an assertion error. The direct-compile constructor incorrectly assumed the model was compiled for CFG based on the default config's guidance_scale, even though no reshape() was called and the model has dynamic shapes. Also added a regression test for this scenario.