### PR TITLE
Fix perf metrics processing for Whisper (static) pipeline

### DIFF
--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -1268,10 +1268,6 @@ WhisperDecodedResults WhisperPipeline::StaticWhisperPipeline::generate(
     result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(
             PerfMetrics::get_microsec(std::chrono::steady_clock::now() - decode_start_time));
 
-    // if return_timestamps wasn't enabled by user
-    if (!config.return_timestamps) {
-        return result;
-    }
 
     if (segments.size()) {
         std::vector<WhisperDecodedResultChunk> chunks;


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Fixed perf metrics processing in Whisper static pipeline - when timestamps are disabled, evaluate statistics hasn't been called and some performance data in the logs was affected.

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
