### PR TITLE
[Video Generation] Add VAE encoder support to AutoencoderKLLTXVideo

### DIFF
--- a/site/docs/use-cases/video-generation/_sections/_run_model/index.mdx
+++ b/site/docs/use-cases/video-generation/_sections/_run_model/index.mdx
@@ -6,6 +6,8 @@ import Text2VideoPython from './_text2video_python.mdx';
 OpenVINO GenAI supports the following video generation pipeline:
 - [`Text2VideoPipeline`](https://docs.openvino.ai/2026/api/genai_api/_autosummary/openvino_genai.Text2VideoPipeline.html) for creating videos from text prompts.
 
+[`AutoencoderKLLTXVideo`](https://docs.openvino.ai/2026/api/genai_api/_autosummary/openvino_genai.AutoencoderKLLTXVideo.html) also exposes an `encode()` method for encoding video frames into latent space, enabling Image-to-Video workflows where a conditioning frame is provided alongside the text prompt.
+
 <LanguageTabs>
     <TabItemPython>
         <Tabs groupId="device">

--- a/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
@@ -50,6 +50,8 @@ public:
 
     AutoencoderKLLTXVideo& compile(const std::string& device, const ov::AnyMap& properties = {});
 
+    ov::Tensor encode(const ov::Tensor& video, std::shared_ptr<Generator> generator);
+
     ov::Tensor decode(const ov::Tensor& latent);
 
     const Config& get_config() const;

--- a/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
@@ -66,6 +66,7 @@ private:
     Config m_config;
     ov::InferRequest m_encoder_request, m_decoder_request;
     std::shared_ptr<ov::Model> m_encoder_model = nullptr, m_decoder_model = nullptr;
+    std::string m_encoder_output_name;
 
     int64_t m_transformer_patch_size = -1, m_transformer_patch_size_t = -1;
 };

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <numeric>
 

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -90,7 +90,6 @@ public:
     }
 
 private:
-    ov::Tensor m_parameters;
     ov::Tensor m_mean, m_std;
 };
 

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -44,32 +44,27 @@ public:
 
         m_mean = ov::Tensor(parameters.get_element_type(), reduced_shape);
         m_std  = ov::Tensor(parameters.get_element_type(), reduced_shape);
-        ov::Tensor logvar(parameters.get_element_type(), reduced_shape);
 
         size_t spatial = 1;
         for (size_t i = 2; i < full_shape.size(); ++i)
             spatial *= full_shape[i];
 
-        const float* src  = parameters.data<float>();
-        float* mean_data  = m_mean.data<float>();
-        float* logvar_data = logvar.data<float>();
-        float* std_data   = m_std.data<float>();
+        const float* src = parameters.data<float>();
+        float* mean_data = m_mean.data<float>();
+        float* std_data  = m_std.data<float>();
 
+        // Split mean and logvar, clamp and compute std in a single pass — no intermediate tensor.
         for (size_t b = 0; b < batch; ++b) {
             for (size_t c = 0; c < channels; ++c) {
                 const size_t dst_off  = (b * channels + c) * spatial;
                 const size_t mean_off = (b * full_shape[1] + c) * spatial;
                 const size_t lvar_off = (b * full_shape[1] + channels + c) * spatial;
                 for (size_t s = 0; s < spatial; ++s) {
-                    mean_data[dst_off + s]  = src[mean_off + s];
-                    logvar_data[dst_off + s] = src[lvar_off + s];
+                    mean_data[dst_off + s] = src[mean_off + s];
+                    const float logvar = std::min(std::max(src[lvar_off + s], -30.0f), 20.0f);
+                    std_data[dst_off + s]  = std::exp(0.5f * logvar);
                 }
             }
-        }
-
-        for (size_t i = 0; i < logvar.get_size(); ++i) {
-            logvar_data[i] = std::min(std::max(logvar_data[i], -30.0f), 20.0f);
-            std_data[i]    = std::exp(0.5f * logvar_data[i]);
         }
     }
 

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -23,6 +23,48 @@ using namespace ov::genai;
 
 namespace {
 
+class DiagonalGaussianDistribution {
+public:
+    explicit DiagonalGaussianDistribution(ov::Tensor parameters)
+        : m_parameters(parameters) {
+        ov::Shape shape = parameters.get_shape();
+        OPENVINO_ASSERT(shape[0] == 1, "Batch size must be 1");
+        shape[1] /= 2;
+
+        m_mean = ov::Tensor(parameters.get_element_type(), shape, parameters.data());
+        m_std = ov::Tensor(m_mean.get_element_type(), shape);
+        ov::Tensor logvar(parameters.get_element_type(), shape, m_mean.data<float>() + m_mean.get_size());
+
+        float* logvar_data = logvar.data<float>();
+        float* std_data = m_std.data<float>();
+
+        for (size_t i = 0; i < logvar.get_size(); ++i) {
+            logvar_data[i] = std::min(std::max(logvar_data[i], -30.0f), 20.0f);
+            std_data[i] = std::exp(0.5f * logvar_data[i]);
+        }
+    }
+
+    ov::Tensor sample(std::shared_ptr<ov::genai::Generator> generator) const {
+        OPENVINO_ASSERT(generator, "Generator must not be nullptr");
+
+        ov::Tensor rand_tensor = generator->randn_tensor(m_mean.get_shape());
+
+        float* rand_tensor_data = rand_tensor.data<float>();
+        const float* mean_data = m_mean.data<float>();
+        const float* std_data = m_std.data<float>();
+
+        for (size_t i = 0; i < rand_tensor.get_size(); ++i) {
+            rand_tensor_data[i] = mean_data[i] + std_data[i] * rand_tensor_data[i];
+        }
+
+        return rand_tensor;
+    }
+
+private:
+    ov::Tensor m_parameters;
+    ov::Tensor m_mean, m_std;
+};
+
 // for BW compatibility with 2024.6.0
 ov::AnyMap handle_scale_factor(std::shared_ptr<ov::Model> model, const std::string& device, ov::AnyMap properties) {
     auto it = properties.find("WA_INFERENCE_PRECISION_HINT");
@@ -119,8 +161,12 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::compile(const std::string& device,
     std::optional<AdapterConfig> unused;
     auto filtered_properties = extract_adapters_from_properties(properties, &unused);
 
-    // TODO: for img2video
-    // if (m_encoder_model) {...}
+    if (m_encoder_model) {
+        ov::CompiledModel encoder_compiled_model = core.compile_model(m_encoder_model, device, handle_scale_factor(m_encoder_model, device, *filtered_properties));
+        ov::genai::utils::print_compiled_model_properties(encoder_compiled_model, "Auto encoder KL LTX video encoder model");
+        m_encoder_request = encoder_compiled_model.create_infer_request();
+        m_encoder_model.reset();
+    }
 
     ov::CompiledModel decoder_compiled_model = core.compile_model(m_decoder_model, device, handle_scale_factor(m_decoder_model, device, *filtered_properties));
     ov::genai::utils::print_compiled_model_properties(decoder_compiled_model, "Auto encoder KL LTX video decoder model");
@@ -141,8 +187,11 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::reshape(int64_t batch_size,
     OPENVINO_ASSERT(width > 0, "Width must be positive");
     OPENVINO_ASSERT(width % 32 == 0, "Width have to be divisible by 32 but got ", width);
 
-    // TODO: for img2video
-    // if (m_encoder_model) {...}
+    if (m_encoder_model) {
+        ov::PartialShape input_shape = m_encoder_model->input(0).get_partial_shape();
+        std::map<size_t, ov::PartialShape> idx_to_shape{{0, {batch_size, input_shape[1], num_frames, height, width}}};
+        m_encoder_model->reshape(idx_to_shape);
+    }
 
     int64_t spatial_compression_ratio =
         get_config().patch_size *
@@ -172,6 +221,55 @@ ov::Tensor AutoencoderKLLTXVideo::decode(const ov::Tensor& latent) {
     m_decoder_request.set_input_tensor(latent);
     m_decoder_request.infer();
     return m_decoder_request.get_output_tensor();
+}
+
+ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_ptr<Generator> generator) {
+    OPENVINO_ASSERT(m_encoder_request || m_encoder_model,
+        "AutoencoderKLLTXVideo is created without 'VAE encoder' capability. "
+        "Please, pass 'vae_encoder_path' argument to constructor.");
+    OPENVINO_ASSERT(m_encoder_request,
+        "VAE encoder model must be compiled first. Cannot infer non-compiled model");
+
+    m_encoder_request.set_input_tensor(video);
+    m_encoder_request.infer();
+
+    ov::Tensor output = m_encoder_request.get_output_tensor(), latent;
+
+    ov::CompiledModel compiled_model = m_encoder_request.get_compiled_model();
+    auto outputs = compiled_model.outputs();
+    OPENVINO_ASSERT(outputs.size() == 1, "AutoencoderKLLTXVideo encoder model is expected to have a single output");
+
+    const std::string output_name = outputs[0].get_any_name();
+    if (output_name == "latent_sample") {
+        latent = output;
+    } else if (output_name == "latent_parameters") {
+        latent = DiagonalGaussianDistribution(output).sample(generator);
+    } else {
+        OPENVINO_THROW("Unexpected output name for AutoencoderKLLTXVideo encoder '", output_name, "'");
+    }
+
+    // normalize latents channel-wise: (latents - latents_mean) * scaling_factor / latents_std
+    // inverse of denormalize_latents used in the decode path
+    const ov::Shape shape = latent.get_shape();
+    OPENVINO_ASSERT(shape.size() == 5, "Encoder output expected to be [B, C, F, H, W]");
+    const size_t B = shape[0], C = shape[1], spatial = shape[2] * shape[3] * shape[4];
+
+    float* latent_data = latent.data<float>();
+    const auto& mean = m_config.latents_mean_data;
+    const auto& std_data = m_config.latents_std_data;
+    const float scale = m_config.scaling_factor;
+
+    for (size_t b = 0; b < B; ++b) {
+        for (size_t c = 0; c < C; ++c) {
+            float* ptr = latent_data + (b * C + c) * spatial;
+            const float m = mean[c], s = std_data[c];
+            for (size_t i = 0; i < spatial; ++i) {
+                ptr[i] = (ptr[i] - m) * scale / s;
+            }
+        }
+    }
+
+    return latent;
 }
 
 const AutoencoderKLLTXVideo::Config& AutoencoderKLLTXVideo::get_config() const {

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -213,9 +213,9 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::reshape(int64_t batch_size,
                                                       int64_t width) {
     OPENVINO_ASSERT(m_decoder_model, "Model has been already compiled. Cannot reshape already compiled model");
     OPENVINO_ASSERT(height > 0, "Height must be positive");
-    OPENVINO_ASSERT(height % 32 == 0, "Height have to be divisible by 32 but got ", height);
+    OPENVINO_ASSERT(height % 32 == 0, "Height must be divisible by 32 but got ", height);
     OPENVINO_ASSERT(width > 0, "Width must be positive");
-    OPENVINO_ASSERT(width % 32 == 0, "Width have to be divisible by 32 but got ", width);
+    OPENVINO_ASSERT(width % 32 == 0, "Width must be divisible by 32 but got ", width);
 
     if (m_encoder_model) {
         ov::PartialShape input_shape = m_encoder_model->input(0).get_partial_shape();
@@ -266,7 +266,11 @@ ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_pt
     ov::Tensor output = m_encoder_request.get_output_tensor(), latent;
 
     if (m_encoder_output_name == "latent_sample") {
-        latent = output;
+        // Copy to an owned tensor so the normalization below does not mutate
+        // the infer request's internal buffer (which would alias any tensor
+        // the caller holds across multiple encode() calls).
+        latent = ov::Tensor(output.get_element_type(), output.get_shape());
+        output.copy_to(latent);
     } else if (m_encoder_output_name == "latent_parameters") {
         latent = DiagonalGaussianDistribution(output).sample(generator);
     } else {
@@ -306,7 +310,7 @@ const AutoencoderKLLTXVideo::Config& AutoencoderKLLTXVideo::get_config() const {
     return m_config;
 }
 
-size_t AutoencoderKLLTXVideo::get_vae_scale_factor() const {  // TODO: compare with reference. Drop?
+size_t AutoencoderKLLTXVideo::get_vae_scale_factor() const {
     return std::pow(2, m_config.block_out_channels.size() - 1);
 }
 

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -3,6 +3,8 @@
 
 #include "openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <memory>
 #include <numeric>
@@ -25,22 +27,49 @@ namespace {
 
 class DiagonalGaussianDistribution {
 public:
-    explicit DiagonalGaussianDistribution(ov::Tensor parameters)
-        : m_parameters(parameters) {
-        ov::Shape shape = parameters.get_shape();
-        OPENVINO_ASSERT(shape[0] == 1, "Batch size must be 1");
-        shape[1] /= 2;
+    explicit DiagonalGaussianDistribution(ov::Tensor parameters) {
+        OPENVINO_ASSERT(parameters.get_element_type() == ov::element::f32,
+            "DiagonalGaussianDistribution requires f32 encoder output, got ",
+            parameters.get_element_type());
 
-        m_mean = ov::Tensor(parameters.get_element_type(), shape, parameters.data());
-        m_std = ov::Tensor(m_mean.get_element_type(), shape);
-        ov::Tensor logvar(parameters.get_element_type(), shape, m_mean.data<float>() + m_mean.get_size());
+        const ov::Shape& full_shape = parameters.get_shape();
+        OPENVINO_ASSERT(full_shape.size() >= 2, "Parameters tensor rank must be at least 2");
+        OPENVINO_ASSERT(full_shape[1] % 2 == 0, "Channel dimension must be even to split mean and logvar");
 
+        const size_t batch = full_shape[0];
+        const size_t channels = full_shape[1] / 2;
+
+        ov::Shape reduced_shape = full_shape;
+        reduced_shape[1] = channels;
+
+        m_mean = ov::Tensor(parameters.get_element_type(), reduced_shape);
+        m_std  = ov::Tensor(parameters.get_element_type(), reduced_shape);
+        ov::Tensor logvar(parameters.get_element_type(), reduced_shape);
+
+        size_t spatial = 1;
+        for (size_t i = 2; i < full_shape.size(); ++i)
+            spatial *= full_shape[i];
+
+        const float* src  = parameters.data<float>();
+        float* mean_data  = m_mean.data<float>();
         float* logvar_data = logvar.data<float>();
-        float* std_data = m_std.data<float>();
+        float* std_data   = m_std.data<float>();
+
+        for (size_t b = 0; b < batch; ++b) {
+            for (size_t c = 0; c < channels; ++c) {
+                const size_t dst_off  = (b * channels + c) * spatial;
+                const size_t mean_off = (b * full_shape[1] + c) * spatial;
+                const size_t lvar_off = (b * full_shape[1] + channels + c) * spatial;
+                for (size_t s = 0; s < spatial; ++s) {
+                    mean_data[dst_off + s]  = src[mean_off + s];
+                    logvar_data[dst_off + s] = src[lvar_off + s];
+                }
+            }
+        }
 
         for (size_t i = 0; i < logvar.get_size(); ++i) {
             logvar_data[i] = std::min(std::max(logvar_data[i], -30.0f), 20.0f);
-            std_data[i] = std::exp(0.5f * logvar_data[i]);
+            std_data[i]    = std::exp(0.5f * logvar_data[i]);
         }
     }
 
@@ -252,11 +281,16 @@ ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_pt
     // inverse of denormalize_latents used in the decode path
     const ov::Shape shape = latent.get_shape();
     OPENVINO_ASSERT(shape.size() == 5, "Encoder output expected to be [B, C, F, H, W]");
+    OPENVINO_ASSERT(latent.get_element_type() == ov::element::f32,
+        "Latent normalization requires f32, got ", latent.get_element_type());
     const size_t B = shape[0], C = shape[1], spatial = shape[2] * shape[3] * shape[4];
 
-    float* latent_data = latent.data<float>();
     const auto& mean = m_config.latents_mean_data;
     const auto& std_data = m_config.latents_std_data;
+    OPENVINO_ASSERT(mean.size() == C && std_data.size() == C,
+        "Config latents_mean/std size (", mean.size(), ") does not match latent channels (", C, ")");
+
+    float* latent_data = latent.data<float>();
     const float scale = m_config.scaling_factor;
 
     for (size_t b = 0; b < B; ++b) {

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -72,6 +72,9 @@ public:
         OPENVINO_ASSERT(generator, "Generator must not be nullptr");
 
         ov::Tensor rand_tensor = generator->randn_tensor(m_mean.get_shape());
+        OPENVINO_ASSERT(rand_tensor.get_element_type() == ov::element::f32,
+            "Generator::randn_tensor() must return an f32 tensor, got ",
+            rand_tensor.get_element_type());
 
         float* rand_tensor_data = rand_tensor.data<float>();
         const float* mean_data = m_mean.data<float>();
@@ -187,6 +190,9 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::compile(const std::string& device,
     if (m_encoder_model) {
         ov::CompiledModel encoder_compiled_model = core.compile_model(m_encoder_model, device, handle_scale_factor(m_encoder_model, device, *filtered_properties));
         ov::genai::utils::print_compiled_model_properties(encoder_compiled_model, "Auto encoder KL LTX video encoder model");
+        auto enc_outputs = encoder_compiled_model.outputs();
+        OPENVINO_ASSERT(enc_outputs.size() == 1, "AutoencoderKLLTXVideo encoder model is expected to have a single output");
+        m_encoder_output_name = enc_outputs[0].get_any_name();
         m_encoder_request = encoder_compiled_model.create_infer_request();
         m_encoder_model.reset();
     }
@@ -258,17 +264,12 @@ ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_pt
 
     ov::Tensor output = m_encoder_request.get_output_tensor(), latent;
 
-    ov::CompiledModel compiled_model = m_encoder_request.get_compiled_model();
-    auto outputs = compiled_model.outputs();
-    OPENVINO_ASSERT(outputs.size() == 1, "AutoencoderKLLTXVideo encoder model is expected to have a single output");
-
-    const std::string output_name = outputs[0].get_any_name();
-    if (output_name == "latent_sample") {
+    if (m_encoder_output_name == "latent_sample") {
         latent = output;
-    } else if (output_name == "latent_parameters") {
+    } else if (m_encoder_output_name == "latent_parameters") {
         latent = DiagonalGaussianDistribution(output).sample(generator);
     } else {
-        OPENVINO_THROW("Unexpected output name for AutoencoderKLLTXVideo encoder '", output_name, "'");
+        OPENVINO_THROW("Unexpected output name for AutoencoderKLLTXVideo encoder '", m_encoder_output_name, "'");
     }
 
     // normalize latents channel-wise: (latents - latents_mean) * scaling_factor / latents_std

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -217,6 +217,7 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
              [](ov::genai::AutoencoderKLLTXVideo& self,
                 const ov::Tensor& video,
                 std::shared_ptr<ov::genai::Generator> generator) {
+                 py::gil_scoped_release rel;
                  return self.encode(video, generator);
              },
              py::arg("video"),

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -217,7 +217,6 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
              [](ov::genai::AutoencoderKLLTXVideo& self,
                 const ov::Tensor& video,
                 std::shared_ptr<ov::genai::Generator> generator) {
-                 py::gil_scoped_release rel;
                  return self.encode(video, generator);
              },
              py::arg("video"),

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -213,6 +213,17 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
                 height (int): Video height.
                 width (int): Video width.
             )")
+        .def("encode",
+             &ov::genai::AutoencoderKLLTXVideo::encode,
+             py::call_guard<py::gil_scoped_release>(),
+             py::arg("video"),
+             py::arg("generator"),
+             R"(
+                Encodes a video tensor to latent space.
+                video (ov.Tensor): Input video tensor [B, C, F, H, W].
+                generator (Generator): Random generator for sampling from latent distribution.
+                Returns: Normalized latent tensor.
+            )")
         .def("decode",
              &ov::genai::AutoencoderKLLTXVideo::decode,
              py::call_guard<py::gil_scoped_release>(),

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -217,6 +217,7 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
              [](ov::genai::AutoencoderKLLTXVideo& self,
                 const ov::Tensor& video,
                 std::shared_ptr<ov::genai::Generator> generator) {
+                 py::gil_scoped_release release;
                  return self.encode(video, generator);
              },
              py::arg("video"),

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -214,8 +214,11 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
                 width (int): Video width.
             )")
         .def("encode",
-             &ov::genai::AutoencoderKLLTXVideo::encode,
-             py::call_guard<py::gil_scoped_release>(),
+             [](ov::genai::AutoencoderKLLTXVideo& self,
+                const ov::Tensor& video,
+                std::shared_ptr<ov::genai::Generator> generator) {
+                 return self.encode(video, generator);
+             },
              py::arg("video"),
              py::arg("generator"),
              R"(

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -225,19 +225,19 @@ class TestAutoEncoderKLLTXVideo:
 
 
 class TestAutoEncoderKLLTXVideoEncoder:
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def require_encoder(self, video_generation_model):
         encoder_path = Path(video_generation_model) / "vae_encoder"
         if not encoder_path.exists():
             pytest.skip("vae_encoder not available in test model")
 
-    def test_constructor_with_encoder(self, video_generation_model):
+    def test_constructor_with_encoder(self, video_generation_model, require_encoder):
         encoder_path = Path(video_generation_model) / "vae_encoder"
         decoder_path = Path(video_generation_model) / "vae_decoder"
         vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path))
         assert vae is not None
 
-    def test_encode_without_compile_raises(self, video_generation_model):
+    def test_encode_without_compile_raises(self, video_generation_model, require_encoder):
         import openvino as ov
         import numpy as np
 
@@ -264,7 +264,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         with pytest.raises(Exception, match="without 'VAE encoder' capability"):
             vae.encode(dummy, generator)
 
-    def test_encode_output_shape(self, video_generation_model):
+    def test_encode_output_shape(self, video_generation_model, require_encoder):
         import openvino as ov
         import numpy as np
 
@@ -283,7 +283,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         assert shape[0] == 1
         assert shape[1] == config.latent_channels
 
-    def test_encode_is_deterministic(self, video_generation_model):
+    def test_encode_is_deterministic(self, video_generation_model, require_encoder):
         import openvino as ov
         import numpy as np
 
@@ -297,7 +297,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
 
         np.testing.assert_array_equal(latent1.data, latent2.data)
 
-    def test_encode_varies_with_seed(self, video_generation_model):
+    def test_encode_varies_with_seed(self, video_generation_model, require_encoder):
         import openvino as ov
         import numpy as np
 

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -255,7 +255,8 @@ class TestAutoEncoderKLLTXVideoEncoder:
         import numpy as np
 
         decoder_path = Path(video_generation_model) / "vae_decoder"
-        # Use 1-arg constructor + explicit compile to avoid overload ambiguity with 2-path constructor
+        if not decoder_path.exists():
+            pytest.skip("vae_decoder not available in test model")
         vae = ov_genai.AutoencoderKLLTXVideo(str(decoder_path))
         vae.compile("CPU")
         generator = ov_genai.CppStdGenerator(42)

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -228,8 +228,11 @@ class TestAutoEncoderKLLTXVideoEncoder:
     @pytest.fixture
     def require_encoder(self, video_generation_model):
         encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
         if not encoder_path.exists():
             pytest.skip("vae_encoder not available in test model")
+        if not decoder_path.exists():
+            pytest.skip("vae_decoder not available in test model")
 
     def test_constructor_with_encoder(self, video_generation_model, require_encoder):
         encoder_path = Path(video_generation_model) / "vae_encoder"

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -224,6 +224,93 @@ class TestAutoEncoderKLLTXVideo:
             assert hasattr(config, "scaling_factor")
 
 
+class TestAutoEncoderKLLTXVideoEncoder:
+    @pytest.fixture(autouse=True)
+    def require_encoder(self, video_generation_model):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        if not encoder_path.exists():
+            pytest.skip("vae_encoder not available in test model")
+
+    def test_constructor_with_encoder(self, video_generation_model):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path))
+        assert vae is not None
+
+    def test_encode_without_compile_raises(self, video_generation_model):
+        import openvino as ov
+        import numpy as np
+
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path))  # no compile
+        generator = ov_genai.CppStdGenerator(42)
+        dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+
+        with pytest.raises(Exception, match="must be compiled first"):
+            vae.encode(dummy, generator)
+
+    def test_encode_without_encoder_raises(self, video_generation_model):
+        import openvino as ov
+        import numpy as np
+
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(decoder_path), "CPU")  # decoder-only
+        generator = ov_genai.CppStdGenerator(42)
+        dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+
+        with pytest.raises(Exception, match="without 'VAE encoder' capability"):
+            vae.encode(dummy, generator)
+
+    def test_encode_output_shape(self, video_generation_model):
+        import openvino as ov
+        import numpy as np
+
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+        config = vae.get_config()
+        generator = ov_genai.CppStdGenerator(42)
+
+        video = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+        latent = vae.encode(video, generator)
+
+        assert latent is not None
+        shape = latent.shape
+        assert len(shape) == 5, f"Expected 5D latent [B, C, F, H, W], got shape {shape}"
+        assert shape[0] == 1
+        assert shape[1] == config.latent_channels
+
+    def test_encode_is_deterministic(self, video_generation_model):
+        import openvino as ov
+        import numpy as np
+
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+
+        video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
+        latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
+        latent2 = vae.encode(video, ov_genai.CppStdGenerator(42))
+
+        np.testing.assert_array_equal(np.array(latent1), np.array(latent2))
+
+    def test_encode_varies_with_seed(self, video_generation_model):
+        import openvino as ov
+        import numpy as np
+
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+
+        video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
+        latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
+        latent2 = vae.encode(video, ov_genai.CppStdGenerator(99))
+
+        assert not np.array_equal(np.array(latent1), np.array(latent2)), \
+            "Different generator seeds should produce different latents"
+
+
 class TestText2VideoPipelineAdvanced:
     def test_reshape(self, video_generation_model):
         pipe = ov_genai.Text2VideoPipeline(video_generation_model)

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -255,7 +255,9 @@ class TestAutoEncoderKLLTXVideoEncoder:
         import numpy as np
 
         decoder_path = Path(video_generation_model) / "vae_decoder"
-        vae = ov_genai.AutoencoderKLLTXVideo(str(decoder_path), "CPU")  # decoder-only
+        # Use 1-arg constructor + explicit compile to avoid overload ambiguity with 2-path constructor
+        vae = ov_genai.AutoencoderKLLTXVideo(str(decoder_path))
+        vae.compile("CPU")
         generator = ov_genai.CppStdGenerator(42)
         dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
 
@@ -293,7 +295,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
         latent2 = vae.encode(video, ov_genai.CppStdGenerator(42))
 
-        np.testing.assert_array_equal(np.array(latent1), np.array(latent2))
+        np.testing.assert_array_equal(latent1.data, latent2.data)
 
     def test_encode_varies_with_seed(self, video_generation_model):
         import openvino as ov
@@ -307,7 +309,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
         latent2 = vae.encode(video, ov_genai.CppStdGenerator(99))
 
-        assert not np.array_equal(np.array(latent1), np.array(latent2)), \
+        assert not np.array_equal(latent1.data, latent2.data), \
             "Different generator seeds should produce different latents"
 
 

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -306,12 +306,19 @@ class TestAutoEncoderKLLTXVideoEncoder:
         decoder_path = Path(video_generation_model) / "vae_decoder"
         vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
 
+        output_name = ov.Core().read_model(str(encoder_path / "openvino_model.xml")).outputs[0].get_any_name()
+
         video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
         latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
         latent2 = vae.encode(video, ov_genai.CppStdGenerator(99))
 
-        assert not np.array_equal(latent1.data, latent2.data), \
-            "Different generator seeds should produce different latents"
+        if output_name == "latent_parameters":
+            assert not np.array_equal(latent1.data, latent2.data), \
+                "Different generator seeds should produce different latents"
+        elif output_name == "latent_sample":
+            np.testing.assert_array_equal(latent1.data, latent2.data)
+        else:
+            pytest.skip(f"Unexpected encoder output name '{output_name}'")
 
 
 class TestText2VideoPipelineAdvanced:


### PR DESCRIPTION
This PR implements `AutoencoderKLLTXVideo::encode()`, enabling Image-to-Video workflows where a conditioning frame is encoded into latent space and passed to the diffusion pipeline. 

It is needed before any work can begin on the GSoC project 4 - I2V support in LTX Video Gen pipeline. 

### Changes

- VAE encoder now compiles and runs. `compile()` and `reshape()` had `// TODO: for img2video`. Both are now implemented.
- `encode(video, generator)` - takes a [B, C, F, H, W] video tensor, runs the encoder model, and returns a normalized latent ready for the diffusion transformer. Handles both model output variants:
  - `latent_parameters` - samples z from the predicted distribution
  - `latent_sample` - uses the output directly (no sampling needed)
- Python bindings: `encode()` is exposed to Python.
- Added 6 tests which cover construction, error messages, output shape, determinism with the same seed, and variation across seeds. Tests that require the encoder skip if `vae_encoder` is not present in the test model.


### Tested

Encode - decode on a real image (512×512, CPU):

| Step | Value |
|---|---|
| Input | [1, 3, 1, 512, 512] |
| Latent | [1, 128, 1, 16, 16] (32× spatial compression) |
| Output | [1, 1, 512, 512, 3] |

<img width="1024" height="512" alt="roundtrip_comparison" src="https://github.com/user-attachments/assets/38941bb3-4e71-4ea6-9774-0498a0bec0d6" />
Example of a result generated using the encode and decode loop. Quality degradation is due to 32x spatial compression.


Fixes #3430

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
