### PR TITLE
[Video Generation] Add LoRA adapter support for Text2VideoPipeline (Supersedes #3309)

### DIFF
--- a/samples/cpp/video_generation/CMakeLists.txt
+++ b/samples/cpp/video_generation/CMakeLists.txt
@@ -74,3 +74,29 @@ install(TARGETS taylorseer_text2video
         RUNTIME DESTINATION samples_bin/
         COMPONENT samples_bin
         EXCLUDE_FROM_ALL)
+
+# create LoRA sample executable
+add_executable(lora_text2video lora_text2video.cpp imwrite_video.cpp)
+
+target_include_directories(lora_text2video PRIVATE ${CMAKE_BINARY_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/../image_generation/" "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/cpp/src/")
+ov_genai_link_opencv(lora_text2video core imgproc videoio imgcodecs)
+target_link_libraries(lora_text2video PRIVATE openvino::genai indicators::indicators)
+
+if(UNIX AND NOT APPLE)
+    set_target_properties(lora_text2video PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib"
+    )
+elseif(APPLE)
+    set_target_properties(lora_text2video PROPERTIES
+        INSTALL_RPATH "@loader_path/../lib"
+    )
+endif()
+
+set_target_properties(lora_text2video PROPERTIES
+    # Ensure out of box LC_RPATH on macOS with SIP
+    INSTALL_RPATH_USE_LINK_PATH ON)
+
+install(TARGETS lora_text2video
+        RUNTIME DESTINATION samples_bin/
+        COMPONENT samples_bin
+        EXCLUDE_FROM_ALL)

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -35,7 +35,7 @@ Alternatively, do it in Python code:
 from optimum.intel.openvino import OVLTXPipeline
 
 pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False)
-pipeline.save_pretrained("ltx_video_ov")
+pipeline.save_pretrained("ltx_video_ov/FP32")
 ```
 
 ## Sample Descriptions

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -24,7 +24,7 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov
 ```
 
 Alternatively, do it in Python code:

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -24,7 +24,7 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov
 ```
 
 Alternatively, do it in Python code:
@@ -32,7 +32,7 @@ Alternatively, do it in Python code:
 ```python
 from optimum.intel.openvino import OVLTXPipeline
 
-pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video-0.9.8-13B-distilled", export=True, compile=False)
+pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False)
 pipeline.save_pretrained("ltx_video_ov")
 ```
 
@@ -50,7 +50,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 - **Description:**
   Basic video generation using a text-to-video model. This sample demonstrates how to generate videos from text prompts using the OpenVINO GenAI Text2VideoPipeline. The LTX-Video model is recommended for this sample.
 
-  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+  Recommended models: Lightricks/LTX-Video
 
 - **Main Feature:** Generate videos from text descriptions with customizable parameters.
 
@@ -80,7 +80,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
 - **Run Command:**
   ```bash
-  ./lora_text2video model_dir prompt [lora_adapter_path] [alpha] ...
+  ./lora_text2video model_dir prompt [lora_adapter_path alpha] ...
   ```
 
   Example:

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -85,7 +85,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
   ./lora_text2video ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"  adapter1.safetensors 1.0 adapter2.safetensors 0.5
   ```
 
-The sample will generate a video file `genai_video.avi` in the current directory.
+The LoRA text-to-video sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.
 
 Users can modify the source code to experiment with different generation parameters:
 - Change width or height of generated video

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -24,18 +24,16 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format int8 ltx_video_ov/INT8
+optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video ltx_video_ov
 ```
 
-Alternatively, do it in Python code. If NNCF is installed, the model will be compressed to INT8 automatically.
+Alternatively, do it in Python code:
 
 ```python
 from optimum.intel.openvino import OVLTXPipeline
 
-output_dir = "ltx_video_ov/INT8"
-
-pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False, load_in_8bit=True)
-pipeline.save_pretrained(output_dir)
+pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video-0.9.8-13B-distilled", export=True, compile=False)
+pipeline.save_pretrained("ltx_video_ov")
 ```
 
 ## Sample Descriptions
@@ -52,7 +50,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 - **Description:**
   Basic video generation using a text-to-video model. This sample demonstrates how to generate videos from text prompts using the OpenVINO GenAI Text2VideoPipeline. The LTX-Video model is recommended for this sample.
 
-  Recommended models: Lightricks/LTX-Video
+  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
 
 - **Main Feature:** Generate videos from text descriptions with customizable parameters.
 
@@ -63,7 +61,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
   Example:
   ```bash
-  ./text2video ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
+  ./text2video ltx_video_ov "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
   ```
 
 ### LoRA Text to Video Sample (`lora_text2video.cpp`)
@@ -71,7 +69,12 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 - **Description:**
   Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying multiple LoRA adapters.
 
-  Recommended models: Lightricks/LTX-Video
+  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+
+  To download the LoRA adapter used in the example below:
+  ```sh
+  huggingface-cli download Cseti/LTXV-13B-LoRA-Wallace_and_Gromit-v1 walgro_style_step_42000_comfy.safetensors
+  ```
 
 - **Main Feature:** Apply LoRA adapters to a text-to-video pipeline for customized generation.
 
@@ -82,7 +85,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
   Example:
   ```bash
-  ./lora_text2video ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"  adapter1.safetensors 1.0 adapter2.safetensors 0.5
+  ./lora_text2video ltx_video_ov "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
   ```
 
 The LoRA text-to-video sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -66,6 +66,25 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
   ./text2video ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
   ```
 
+### LoRA Text to Video Sample (`lora_text2video.cpp`)
+
+- **Description:**
+  Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying multiple LoRA adapters.
+
+  Recommended models: Lightricks/LTX-Video
+
+- **Main Feature:** Apply LoRA adapters to a text-to-video pipeline for customized generation.
+
+- **Run Command:**
+  ```bash
+  ./lora_text2video model_dir prompt [lora_adapter_path] [alpha] ...
+  ```
+
+  Example:
+  ```bash
+  ./lora_text2video ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"  adapter1.safetensors 1.0 adapter2.safetensors 0.5
+  ```
+
 The sample will generate a video file `genai_video.avi` in the current directory.
 
 Users can modify the source code to experiment with different generation parameters:

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -69,11 +69,11 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 - **Description:**
   Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying multiple LoRA adapters.
 
-  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+  Recommended models: Lightricks/LTX-Video
 
   To download the LoRA adapter used in the example below:
   ```sh
-  huggingface-cli download Cseti/LTXV-13B-LoRA-Wallace_and_Gromit-v1 walgro_style_step_42000_comfy.safetensors
+  huggingface-cli download svjack/ltx_video_pixel_early_lora ltx_pixel_pytorch_lora_weights.safetensors
   ```
 
 - **Main Feature:** Apply LoRA adapters to a text-to-video pipeline for customized generation.
@@ -85,7 +85,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
   Example:
   ```bash
-  ./lora_text2video ltx_video_ov "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
+  ./lora_text2video ltx_video_ov "In the style of Pixel, the video shifts to a majestic castle under a starry sky." ltx_pixel_pytorch_lora_weights.safetensors 3.0
   ```
 
 The LoRA text-to-video sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/cpp/video_generation/README.md
+++ b/samples/cpp/video_generation/README.md
@@ -24,8 +24,10 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov/FP32
 ```
+
+> **Note:** `--weight-format fp32` is required for LoRA adapter support. For basic video generation without LoRA, `--weight-format int8` produces a smaller model.
 
 Alternatively, do it in Python code:
 
@@ -61,7 +63,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
   Example:
   ```bash
-  ./text2video ltx_video_ov "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
+  ./text2video ltx_video_ov/FP32 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
   ```
 
 ### LoRA Text to Video Sample (`lora_text2video.cpp`)
@@ -85,7 +87,7 @@ GPUs usually provide better performance compared to CPUs. Modify the source code
 
   Example:
   ```bash
-  ./lora_text2video ltx_video_ov "In the style of Pixel, the video shifts to a majestic castle under a starry sky." ltx_pixel_pytorch_lora_weights.safetensors 3.0
+  ./lora_text2video ltx_video_ov/FP32 "In the style of Pixel, the video shifts to a majestic castle under a starry sky." ltx_pixel_pytorch_lora_weights.safetensors 3.0
   ```
 
 The LoRA text-to-video sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <string>
+#include <random>
+#include <filesystem>
+
+#include "progress_bar.hpp"
+#include "imwrite_video.hpp"
+
+#include <openvino/genai/video_generation/text2video_pipeline.hpp>
+
+int main(int32_t argc, char* argv[]) try {
+    OPENVINO_ASSERT(argc >= 3 && (argc - 3) % 2 == 0, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' [<LORA_SAFETENSORS> <ALPHA> ...]]");
+
+    std::filesystem::path models_dir = argv[1];
+    std::string prompt = argv[2];
+
+    const std::string device = "CPU";  // GPU can be used as well
+    float frame_rate = 25.0f;
+
+    ov::genai::AdapterConfig adapter_config;
+    // Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
+    for(size_t i = 0; i < (argc - 3)/2; ++i) {
+        ov::genai::Adapter adapter(argv[3 + 2*i]);
+        float alpha = std::atof(argv[3 + 2*i + 1]);
+        adapter_config.add(adapter, alpha);
+    }
+
+    // LoRA adapters passed to the constructor will be activated by default in next generates
+    ov::genai::Text2VideoPipeline pipe(models_dir, device, ov::genai::adapters(adapter_config));
+
+    std::cout << "Generating video with LoRA adapters applied, resulting video will be in lora_video.avi\n";
+    auto output = pipe.generate(
+        prompt,
+        ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
+        ov::genai::height(480),
+        ov::genai::width(704),
+        ov::genai::num_frames(161),
+        ov::genai::num_inference_steps(25),
+        ov::genai::num_videos_per_prompt(1),
+        ov::genai::callback(progress_bar),
+        ov::genai::frame_rate(frame_rate),
+        ov::genai::guidance_scale(3)
+    );
+
+    save_video("lora_video.avi", output.video, frame_rate);
+
+    std::cout << "Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi\n";
+    output = pipe.generate(
+        prompt,
+        ov::genai::adapters(),  // passing adapters in generate overrides adapters set in the constructor; adapters() means no adapters
+        ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
+        ov::genai::height(480),
+        ov::genai::width(704),
+        ov::genai::num_frames(161),
+        ov::genai::num_inference_steps(25),
+        ov::genai::num_videos_per_prompt(1),
+        ov::genai::callback(progress_bar),
+        ov::genai::frame_rate(frame_rate),
+        ov::genai::guidance_scale(3)
+    );
+
+    save_video("baseline_video.avi", output.video, frame_rate);
+
+    return EXIT_SUCCESS;
+} catch (const std::exception& error) {
+    try {
+        std::cerr << error.what() << '\n';
+    } catch (const std::ios_base::failure&) {}
+    return EXIT_FAILURE;
+} catch (...) {
+    try {
+        std::cerr << "Non-exception object thrown\n";
+    } catch (const std::ios_base::failure&) {}
+    return EXIT_FAILURE;
+}

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -1,9 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <memory>
 #include <string>
-#include <random>
 #include <filesystem>
 
 #include "progress_bar.hpp"
@@ -12,7 +10,7 @@
 #include <openvino/genai/video_generation/text2video_pipeline.hpp>
 
 int main(int32_t argc, char* argv[]) try {
-    OPENVINO_ASSERT(argc >= 3 && (argc - 3) % 2 == 0, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' [<LORA_SAFETENSORS> <ALPHA> ...]]");
+    OPENVINO_ASSERT(argc >= 3 && (argc - 3) % 2 == 0, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' [<LORA_SAFETENSORS> <ALPHA> ...]");
 
     std::filesystem::path models_dir = argv[1];
     std::string prompt = argv[2];

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -9,7 +9,7 @@
 
 #include <openvino/genai/video_generation/text2video_pipeline.hpp>
 
-void print_perf_metrics(const ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
+void print_perf_metrics(ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
     std::cout << "\nPerformance metrics:\n"
               << "  Load time: " << perf_metrics.get_load_time() << " ms\n"
               << "  Generate duration: " << perf_metrics.get_generate_duration() << " ms\n"

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -36,21 +36,19 @@ int main(int32_t argc, char* argv[]) try {
     // LoRA adapters passed to the constructor will be activated by default in next generates
     ov::genai::Text2VideoPipeline pipe(models_dir, device, ov::genai::adapters(adapter_config));
 
+    const float frame_rate = 25.0f;
+
     std::cout << "Generating video with LoRA adapters applied, resulting video will be in lora_video.avi\n";
     auto output = pipe.generate(
         prompt,
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
-        ov::genai::width(704),
-        ov::genai::num_frames(161),
-        ov::genai::num_videos_per_prompt(1),
         ov::genai::num_inference_steps(25),
-        ov::genai::frame_rate(25.0f),
         ov::genai::callback(progress_bar),
         ov::genai::guidance_scale(3)
     );
 
-    save_video("lora_video.avi", output.video, 25);
+    save_video("lora_video.avi", output.video, frame_rate);
     print_perf_metrics(output.perf_metrics);
 
     std::cout << "Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi\n";
@@ -59,16 +57,12 @@ int main(int32_t argc, char* argv[]) try {
         ov::genai::adapters(),  // passing adapters in generate overrides adapters set in the constructor; adapters() means no adapters
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
-        ov::genai::width(704),
-        ov::genai::num_frames(161),
-        ov::genai::num_videos_per_prompt(1),
         ov::genai::num_inference_steps(25),
-        ov::genai::frame_rate(25.0f),
         ov::genai::callback(progress_bar),
         ov::genai::guidance_scale(3)
     );
 
-    save_video("baseline_video.avi", output.video, 25);
+    save_video("baseline_video.avi", output.video, frame_rate);
     print_perf_metrics(output.perf_metrics);
 
     return EXIT_SUCCESS;

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -9,6 +9,14 @@
 
 #include <openvino/genai/video_generation/text2video_pipeline.hpp>
 
+void print_perf_metrics(const ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
+    std::cout << "\nPerformance metrics:\n"
+              << "  Load time: " << perf_metrics.get_load_time() << " ms\n"
+              << "  Generate duration: " << perf_metrics.get_generate_duration() << " ms\n"
+              << "  Transformer duration: " << perf_metrics.get_transformer_infer_duration().mean << " ms\n"
+              << "  VAE decoder duration: " << perf_metrics.get_vae_decoder_infer_duration() << " ms\n";
+}
+
 int main(int32_t argc, char* argv[]) try {
     OPENVINO_ASSERT(argc >= 3 && (argc - 3) % 2 == 0, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>' [<LORA_SAFETENSORS> <ALPHA> ...]");
 
@@ -16,7 +24,6 @@ int main(int32_t argc, char* argv[]) try {
     std::string prompt = argv[2];
 
     const std::string device = "CPU";  // GPU can be used as well
-    float frame_rate = 25.0f;
 
     ov::genai::AdapterConfig adapter_config;
     // Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
@@ -34,12 +41,17 @@ int main(int32_t argc, char* argv[]) try {
         prompt,
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
+        ov::genai::width(704),
+        ov::genai::num_frames(161),
+        ov::genai::num_videos_per_prompt(1),
         ov::genai::num_inference_steps(25),
+        ov::genai::frame_rate(25.0f),
         ov::genai::callback(progress_bar),
         ov::genai::guidance_scale(3)
     );
 
-    save_video("lora_video.avi", output.video, frame_rate);
+    save_video("lora_video.avi", output.video, 25);
+    print_perf_metrics(output.perf_metrics);
 
     std::cout << "Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi\n";
     output = pipe.generate(
@@ -47,12 +59,17 @@ int main(int32_t argc, char* argv[]) try {
         ov::genai::adapters(),  // passing adapters in generate overrides adapters set in the constructor; adapters() means no adapters
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
+        ov::genai::width(704),
+        ov::genai::num_frames(161),
+        ov::genai::num_videos_per_prompt(1),
         ov::genai::num_inference_steps(25),
+        ov::genai::frame_rate(25.0f),
         ov::genai::callback(progress_bar),
         ov::genai::guidance_scale(3)
     );
 
-    save_video("baseline_video.avi", output.video, frame_rate);
+    save_video("baseline_video.avi", output.video, 25);
+    print_perf_metrics(output.perf_metrics);
 
     return EXIT_SUCCESS;
 } catch (const std::exception& error) {

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -9,7 +9,7 @@
 
 #include <openvino/genai/video_generation/text2video_pipeline.hpp>
 
-void print_perf_metrics(const ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
+void print_perf_metrics(ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
     std::cout << "\nPerformance metrics:\n"
               << "  Load time: " << perf_metrics.get_load_time() << " ms\n"
               << "  Generate duration: " << perf_metrics.get_generate_duration() << " ms\n"
@@ -49,7 +49,7 @@ int main(int32_t argc, char* argv[]) try {
     );
 
     save_video("lora_video.avi", output.video, frame_rate);
-    print_perf_metrics(output.perf_metrics);
+    print_perf_metrics(output.performance_stat);
 
     std::cout << "Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi\n";
     output = pipe.generate(
@@ -63,7 +63,7 @@ int main(int32_t argc, char* argv[]) try {
     );
 
     save_video("baseline_video.avi", output.video, frame_rate);
-    print_perf_metrics(output.perf_metrics);
+    print_perf_metrics(output.performance_stat);
 
     return EXIT_SUCCESS;
 } catch (const std::exception& error) {

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -9,7 +9,7 @@
 
 #include <openvino/genai/video_generation/text2video_pipeline.hpp>
 
-void print_perf_metrics(ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
+void print_perf_metrics(const ov::genai::VideoGenerationPerfMetrics& perf_metrics) {
     std::cout << "\nPerformance metrics:\n"
               << "  Load time: " << perf_metrics.get_load_time() << " ms\n"
               << "  Generate duration: " << perf_metrics.get_generate_duration() << " ms\n"

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -20,7 +20,7 @@ int main(int32_t argc, char* argv[]) try {
 
     ov::genai::AdapterConfig adapter_config;
     // Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
-    for(size_t i = 0; i < (argc - 3)/2; ++i) {
+    for (size_t i = 0; i < (argc - 3)/2; ++i) {
         ov::genai::Adapter adapter(argv[3 + 2*i]);
         float alpha = std::atof(argv[3 + 2*i + 1]);
         adapter_config.add(adapter, alpha);

--- a/samples/cpp/video_generation/lora_text2video.cpp
+++ b/samples/cpp/video_generation/lora_text2video.cpp
@@ -34,12 +34,8 @@ int main(int32_t argc, char* argv[]) try {
         prompt,
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
-        ov::genai::width(704),
-        ov::genai::num_frames(161),
         ov::genai::num_inference_steps(25),
-        ov::genai::num_videos_per_prompt(1),
         ov::genai::callback(progress_bar),
-        ov::genai::frame_rate(frame_rate),
         ov::genai::guidance_scale(3)
     );
 
@@ -51,12 +47,8 @@ int main(int32_t argc, char* argv[]) try {
         ov::genai::adapters(),  // passing adapters in generate overrides adapters set in the constructor; adapters() means no adapters
         ov::genai::negative_prompt("worst quality, inconsistent motion, blurry, jittery, distorted"),
         ov::genai::height(480),
-        ov::genai::width(704),
-        ov::genai::num_frames(161),
         ov::genai::num_inference_steps(25),
-        ov::genai::num_videos_per_prompt(1),
         ov::genai::callback(progress_bar),
-        ov::genai::frame_rate(frame_rate),
         ov::genai::guidance_scale(3)
     );
 

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -35,7 +35,7 @@ Alternatively, do it in Python code:
 from optimum.intel.openvino import OVLTXPipeline
 
 pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False)
-pipeline.save_pretrained("ltx_video_ov")
+pipeline.save_pretrained("ltx_video_ov/FP32")
 ```
 
 ## Sample Descriptions

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -24,7 +24,7 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov
 ```
 
 Alternatively, do it in Python code:
@@ -32,7 +32,7 @@ Alternatively, do it in Python code:
 ```python
 from optimum.intel.openvino import OVLTXPipeline
 
-pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video-0.9.8-13B-distilled", export=True, compile=False)
+pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False)
 pipeline.save_pretrained("ltx_video_ov")
 ```
 
@@ -55,7 +55,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 - **Description:**
   Basic video generation using a text-to-video model. This sample demonstrates how to generate videos from text prompts using the OpenVINO GenAI Text2VideoPipeline. The LTX-Video model is recommended for this sample.
 
-  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+  Recommended models: Lightricks/LTX-Video
 
 - **Main Feature:** Generate videos from text descriptions with customizable parameters.
 

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -24,10 +24,10 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format int8 ltx_video_ov/INT8
 ```
 
-> **Note:** `--weight-format fp32` is required for LoRA adapter support. For basic video generation without LoRA, you can use `--weight-format int8` for a smaller model.
+> **Note:** `--weight-format fp32` is required for LoRA adapter support. For basic video generation without LoRA, `--weight-format int8` (default above) produces a smaller model.
 
 Alternatively, do it in Python code:
 

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -24,7 +24,7 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video ltx_video_ov
+optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov
 ```
 
 Alternatively, do it in Python code:

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -82,12 +82,12 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
 - **Run Command:**
   ```bash
-  python lora_text2video.py model_dir prompt lora_adapter_path
+  python lora_text2video.py model_dir prompt [lora_adapter_path alpha] ...
   ```
 
   Example:
   ```bash
-  python lora_text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic" adapter.safetensors
+  python lora_text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic" adapter.safetensors 1.0
   ```
 
 The sample will generate a video file `genai_video.avi` in the current directory.

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -27,6 +27,8 @@ Then, run the export with Optimum CLI:
 optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov
 ```
 
+> **Note:** `--weight-format fp32` is required for LoRA adapter support. For basic video generation without LoRA, you can use `--weight-format int8` for a smaller model.
+
 Alternatively, do it in Python code:
 
 ```python

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -90,7 +90,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
   python lora_text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic" adapter.safetensors 1.0
   ```
 
-The sample will generate a video file `genai_video.avi` in the current directory.
+The sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.
 
 Users can modify the source code to experiment with different generation parameters:
 - Change width or height of generated video

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -24,18 +24,16 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format int8 ltx_video_ov/INT8
+optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video ltx_video_ov
 ```
 
-Alternatively, do it in Python code. If NNCF is installed, the model will be compressed to INT8 automatically.
+Alternatively, do it in Python code:
 
 ```python
 from optimum.intel.openvino import OVLTXPipeline
 
-output_dir = "ltx_video_ov/INT8"
-
-pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video", export=True, compile=False, load_in_8bit=True)
-pipeline.save_pretrained(output_dir)
+pipeline = OVLTXPipeline.from_pretrained("Lightricks/LTX-Video-0.9.8-13B-distilled", export=True, compile=False)
+pipeline.save_pretrained("ltx_video_ov")
 ```
 
 ## Sample Descriptions
@@ -57,7 +55,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 - **Description:**
   Basic video generation using a text-to-video model. This sample demonstrates how to generate videos from text prompts using the OpenVINO GenAI Text2VideoPipeline. The LTX-Video model is recommended for this sample.
 
-  Recommended models: Lightricks/LTX-Video
+  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
 
 - **Main Feature:** Generate videos from text descriptions with customizable parameters.
 
@@ -68,7 +66,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic"
+  python text2video.py ./ltx_video_ov "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
   ```
 
 ### LoRA Text to Video Sample (`lora_text2video.py`)
@@ -76,7 +74,12 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 - **Description:**
   Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying a LoRA adapter.
 
-  Recommended models: Lightricks/LTX-Video
+  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+
+  To download the LoRA adapter used in the example below:
+  ```sh
+  huggingface-cli download Cseti/LTXV-13B-LoRA-Wallace_and_Gromit-v1 walgro_style_step_42000_comfy.safetensors
+  ```
 
 - **Main Feature:** Apply a LoRA adapter to a text-to-video pipeline for customized generation.
 
@@ -87,7 +90,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python lora_text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic" adapter.safetensors 1.0
+  python lora_text2video.py ./ltx_video_ov "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
   ```
 
 The sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -24,10 +24,10 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format int8 ltx_video_ov/INT8
+optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov/FP32
 ```
 
-> **Note:** `--weight-format fp32` is required for LoRA adapter support. For basic video generation without LoRA, `--weight-format int8` (default above) produces a smaller model.
+> **Note:** For basic video generation without LoRA, `--weight-format int8` produces a smaller model.
 
 Alternatively, do it in Python code:
 
@@ -68,7 +68,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python text2video.py ./ltx_video_ov "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
+  python text2video.py ./ltx_video_ov/FP32 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
   ```
 
 ### LoRA Text to Video Sample (`lora_text2video.py`)
@@ -81,11 +81,6 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
   To download the LoRA adapter used in the example below:
   ```sh
   huggingface-cli download svjack/ltx_video_pixel_early_lora ltx_pixel_pytorch_lora_weights.safetensors
-  ```
-
-  LoRA adapters require an fp32 model. Export with:
-  ```sh
-  optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov/FP32
   ```
 
 - **Main Feature:** Apply a LoRA adapter to a text-to-video pipeline for customized generation.

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -76,16 +76,16 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 - **Description:**
   Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying a LoRA adapter.
 
-  Recommended models: Lightricks/LTX-Video-0.9.8-13B-distilled
+  Recommended models: Lightricks/LTX-Video
 
   To download the LoRA adapter used in the example below:
   ```sh
-  huggingface-cli download Cseti/LTXV-13B-LoRA-Wallace_and_Gromit-v1 walgro_style_step_42000_comfy.safetensors
+  huggingface-cli download svjack/ltx_video_pixel_early_lora ltx_pixel_pytorch_lora_weights.safetensors
   ```
 
   LoRA adapters require an fp32 model. Export with:
   ```sh
-  optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov/FP32
+  optimum-cli export openvino --model Lightricks/LTX-Video --task text-to-video --weight-format fp32 ltx_video_ov/FP32
   ```
 
 - **Main Feature:** Apply a LoRA adapter to a text-to-video pipeline for customized generation.
@@ -97,7 +97,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python lora_text2video.py ./ltx_video_ov/FP32 "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
+  python lora_text2video.py ./ltx_video_ov/FP32 "In the style of Pixel, the video shifts to a majestic castle under a starry sky." ltx_pixel_pytorch_lora_weights.safetensors 3.0
   ```
 
 The sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -68,7 +68,26 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python text2video.py ./ltx_video_ov/INT8 "A woman with long brown hair and light skin smiles at another woman with long blonde hair"
+  python text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic"
+  ```
+
+### LoRA Text to Video Sample (`lora_text2video.py`)
+
+- **Description:**
+  Video generation with LoRA adapters using a text-to-video model. This sample demonstrates how to generate videos from text prompts while applying a LoRA adapter.
+
+  Recommended models: Lightricks/LTX-Video
+
+- **Main Feature:** Apply a LoRA adapter to a text-to-video pipeline for customized generation.
+
+- **Run Command:**
+  ```bash
+  python lora_text2video.py model_dir prompt lora_adapter_path
+  ```
+
+  Example:
+  ```bash
+  python lora_text2video.py ./ltx_video_ov/INT8 "A cute golden retriever puppy running in a green grassy field on a sunny day, high quality, photorealistic" adapter.safetensors
   ```
 
 The sample will generate a video file `genai_video.avi` in the current directory.

--- a/samples/python/video_generation/README.md
+++ b/samples/python/video_generation/README.md
@@ -83,6 +83,11 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
   huggingface-cli download Cseti/LTXV-13B-LoRA-Wallace_and_Gromit-v1 walgro_style_step_42000_comfy.safetensors
   ```
 
+  LoRA adapters require an fp32 model. Export with:
+  ```sh
+  optimum-cli export openvino --model Lightricks/LTX-Video-0.9.8-13B-distilled --task text-to-video --weight-format fp32 ltx_video_ov/FP32
+  ```
+
 - **Main Feature:** Apply a LoRA adapter to a text-to-video pipeline for customized generation.
 
 - **Run Command:**
@@ -92,7 +97,7 @@ pip install --upgrade-strategy eager -r ../../deployment-requirements.txt
 
   Example:
   ```bash
-  python lora_text2video.py ./ltx_video_ov "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
+  python lora_text2video.py ./ltx_video_ov/FP32 "Walgro style. A woman waits at a bus stop in the early morning, headphones resting over her blue hair, her gaze focused on her phone as she scrolls. The rising sun casts soft light across the pavement, illuminating the quiet street." walgro_style_step_42000_comfy.safetensors 1.0
   ```
 
 The sample will generate two video files, `lora_video.avi` and `baseline_video.avi`, in the current directory.

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import cv2
+import openvino_genai
+
+
+def save_video(filename: str, video_tensor, fps: int = 25):
+    batch_size, num_frames, height, width, _ = video_tensor.shape
+    video_data = video_tensor.data
+
+    for b in range(batch_size):
+        if batch_size == 1:
+            output_path = filename
+        else:
+            base, ext = filename.rsplit(".", 1) if "." in filename else (filename, "avi")
+            output_path = f"{base}_b{b}.{ext}"
+
+        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+        writer = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+
+        for f in range(num_frames):
+            frame_bgr = cv2.cvtColor(video_data[b, f], cv2.COLOR_RGB2BGR)
+            writer.write(frame_bgr)
+
+        writer.release()
+        print(f"Wrote {output_path} ({num_frames} frames, {width}x{height} @ {fps} fps)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate video from text prompt using OpenVINO GenAI with LoRA adapters"
+    )
+    parser.add_argument("model_dir", help="Path to the model directory")
+    parser.add_argument("prompt", help="Text prompt for video generation")
+    parser.add_argument("lora_adapter", help="Path to the LoRA adapter file (.safetensors)")
+    args = parser.parse_args()
+
+    # Load adapter
+    adapter_config = openvino_genai.AdapterConfig()
+    adapter_config.add(openvino_genai.Adapter(args.lora_adapter))
+
+    pipe = openvino_genai.Text2VideoPipeline(args.model_dir, "CPU", adapters=adapter_config)  # GPU can be used as well
+
+    frame_rate = 25
+
+    def callback(step, num_steps, latent):
+        print(f"Generation step {step + 1} / {num_steps}")
+        return False
+
+    output = pipe.generate(
+        args.prompt,
+        negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
+        height=480,
+        width=704,
+        num_frames=161,
+        num_inference_steps=25,
+        num_videos_per_prompt=1,
+        callback=callback,
+        frame_rate=frame_rate,
+        guidance_scale=3,
+        adapters=adapter_config,
+    )
+
+    save_video("genai_video.avi", output.video, frame_rate)
+
+    print(f"\nPerformance metrics:")
+    print(f"  Load time: {output.perf_metrics.get_load_time():.2f} ms")
+    print(f"  Generate duration: {output.perf_metrics.get_generate_duration():.2f} ms")
+    print(f"  Transformer duration: {output.perf_metrics.get_transformer_infer_duration().mean:.2f} ms")
+    print(f"  VAE decoder duration: {output.perf_metrics.get_vae_decoder_infer_duration():.2f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -23,12 +23,19 @@ def main():
     parser.add_argument("prompt", help="Text prompt for video generation")
     args, adapters = parser.parse_known_args()
 
+    if len(adapters) % 2 != 0:
+        parser.error("Each LoRA adapter path must be followed by a numeric alpha value (got an odd number of extra arguments).")
+
     # Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
     adapter_config = openvino_genai.AdapterConfig()
-    for i in range(int(len(adapters) / 2)):
-        adapter = openvino_genai.Adapter(adapters[2 * i])
-        alpha = float(adapters[2 * i + 1])
-        adapter_config.add(adapter, alpha)
+    for i in range(len(adapters) // 2):
+        adapter_path = adapters[2 * i]
+        alpha_str = adapters[2 * i + 1]
+        try:
+            alpha = float(alpha_str)
+        except ValueError:
+            parser.error(f"Invalid alpha value for LoRA adapter '{adapter_path}': '{alpha_str}' is not a number.")
+        adapter_config.add(openvino_genai.Adapter(adapter_path), alpha)
 
     pipe = openvino_genai.Text2VideoPipeline(args.model_dir, "CPU", adapters=adapter_config)  # GPU can be used as well
 

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -63,7 +63,6 @@ def main():
         callback=callback,
         frame_rate=frame_rate,
         guidance_scale=3,
-        adapters=adapter_config,
     )
 
     save_video("genai_video.avi", output.video, frame_rate)

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -35,12 +35,14 @@ def main():
     )
     parser.add_argument("model_dir", help="Path to the model directory")
     parser.add_argument("prompt", help="Text prompt for video generation")
-    parser.add_argument("lora_adapter", help="Path to the LoRA adapter file (.safetensors)")
-    args = parser.parse_args()
+    args, adapters = parser.parse_known_args()
 
-    # Load adapter
+    # Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
     adapter_config = openvino_genai.AdapterConfig()
-    adapter_config.add(openvino_genai.Adapter(args.lora_adapter))
+    for i in range(int(len(adapters) / 2)):
+        adapter = openvino_genai.Adapter(adapters[2 * i])
+        alpha = float(adapters[2 * i + 1])
+        adapter_config.add(adapter, alpha)
 
     pipe = openvino_genai.Text2VideoPipeline(args.model_dir, "CPU", adapters=adapter_config)  # GPU can be used as well
 

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -3,30 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import cv2
 import openvino_genai
-
-
-def save_video(filename: str, video_tensor, fps: int = 25):
-    batch_size, num_frames, height, width, _ = video_tensor.shape
-    video_data = video_tensor.data
-
-    for b in range(batch_size):
-        if batch_size == 1:
-            output_path = filename
-        else:
-            base, ext = filename.rsplit(".", 1) if "." in filename else (filename, "avi")
-            output_path = f"{base}_b{b}.{ext}"
-
-        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
-        writer = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
-
-        for f in range(num_frames):
-            frame_bgr = cv2.cvtColor(video_data[b, f], cv2.COLOR_RGB2BGR)
-            writer.write(frame_bgr)
-
-        writer.release()
-        print(f"Wrote {output_path} ({num_frames} frames, {width}x{height} @ {fps} fps)")
+from video_utils import save_video
 
 
 def main():

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -52,8 +52,7 @@ def main():
         print(f"Generation step {step + 1} / {num_steps}")
         return False
 
-    output = pipe.generate(
-        args.prompt,
+    generate_args = dict(
         negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
         height=480,
         width=704,
@@ -65,7 +64,24 @@ def main():
         guidance_scale=3,
     )
 
-    save_video("genai_video.avi", output.video, frame_rate)
+    print("Generating video with LoRA adapters applied, resulting video will be in lora_video.avi")
+    output = pipe.generate(args.prompt, **generate_args)
+    save_video("lora_video.avi", output.video, frame_rate)
+
+    print(f"\nPerformance metrics:")
+    print(f"  Load time: {output.perf_metrics.get_load_time():.2f} ms")
+    print(f"  Generate duration: {output.perf_metrics.get_generate_duration():.2f} ms")
+    print(f"  Transformer duration: {output.perf_metrics.get_transformer_infer_duration().mean:.2f} ms")
+    print(f"  VAE decoder duration: {output.perf_metrics.get_vae_decoder_infer_duration():.2f} ms")
+
+    print("Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi")
+    output = pipe.generate(
+        args.prompt,
+        # passing adapters in generate overrides adapters set in the constructor; openvino_genai.AdapterConfig() means no adapters
+        adapters=openvino_genai.AdapterConfig(),
+        **generate_args,
+    )
+    save_video("baseline_video.avi", output.video, frame_rate)
 
     print(f"\nPerformance metrics:")
     print(f"  Load time: {output.perf_metrics.get_load_time():.2f} ms")

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -7,6 +7,14 @@ import openvino_genai
 from video_utils import save_video
 
 
+def print_perf_metrics(perf_metrics):
+    print(f"\nPerformance metrics:")
+    print(f"  Load time: {perf_metrics.get_load_time():.2f} ms")
+    print(f"  Generate duration: {perf_metrics.get_generate_duration():.2f} ms")
+    print(f"  Transformer duration: {perf_metrics.get_transformer_infer_duration().mean:.2f} ms")
+    print(f"  VAE decoder duration: {perf_metrics.get_vae_decoder_infer_duration():.2f} ms")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate video from text prompt using OpenVINO GenAI with LoRA adapters"
@@ -24,8 +32,6 @@ def main():
 
     pipe = openvino_genai.Text2VideoPipeline(args.model_dir, "CPU", adapters=adapter_config)  # GPU can be used as well
 
-    frame_rate = 25
-
     def callback(step, num_steps, latent):
         print(f"Generation step {step + 1} / {num_steps}")
         return False
@@ -38,19 +44,14 @@ def main():
         num_inference_steps=25,
         num_videos_per_prompt=1,
         callback=callback,
-        frame_rate=frame_rate,
+        frame_rate=25,
         guidance_scale=3,
     )
 
     print("Generating video with LoRA adapters applied, resulting video will be in lora_video.avi")
     output = pipe.generate(args.prompt, **generate_args)
-    save_video("lora_video.avi", output.video, frame_rate)
-
-    print(f"\nPerformance metrics:")
-    print(f"  Load time: {output.perf_metrics.get_load_time():.2f} ms")
-    print(f"  Generate duration: {output.perf_metrics.get_generate_duration():.2f} ms")
-    print(f"  Transformer duration: {output.perf_metrics.get_transformer_infer_duration().mean:.2f} ms")
-    print(f"  VAE decoder duration: {output.perf_metrics.get_vae_decoder_infer_duration():.2f} ms")
+    save_video("lora_video.avi", output.video, 25)
+    print_perf_metrics(output.perf_metrics)
 
     print("Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi")
     output = pipe.generate(
@@ -59,13 +60,8 @@ def main():
         adapters=openvino_genai.AdapterConfig(),
         **generate_args,
     )
-    save_video("baseline_video.avi", output.video, frame_rate)
-
-    print(f"\nPerformance metrics:")
-    print(f"  Load time: {output.perf_metrics.get_load_time():.2f} ms")
-    print(f"  Generate duration: {output.perf_metrics.get_generate_duration():.2f} ms")
-    print(f"  Transformer duration: {output.perf_metrics.get_transformer_infer_duration().mean:.2f} ms")
-    print(f"  VAE decoder duration: {output.perf_metrics.get_vae_decoder_infer_duration():.2f} ms")
+    save_video("baseline_video.avi", output.video, 25)
+    print_perf_metrics(output.perf_metrics)
 
 
 if __name__ == "__main__":

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -43,21 +43,19 @@ def main():
         print(f"Generation step {step + 1} / {num_steps}")
         return False
 
+    frame_rate = 25
+
     generate_args = dict(
         negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
         height=480,
-        width=704,
-        num_frames=161,
         num_inference_steps=25,
-        num_videos_per_prompt=1,
         callback=callback,
-        frame_rate=25,
         guidance_scale=3,
     )
 
     print("Generating video with LoRA adapters applied, resulting video will be in lora_video.avi")
     output = pipe.generate(args.prompt, **generate_args)
-    save_video("lora_video.avi", output.video, 25)
+    save_video("lora_video.avi", output.video, frame_rate)
     print_perf_metrics(output.perf_metrics)
 
     print("Generating video without LoRA adapters applied, resulting video will be in baseline_video.avi")
@@ -67,7 +65,7 @@ def main():
         adapters=openvino_genai.AdapterConfig(),
         **generate_args,
     )
-    save_video("baseline_video.avi", output.video, 25)
+    save_video("baseline_video.avi", output.video, frame_rate)
     print_perf_metrics(output.perf_metrics)
 
 

--- a/samples/python/video_generation/lora_text2video.py
+++ b/samples/python/video_generation/lora_text2video.py
@@ -24,7 +24,9 @@ def main():
     args, adapters = parser.parse_known_args()
 
     if len(adapters) % 2 != 0:
-        parser.error("Each LoRA adapter path must be followed by a numeric alpha value (got an odd number of extra arguments).")
+        parser.error(
+            "Each LoRA adapter path must be followed by a numeric alpha value (got an odd number of extra arguments)."
+        )
 
     # Multiple LoRA adapters applied simultaneously are supported, parse them all and corresponding alphas from cmd parameters:
     adapter_config = openvino_genai.AdapterConfig()

--- a/site/docs/guides/lora-adapters.mdx
+++ b/site/docs/guides/lora-adapters.mdx
@@ -13,7 +13,7 @@ LoRA adapters enable customization of model outputs for specific tasks, styles, 
 For more details about LoRA, see [Low-Rank Adaptation (LoRA)](/docs/concepts/lora).
 :::
 
-OpenVINO GenAI provides built-in support for LoRA adapters in [text generation](/docs/use-cases/text-generation/), [image generation](/docs/use-cases/image-generation/), and [image processing (VLM)](/docs/use-cases/image-processing) pipelines.
+OpenVINO GenAI provides built-in support for LoRA adapters in [text generation](/docs/use-cases/text-generation/), [image generation](/docs/use-cases/image-generation/), [image processing (VLM)](/docs/use-cases/image-processing), and [video generation](/docs/use-cases/video-generation/) pipelines.
 This capability allows you to dynamically switch between or combine multiple adapters without recompiling the model.
 
 :::info

--- a/site/docs/use-cases/video-generation/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/video-generation/_sections/_usage_options/index.mdx
@@ -66,6 +66,12 @@ You can adjust several parameters to control the video generation process, inclu
     </TabItemCpp>
 </LanguageTabs>
 
+### Working with LoRA Adapters
+
+For video generation models like LTX-Video, LoRA adapters can modify the generation process to produce videos with specific artistic styles, content types, or quality enhancements.
+
+Refer to the [LoRA Adapters](/docs/guides/lora-adapters.mdx) for more details on working with LoRA adapters.
+
 :::info Understanding Video Generation Parameters
 
 - `negative_prompt`: Negative prompt for video(s) generation.

--- a/site/docs/use-cases/video-generation/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/video-generation/_sections/_usage_options/index.mdx
@@ -70,7 +70,7 @@ You can adjust several parameters to control the video generation process, inclu
 
 For video generation models like LTX-Video, LoRA adapters can modify the generation process to produce videos with specific artistic styles, content types, or quality enhancements.
 
-Refer to the [LoRA Adapters](/docs/guides/lora-adapters.mdx) for more details on working with LoRA adapters.
+Refer to the [LoRA Adapters](/docs/guides/lora-adapters) for more details on working with LoRA adapters.
 
 :::info Understanding Video Generation Parameters
 

--- a/src/cpp/include/openvino/genai/lora_adapter.hpp
+++ b/src/cpp/include/openvino/genai/lora_adapter.hpp
@@ -33,6 +33,7 @@ class OPENVINO_GENAI_EXPORTS Adapter {
 
     friend Adapter flux_adapter_normalization(const Adapter& adapter);
     friend Adapter diffusers_adapter_normalization(const Adapter& adapter);
+    friend std::string detect_lora_prefix(const AdapterConfig& adapters);
 
     Adapter(const std::shared_ptr<AdapterImpl>& pimpl);
 public:

--- a/src/cpp/include/openvino/genai/lora_adapter.hpp
+++ b/src/cpp/include/openvino/genai/lora_adapter.hpp
@@ -22,6 +22,7 @@ namespace genai {
 class OPENVINO_GENAI_EXPORTS AdapterController;
 struct AdapterControllerImpl;
 class AdapterImpl;
+struct AdapterConfig;
 
 // Immutable LoRA Adapter that carries the adaptation matrices and serves as unique adapter identifier
 class OPENVINO_GENAI_EXPORTS Adapter {

--- a/src/cpp/include/openvino/genai/video_generation/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/generation_config.hpp
@@ -7,7 +7,7 @@
 #include <optional>
 
 #include "openvino/genai/image_generation/generation_config.hpp"
-
+#include "openvino/genai/lora_adapter.hpp"
 
 namespace ov::genai {
 /**
@@ -63,6 +63,9 @@ struct VideoGenerationConfig {
      * and predicts outputs using Taylor series approximation.
      */
     std::optional<TaylorSeerCacheConfig> taylorseer_config;
+
+    /// LoRA adapters applied during generation.
+    std::optional<AdapterConfig> adapters = std::nullopt;
 };
 
 /**

--- a/src/cpp/include/openvino/genai/video_generation/ltx_video_transformer_3d_model.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/ltx_video_transformer_3d_model.hpp
@@ -11,6 +11,7 @@
 #include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/tensor.hpp"
+#include "openvino/genai/lora_adapter.hpp"
 #include "openvino/genai/visibility.hpp"
 
 namespace ov::genai {
@@ -46,6 +47,8 @@ public:
 
     void set_hidden_states(const std::string& tensor_name, const ov::Tensor& encoder_hidden_states);
 
+    void set_adapters(const std::optional<AdapterConfig>& adapters);
+
     ov::Tensor infer(const ov::Tensor& latent, const ov::Tensor& timestep);
 
     LTXVideoTransformer3DModel& reshape(int64_t batch_size, int64_t num_frames, int64_t height, int64_t width, int64_t tokenizer_model_max_length);
@@ -58,6 +61,7 @@ private:
     std::shared_ptr<Inference> m_impl;
 
     Config m_config;
+    AdapterController m_adapter_controller;
     ov::InferRequest m_request;
     std::shared_ptr<ov::Model> m_model;
     size_t m_expected_batch_size = 0;

--- a/src/cpp/include/openvino/genai/video_generation/ltx_video_transformer_3d_model.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/ltx_video_transformer_3d_model.hpp
@@ -62,6 +62,7 @@ private:
 
     Config m_config;
     AdapterController m_adapter_controller;
+    std::string m_lora_prefix;
     ov::InferRequest m_request;
     std::shared_ptr<ov::Model> m_model;
     size_t m_expected_batch_size = 0;

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1230,9 +1230,9 @@ Adapter diffusers_adapter_normalization(const Adapter& adapter) {
 }
 
 std::string detect_lora_prefix(const AdapterConfig& adapters) {
-    auto adapters_vec = adapters.get_adapters_and_alphas();
-    if (!adapters_vec.empty() && adapters_vec[0].first) {
-        const auto& tensors = adapters_vec[0].first.m_pimpl->get_tensors();
+    const auto& adapters_vec = adapters.get_adapters();
+    if (!adapters_vec.empty() && adapters_vec[0]) {
+        const auto& tensors = adapters_vec[0].m_pimpl->get_tensors();
         if (!tensors.empty()) {
             const std::string& first_key = tensors.begin()->first;
             auto dot_pos = first_key.find('.');

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1229,6 +1229,21 @@ Adapter diffusers_adapter_normalization(const Adapter& adapter) {
     return Adapter(std::make_shared<DiffusersDerivedAdapter>(origin, diffusers_normalization));
 }
 
+std::string detect_lora_prefix(const AdapterConfig& adapters) {
+    auto adapters_vec = adapters.get_adapters_and_alphas();
+    if (!adapters_vec.empty()) {
+        const auto& tensors = adapters_vec[0].first.m_pimpl->get_tensors();
+        if (!tensors.empty()) {
+            const std::string& first_key = tensors.begin()->first;
+            auto dot_pos = first_key.find('.');
+            if (dot_pos != std::string::npos) {
+                return first_key.substr(0, dot_pos);
+            }
+        }
+    }
+    return "transformer";
+}
+
 Adapter flux_adapter_normalization(const Adapter& adapter) {
     auto origin = adapter.m_pimpl;
     using FluxDerivedAdapter = DerivedAdapterImpl<decltype(&flux_normalization)>;

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1231,7 +1231,7 @@ Adapter diffusers_adapter_normalization(const Adapter& adapter) {
 
 std::string detect_lora_prefix(const AdapterConfig& adapters) {
     auto adapters_vec = adapters.get_adapters_and_alphas();
-    if (!adapters_vec.empty()) {
+    if (!adapters_vec.empty() && adapters_vec[0].first) {
         const auto& tensors = adapters_vec[0].first.m_pimpl->get_tensors();
         if (!tensors.empty()) {
             const std::string& first_key = tensors.begin()->first;

--- a/src/cpp/src/lora/names_mapping.hpp
+++ b/src/cpp/src/lora/names_mapping.hpp
@@ -42,5 +42,7 @@ Adapter flux_adapter_normalization(const Adapter& adapter);
 
 Adapter diffusers_adapter_normalization(const Adapter& adapter);
 
+std::string detect_lora_prefix(const AdapterConfig& adapters);
+
 }
 }

--- a/src/cpp/src/video_generation/generation_config_utils.cpp
+++ b/src/cpp/src/video_generation/generation_config_utils.cpp
@@ -30,6 +30,8 @@ void update_generation_config(VideoGenerationConfig& config, const ov::AnyMap& p
     read_anymap_param(properties, "max_sequence_length", config.max_sequence_length);
     read_anymap_param(properties, "taylorseer_config", config.taylorseer_config);
 
+    read_anymap_param(properties, "adapters", config.adapters);
+
     // 'generator' has higher priority than 'seed' parameter
     const bool have_generator_param =
         properties.find(ov::genai::generator.name()) != properties.end();

--- a/src/cpp/src/video_generation/ltx_pipeline.hpp
+++ b/src/cpp/src/video_generation/ltx_pipeline.hpp
@@ -20,6 +20,7 @@
 #include "image_generation/schedulers/ischeduler.hpp"
 #include "image_generation/threaded_callback.hpp"
 #include "diffusion_caching/taylorseer_lite.hpp"
+#include "lora/helper.hpp"
 #include "logger.hpp"
 #include "openvino/genai/video_generation/ltx_video_transformer_3d_model.hpp"
 #include "generation_config_utils.hpp"
@@ -412,6 +413,7 @@ public:
         m_vae_device = device;
         m_compile_properties = properties;
         m_is_compiled = true;
+        update_adapters_from_properties(properties, m_generation_config.adapters);
         const std::filesystem::path model_index_path = models_dir / "model_index.json";
         std::ifstream file(model_index_path);
         OPENVINO_ASSERT(file.is_open(), "Failed to open ", model_index_path);
@@ -713,6 +715,7 @@ public:
                  const std::string& denoise_device,
                  const std::string& vae_device,
                  const ov::AnyMap& properties) {
+        update_adapters_from_properties(properties, m_generation_config.adapters);
         m_t5_text_encoder->compile(text_encode_device, properties);
         m_vae->compile(vae_device, properties);
         m_transformer->compile(denoise_device, properties);

--- a/src/cpp/src/video_generation/ltx_pipeline.hpp
+++ b/src/cpp/src/video_generation/ltx_pipeline.hpp
@@ -424,9 +424,9 @@ public:
     }
 
     void rebuild_models() {
-        m_t5_text_encoder = std::make_shared<T5EncoderModel>(m_models_dir / "text_encoder");
-        m_transformer = std::make_shared<LTXVideoTransformer3DModel>(m_models_dir / "transformer");
-        m_vae = std::make_shared<AutoencoderKLLTXVideo>(m_models_dir / "vae_decoder");
+        m_t5_text_encoder = std::make_shared<T5EncoderModel>(m_models_dir / "text_encoder", m_text_encode_device, m_compile_properties);
+        m_transformer = std::make_shared<LTXVideoTransformer3DModel>(m_models_dir / "transformer", m_denoise_device, m_compile_properties);
+        m_vae = std::make_shared<AutoencoderKLLTXVideo>(m_models_dir / "vae_decoder", m_vae_device, m_compile_properties);
     }
 
     void reshape_models(const VideoGenerationConfig& generation_config, size_t batch_size_multiplier) {
@@ -500,6 +500,8 @@ public:
         const size_t vae_scale_factor = m_vae->get_vae_scale_factor();
         const auto& transformer_config = m_transformer->get_config();
         check_inputs(merged_generation_config, vae_scale_factor);
+
+        m_transformer->set_adapters(merged_generation_config.adapters);
 
         // use callback if defined
         std::shared_ptr<ThreadedCallbackWrapper> callback_ptr = nullptr;

--- a/src/cpp/src/video_generation/ltx_pipeline.hpp
+++ b/src/cpp/src/video_generation/ltx_pipeline.hpp
@@ -426,9 +426,9 @@ public:
     }
 
     void rebuild_models() {
-        m_t5_text_encoder = std::make_shared<T5EncoderModel>(m_models_dir / "text_encoder", m_text_encode_device, m_compile_properties);
-        m_transformer = std::make_shared<LTXVideoTransformer3DModel>(m_models_dir / "transformer", m_denoise_device, m_compile_properties);
-        m_vae = std::make_shared<AutoencoderKLLTXVideo>(m_models_dir / "vae_decoder", m_vae_device, m_compile_properties);
+        m_t5_text_encoder = std::make_shared<T5EncoderModel>(m_models_dir / "text_encoder");
+        m_transformer = std::make_shared<LTXVideoTransformer3DModel>(m_models_dir / "transformer");
+        m_vae = std::make_shared<AutoencoderKLLTXVideo>(m_models_dir / "vae_decoder");
     }
 
     void reshape_models(const VideoGenerationConfig& generation_config, size_t batch_size_multiplier) {

--- a/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
+++ b/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
@@ -70,7 +70,10 @@ LTXVideoTransformer3DModel& LTXVideoTransformer3DModel::compile(const std::strin
     OPENVINO_ASSERT(m_model, "Model has been already compiled. Cannot re-compile already compiled model");
     std::optional<AdapterConfig> adapters;
     auto filtered_properties = extract_adapters_from_properties(properties, &adapters);
-    OPENVINO_ASSERT(!adapters, "Adapters are not currently supported for Video Generation Pipeline.");
+    if (adapters) {
+        adapters->set_tensor_name_prefix(adapters->get_tensor_name_prefix().value_or("transformer"));
+        m_adapter_controller = AdapterController(m_model, *adapters, device);
+    }
     ov::CompiledModel compiled_model = utils::singleton_core().compile_model(m_model, device, *filtered_properties);
     ov::genai::utils::print_compiled_model_properties(compiled_model, "LTX Video Transformer 3D model");
     m_request = compiled_model.create_infer_request();
@@ -85,6 +88,15 @@ LTXVideoTransformer3DModel& LTXVideoTransformer3DModel::compile(const std::strin
 void LTXVideoTransformer3DModel::set_hidden_states(const std::string& tensor_name, const ov::Tensor& encoder_hidden_states) {
     OPENVINO_ASSERT(m_request, "Transformer model must be compiled first");
     m_request.set_tensor(tensor_name, encoder_hidden_states);
+}
+
+void LTXVideoTransformer3DModel::set_adapters(const std::optional<AdapterConfig>& adapters) {
+    OPENVINO_ASSERT(m_request, "Transformer model must be compiled first");
+    if (adapters) {
+        OPENVINO_ASSERT(m_adapter_controller,
+            "Adapter controller is not initialized. Adapters must be provided during model construction or compilation to enable adapter support.");
+        m_adapter_controller.apply(m_request, *adapters);
+    }
 }
 
 ov::Tensor LTXVideoTransformer3DModel::infer(const ov::Tensor& latent_model_input, const ov::Tensor& timestep) {

--- a/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
+++ b/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
@@ -9,6 +9,7 @@
 #include "json_utils.hpp"
 #include "utils.hpp"
 #include "lora/helper.hpp"
+#include "lora/names_mapping.hpp"
 
 using namespace ov::genai;
 
@@ -71,7 +72,8 @@ LTXVideoTransformer3DModel& LTXVideoTransformer3DModel::compile(const std::strin
     std::optional<AdapterConfig> adapters;
     auto filtered_properties = extract_adapters_from_properties(properties, &adapters);
     if (adapters) {
-        adapters->set_tensor_name_prefix(adapters->get_tensor_name_prefix().value_or("transformer"));
+        m_lora_prefix = adapters->get_tensor_name_prefix().value_or(detect_lora_prefix(*adapters));
+        adapters->set_tensor_name_prefix(m_lora_prefix);
         m_adapter_controller = AdapterController(m_model, *adapters, device);
     }
     ov::CompiledModel compiled_model = utils::singleton_core().compile_model(m_model, device, *filtered_properties);
@@ -95,7 +97,13 @@ void LTXVideoTransformer3DModel::set_adapters(const std::optional<AdapterConfig>
     if (adapters && *adapters) {
         OPENVINO_ASSERT(m_adapter_controller,
             "Adapter controller is not initialized. Adapters must be provided during model construction or compilation to enable adapter support.");
-        m_adapter_controller.apply(m_request, *adapters);
+        if (!adapters->get_tensor_name_prefix().has_value()) {
+            AdapterConfig adapters_with_prefix = *adapters;
+            adapters_with_prefix.set_tensor_name_prefix(m_lora_prefix);
+            m_adapter_controller.apply(m_request, adapters_with_prefix);
+        } else {
+            m_adapter_controller.apply(m_request, *adapters);
+        }
     }
 }
 

--- a/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
+++ b/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
@@ -94,10 +94,8 @@ void LTXVideoTransformer3DModel::set_hidden_states(const std::string& tensor_nam
 
 void LTXVideoTransformer3DModel::set_adapters(const std::optional<AdapterConfig>& adapters) {
     OPENVINO_ASSERT(m_request, "Transformer model must be compiled first");
-    if (adapters && *adapters) {
-        OPENVINO_ASSERT(m_adapter_controller,
-            "Adapter controller is not initialized. Adapters must be provided during model construction or compilation to enable adapter support.");
-        if (!adapters->get_tensor_name_prefix().has_value()) {
+    if (adapters) {
+        if (*adapters && !adapters->get_tensor_name_prefix().has_value()) {
             AdapterConfig adapters_with_prefix = *adapters;
             adapters_with_prefix.set_tensor_name_prefix(m_lora_prefix);
             m_adapter_controller.apply(m_request, adapters_with_prefix);

--- a/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
+++ b/src/cpp/src/video_generation/models/ltx_video_transformer_3d_model.cpp
@@ -92,7 +92,7 @@ void LTXVideoTransformer3DModel::set_hidden_states(const std::string& tensor_nam
 
 void LTXVideoTransformer3DModel::set_adapters(const std::optional<AdapterConfig>& adapters) {
     OPENVINO_ASSERT(m_request, "Transformer model must be compiled first");
-    if (adapters) {
+    if (adapters && *adapters) {
         OPENVINO_ASSERT(m_adapter_controller,
             "Adapter controller is not initialized. Adapters must be provided during model construction or compilation to enable adapter support.");
         m_adapter_controller.apply(m_request, *adapters);

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2010,6 +2010,8 @@ class LTXVideoTransformer3DModel:
                         width (int): Video width.
                         tokenizer_model_max_length (int): Maximum sequence length for tokenizer.
         """
+    def set_adapters(self, adapters: openvino_genai.py_openvino_genai.AdapterConfig | None) -> None:
+        ...
     def set_hidden_states(self, tensor_name: str, encoder_hidden_states: openvino._pyopenvino.Tensor) -> None:
         """
                         Sets encoder hidden states tensor.

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2011,7 +2011,10 @@ class LTXVideoTransformer3DModel:
                         tokenizer_model_max_length (int): Maximum sequence length for tokenizer.
         """
     def set_adapters(self, adapters: openvino_genai.py_openvino_genai.AdapterConfig | None) -> None:
-        ...
+        """
+                        Sets LoRA adapters for the transformer model.
+                        adapters (AdapterConfig or None): Adapter configuration to apply.
+        """
     def set_hidden_states(self, tensor_name: str, encoder_hidden_states: openvino._pyopenvino.Tensor) -> None:
         """
                         Sets encoder hidden states tensor.
@@ -4302,7 +4305,7 @@ class VLMRawPerfMetrics:
     def prepare_embeddings_durations(self) -> list[float]:
         ...
 class VideoGenerationConfig:
-    adapters: AdapterConfig | None
+    adapters: openvino_genai.py_openvino_genai.AdapterConfig | None
     generator: Generator
     negative_prompt: str | None
     taylorseer_config: openvino_genai.py_openvino_genai.TaylorSeerCacheConfig | None

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -4302,6 +4302,7 @@ class VLMRawPerfMetrics:
     def prepare_embeddings_durations(self) -> list[float]:
         ...
 class VideoGenerationConfig:
+    adapters: AdapterConfig | None
     generator: Generator
     negative_prompt: str | None
     taylorseer_config: openvino_genai.py_openvino_genai.TaylorSeerCacheConfig | None

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2014,6 +2014,8 @@ class LTXVideoTransformer3DModel:
         """
                         Sets LoRA adapters for the transformer model.
                         adapters (AdapterConfig or None): Adapter configuration to apply.
+                        Passing None keeps currently configured adapters unchanged.
+                        Pass an empty AdapterConfig() to disable all adapters.
         """
     def set_hidden_states(self, tensor_name: str, encoder_hidden_states: openvino._pyopenvino.Tensor) -> None:
         """

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -100,6 +100,9 @@ void init_ltx_video_transformer_3d_model(py::module_& m) {
                 tensor_name (str): Name of the tensor input.
                 encoder_hidden_states (ov.Tensor): Hidden states from text encoder.
             )")
+        .def("set_adapters",
+             &ov::genai::LTXVideoTransformer3DModel::set_adapters,
+             py::arg("adapters"))
         .def("infer",
              &ov::genai::LTXVideoTransformer3DModel::infer,
              py::call_guard<py::gil_scoped_release>(),

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -106,6 +106,8 @@ void init_ltx_video_transformer_3d_model(py::module_& m) {
              R"(
                 Sets LoRA adapters for the transformer model.
                 adapters (AdapterConfig or None): Adapter configuration to apply.
+                Passing None keeps currently configured adapters unchanged.
+                Pass an empty AdapterConfig() to disable all adapters.
             )")
         .def("infer",
              &ov::genai::LTXVideoTransformer3DModel::infer,

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -102,7 +102,11 @@ void init_ltx_video_transformer_3d_model(py::module_& m) {
             )")
         .def("set_adapters",
              &ov::genai::LTXVideoTransformer3DModel::set_adapters,
-             py::arg("adapters"))
+             py::arg("adapters"),
+             R"(
+                Sets LoRA adapters for the transformer model.
+                adapters (AdapterConfig or None): Adapter configuration to apply.
+            )")
         .def("infer",
              &ov::genai::LTXVideoTransformer3DModel::infer,
              py::call_guard<py::gil_scoped_release>(),

--- a/src/python/py_video_generation_pipelines.cpp
+++ b/src/python/py_video_generation_pipelines.cpp
@@ -32,7 +32,8 @@ void init_video_generation_pipelines(py::module_& m) {
         .def_readwrite("width", &ov::genai::VideoGenerationConfig::width)
         .def_readwrite("num_inference_steps", &ov::genai::VideoGenerationConfig::num_inference_steps)
         .def_readwrite("max_sequence_length", &ov::genai::VideoGenerationConfig::max_sequence_length)
-        .def_readwrite("taylorseer_config", &ov::genai::VideoGenerationConfig::taylorseer_config);
+        .def_readwrite("taylorseer_config", &ov::genai::VideoGenerationConfig::taylorseer_config)
+        .def_readwrite("adapters", &ov::genai::VideoGenerationConfig::adapters);
 
     py::class_<ov::genai::VideoGenerationResult>(m, "VideoGenerationResult")
         .def_readonly("video", &ov::genai::VideoGenerationResult::video)

--- a/tests/python_tests/samples/conftest.py
+++ b/tests/python_tests/samples/conftest.py
@@ -195,7 +195,7 @@ TEST_FILES = {
     "cmu_us_awb_arctic-wav-arctic_a0001.bin": "https://huggingface.co/datasets/Xenova/cmu-arctic-xvectors-extracted/resolve/main/cmu_us_awb_arctic-wav-arctic_a0001.bin",
     "video0.mp4": "https://storage.openvinotoolkit.org/repositories/openvino_notebooks/data/data/video/Coco%20Walking%20in%20Berkeley.mp4",
     "qwen2b_lora_100_adapter_model.safetensors": "https://huggingface.co/saim1212/qwen2b-lora-100/resolve/main/adapter_model.safetensors",
-    "ltx_tiny_dummy_lora.safetensors": "https://huggingface.co/goyaladitya05/openvino-genai-test-files/resolve/main/ltx_tiny_dummy_lora.safetensors"
+    "ltx_tiny_dummy_lora.safetensors": "https://huggingface.co/goyaladitya05/openvino-genai-test-files/resolve/main/ltx_tiny_dummy_lora.safetensors",
 }
 
 SAMPLES_PY_DIR = Path(

--- a/tests/python_tests/samples/conftest.py
+++ b/tests/python_tests/samples/conftest.py
@@ -195,6 +195,7 @@ TEST_FILES = {
     "cmu_us_awb_arctic-wav-arctic_a0001.bin": "https://huggingface.co/datasets/Xenova/cmu-arctic-xvectors-extracted/resolve/main/cmu_us_awb_arctic-wav-arctic_a0001.bin",
     "video0.mp4": "https://storage.openvinotoolkit.org/repositories/openvino_notebooks/data/data/video/Coco%20Walking%20in%20Berkeley.mp4",
     "qwen2b_lora_100_adapter_model.safetensors": "https://huggingface.co/saim1212/qwen2b-lora-100/resolve/main/adapter_model.safetensors",
+    "ltx_tiny_dummy_lora.safetensors": "https://huggingface.co/goyaladitya05/openvino-genai-test-files/resolve/main/ltx_tiny_dummy_lora.safetensors"
 }
 
 SAMPLES_PY_DIR = Path(

--- a/tests/python_tests/samples/test_lora_text2video.py
+++ b/tests/python_tests/samples/test_lora_text2video.py
@@ -21,9 +21,12 @@ class TestLoraText2Video:
         indirect=["convert_model"],
     )
     @pytest.mark.parametrize("download_test_content", ["ltx_tiny_dummy_lora.safetensors"], indirect=True)
-    @pytest.mark.parametrize("executable", [
-        [SAMPLES_CPP_DIR / "lora_text2video"],
-        [sys.executable, SAMPLES_PY_DIR / "video_generation/lora_text2video.py"],
-    ])
+    @pytest.mark.parametrize(
+        "executable",
+        [
+            [SAMPLES_CPP_DIR / "lora_text2video"],
+            [sys.executable, SAMPLES_PY_DIR / "video_generation/lora_text2video.py"],
+        ],
+    )
     def test_sample_lora_text2video(self, convert_model, sample_args, download_test_content, executable):
         run_sample(executable + [convert_model, sample_args, download_test_content, "0.7"])

--- a/tests/python_tests/samples/test_lora_text2video.py
+++ b/tests/python_tests/samples/test_lora_text2video.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import sys
+
+from conftest import SAMPLES_PY_DIR, SAMPLES_CPP_DIR
+from test_utils import run_sample
+
+
+class TestLoraText2Video:
+    PROMPT = "A woman with long brown hair smiles at another woman with long blonde hair"
+
+    @pytest.mark.samples
+    @pytest.mark.video_generation
+    @pytest.mark.parametrize(
+        "convert_model, sample_args",
+        [
+            pytest.param("tiny-random-ltx-video", PROMPT),
+        ],
+        indirect=["convert_model"],
+    )
+    @pytest.mark.parametrize("download_test_content", ["ltx_tiny_dummy_lora.safetensors"], indirect=True)
+    @pytest.mark.parametrize("executable", [
+        [SAMPLES_CPP_DIR / "lora_text2video"],
+        [sys.executable, SAMPLES_PY_DIR / "video_generation/lora_text2video.py"],
+    ])
+    def test_sample_lora_text2video(self, convert_model, sample_args, download_test_content, executable):
+        run_sample(executable + [convert_model, sample_args, download_test_content, "0.7"])

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -331,3 +331,33 @@ class TestTaylorSeer:
         assert not np.array_equal(baseline_latents[-1], taylorseer_latents[-1]), (
             "Last step latents are identical — TaylorSeer prediction should have changed the result"
         )
+
+
+class TestLoRAVideoGeneration:
+    def test_lora_adapters_constructor(self, video_generation_model):
+        """Test that LoRA adapters can be passed to the constructor without error"""
+        adapter_config = ov_genai.AdapterConfig()
+        pipe = ov_genai.Text2VideoPipeline(video_generation_model, "CPU", adapters=adapter_config)
+        assert pipe is not None
+
+    def test_lora_adapters_generate(self, video_generation_model):
+        """Test that LoRA adapters can be passed to generate() without error"""
+        adapter_config = ov_genai.AdapterConfig()
+        pipe = ov_genai.Text2VideoPipeline(video_generation_model, "CPU", adapters=adapter_config)
+
+        result = pipe.generate(
+            "test prompt", height=32, width=32, num_frames=9, num_inference_steps=2, adapters=adapter_config
+        )
+        assert result is not None
+        assert result.video is not None
+
+    def test_transformer_has_set_adapters_method(self, video_generation_model):
+        """Test that the LTXVideoTransformer3DModel has the set_adapters method"""
+        model_path = Path(video_generation_model) / "transformer"
+        if model_path.exists():
+            model = ov_genai.LTXVideoTransformer3DModel(str(model_path))
+            model.compile("CPU")
+
+            assert hasattr(model, "set_adapters")
+
+            model.set_adapters(None)

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -368,10 +368,10 @@ class TestLoRAVideoGeneration:
     def test_transformer_has_set_adapters_method(self, video_generation_model):
         """Test that the LTXVideoTransformer3DModel has the set_adapters method"""
         model_path = Path(video_generation_model) / "transformer"
-        if model_path.exists():
-            model = ov_genai.LTXVideoTransformer3DModel(str(model_path))
-            model.compile("CPU")
+        assert model_path.exists(), f"Transformer subdirectory not found at: {model_path}"
+        model = ov_genai.LTXVideoTransformer3DModel(str(model_path))
+        model.compile("CPU")
 
-            assert hasattr(model, "set_adapters")
+        assert hasattr(model, "set_adapters")
 
-            model.set_adapters(None)
+        model.set_adapters(None)

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -351,6 +351,20 @@ class TestLoRAVideoGeneration:
         assert result is not None
         assert result.video is not None
 
+    def test_lora_adapters_default_from_constructor(self, video_generation_model):
+        """Test that LoRA adapters passed to the constructor are used by default in generate()"""
+        adapter_config = ov_genai.AdapterConfig()
+        pipe = ov_genai.Text2VideoPipeline(video_generation_model, "CPU", adapters=adapter_config)
+        result = pipe.generate(
+            "test prompt",
+            height=32,
+            width=32,
+            num_frames=9,
+            num_inference_steps=2,
+        )
+        assert result is not None
+        assert result.video is not None
+
     def test_transformer_has_set_adapters_method(self, video_generation_model):
         """Test that the LTXVideoTransformer3DModel has the set_adapters method"""
         model_path = Path(video_generation_model) / "transformer"


### PR DESCRIPTION
This PR implements LoRA adapter support for `Text2VideoPipeline`.

## Changes

C++ (LTXVideoTransformer3DModel)
- Removed the blocking assertion in compile() and initialized AdapterController following the FluxTransformer2DModel pattern
- Implemented set_adapters() with a safety check to prevent segfaults on uninitialized controllers
- Added `std::optional<AdapterConfig> adapters` to VideoGenerationConfig

Pipeline (ltx_pipeline.hpp)
- Added m_transformer->set_adapters() before the denoising loop. Adapters were previously extracted from properties but never applied.
- Fixed rebuild_models() to forward m_compile_properties so adapters survive model reshapes

Python
- Exposed LTXVideoTransformer3DModel.set_adapters() via pybind11 and updated the stub files

Samples & docs
- Added C++ and Python samples
- Updated both READMEs with LoRA usage instructions

Tests
- Added TestLoRAVideoGeneration covering constructor, generate(), and set_adapters(). All tests use an empty AdapterConfig() and run without real LoRA files


## Verification
without LoRA
![564786724-f3189e62-e088-4aea-8de0-50048622272e](https://github.com/user-attachments/assets/4dc2a129-a594-44cf-b614-ca3cd7bd22bd)




with LoRA 
Adapter:[(ltx_pixel_pytorch_lora_weights.safetensors)](https://huggingface.co/svjack/ltx_video_pixel_early_lora)
![564786695-3a0c0714-b14f-4881-99bd-be69f5861bc2](https://github.com/user-attachments/assets/e9e5cb7b-5c63-43b5-a644-b05295e0e235)



These samples demonstrate that the LoRA adapter is successfully loaded and applied during the denoising process in the Text2VideoPipeline.

Environment:
Model: LTX-Video
Alpha: 3.0
Prompt: "In the style of Pixel, the video shifts to a majestic castle under a starry sky."

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). 
- [x] Tests have been updated or added to cover the new code. 
    * Verified `tests/python_tests/test_video_generation.py` passes locally.
- [x] This PR fully addresses the ticket. 
- [x] I have made corresponding changes to the documentation.

Closes #3306
Supersedes #3309