### PR TITLE
[GPU] Route VLM per-model properties via utils::get_model_properties

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -60,8 +60,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        auto vision_encoder_properties_for_embedder = utils::inherit_cache_properties(vision_encoder_properties, properties);
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties_for_embedder);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device,
+            utils::inherit_cache_properties(vision_encoder_properties, properties));
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -112,8 +112,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(const std::shared_ptr<ov:
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        auto vision_encoder_properties_for_embedder = utils::inherit_cache_properties(vision_encoder_properties, properties);
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties_for_embedder);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device,
+            utils::inherit_cache_properties(vision_encoder_properties, properties));
     }
 
     utils::print_scheduler_config_info(scheduler_config);

--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -60,7 +60,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties);
+        auto vision_encoder_properties_for_embedder = utils::inherit_cache_properties(vision_encoder_properties, properties);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties_for_embedder);
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -111,7 +112,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(const std::shared_ptr<ov:
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties);
+        auto vision_encoder_properties_for_embedder = utils::inherit_cache_properties(vision_encoder_properties, properties);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_encoder_properties_for_embedder);
     }
 
     utils::print_scheduler_config_info(scheduler_config);

--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -60,8 +60,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(models_path, device,
-            utils::inherit_cache_properties(vision_encoder_properties, properties));
+        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings", device);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_props);
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -112,8 +112,8 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(const std::shared_ptr<ov:
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(models_path, device,
-            utils::inherit_cache_properties(vision_encoder_properties, properties));
+        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings", device);
+        embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_props);
     }
 
     utils::print_scheduler_config_info(scheduler_config);

--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -60,7 +60,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings", device);
+        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings");
         embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_props);
     }
 
@@ -112,7 +112,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(const std::shared_ptr<ov:
 
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings", device);
+        auto vision_props = utils::get_model_properties(properties_without_draft_model, "vision_embeddings");
         embedder = std::make_shared<InputsEmbedder>(models_path, device, vision_props);
     }
 

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -4,7 +4,6 @@
 #include "utils.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cctype>
 #include <variant>
 #include <fstream>

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -3,10 +3,12 @@
 
 #include "utils.hpp"
 
+#include <array>
 #include <variant>
 #include <fstream>
 #include <memory>
 
+#include "openvino/runtime/properties.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/divide.hpp"
 #include "openvino/op/gather.hpp"

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -378,7 +378,6 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 } // namespace
 
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
-const std::string DEVICE_PROPERTIES    = "DEVICE_PROPERTIES";
 
 namespace {
 std::string to_lower(const std::string& s) {
@@ -408,7 +407,7 @@ ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string&
     // Meta key exclusion is case-insensitive (e.g. "per_model_properties"
     // is also treated as a meta key).
     const auto per_model_lowered = to_lower(PER_MODEL_PROPERTIES);
-    const auto device_props_lowered = to_lower(DEVICE_PROPERTIES);
+    const auto device_props_lowered = to_lower(ov::device::properties.name());
     for (const auto& kv : properties) {
         const auto key_lowered = to_lower(kv.first);
         if (key_lowered == per_model_lowered || key_lowered == device_props_lowered) {
@@ -417,9 +416,9 @@ ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string&
         result.insert_or_assign(kv.first, kv.second);
     }
 
-    // Layer 2: DEVICE_PROPERTIES[device] overrides globals for this device.
+    // Layer 2: ov::device::properties[device] overrides globals for this device.
     // Both the meta key and the device name are matched case-insensitively.
-    auto dev_it = find_case_insensitive(properties, DEVICE_PROPERTIES);
+    auto dev_it = find_case_insensitive(properties, ov::device::properties.name());
     if (dev_it != properties.end()) {
         const auto& by_device = dev_it->second.as<ov::AnyMap>();
         auto role_dev_it = find_case_insensitive(by_device, device);

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -4,7 +4,6 @@
 #include "utils.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <variant>
 #include <fstream>
 #include <memory>

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -379,7 +379,6 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 
-namespace {
 std::string to_lower(const std::string& s) {
     std::string result(s.size(), '\0');
     std::transform(s.begin(), s.end(), result.begin(),
@@ -398,7 +397,6 @@ ov::AnyMap::const_iterator find_case_insensitive(const ov::AnyMap& map, const st
     }
     return map.end();
 }
-} // namespace
 
 ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device) {
     ov::AnyMap result;
@@ -421,9 +419,9 @@ ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string&
     auto dev_it = find_case_insensitive(properties, ov::device::properties.name());
     if (dev_it != properties.end()) {
         const auto& by_device = dev_it->second.as<ov::AnyMap>();
-        auto role_dev_it = find_case_insensitive(by_device, device);
-        if (role_dev_it != by_device.end()) {
-            for (const auto& kv : role_dev_it->second.as<ov::AnyMap>()) {
+        auto device_it = find_case_insensitive(by_device, device);
+        if (device_it != by_device.end()) {
+            for (const auto& kv : device_it->second.as<ov::AnyMap>()) {
                 result.insert_or_assign(kv.first, kv.second);
             }
         }

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -379,17 +379,20 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 
 ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role) {
-    ov::AnyMap result;
+    ov::AnyMap result = properties;
+    result.erase(PER_MODEL_PROPERTIES);
+
     auto model_properties = properties.find(PER_MODEL_PROPERTIES);
     if (model_properties != properties.end()) {
         const ov::AnyMap& model_map = model_properties->second.as<ov::AnyMap>();
         auto role = model_map.find(model_role);
         if (role != model_map.end()) {
-            result = role->second.as<ov::AnyMap>();
+            const ov::AnyMap& role_properties = role->second.as<ov::AnyMap>();
+            for (const auto& property : role_properties) {
+                result.insert_or_assign(property.first, property.second);
+            }
         }
     }
-    result.merge(properties);
-    result.erase(PER_MODEL_PROPERTIES);
 
     return result;
 }

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -379,25 +379,6 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 
-std::string to_lower(const std::string& s) {
-    std::string result(s.size(), '\0');
-    std::transform(s.begin(), s.end(), result.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    return result;
-}
-
-// Case-insensitive lookup of @p key in @p map. Returns end() iterator when
-// no matching key exists.
-ov::AnyMap::const_iterator find_case_insensitive(const ov::AnyMap& map, const std::string& key) {
-    const auto lowered = to_lower(key);
-    for (auto it = map.begin(); it != map.end(); ++it) {
-        if (to_lower(it->first) == lowered) {
-            return it;
-        }
-    }
-    return map.end();
-}
-
 ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role) {
     ov::AnyMap result;
     auto model_properties = properties.find(PER_MODEL_PROPERTIES);

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -3,7 +3,9 @@
 
 #include "utils.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <variant>
 #include <fstream>
 #include <memory>
@@ -375,23 +377,72 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 } // namespace
 
-ov::AnyMap inherit_cache_properties(const ov::AnyMap& sub_properties,
-                                    const ov::AnyMap& main_properties) {
-    const std::array<std::string, 3> inheritable_keys = {
-        ov::cache_dir.name(),
-        ov::cache_mode.name(),
-        ov::cache_encryption_callbacks.name(),
-    };
-    ov::AnyMap result = sub_properties;
-    for (const auto& key : inheritable_keys) {
-        if (result.find(key) != result.end()) {
-            continue;
-        }
-        auto it = main_properties.find(key);
-        if (it != main_properties.end()) {
-            result[key] = it->second;
+const std::string PER_MODEL_PROPERTIES = "PER_MODEL_PROPERTIES";
+const std::string DEVICE_PROPERTIES    = "DEVICE_PROPERTIES";
+
+namespace {
+std::string to_lower(const std::string& s) {
+    std::string result(s.size(), '\0');
+    std::transform(s.begin(), s.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return result;
+}
+
+// Case-insensitive lookup of @p key in @p map. Returns end() iterator when
+// no matching key exists.
+ov::AnyMap::const_iterator find_case_insensitive(const ov::AnyMap& map, const std::string& key) {
+    const auto lowered = to_lower(key);
+    for (auto it = map.begin(); it != map.end(); ++it) {
+        if (to_lower(it->first) == lowered) {
+            return it;
         }
     }
+    return map.end();
+}
+} // namespace
+
+ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device) {
+    ov::AnyMap result;
+
+    // Layer 1 (lowest priority): global properties, excluding meta keys.
+    // Meta key exclusion is case-insensitive (e.g. "per_model_properties"
+    // is also treated as a meta key).
+    const auto per_model_lowered = to_lower(PER_MODEL_PROPERTIES);
+    const auto device_props_lowered = to_lower(DEVICE_PROPERTIES);
+    for (const auto& kv : properties) {
+        const auto key_lowered = to_lower(kv.first);
+        if (key_lowered == per_model_lowered || key_lowered == device_props_lowered) {
+            continue;
+        }
+        result.insert_or_assign(kv.first, kv.second);
+    }
+
+    // Layer 2: DEVICE_PROPERTIES[device] overrides globals for this device.
+    // Both the meta key and the device name are matched case-insensitively.
+    auto dev_it = find_case_insensitive(properties, DEVICE_PROPERTIES);
+    if (dev_it != properties.end()) {
+        const auto& by_device = dev_it->second.as<ov::AnyMap>();
+        auto role_dev_it = find_case_insensitive(by_device, device);
+        if (role_dev_it != by_device.end()) {
+            for (const auto& kv : role_dev_it->second.as<ov::AnyMap>()) {
+                result.insert_or_assign(kv.first, kv.second);
+            }
+        }
+    }
+
+    // Layer 3 (highest priority): PER_MODEL_PROPERTIES[model_role].
+    // Both the meta key and the model role are matched case-insensitively.
+    auto pm_it = find_case_insensitive(properties, PER_MODEL_PROPERTIES);
+    if (pm_it != properties.end()) {
+        const auto& per_model = pm_it->second.as<ov::AnyMap>();
+        auto role_it = find_case_insensitive(per_model, model_role);
+        if (role_it != per_model.end()) {
+            for (const auto& kv : role_it->second.as<ov::AnyMap>()) {
+                result.insert_or_assign(kv.first, kv.second);
+            }
+        }
+    }
+
     return result;
 }
 

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -387,9 +387,17 @@ ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model
 
     auto model_properties = properties.find(PER_MODEL_PROPERTIES);
     if (model_properties != properties.end()) {
+        OPENVINO_ASSERT(!model_properties->second.empty() && model_properties->second.is<ov::AnyMap>(),
+                        "Invalid '",
+                        PER_MODEL_PROPERTIES,
+                        "' property: expected non-empty ov::AnyMap.");
         const ov::AnyMap& model_map = model_properties->second.as<ov::AnyMap>();
         auto role = model_map.find(model_role);
         if (role != model_map.end()) {
+            OPENVINO_ASSERT(!role->second.empty() && role->second.is<ov::AnyMap>(),
+                            "Invalid model properties for role '",
+                            model_role,
+                            "': expected non-empty ov::AnyMap.");
             const ov::AnyMap& role_properties = role->second.as<ov::AnyMap>();
             for (const auto& property : role_properties) {
                 result.insert_or_assign(property.first, property.second);

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -377,7 +377,7 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 } // namespace
 
-const std::string PER_MODEL_PROPERTIES = "PER_MODEL_PROPERTIES";
+const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 const std::string DEVICE_PROPERTIES    = "DEVICE_PROPERTIES";
 
 namespace {

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -398,47 +398,18 @@ ov::AnyMap::const_iterator find_case_insensitive(const ov::AnyMap& map, const st
     return map.end();
 }
 
-ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device) {
+ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role) {
     ov::AnyMap result;
-
-    // Layer 1 (lowest priority): global properties, excluding meta keys.
-    // Meta key exclusion is case-insensitive (e.g. "per_model_properties"
-    // is also treated as a meta key).
-    const auto per_model_lowered = to_lower(PER_MODEL_PROPERTIES);
-    const auto device_props_lowered = to_lower(ov::device::properties.name());
-    for (const auto& kv : properties) {
-        const auto key_lowered = to_lower(kv.first);
-        if (key_lowered == per_model_lowered || key_lowered == device_props_lowered) {
-            continue;
-        }
-        result.insert_or_assign(kv.first, kv.second);
-    }
-
-    // Layer 2: ov::device::properties[device] overrides globals for this device.
-    // Both the meta key and the device name are matched case-insensitively.
-    auto dev_it = find_case_insensitive(properties, ov::device::properties.name());
-    if (dev_it != properties.end()) {
-        const auto& by_device = dev_it->second.as<ov::AnyMap>();
-        auto device_it = find_case_insensitive(by_device, device);
-        if (device_it != by_device.end()) {
-            for (const auto& kv : device_it->second.as<ov::AnyMap>()) {
-                result.insert_or_assign(kv.first, kv.second);
-            }
+    auto model_properties = properties.find(PER_MODEL_PROPERTIES);
+    if (model_properties != properties.end()) {
+        const ov::AnyMap& model_map = model_properties->second.as<ov::AnyMap>();
+        auto role = model_map.find(model_role);
+        if (role != model_map.end()) {
+            result = role->second.as<ov::AnyMap>();
         }
     }
-
-    // Layer 3 (highest priority): PER_MODEL_PROPERTIES[model_role].
-    // Both the meta key and the model role are matched case-insensitively.
-    auto pm_it = find_case_insensitive(properties, PER_MODEL_PROPERTIES);
-    if (pm_it != properties.end()) {
-        const auto& per_model = pm_it->second.as<ov::AnyMap>();
-        auto role_it = find_case_insensitive(per_model, model_role);
-        if (role_it != per_model.end()) {
-            for (const auto& kv : role_it->second.as<ov::AnyMap>()) {
-                result.insert_or_assign(kv.first, kv.second);
-            }
-        }
-    }
+    result.merge(properties);
+    result.erase(PER_MODEL_PROPERTIES);
 
     return result;
 }

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -373,6 +373,26 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 } // namespace
 
+ov::AnyMap inherit_cache_properties(const ov::AnyMap& sub_properties,
+                                    const ov::AnyMap& main_properties) {
+    const std::array<std::string, 3> inheritable_keys = {
+        ov::cache_dir.name(),
+        ov::cache_mode.name(),
+        ov::cache_encryption_callbacks.name(),
+    };
+    ov::AnyMap result = sub_properties;
+    for (const auto& key : inheritable_keys) {
+        if (result.find(key) != result.end()) {
+            continue;
+        }
+        auto it = main_properties.find(key);
+        if (it != main_properties.end()) {
+            result[key] = it->second;
+        }
+    }
+    return result;
+}
+
 std::pair<ov::AnyMap, bool> extract_gguf_properties(const ov::AnyMap& external_properties) {
     bool enable_save_ov_model = false;
     ov::AnyMap properties = external_properties;

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -378,8 +378,12 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 
 ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role) {
-    ov::AnyMap result = properties;
-    result.erase(PER_MODEL_PROPERTIES);
+    ov::AnyMap result;
+    for (const auto& property : properties) {
+        if (property.first != PER_MODEL_PROPERTIES) {
+            result.insert(property);
+        }
+    }
 
     auto model_properties = properties.find(PER_MODEL_PROPERTIES);
     if (model_properties != properties.end()) {

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -377,6 +377,9 @@ bool is_gguf_model(const std::filesystem::path& file_path) {
 
 const std::string PER_MODEL_PROPERTIES = "MODEL_PROPERTIES";
 
+// Merge global properties with per-role overrides. Type mismatches fall out
+// of .as<ov::AnyMap>() as a throw; empty or missing maps are treated as
+// "no overrides" rather than errors.
 ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role) {
     ov::AnyMap result;
     for (const auto& property : properties) {
@@ -385,26 +388,21 @@ ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model
         }
     }
 
-    auto model_properties = properties.find(PER_MODEL_PROPERTIES);
-    if (model_properties != properties.end()) {
-        OPENVINO_ASSERT(!model_properties->second.empty() && model_properties->second.is<ov::AnyMap>(),
-                        "Invalid '",
-                        PER_MODEL_PROPERTIES,
-                        "' property: expected non-empty ov::AnyMap.");
-        const ov::AnyMap& model_map = model_properties->second.as<ov::AnyMap>();
-        auto role = model_map.find(model_role);
-        if (role != model_map.end()) {
-            OPENVINO_ASSERT(!role->second.empty() && role->second.is<ov::AnyMap>(),
-                            "Invalid model properties for role '",
-                            model_role,
-                            "': expected non-empty ov::AnyMap.");
-            const ov::AnyMap& role_properties = role->second.as<ov::AnyMap>();
-            for (const auto& property : role_properties) {
-                result.insert_or_assign(property.first, property.second);
-            }
-        }
+    auto it = properties.find(PER_MODEL_PROPERTIES);
+    if (it == properties.end()) {
+        return result;
     }
 
+    const auto& model_map = it->second.as<ov::AnyMap>();
+    auto role_it = model_map.find(model_role);
+    if (role_it == model_map.end()) {
+        return result;
+    }
+
+    // Role-specific values win over globals.
+    for (const auto& property : role_it->second.as<ov::AnyMap>()) {
+        result.insert_or_assign(property.first, property.second);
+    }
     return result;
 }
 

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -142,6 +142,15 @@ ov::Core& singleton_core();
 
 std::pair<ov::AnyMap, bool> extract_gguf_properties(const ov::AnyMap& external_properties);
 
+/// @brief Inherit cache-related properties from main properties into a sub-model
+/// property map when they are not explicitly set.
+///
+/// Copies ov::cache_dir, ov::cache_mode, and ov::cache_encryption_callbacks from
+/// @p main_properties into @p sub_properties only if the sub map does not already
+/// define them, so explicit sub-model overrides are preserved.
+ov::AnyMap inherit_cache_properties(const ov::AnyMap& sub_properties,
+                                    const ov::AnyMap& main_properties);
+
 std::pair<ov::AnyMap, bool> extract_paired_input_props(const ov::AnyMap& external_properties);
 
 std::shared_ptr<ov::Model> read_model(const std::filesystem::path& model_dir,  const ov::AnyMap& config);

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -142,14 +142,27 @@ ov::Core& singleton_core();
 
 std::pair<ov::AnyMap, bool> extract_gguf_properties(const ov::AnyMap& external_properties);
 
-/// @brief Inherit cache-related properties from main properties into a sub-model
-/// property map when they are not explicitly set.
-///
-/// Copies ov::cache_dir, ov::cache_mode, and ov::cache_encryption_callbacks from
-/// @p main_properties into @p sub_properties only if the sub map does not already
-/// define them, so explicit sub-model overrides are preserved.
-ov::AnyMap inherit_cache_properties(const ov::AnyMap& sub_properties,
-                                    const ov::AnyMap& main_properties);
+/// @brief Key used in the main properties map to carry per-model property sub-maps.
+/// Value shape: ov::AnyMap keyed by model role (e.g. "vision_embeddings").
+extern const std::string PER_MODEL_PROPERTIES;
+
+/// @brief Key used in the main properties map to carry per-device property sub-maps.
+/// Value shape: ov::AnyMap keyed by device name (e.g. "GPU", "NPU").
+extern const std::string DEVICE_PROPERTIES;
+
+/// @brief Resolve properties for @p model_role on @p device by merging three
+///        layers (priority low to high):
+///        1. global (top-level keys, excluding meta keys PER_MODEL_PROPERTIES and DEVICE_PROPERTIES)
+///        2. DEVICE_PROPERTIES[device]
+///        3. PER_MODEL_PROPERTIES[model_role]
+/// @param properties The main properties map. Not modified.
+/// @param model_role Sub-model role (e.g. "vision_embeddings"). Matched
+///        case-insensitively against PER_MODEL_PROPERTIES keys.
+/// @param device Device for the sub-model (e.g. "GPU"). Matched
+///        case-insensitively against DEVICE_PROPERTIES keys.
+/// @return A new ov::AnyMap with the merged result. The input map is left
+///         untouched so callers may continue using the meta keys.
+ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device);
 
 std::pair<ov::AnyMap, bool> extract_paired_input_props(const ov::AnyMap& external_properties);
 

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -146,20 +146,14 @@ std::pair<ov::AnyMap, bool> extract_gguf_properties(const ov::AnyMap& external_p
 /// Value shape: ov::AnyMap keyed by model role (e.g. "vision_embeddings").
 extern const std::string PER_MODEL_PROPERTIES;
 
-/// @brief Resolve properties for @p model_role on @p device by merging three
-///        layers (priority low to high):
-///        1. global (top-level keys, excluding meta keys PER_MODEL_PROPERTIES
-///           and ov::device::properties)
-///        2. ov::device::properties[device]  (i.e. main_props["DEVICE_PROPERTIES"])
-///        3. PER_MODEL_PROPERTIES[model_role]
+/// @brief Resolve properties for @p model_role by merging two layers (priority low to high):
+///        1. global (top-level keys, excluding meta keys PER_MODEL_PROPERTIES)
+///        2. PER_MODEL_PROPERTIES[model_role]
 /// @param properties The main properties map. Not modified.
-/// @param model_role Sub-model role (e.g. "vision_embeddings"). Matched
-///        case-insensitively against PER_MODEL_PROPERTIES keys.
-/// @param device Device for the sub-model (e.g. "GPU"). Matched
-///        case-insensitively against ov::device::properties keys.
+/// @param model_role Sub-model role (e.g. "vision_embeddings").
 /// @return A new ov::AnyMap with the merged result. The input map is left
 ///         untouched so callers may continue using the meta keys.
-ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device);
+ov::AnyMap get_model_properties(ov::AnyMap& properties, const std::string& model_role);
 
 std::pair<ov::AnyMap, bool> extract_paired_input_props(const ov::AnyMap& external_properties);
 

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -146,20 +146,17 @@ std::pair<ov::AnyMap, bool> extract_gguf_properties(const ov::AnyMap& external_p
 /// Value shape: ov::AnyMap keyed by model role (e.g. "vision_embeddings").
 extern const std::string PER_MODEL_PROPERTIES;
 
-/// @brief Key used in the main properties map to carry per-device property sub-maps.
-/// Value shape: ov::AnyMap keyed by device name (e.g. "GPU", "NPU").
-extern const std::string DEVICE_PROPERTIES;
-
 /// @brief Resolve properties for @p model_role on @p device by merging three
 ///        layers (priority low to high):
-///        1. global (top-level keys, excluding meta keys PER_MODEL_PROPERTIES and DEVICE_PROPERTIES)
-///        2. DEVICE_PROPERTIES[device]
+///        1. global (top-level keys, excluding meta keys PER_MODEL_PROPERTIES
+///           and ov::device::properties)
+///        2. ov::device::properties[device]  (i.e. main_props["DEVICE_PROPERTIES"])
 ///        3. PER_MODEL_PROPERTIES[model_role]
 /// @param properties The main properties map. Not modified.
 /// @param model_role Sub-model role (e.g. "vision_embeddings"). Matched
 ///        case-insensitively against PER_MODEL_PROPERTIES keys.
 /// @param device Device for the sub-model (e.g. "GPU"). Matched
-///        case-insensitively against DEVICE_PROPERTIES keys.
+///        case-insensitively against ov::device::properties keys.
 /// @return A new ov::AnyMap with the merged result. The input map is left
 ///         untouched so callers may continue using the meta keys.
 ov::AnyMap get_model_properties(const ov::AnyMap& properties, const std::string& model_role, const std::string& device);

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -447,7 +447,7 @@ void init_generation_config(py::module_& m) {
         .def_readwrite("include_stop_str_in_output", &GenerationConfig::include_stop_str_in_output)
         .def_readwrite("stop_token_ids", &GenerationConfig::stop_token_ids)
         .def_readwrite("structured_output_config", &GenerationConfig::structured_output_config)
-        .def_readwrite("parsers", &GenerationConfig::parsers)
+        .def_readwrite("parsers", &GenerationConfig::parsers, py::keep_alive<1, 2>())
         .def_readwrite("adapters", &GenerationConfig::adapters)
         .def_readwrite("apply_chat_template", &GenerationConfig::apply_chat_template)
         .def("set_eos_token_id", &GenerationConfig::set_eos_token_id, py::arg("tokenizer_eos_token_id"))

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -447,7 +447,7 @@ void init_generation_config(py::module_& m) {
         .def_readwrite("include_stop_str_in_output", &GenerationConfig::include_stop_str_in_output)
         .def_readwrite("stop_token_ids", &GenerationConfig::stop_token_ids)
         .def_readwrite("structured_output_config", &GenerationConfig::structured_output_config)
-        .def_readwrite("parsers", &GenerationConfig::parsers, py::keep_alive<1, 2>())
+        .def_readwrite("parsers", &GenerationConfig::parsers)
         .def_readwrite("adapters", &GenerationConfig::adapters)
         .def_readwrite("apply_chat_template", &GenerationConfig::apply_chat_template)
         .def("set_eos_token_id", &GenerationConfig::set_eos_token_id, py::arg("tokenizer_eos_token_id"))

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -29,6 +29,8 @@ TEST(TestGetModelProperties, returns_globals_when_no_meta_keys) {
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
     EXPECT_EQ(result.size(), 2u);
+    ASSERT_EQ(result.count("CACHE_DIR"), 1u);
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }
@@ -42,6 +44,7 @@ TEST(TestGetModelProperties, excludes_meta_keys_from_globals) {
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
     EXPECT_EQ(result.count(PER_MODEL_PROPERTIES), 0u);
     EXPECT_EQ(result.count(DEVICE_PROPERTIES), 0u);
+    ASSERT_EQ(result.count("CACHE_DIR"), 1u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
 }
 
@@ -53,6 +56,7 @@ TEST(TestGetModelProperties, device_overrides_global) {
         }},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
@@ -64,6 +68,7 @@ TEST(TestGetModelProperties, device_layer_skipped_when_device_not_listed) {
         }},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }
 
@@ -78,6 +83,7 @@ TEST(TestGetModelProperties, per_model_overrides_device_and_global) {
         }},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
@@ -89,6 +95,7 @@ TEST(TestGetModelProperties, per_model_missing_role_leaves_lower_layers) {
         }},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }
 
@@ -107,6 +114,7 @@ TEST(TestGetModelProperties, does_not_mutate_input_map) {
     EXPECT_EQ(main_props.size(), snapshot.size());
     EXPECT_EQ(main_props.count(PER_MODEL_PROPERTIES), 1u);
     EXPECT_EQ(main_props.count(DEVICE_PROPERTIES), 1u);
+    ASSERT_EQ(main_props.count("CACHE_DIR"), 1u);
     EXPECT_EQ(main_props.at("CACHE_DIR").as<std::string>(), "/tmp");
 }
 
@@ -116,10 +124,13 @@ TEST(TestGetModelProperties, device_lookup_is_case_insensitive) {
             {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
-    EXPECT_EQ(get_model_properties(main_props, "vision_embeddings", "gpu")
-                  .at("NUM_STREAMS").as<std::string>(), "8");
-    EXPECT_EQ(get_model_properties(main_props, "vision_embeddings", "Gpu")
-                  .at("NUM_STREAMS").as<std::string>(), "8");
+    auto result_lower = get_model_properties(main_props, "vision_embeddings", "gpu");
+    ASSERT_EQ(result_lower.count("NUM_STREAMS"), 1u);
+    EXPECT_EQ(result_lower.at("NUM_STREAMS").as<std::string>(), "8");
+
+    auto result_mixed = get_model_properties(main_props, "vision_embeddings", "Gpu");
+    ASSERT_EQ(result_mixed.count("NUM_STREAMS"), 1u);
+    EXPECT_EQ(result_mixed.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
 TEST(TestGetModelProperties, role_lookup_is_case_insensitive) {
@@ -128,10 +139,13 @@ TEST(TestGetModelProperties, role_lookup_is_case_insensitive) {
             {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
-    EXPECT_EQ(get_model_properties(main_props, "VISION_EMBEDDINGS", "GPU")
-                  .at("NUM_STREAMS").as<std::string>(), "8");
-    EXPECT_EQ(get_model_properties(main_props, "Vision_Embeddings", "GPU")
-                  .at("NUM_STREAMS").as<std::string>(), "8");
+    auto result_upper = get_model_properties(main_props, "VISION_EMBEDDINGS", "GPU");
+    ASSERT_EQ(result_upper.count("NUM_STREAMS"), 1u);
+    EXPECT_EQ(result_upper.at("NUM_STREAMS").as<std::string>(), "8");
+
+    auto result_mixed = get_model_properties(main_props, "Vision_Embeddings", "GPU");
+    ASSERT_EQ(result_mixed.count("NUM_STREAMS"), 1u);
+    EXPECT_EQ(result_mixed.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
 TEST(TestGetModelProperties, merges_disjoint_keys_across_layers) {
@@ -145,6 +159,9 @@ TEST(TestGetModelProperties, merges_disjoint_keys_across_layers) {
         }},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    ASSERT_EQ(result.count("CACHE_DIR"), 1u);
+    ASSERT_EQ(result.count("GPU_QUEUE_PRIORITY"), 1u);
+    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
     EXPECT_EQ(result.at("GPU_QUEUE_PRIORITY").as<std::string>(), "HIGH");
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include "utils.hpp"
 
+#include "openvino/runtime/properties.hpp"
+
 
 using namespace ov::genai::utils;
 using map_type = std::map<std::string, int64_t>;
@@ -18,4 +20,60 @@ TEST(TestIsContainer, test_is_container) {
     EXPECT_EQ(is_container<std::vector<float>>, true);
     EXPECT_EQ(is_container<map_type>, true);
     EXPECT_EQ(is_container<std::set<int64_t>>, true);
+}
+
+TEST(TestInheritCacheProperties, inherits_cache_dir_when_absent_in_sub) {
+    ov::AnyMap main_props = {{ov::cache_dir.name(), std::string("/tmp/main")}};
+    ov::AnyMap sub_props = {};
+
+    auto result = inherit_cache_properties(sub_props, main_props);
+
+    ASSERT_EQ(result.count(ov::cache_dir.name()), 1u);
+    EXPECT_EQ(result.at(ov::cache_dir.name()).as<std::string>(), "/tmp/main");
+}
+
+TEST(TestInheritCacheProperties, does_not_override_explicit_sub_value) {
+    ov::AnyMap main_props = {{ov::cache_dir.name(), std::string("/tmp/main")}};
+    ov::AnyMap sub_props  = {{ov::cache_dir.name(), std::string("/tmp/sub")}};
+
+    auto result = inherit_cache_properties(sub_props, main_props);
+
+    EXPECT_EQ(result.at(ov::cache_dir.name()).as<std::string>(), "/tmp/sub");
+}
+
+TEST(TestInheritCacheProperties, inherits_cache_mode_independently_of_other_sub_keys) {
+    ov::AnyMap main_props = {{ov::cache_mode.name(), ov::CacheMode::OPTIMIZE_SPEED}};
+    // Sub map is non-empty but does not set cache_mode.
+    ov::AnyMap sub_props  = {{"NUM_STREAMS", std::string("2")}};
+
+    auto result = inherit_cache_properties(sub_props, main_props);
+
+    ASSERT_EQ(result.count(ov::cache_mode.name()), 1u);
+    EXPECT_EQ(result.at(ov::cache_mode.name()).as<ov::CacheMode>(), ov::CacheMode::OPTIMIZE_SPEED);
+    // Original sub key preserved.
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
+}
+
+TEST(TestInheritCacheProperties, does_not_inherit_non_cache_keys) {
+    ov::AnyMap main_props = {
+        {ov::cache_dir.name(), std::string("/tmp/main")},
+        {"NUM_STREAMS", std::string("4")},
+    };
+    ov::AnyMap sub_props = {};
+
+    auto result = inherit_cache_properties(sub_props, main_props);
+
+    EXPECT_EQ(result.count(ov::cache_dir.name()), 1u);
+    EXPECT_EQ(result.count("NUM_STREAMS"), 0u);
+}
+
+TEST(TestInheritCacheProperties, empty_main_leaves_sub_unchanged) {
+    ov::AnyMap main_props = {};
+    ov::AnyMap sub_props  = {{"NUM_STREAMS", std::string("2")}};
+
+    auto result = inherit_cache_properties(sub_props, main_props);
+
+    EXPECT_EQ(result.size(), 1u);
+    EXPECT_EQ(result.count(ov::cache_dir.name()), 0u);
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -5,8 +5,6 @@
 #include <gtest/gtest.h>
 #include "utils.hpp"
 
-#include "openvino/runtime/properties.hpp"
-
 
 using namespace ov::genai::utils;
 using map_type = std::map<std::string, int64_t>;
@@ -27,7 +25,7 @@ TEST(TestGetModelProperties, returns_globals_when_no_meta_keys) {
         {"CACHE_DIR", std::string("/tmp")},
         {"NUM_STREAMS", std::string("2")},
     };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    auto result = get_model_properties(main_props, "vision_embeddings");
     EXPECT_EQ(result.size(), 2u);
     ASSERT_EQ(result.count("CACHE_DIR"), 1u);
     ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
@@ -35,134 +33,52 @@ TEST(TestGetModelProperties, returns_globals_when_no_meta_keys) {
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }
 
-TEST(TestGetModelProperties, excludes_meta_keys_from_globals) {
+TEST(TestGetModelProperties, excludes_per_model_meta_key_from_globals) {
     ov::AnyMap main_props = {
         {"CACHE_DIR", std::string("/tmp")},
         {PER_MODEL_PROPERTIES, ov::AnyMap{}},
-        {ov::device::properties.name(), ov::AnyMap{}},
     };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    auto result = get_model_properties(main_props, "vision_embeddings");
     EXPECT_EQ(result.count(PER_MODEL_PROPERTIES), 0u);
-    EXPECT_EQ(result.count(ov::device::properties.name()), 0u);
     ASSERT_EQ(result.count("CACHE_DIR"), 1u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
 }
 
-TEST(TestGetModelProperties, device_overrides_global) {
+TEST(TestGetModelProperties, per_model_overrides_global) {
     ov::AnyMap main_props = {
         {"NUM_STREAMS", std::string("2")},
-        {ov::device::properties.name(), ov::AnyMap{
-            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
-        }},
-    };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
-    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
-}
-
-TEST(TestGetModelProperties, device_layer_skipped_when_device_not_listed) {
-    ov::AnyMap main_props = {
-        {"NUM_STREAMS", std::string("2")},
-        {ov::device::properties.name(), ov::AnyMap{
-            {"NPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
-        }},
-    };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
-    ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
-}
-
-TEST(TestGetModelProperties, per_model_overrides_device_and_global) {
-    ov::AnyMap main_props = {
-        {"NUM_STREAMS", std::string("2")},
-        {ov::device::properties.name(), ov::AnyMap{
-            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
-        }},
         {PER_MODEL_PROPERTIES, ov::AnyMap{
             {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    auto result = get_model_properties(main_props, "vision_embeddings");
     ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
-TEST(TestGetModelProperties, per_model_missing_role_leaves_lower_layers) {
+TEST(TestGetModelProperties, per_model_missing_role_leaves_globals) {
     ov::AnyMap main_props = {
         {"NUM_STREAMS", std::string("2")},
         {PER_MODEL_PROPERTIES, ov::AnyMap{
             {"text_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    auto result = get_model_properties(main_props, "vision_embeddings");
     ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
-}
-
-TEST(TestGetModelProperties, does_not_mutate_input_map) {
-    ov::AnyMap main_props = {
-        {"CACHE_DIR", std::string("/tmp")},
-        {PER_MODEL_PROPERTIES, ov::AnyMap{
-            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
-        }},
-        {ov::device::properties.name(), ov::AnyMap{
-            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
-        }},
-    };
-    auto snapshot = main_props;
-    (void)get_model_properties(main_props, "vision_embeddings", "GPU");
-    EXPECT_EQ(main_props.size(), snapshot.size());
-    EXPECT_EQ(main_props.count(PER_MODEL_PROPERTIES), 1u);
-    EXPECT_EQ(main_props.count(ov::device::properties.name()), 1u);
-    ASSERT_EQ(main_props.count("CACHE_DIR"), 1u);
-    EXPECT_EQ(main_props.at("CACHE_DIR").as<std::string>(), "/tmp");
-}
-
-TEST(TestGetModelProperties, device_lookup_is_case_insensitive) {
-    ov::AnyMap main_props = {
-        {ov::device::properties.name(), ov::AnyMap{
-            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
-        }},
-    };
-    auto result_lower = get_model_properties(main_props, "vision_embeddings", "gpu");
-    ASSERT_EQ(result_lower.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result_lower.at("NUM_STREAMS").as<std::string>(), "8");
-
-    auto result_mixed = get_model_properties(main_props, "vision_embeddings", "Gpu");
-    ASSERT_EQ(result_mixed.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result_mixed.at("NUM_STREAMS").as<std::string>(), "8");
-}
-
-TEST(TestGetModelProperties, role_lookup_is_case_insensitive) {
-    ov::AnyMap main_props = {
-        {PER_MODEL_PROPERTIES, ov::AnyMap{
-            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
-        }},
-    };
-    auto result_upper = get_model_properties(main_props, "VISION_EMBEDDINGS", "GPU");
-    ASSERT_EQ(result_upper.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result_upper.at("NUM_STREAMS").as<std::string>(), "8");
-
-    auto result_mixed = get_model_properties(main_props, "Vision_Embeddings", "GPU");
-    ASSERT_EQ(result_mixed.count("NUM_STREAMS"), 1u);
-    EXPECT_EQ(result_mixed.at("NUM_STREAMS").as<std::string>(), "8");
 }
 
 TEST(TestGetModelProperties, merges_disjoint_keys_across_layers) {
     ov::AnyMap main_props = {
         {"CACHE_DIR", std::string("/tmp")},
-        {ov::device::properties.name(), ov::AnyMap{
-            {"GPU", ov::AnyMap{{"GPU_QUEUE_PRIORITY", std::string("HIGH")}}},
-        }},
         {PER_MODEL_PROPERTIES, ov::AnyMap{
             {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
-    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    auto result = get_model_properties(main_props, "vision_embeddings");
     ASSERT_EQ(result.count("CACHE_DIR"), 1u);
-    ASSERT_EQ(result.count("GPU_QUEUE_PRIORITY"), 1u);
     ASSERT_EQ(result.count("NUM_STREAMS"), 1u);
+    EXPECT_EQ(result.count(PER_MODEL_PROPERTIES), 0u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
-    EXPECT_EQ(result.at("GPU_QUEUE_PRIORITY").as<std::string>(), "HIGH");
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
 }

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -22,58 +22,130 @@ TEST(TestIsContainer, test_is_container) {
     EXPECT_EQ(is_container<std::set<int64_t>>, true);
 }
 
-TEST(TestInheritCacheProperties, inherits_cache_dir_when_absent_in_sub) {
-    ov::AnyMap main_props = {{ov::cache_dir.name(), std::string("/tmp/main")}};
-    ov::AnyMap sub_props = {};
-
-    auto result = inherit_cache_properties(sub_props, main_props);
-
-    ASSERT_EQ(result.count(ov::cache_dir.name()), 1u);
-    EXPECT_EQ(result.at(ov::cache_dir.name()).as<std::string>(), "/tmp/main");
-}
-
-TEST(TestInheritCacheProperties, does_not_override_explicit_sub_value) {
-    ov::AnyMap main_props = {{ov::cache_dir.name(), std::string("/tmp/main")}};
-    ov::AnyMap sub_props  = {{ov::cache_dir.name(), std::string("/tmp/sub")}};
-
-    auto result = inherit_cache_properties(sub_props, main_props);
-
-    EXPECT_EQ(result.at(ov::cache_dir.name()).as<std::string>(), "/tmp/sub");
-}
-
-TEST(TestInheritCacheProperties, inherits_cache_mode_independently_of_other_sub_keys) {
-    ov::AnyMap main_props = {{ov::cache_mode.name(), ov::CacheMode::OPTIMIZE_SPEED}};
-    // Sub map is non-empty but does not set cache_mode.
-    ov::AnyMap sub_props  = {{"NUM_STREAMS", std::string("2")}};
-
-    auto result = inherit_cache_properties(sub_props, main_props);
-
-    ASSERT_EQ(result.count(ov::cache_mode.name()), 1u);
-    EXPECT_EQ(result.at(ov::cache_mode.name()).as<ov::CacheMode>(), ov::CacheMode::OPTIMIZE_SPEED);
-    // Original sub key preserved.
-    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
-}
-
-TEST(TestInheritCacheProperties, does_not_inherit_non_cache_keys) {
+TEST(TestGetModelProperties, returns_globals_when_no_meta_keys) {
     ov::AnyMap main_props = {
-        {ov::cache_dir.name(), std::string("/tmp/main")},
-        {"NUM_STREAMS", std::string("4")},
+        {"CACHE_DIR", std::string("/tmp")},
+        {"NUM_STREAMS", std::string("2")},
     };
-    ov::AnyMap sub_props = {};
-
-    auto result = inherit_cache_properties(sub_props, main_props);
-
-    EXPECT_EQ(result.count(ov::cache_dir.name()), 1u);
-    EXPECT_EQ(result.count("NUM_STREAMS"), 0u);
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.size(), 2u);
+    EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
 }
 
-TEST(TestInheritCacheProperties, empty_main_leaves_sub_unchanged) {
-    ov::AnyMap main_props = {};
-    ov::AnyMap sub_props  = {{"NUM_STREAMS", std::string("2")}};
+TEST(TestGetModelProperties, excludes_meta_keys_from_globals) {
+    ov::AnyMap main_props = {
+        {"CACHE_DIR", std::string("/tmp")},
+        {PER_MODEL_PROPERTIES, ov::AnyMap{}},
+        {DEVICE_PROPERTIES, ov::AnyMap{}},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.count(PER_MODEL_PROPERTIES), 0u);
+    EXPECT_EQ(result.count(DEVICE_PROPERTIES), 0u);
+    EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
+}
 
-    auto result = inherit_cache_properties(sub_props, main_props);
+TEST(TestGetModelProperties, device_overrides_global) {
+    ov::AnyMap main_props = {
+        {"NUM_STREAMS", std::string("2")},
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
+}
 
-    EXPECT_EQ(result.size(), 1u);
-    EXPECT_EQ(result.count(ov::cache_dir.name()), 0u);
+TEST(TestGetModelProperties, device_layer_skipped_when_device_not_listed) {
+    ov::AnyMap main_props = {
+        {"NUM_STREAMS", std::string("2")},
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"NPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
     EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
+}
+
+TEST(TestGetModelProperties, per_model_overrides_device_and_global) {
+    ov::AnyMap main_props = {
+        {"NUM_STREAMS", std::string("2")},
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
+        }},
+        {PER_MODEL_PROPERTIES, ov::AnyMap{
+            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
+}
+
+TEST(TestGetModelProperties, per_model_missing_role_leaves_lower_layers) {
+    ov::AnyMap main_props = {
+        {"NUM_STREAMS", std::string("2")},
+        {PER_MODEL_PROPERTIES, ov::AnyMap{
+            {"text_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "2");
+}
+
+TEST(TestGetModelProperties, does_not_mutate_input_map) {
+    ov::AnyMap main_props = {
+        {"CACHE_DIR", std::string("/tmp")},
+        {PER_MODEL_PROPERTIES, ov::AnyMap{
+            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
+        }},
+    };
+    auto snapshot = main_props;
+    (void)get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(main_props.size(), snapshot.size());
+    EXPECT_EQ(main_props.count(PER_MODEL_PROPERTIES), 1u);
+    EXPECT_EQ(main_props.count(DEVICE_PROPERTIES), 1u);
+    EXPECT_EQ(main_props.at("CACHE_DIR").as<std::string>(), "/tmp");
+}
+
+TEST(TestGetModelProperties, device_lookup_is_case_insensitive) {
+    ov::AnyMap main_props = {
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    EXPECT_EQ(get_model_properties(main_props, "vision_embeddings", "gpu")
+                  .at("NUM_STREAMS").as<std::string>(), "8");
+    EXPECT_EQ(get_model_properties(main_props, "vision_embeddings", "Gpu")
+                  .at("NUM_STREAMS").as<std::string>(), "8");
+}
+
+TEST(TestGetModelProperties, role_lookup_is_case_insensitive) {
+    ov::AnyMap main_props = {
+        {PER_MODEL_PROPERTIES, ov::AnyMap{
+            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    EXPECT_EQ(get_model_properties(main_props, "VISION_EMBEDDINGS", "GPU")
+                  .at("NUM_STREAMS").as<std::string>(), "8");
+    EXPECT_EQ(get_model_properties(main_props, "Vision_Embeddings", "GPU")
+                  .at("NUM_STREAMS").as<std::string>(), "8");
+}
+
+TEST(TestGetModelProperties, merges_disjoint_keys_across_layers) {
+    ov::AnyMap main_props = {
+        {"CACHE_DIR", std::string("/tmp")},
+        {DEVICE_PROPERTIES, ov::AnyMap{
+            {"GPU", ov::AnyMap{{"GPU_QUEUE_PRIORITY", std::string("HIGH")}}},
+        }},
+        {PER_MODEL_PROPERTIES, ov::AnyMap{
+            {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
+        }},
+    };
+    auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
+    EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
+    EXPECT_EQ(result.at("GPU_QUEUE_PRIORITY").as<std::string>(), "HIGH");
+    EXPECT_EQ(result.at("NUM_STREAMS").as<std::string>(), "8");
 }

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -39,11 +39,11 @@ TEST(TestGetModelProperties, excludes_meta_keys_from_globals) {
     ov::AnyMap main_props = {
         {"CACHE_DIR", std::string("/tmp")},
         {PER_MODEL_PROPERTIES, ov::AnyMap{}},
-        {DEVICE_PROPERTIES, ov::AnyMap{}},
+        {ov::device::properties.name(), ov::AnyMap{}},
     };
     auto result = get_model_properties(main_props, "vision_embeddings", "GPU");
     EXPECT_EQ(result.count(PER_MODEL_PROPERTIES), 0u);
-    EXPECT_EQ(result.count(DEVICE_PROPERTIES), 0u);
+    EXPECT_EQ(result.count(ov::device::properties.name()), 0u);
     ASSERT_EQ(result.count("CACHE_DIR"), 1u);
     EXPECT_EQ(result.at("CACHE_DIR").as<std::string>(), "/tmp");
 }
@@ -51,7 +51,7 @@ TEST(TestGetModelProperties, excludes_meta_keys_from_globals) {
 TEST(TestGetModelProperties, device_overrides_global) {
     ov::AnyMap main_props = {
         {"NUM_STREAMS", std::string("2")},
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
@@ -63,7 +63,7 @@ TEST(TestGetModelProperties, device_overrides_global) {
 TEST(TestGetModelProperties, device_layer_skipped_when_device_not_listed) {
     ov::AnyMap main_props = {
         {"NUM_STREAMS", std::string("2")},
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"NPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
@@ -75,7 +75,7 @@ TEST(TestGetModelProperties, device_layer_skipped_when_device_not_listed) {
 TEST(TestGetModelProperties, per_model_overrides_device_and_global) {
     ov::AnyMap main_props = {
         {"NUM_STREAMS", std::string("2")},
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
         }},
         {PER_MODEL_PROPERTIES, ov::AnyMap{
@@ -105,7 +105,7 @@ TEST(TestGetModelProperties, does_not_mutate_input_map) {
         {PER_MODEL_PROPERTIES, ov::AnyMap{
             {"vision_embeddings", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("4")}}},
         }},
     };
@@ -113,14 +113,14 @@ TEST(TestGetModelProperties, does_not_mutate_input_map) {
     (void)get_model_properties(main_props, "vision_embeddings", "GPU");
     EXPECT_EQ(main_props.size(), snapshot.size());
     EXPECT_EQ(main_props.count(PER_MODEL_PROPERTIES), 1u);
-    EXPECT_EQ(main_props.count(DEVICE_PROPERTIES), 1u);
+    EXPECT_EQ(main_props.count(ov::device::properties.name()), 1u);
     ASSERT_EQ(main_props.count("CACHE_DIR"), 1u);
     EXPECT_EQ(main_props.at("CACHE_DIR").as<std::string>(), "/tmp");
 }
 
 TEST(TestGetModelProperties, device_lookup_is_case_insensitive) {
     ov::AnyMap main_props = {
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"GPU", ov::AnyMap{{"NUM_STREAMS", std::string("8")}}},
         }},
     };
@@ -151,7 +151,7 @@ TEST(TestGetModelProperties, role_lookup_is_case_insensitive) {
 TEST(TestGetModelProperties, merges_disjoint_keys_across_layers) {
     ov::AnyMap main_props = {
         {"CACHE_DIR", std::string("/tmp")},
-        {DEVICE_PROPERTIES, ov::AnyMap{
+        {ov::device::properties.name(), ov::AnyMap{
             {"GPU", ov::AnyMap{{"GPU_QUEUE_PRIORITY", std::string("HIGH")}}},
         }},
         {PER_MODEL_PROPERTIES, ov::AnyMap{


### PR DESCRIPTION
## Summary
- Add `utils::get_model_properties(properties, model_role)` that resolves
a sub-model's effective config by merging two priority layers
(global → `PER_MODEL_PROPERTIES[model_role]`). The `PER_MODEL_PROPERTIES`
meta key is stripped from the result. Meta keys and model roles are
matched exactly (case-sensitive).
- Wire the helper into both VLM-aware `ContinuousBatchingPipeline`
constructors so callers can already route `cache_dir`, `NUM_STREAMS`,
and other properties to the vision encoder per model on the current
public API — no breaking changes.

CVS-182861

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](../CONTRIBUTING.md).
- [x] Tests have been updated or added to cover the new code.
  Added five unit tests in `tests/cpp/utils.cpp` for `utils::get_model_properties()`:
  globals-only passthrough, `PER_MODEL_PROPERTIES` meta-key exclusion,
  per-model overriding global, per-model missing role falls back to
  globals, and disjoint-key merging across both layers.
- [x] This PR fully addresses the ticket (CVS-182861).
- [x] I have made corresponding changes to the documentation.
  No doc update required: this is an internal behavior fix; the public
  constructor signatures of `ContinuousBatchingPipeline` are unchanged.


---------
Target Machine: PTLH
Ran it four times in a row after removing the cache files.

### master
```
| Task                                      | R1.LAT   | R2.LAT   | R3.LAT   | R4.LAT   |
| ContinuousBatchingPipeline constructor #1 | 8.123 s  | 4.586 s  | 3.283 s  | 3.270 s  |
| │  └─ Language model read                 | 0.177 s  | 0.124 s  | 0.123 s  | 0.127 s  |
| │  └─ *Tokenizer*                         | 0.896 s  | 0.628 s  | 0.633 s  | 0.650 s  |
| │  └─ InputsEmbedder creation             | 2.247 s  | 2.167 s  | 2.026 s  | 1.986 s  |
| │    └─ VisionEncoder                     | 0.366 s  | 0.311 s  | 0.235 s  | 0.241 s  |
| │    └─ EmbeddingsModel                   | 0.173 s  | 0.182 s  | 0.174 s  | 0.175 s  |
| │    └─ *Tokenizer*                       | 0.646 s  | 0.618 s  | 0.645 s  | 0.618 s  |
| │    └─ *VisionEmbeddingsMerger*          | 0.987 s  | 0.964 s  | 0.897 s  | 0.872 s  |  no cache
| │    └─ VisionEmbeddingsPos               | 0.016 s  | 0.032 s  | 0.015 s  | 0.014 s  |  no cache
| │  └─ Language model                      | 4.612 s  | 1.606 s  | 0.447 s  | 0.447 s  |  cache
```

### master + This PR
* Tokenizer: 650 ms -> 55 ms, 618 ms -> 47 ms
* VisionEmbeddingsMerger: 872 ms -> 408 ms
```
| Task                                      | R1.LAT   | R2.LAT   | R3.LAT   | R4.LAT   |
| ContinuousBatchingPipeline constructor #1 | 8.317 s  | 4.436 s  | 2.143 s  | 2.191 s  |
| │  └─ Language model read                 | 0.178 s  | 0.126 s  | 0.125 s  | 0.134 s  |
| │  └─ *Tokenizer*                         | 0.305 s  | 0.054 s  | 0.055 s  | 0.055 s  |
| │  └─ InputsEmbedder creation             | 2.966 s  | 2.519 s  | 1.477 s  | 1.482 s  |
| │    └─ VisionEncoder                     | 0.359 s  | 0.375 s  | 0.157 s  | 0.172 s  |
| │    └─ EmbeddingsModel                   | 0.595 s  | 0.881 s  | 0.182 s  | 0.185 s  |
| │    └─ *Tokenizer*                       | 0.049 s  | 0.045 s  | 0.048 s  | 0.047 s  |
| │    └─ *VisionEmbeddingsMerger*          | 1.277 s  | 0.520 s  | 0.437 s  | 0.408 s  |  cache
| │    └─ VisionEmbeddingsPos               | 0.020 s  | 0.035 s  | 0.004 s  | 0.004 s  |  cache
| │  └─ Language model                      | 4.664 s  | 1.680 s  | 0.428 s  | 0.461 s  |  cache
```