### PR TITLE
drop incremental parsers, add tool call sample and include lfm2 parse…

### DIFF
--- a/samples/cpp/text_generation/CMakeLists.txt
+++ b/samples/cpp/text_generation/CMakeLists.txt
@@ -22,6 +22,7 @@ endfunction()
 
 set (SAMPLE_LIST
     greedy_causal_lm
+    tool_calling
     encrypted_model_causal_lm
     beam_search_causal_lm
     chat_sample

--- a/samples/cpp/text_generation/tool_calling.cpp
+++ b/samples/cpp/text_generation/tool_calling.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2023-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "openvino/genai/continuous_batching_pipeline.hpp"
+#include "openvino/genai/parsers/lfm2_tool_parser.hpp"
+#include "openvino/genai/text_streamer.hpp"
+
+std::string get_prompt(const std::string& file_path) {
+    std::ifstream f(file_path, std::ios::in);
+    if (!f.is_open()) {
+        throw std::runtime_error("Cannot open prompt file: " + file_path);
+    }
+    std::stringstream buffer;
+    buffer << f.rdbuf();
+    return buffer.str();
+}
+
+void print_handle_response(const ov::genai::GenerationHandle& h,
+                           ov::genai::Tokenizer& tokenizer,
+                           const std::shared_ptr<ov::genai::Lfm2Parser>& parser) {
+    const auto outputs = h->read_all();
+    
+    for (size_t out_idx = 0; out_idx < outputs.size(); ++out_idx) {
+        const auto text = tokenizer.decode(outputs[out_idx].generated_ids);
+        ov::genai::JsonContainer parsed_message;
+        parsed_message["content"] = text;
+        parser->parse(parsed_message);
+
+        std::cout << "Response: " << text << std::endl;
+        std::cout << "Parsed: " << parsed_message.to_json_string(2) << std::endl;
+
+        if (parsed_message.contains("tool_calls")) {
+            std::cout << "Tool calls: " << parsed_message["tool_calls"].to_json_string(2) << std::endl;
+        }
+    }
+}
+
+
+int main(int argc, char* argv[]) try {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <model_dir> <prompt_file> \n";
+        return EXIT_FAILURE;
+    }
+
+    const std::string model_dir = argv[1];
+    const std::string prompt_file1 = argv[2];
+
+    const std::string prompt1 = get_prompt(prompt_file1);
+
+    const std::string device = "CPU";
+
+    ov::genai::SchedulerConfig scheduler_config;
+    scheduler_config.enable_prefix_caching = true;
+
+    ov::genai::ContinuousBatchingPipeline pipe(model_dir, scheduler_config, device);
+
+    ov::genai::GenerationConfig config;
+    config.temperature = 0.0f;
+    config.max_new_tokens = 10;
+    config.apply_chat_template = false;
+    auto parser = std::make_shared<ov::genai::Lfm2Parser>();
+    config.parsers.push_back(parser);
+    auto tokenizer = pipe.get_tokenizer();
+
+    auto h1 = pipe.add_request(5, prompt1, config);
+
+    while (pipe.has_non_finished_requests()) {
+        pipe.step();
+    }
+    std::cout << "Generation finished for Unary call\n";
+    print_handle_response(h1, tokenizer, parser);
+
+
+    std::cout << "Adding second request with streaming\n";
+    parser->reset();
+    auto streaming_callback = [parser](std::string chunk) -> ov::genai::StreamingStatus {
+        std::string delta_text = chunk;
+        ov::genai::JsonContainer delta_message;
+        const std::string filtered_text = parser->parseChunk(delta_message, delta_text);
+
+        std::cout << "Delta text: " << delta_text << std::endl;
+        std::cout << "Filtered text: " << filtered_text << std::endl;
+        std::cout << "Delta message: " << delta_message.to_json_string(2) << std::endl;
+
+        if (delta_message.contains("tool_calls")) {
+            std::cout << "Tool calls: " << delta_message["tool_calls"].to_json_string(2) << std::endl;
+        }
+        return ov::genai::StreamingStatus::RUNNING;
+    };
+
+    auto text_streamer = std::make_shared<ov::genai::TextStreamer>(tokenizer, streaming_callback);
+    std::vector<std::string> prompts = {prompt1};
+    std::vector<ov::genai::GenerationConfig> sampling_params = {config};
+    pipe.generate(prompts, sampling_params, text_streamer);
+    std::cout << "Generation finished for streaming call\n";
+
+
+
+    return EXIT_SUCCESS;
+} catch (const std::exception& e) {
+    std::cerr << e.what() << "\n";
+    return EXIT_FAILURE;
+}

--- a/src/cpp/include/openvino/genai/parsers.hpp
+++ b/src/cpp/include/openvino/genai/parsers.hpp
@@ -25,8 +25,31 @@ public:
      * information as needed. The results are stored in the provided JsonContainer.
      *
      * @param message JsonContainer containing the text to parse and to store results
+     * @param tokens Optional vector of token IDs associated with the text, which can be used for more efficient token-based parsing if supported by the implementation.
      */
-    virtual void parse(JsonContainer& message) = 0;
+    virtual void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens = std::nullopt) = 0;
+
+        /**
+     * @brief Parse incremental text content and return filtered text.
+     *
+     * This method processes incoming delta_text and returns filtered text that should
+     * be added to the content.
+     *
+     * @param delta_message JsonContainer to store parsed results and metadata
+     * @param delta_text New text chunk to be processed in this step and modified in place
+     * @param delta_tokens Optional vector of new token IDs to be processed in case if more fast token-based processing is needed.
+     * @return std::string filtered text that should be added to the 'content'
+     */
+    virtual std::string parseChunk(
+        JsonContainer& delta_message,
+        std::string& delta_text,
+        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
+    ) = 0;
+
+    /**
+     * @brief Reset the internal state of the parser.
+     */
+    virtual void reset() = 0;
 };
 
 class OPENVINO_GENAI_EXPORTS ReasoningParser : public Parser {
@@ -46,6 +69,9 @@ public:
         bool keep_original_content = true,
         const std::string& open_tag = "<think>",
         const std::string& close_tag = "</think>");
+
+    ReasoningParser(ReasoningParser&&) noexcept;
+    ReasoningParser& operator=(ReasoningParser&&) noexcept;
     
     /**
      * @brief Parse complete text content at the end of generate call.
@@ -54,8 +80,29 @@ public:
      * information as needed. The results are stored in the provided JsonContainer.
      *
      * @param message JsonContainer containing the text to parse and to store results
+     * @param tokens Optional vector of token IDs associated with the text, which can be used for more efficient token-based parsing if supported by the implementation.
      */
-    void parse(JsonContainer& message) override;
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens = std::nullopt) override;
+
+    /**
+     * @brief Parse incremental text content and return filtered text.
+     *
+     * ReasoningParser does not implement streaming-specific filtering.
+     * This default implementation returns the incoming delta_text unchanged.
+     */
+    std::string parseChunk(
+        JsonContainer& delta_message,
+        std::string& delta_text,
+        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
+    ) override;
+
+    /**
+     * @brief Reset the internal state of the parser.
+     *
+     * ReasoningParser does not maintain streaming state in this default implementation.
+     */
+    void reset() override;
+
     ~ReasoningParser();
 private:
     class ReasoningParserImpl;
@@ -102,8 +149,32 @@ public:
      * and adds the 'tool_calls' to the JsonContainer without modifying the original content.
      *
      * @param message JsonContainer containing the text to parse and to store tool call results
+     * @param tokens Optional vector of token IDs associated with the text, which can be used for more efficient token-based parsing if supported by the implementation.
      */
-    void parse(JsonContainer& message) override;
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens = std::nullopt) override;
+
+    /**
+     * @brief Parse incremental text content for Llama 3 Pythonic tool calls.
+     *
+     * Current implementation does not perform incremental tool-call extraction and
+     * returns the input delta_text unchanged.
+     */
+    std::string parseChunk(
+        JsonContainer& delta_message,
+        std::string& delta_text,
+        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
+    ) override {
+        (void)delta_message;
+        (void)delta_tokens;
+        return delta_text;
+    }
+
+    /**
+     * @brief Reset internal parser state.
+     *
+     * Current implementation has no internal state to reset.
+     */
+    void reset() override {}
 private:
     class Llama3PythonicToolParserImpl;
     std::unique_ptr<Llama3PythonicToolParserImpl> m_impl;
@@ -128,132 +199,36 @@ public:
      * and adds the tool calls to the JsonContainer without modifying the original content.
      *
      * @param message JsonContainer containing the text to parse and to store tool call results
+     * @param tokens Optional vector of token IDs associated with the text, which can be used for more efficient token-based parsing if supported by the implementation.
+     */ 
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens = std::nullopt) override;
+
+    /**
+     * @brief Parse incremental text content for Llama 3 JSON tool calls.
+     *
+     * Current implementation does not perform incremental tool-call extraction and
+     * returns the input delta_text unchanged.
      */
-    void parse(JsonContainer& message) override;
+    std::string parseChunk(
+        JsonContainer& delta_message,
+        std::string& delta_text,
+        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
+    ) override {
+        (void)delta_message;
+        (void)delta_tokens;
+        return delta_text;
+    }
+
+    /**
+     * @brief Reset internal parser state.
+     *
+     * Current implementation has no internal state to reset.
+     */
+    void reset() override {}
+
 private:
     class Llama3JsonToolParserImpl;
     std::unique_ptr<Llama3JsonToolParserImpl> m_impl;
-};
-
-/**
- * @brief Abstract base class for incremental parsers that process text during streaming.
- *
- * Derived classes must implement both the `parse()` and `reset()` methods, as these are pure virtual.
- *
- * Use `IncrementalParser` when you need to process text as it is generated (e.g., in streaming scenarios),
- * handling partial content and maintaining internal state between increments. 
- * In case of processing complete text after generation has finished, `Parser` should be used.
- *
- * Example:
- * @code
- * class MyIncrementalParser : public ov::genai::IncrementalParser {
- * public:
- *     std::string parse(JsonContainer& delta_message, std::string& delta_text,
- *                       const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt) override {
- *         // Implement incremental parsing logic here
- *         return delta_text; // Example: simply return the input
- *     }
- *     void reset() override {
- *         // Reset internal state here
- *     }
- * };
- * @endcode
- */
-class OPENVINO_GENAI_EXPORTS IncrementalParser {
-public:
-    IncrementalParser() = default;
-
-    /**
-     * @brief Parse incremental text content and return filtered text.
-     *
-     * This method processes incoming delta_text and returns filtered text that should
-     * be added to the content.
-     *
-     * @param delta_message JsonContainer to store parsed results and metadata
-     * @param delta_text New text chunk to be processed in this step and modified in place
-     * @param delta_tokens Optional vector of new token IDs to be processed in case if more fast token-based processing is needed.
-     * @return std::string filtered text that should be added to the 'content'
-     */
-    virtual std::string parse(
-        JsonContainer& delta_message,
-        std::string& delta_text,
-        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
-    ) = 0;
-
-    /**
-     * @brief Reset the internal state of the parser.
-     */
-    virtual void reset() = 0;
-
-    virtual ~IncrementalParser() = default;
-};
-
-/**
- * @brief Incremental parser for reasoning content with configurable tags.
- *
- * Extracts text with open and close tags. Original JsonContainer must have 'content' field.
- * The reasoning content is stored in the 'reasoning_content' field of the JsonContainer.
- */
-class OPENVINO_GENAI_EXPORTS ReasoningIncrementalParser : public IncrementalParser {
-public:
-    /**
-     * @brief Constructor for ReasoningIncrementalParser.
-     *
-     * @param expect_open_tag If true then open_tag is expected to be generated, if false then it's already part of the model input string
-     * @param keep_original_content If true then original 'content' is preserved, otherwise reasoning text is removed from 'content'
-     * @param open_tag The opening tag (default: "<think>")
-     * @param close_tag The closing tag (default: "</think>")
-     */
-    ReasoningIncrementalParser(bool expect_open_tag = true,
-                    bool keep_original_content = true,
-                    const std::string& open_tag = "<think>",
-                    const std::string& close_tag = "</think>");
-    virtual ~ReasoningIncrementalParser();
-
-    /**
-     * @brief Parse reasoning content incrementally.
-     *
-     * Processes text streams containing reasoning sections marked by configurable tags.
-     * Can filter out reasoning content or preserve it based on parser configuration.
-     *
-     * @param delta_message JsonContainer to store parsed results and reasoning metadata
-     * @param delta_text New text chunk to be processed in this step
-     * @param delta_tokens Optional vector of new token IDs to be processed
-     * @return std::string filtered text that should be added to the 'content'
-     */
-    std::string parse(
-        JsonContainer& delta_message,
-        std::string& delta_text,
-        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
-    ) override;
-
-    /**
-     * @brief Reset the internal state of the parser.
-     */
-    void reset() override;
-private:
-    class ReasoningParserImpl;
-    std::unique_ptr<ReasoningParserImpl> m_impl;
-};
-
-/**
- * @brief Incremental parser for DeepSeek R1 model reasoning format.
- *
- * DeepSeekR1ReasoningIncrementalParser is configured for the DeepSeek R1 model's reasoning format, which doesn't expect an opening tag.
- */
-class OPENVINO_GENAI_EXPORTS DeepSeekR1ReasoningIncrementalParser : public ReasoningIncrementalParser {
-public:
-    DeepSeekR1ReasoningIncrementalParser() : ReasoningIncrementalParser(/*expect_open_tag=*/false) {};
-};
-
-/**
- * @brief Incremental parser for Phi-4 model reasoning format.
- *
- * Phi4ReasoningIncrementalParser is configured specifically for the Phi-4 model's reasoning format, which expects an opening tag by default.
- */
-class OPENVINO_GENAI_EXPORTS Phi4ReasoningIncrementalParser : public ReasoningIncrementalParser {
-public:
-    Phi4ReasoningIncrementalParser() : ReasoningIncrementalParser(/*expect_open_tag=*/true) {};
 };
 
 }  // namespace genai

--- a/src/cpp/include/openvino/genai/parsers/lfm2_tool_parser.hpp
+++ b/src/cpp/include/openvino/genai/parsers/lfm2_tool_parser.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "../parsers.hpp"
+
+namespace ov {
+namespace genai {
+
+
+
+/**
+ * @brief Parser for Lfm2 calls format.
+ *
+ * Lfm2Parser extracts tool calls from text content formatted
+ * in Lfm2's style, e.g. {"type": "function", "function": {"name": "get_weather", "parameters": {"location": "New York, NY", ...}}}.
+ * It does not modify the original content, only extracts and adds tool call information to the message.
+ */
+class OPENVINO_GENAI_EXPORTS Lfm2Parser : public Parser {
+public:
+    Lfm2Parser();
+    ~Lfm2Parser();
+    
+    /**
+     * @brief Parse Lfm2 tool calls from text.
+     *
+     * Extracts tool call information from text formatted in Lfm2's style
+     * and adds the tool calls to the JsonContainer without modifying the original content.
+     *
+     * @param message JsonContainer containing the text to parse and to store tool call results
+     * @param tokens Optional vector of token IDs associated with the text, which can be used for more efficient token-based parsing if supported by the implementation.
+     */ 
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens = std::nullopt) override;
+
+    std::string parseChunk(
+        JsonContainer& delta_message,
+        std::string& delta_text,
+        const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
+    ) override;
+
+    void reset() override;
+private:
+    class Lfm2ParserImpl;
+    std::unique_ptr<Lfm2ParserImpl> m_impl;
+};
+
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/include/openvino/genai/text_streamer.hpp
+++ b/src/cpp/include/openvino/genai/text_streamer.hpp
@@ -52,7 +52,7 @@ public:
     class TextParserStreamerImpl;
     using TextStreamer::write;
     
-    TextParserStreamer(const Tokenizer& tokenizer, std::vector<std::shared_ptr<IncrementalParser>> parsers = {});
+    TextParserStreamer(const Tokenizer& tokenizer, std::vector<std::shared_ptr<Parser>> parsers = {});
     ~TextParserStreamer();
     
     virtual StreamingStatus write(JsonContainer& message) = 0;

--- a/src/cpp/src/parsers.cpp
+++ b/src/cpp/src/parsers.cpp
@@ -8,34 +8,21 @@
 
 namespace ov::genai {
 
-class ReasoningIncrementalParser::ReasoningParserImpl {
+class ReasoningParser::ReasoningParserImpl {
 private:
-    // Values initialized from constructor don't need default member initializer.
     bool m_expect_open_tag;
     bool m_keep_original_content;
     std::string m_open_tag;
     std::string m_close_tag;
-    // Values with default member initializers are reset on each reset() call.
     bool m_first_run = true;
     bool m_think_tag_opened = false;
-    std::string m_text_cache = "";
+    std::string m_text_cache;
     bool m_deactivated = false;
 
-    /**
-     * @brief Find the longest suffix of text that is a prefix of the close tag.
-     * 
-     * This is used to detect if the close tag is split across multiple chunks.
-     * For example, if text ends with "</th" and m_close_tag is "</think>", 
-     * this returns 4 (the length of "</th").
-     * 
-     * @param text The text to check (using string_view for efficient read-only access)
-     * @return The number of characters at the end of text that match the start of m_close_tag
-     */
     size_t find_close_tag_prefix_length(std::string_view text) const {
         const size_t max_check = std::min(text.size(), m_close_tag.size());
         size_t longest_match = 0;
         for (size_t i = 1; i <= max_check; ++i) {
-            // Compare the last i characters of text with the first i characters of m_close_tag
             if (text.compare(text.size() - i, i, m_close_tag, 0, i) == 0) {
                 longest_match = i;
             }
@@ -43,17 +30,14 @@ private:
         return longest_match;
     }
 
-    /**
-     * @brief Handle the case where both open and close tags are found in the same chunk.
-     */
     void handle_complete_reasoning(JsonContainer& message, std::string_view txt_chunk,
                                    size_t open_idx, size_t close_idx, std::string& delta_text) {
-        // Extract reasoning content between tags
-        message["reasoning_content"] = std::string(txt_chunk.substr(open_idx + m_open_tag.size(), close_idx - (open_idx + m_open_tag.size())));
+        message["reasoning_content"] = std::string(txt_chunk.substr(open_idx + m_open_tag.size(), 
+                                                                     close_idx - (open_idx + m_open_tag.size())));
         message["content"] = std::string(txt_chunk.substr(close_idx + m_close_tag.size()));
         
         if (!m_keep_original_content) {
-            delta_text = std::string(txt_chunk.substr(close_idx + m_close_tag.size()));
+            delta_text = message["content"].get_string();
         }
         
         m_think_tag_opened = false;
@@ -61,11 +45,8 @@ private:
         m_text_cache.clear();
     }
 
-    /**
-     * @brief Handle the case where only the open tag is found.
-     */
-    void handle_open_tag(JsonContainer& delta_message, std::string_view txt_chunk, size_t open_idx, std::string& delta_text) {
-        // Start accumulating reasoning content
+    void handle_open_tag(JsonContainer& delta_message, std::string_view txt_chunk, 
+                         size_t open_idx, std::string& delta_text) {
         delta_message["reasoning_content"] = std::string(txt_chunk.substr(open_idx + m_open_tag.size()));
         
         if (!m_keep_original_content) {
@@ -78,11 +59,8 @@ private:
         m_text_cache.clear();
     }
 
-    /**
-     * @brief Handle the case where the close tag is found.
-     */
-    void handle_close_tag(JsonContainer& delta_message, std::string_view txt_chunk, size_t close_idx, std::string& delta_text) {
-        // Append text before close tag to reasoning content
+    void handle_close_tag(JsonContainer& delta_message, std::string_view txt_chunk, 
+                          size_t close_idx, std::string& delta_text) {
         delta_message["reasoning_content"] = std::move(std::string(txt_chunk.substr(0, close_idx)));
         auto content = std::string(txt_chunk.substr(close_idx + m_close_tag.size()));
         delta_message["content"] = content;
@@ -102,21 +80,15 @@ private:
         m_deactivated = true;
     }
 
-    /**
-     * @brief Handle accumulating text while inside reasoning tags.
-     */
     void handle_inside_reasoning(JsonContainer& delta_message, std::string_view txt_chunk, std::string& delta_text) {
-        // Find if the end of txt_chunk might be the start of a close tag
         const size_t num_chars_to_keep = find_close_tag_prefix_length(txt_chunk);
         
         std::string reason_str;
         if (num_chars_to_keep > 0) {
-            // Keep potential partial close tag in cache
             m_text_cache = std::string(txt_chunk.substr(txt_chunk.size() - num_chars_to_keep));
-            reason_str = txt_chunk.substr(0, txt_chunk.size() - num_chars_to_keep);
+            reason_str = std::string(txt_chunk.substr(0, txt_chunk.size() - num_chars_to_keep));
         } else {
-            // No partial close tag, accumulate all text
-            reason_str = txt_chunk;
+            reason_str = std::string(txt_chunk);
             m_text_cache.clear();
         }
         delta_message["reasoning_content"] = std::move(reason_str);
@@ -131,19 +103,37 @@ public:
     ReasoningParserImpl() = default;
     
     ReasoningParserImpl(bool expect_open_tag,
-                    bool keep_original_content,
-                    const std::string& open_tag, 
-                    const std::string& close_tag)
+                       bool keep_original_content,
+                       const std::string& open_tag, 
+                       const std::string& close_tag)
         : m_expect_open_tag(expect_open_tag),
           m_keep_original_content(keep_original_content),
           m_open_tag(open_tag),
           m_close_tag(close_tag) {}
 
-    std::string parse(
-        JsonContainer&  delta_message,
-        std::string& delta_text,
-        const std::optional<std::vector<int64_t>>& delta_tokens
-    ) {
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& /*tokens*/) {
+        std::string reasoning_content;
+        std::string content = message["content"].get_string();
+
+        size_t start = content.find(m_open_tag);
+        size_t end = content.find(m_close_tag);
+
+        if (start != std::string::npos && end != std::string::npos && end > start) {
+            reasoning_content = content.substr(start + m_open_tag.size(), 
+                                              end - (start + m_open_tag.size()));
+            if (!m_keep_original_content) {
+                message["content"] = content.substr(0, start) + content.substr(end + m_close_tag.size());
+            }
+        } else {
+            reasoning_content = "";
+        }
+
+        message["reasoning_content"] = reasoning_content;
+    }
+
+    std::string parseChunk(JsonContainer& delta_message,
+                          std::string& delta_text,
+                          const std::optional<std::vector<int64_t>>& /*delta_tokens*/) {
         if (m_deactivated) {
             return delta_text;
         }
@@ -152,15 +142,12 @@ public:
         }
         m_first_run = false;
 
-        
         std::string txt_chunk = m_text_cache + delta_text;
 
-        // Cache find() results to avoid redundant searches
         const auto open_idx = txt_chunk.find(m_open_tag);
         const auto close_idx = txt_chunk.find(m_close_tag);
 
         if (!m_think_tag_opened && open_idx != std::string::npos && m_expect_open_tag) {
-            // Check if close tag is also present after the open tag
             const auto close_idx_after_open = (close_idx != std::string::npos && close_idx > open_idx) 
                                                ? close_idx : std::string::npos;
             
@@ -174,11 +161,7 @@ public:
         } else if (m_think_tag_opened) {
             handle_inside_reasoning(delta_message, txt_chunk, delta_text);
         } else {
-            // Think tag was not opened yet and not found in the current delta_text.
-            // Accumulate text in the cache to detect if <think> is split between several delta_text pieces.
             m_text_cache += delta_text;
-            // Clear delta_text while waiting for complete <think> tag detection in cache.
-            // accumulating partial data in m_text_cache until the full <think> tag is detected.
             delta_text.clear();
         }
         return delta_text;
@@ -187,37 +170,42 @@ public:
     void reset() {
         m_first_run = true;
         m_think_tag_opened = false;
-        m_text_cache = "";
+        m_text_cache.clear();
         m_deactivated = false;
     }
+
+    ~ReasoningParserImpl() = default;
 };
 
-ReasoningIncrementalParser::ReasoningIncrementalParser(bool expect_open_tag, bool keep_original_content, const std::string& open_tag, const std::string& close_tag) {
-    m_impl = std::make_unique<ReasoningParserImpl>(expect_open_tag, keep_original_content, open_tag, close_tag);
+ReasoningParser::ReasoningParser(bool expect_open_tag, bool keep_original_content, 
+                                 const std::string& open_tag, const std::string& close_tag)
+    : m_impl(std::make_unique<ReasoningParserImpl>(expect_open_tag, keep_original_content, open_tag, close_tag)) {}
+
+ReasoningParser::ReasoningParser(ReasoningParser&&) noexcept = default;
+
+ReasoningParser& ReasoningParser::operator=(ReasoningParser&&) noexcept = default;
+
+void ReasoningParser::parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens) {
+    m_impl->parse(message, tokens);
 }
 
-ReasoningIncrementalParser::~ReasoningIncrementalParser() = default;
-
-std::string ReasoningIncrementalParser::parse(
-    JsonContainer& delta_message,
-    std::string& delta_text,
-    const std::optional<std::vector<int64_t>>& delta_tokens
-) {
-    return m_impl->parse(delta_message, delta_text, delta_tokens);
+std::string ReasoningParser::parseChunk(JsonContainer& delta_message, 
+                                       std::string& delta_text,
+                                       const std::optional<std::vector<int64_t>>& delta_tokens) {
+    return std::move(m_impl->parseChunk(delta_message, delta_text, delta_tokens));
 }
 
-void ReasoningIncrementalParser::reset() {
+void ReasoningParser::reset() {
     m_impl->reset();
 }
 
-class Llama3PythonicToolParser::Llama3PythonicToolParserImpl {
-public:
-    std::regex m_pattern = std::regex(R"(\[(.*?)\])");
-    void parse(JsonContainer& message) {
-        // Input example
-        // string message = "[get_weather(location='New York, NY', unit='celsius')]<|eom_id|>";
+ReasoningParser::~ReasoningParser() = default;
 
-        // Regex to capture the [...] part
+class Llama3PythonicToolParser::Llama3PythonicToolParserImpl  {
+public:
+    std::regex m_pattern{R"(\[(.*?)\])"};
+
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& /*tokens*/) {
         std::smatch m;
         const std::string& text = message["content"].get_string();
 
@@ -225,41 +213,27 @@ public:
             return;
         }
 
-        // Strip outer [ ]
         std::string call = m.str().substr(1, m.str().size() - 2);
 
         size_t pos = call.find('(');
         std::string name = call.substr(0, pos);
-        std::string args = call.substr(pos + 1, call.size() - pos - 2); // inside (...)
+        std::string args = call.substr(pos + 1, call.size() - pos - 2);
         
         JsonContainer kv;
-        // Parse arguments of the form key="value"
         std::regex arg_re(R"((\w+)\s*=\s*\"([^"]*)\")");
         auto it = std::sregex_iterator(args.begin(), args.end(), arg_re);
         for (; it != std::sregex_iterator(); ++it) {
             kv[std::string((*it)[1])] = std::string((*it)[2]);
         }
         
-        // Split function name and arguments
         message["tool_calls"] = JsonContainer::array();
         message["tool_calls"].push_back(JsonContainer({{"name", name}, {"arguments", kv}}));
     }
 };
 
-Llama3PythonicToolParser::Llama3PythonicToolParser() {
-    m_impl = std::make_unique<Llama3PythonicToolParserImpl>();
-}
-
-void Llama3PythonicToolParser::parse(JsonContainer& message) {
-    m_impl->parse(message);
-}
-
-Llama3PythonicToolParser::~Llama3PythonicToolParser() = default;
-
 class Llama3JsonToolParser::Llama3JsonToolParserImpl {
 public:
-    void parse(JsonContainer& message) {
-        // Find JSON in the message
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& /*tokens*/) {
         std::string msg_content = message["content"].get_string();
 
         size_t json_start = msg_content.find('{');
@@ -273,63 +247,27 @@ public:
     }
 };
 
+
+Llama3PythonicToolParser::Llama3PythonicToolParser() {
+    m_impl = std::make_unique<Llama3PythonicToolParserImpl>();
+}
+
+void Llama3PythonicToolParser::parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens) {
+    m_impl->parse(message, tokens);
+}
+
+Llama3PythonicToolParser::~Llama3PythonicToolParser() = default;
+
 Llama3JsonToolParser::Llama3JsonToolParser() {
     m_impl = std::make_unique<Llama3JsonToolParserImpl>();
 }
 
-void Llama3JsonToolParser::parse(JsonContainer& message) {
-    m_impl->parse(message);
+void Llama3JsonToolParser::parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens) {
+    m_impl->parse(message, tokens);
 }
 
 Llama3JsonToolParser::~Llama3JsonToolParser() = default;
 
-class ReasoningParser::ReasoningParserImpl {
-public:
-    ReasoningParserImpl(bool expect_open_tag,
-                            bool keep_original_content,
-                            const std::string& open_tag,
-                            const std::string& close_tag):
-    m_expect_open_tag(expect_open_tag),
-    m_keep_original_content(keep_original_content),
-    m_open_tag(open_tag),
-    m_close_tag(close_tag) {};
-
-    void parse(JsonContainer& message) {
-        std::string reasoning_content;
-        std::string content = message["content"].get_string();
-
-        size_t start = content.find(m_open_tag);
-        size_t end = content.find(m_close_tag);
-
-        if (start != std::string::npos && end != std::string::npos && end > start) {
-            reasoning_content = content.substr(start + m_open_tag.size(), end - (start + m_open_tag.size()));
-            if (!m_keep_original_content) {
-                // Remove <think>...</think/> from content
-                message["content"] = content.substr(0, start) + content.substr(end + m_close_tag.size());
-            }
-        } else {
-            reasoning_content = "";
-        }
-
-        message["reasoning_content"] = reasoning_content;
-    }
-private:
-    bool m_expect_open_tag;
-    bool m_keep_original_content;
-    std::string m_open_tag;
-    std::string m_close_tag;
-};
-
-ReasoningParser::ReasoningParser(bool expect_open_tag, bool keep_original_content, const std::string& open_tag, const std::string& close_tag) {
-    m_impl = std::make_unique<ReasoningParserImpl>(expect_open_tag, keep_original_content, open_tag, close_tag);
-}
-
-void ReasoningParser::parse(JsonContainer& message) {
-    m_impl->parse(message);
-}
-
-ReasoningParser::~ReasoningParser() = default;
-
 Parser::~Parser() = default;
 
-} // namespace ov::genai
+}  // namespace ov::genai

--- a/src/cpp/src/parsers/lfm2_tool_parser.cpp
+++ b/src/cpp/src/parsers/lfm2_tool_parser.cpp
@@ -1,0 +1,38 @@
+
+#include "openvino/genai/parsers/lfm2_tool_parser.hpp"
+
+namespace ov::genai {
+
+
+class Lfm2Parser::Lfm2ParserImpl {
+public:
+    void parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& /*tokens*/) {
+        std::string msg_content = message["content"].get_string();
+        auto res = JsonContainer::array();
+        res.push_back(JsonContainer::from_json_string("{\"my tool\":\"test\"}"));
+        message["tool_calls"] = res;
+    }
+};
+
+
+Lfm2Parser::Lfm2Parser() {
+    m_impl = std::make_unique<Lfm2ParserImpl>();
+}
+
+void Lfm2Parser::parse(JsonContainer& message, const std::optional<std::vector<int64_t>>& tokens) {
+    m_impl->parse(message, tokens);
+}
+
+std::string Lfm2Parser::parseChunk(JsonContainer& delta_message,
+                                   std::string& delta_text,
+                                   const std::optional<std::vector<int64_t>>& /*delta_tokens*/) {
+    return delta_text;
+}
+
+void Lfm2Parser::reset() {
+    // Stateless parser; nothing to reset.
+}
+
+Lfm2Parser::~Lfm2Parser() = default;
+
+}

--- a/src/cpp/src/text_streamer.cpp
+++ b/src/cpp/src/text_streamer.cpp
@@ -137,14 +137,14 @@ StreamerBase::~StreamerBase() = default;
 class TextParserStreamer::TextParserStreamerImpl {
 public:
 
-std::vector<std::shared_ptr<IncrementalParser>> m_parsers;
+std::vector<std::shared_ptr<Parser>> m_parsers;
 JsonContainer m_parsed_message;
 
-TextParserStreamerImpl(std::vector<std::shared_ptr<IncrementalParser>> parsers) : m_parsers{parsers} {}
+TextParserStreamerImpl(std::vector<std::shared_ptr<Parser>> parsers) : m_parsers{parsers} {}
 
 };
 
-TextParserStreamer::TextParserStreamer(const Tokenizer& tokenizer, std::vector<std::shared_ptr<IncrementalParser>> parsers) 
+TextParserStreamer::TextParserStreamer(const Tokenizer& tokenizer, std::vector<std::shared_ptr<Parser>> parsers) 
     : TextStreamer(tokenizer, [this](std::string s) -> CallbackTypeVariant {
                 return this->write(s);
     }), m_pimpl{std::make_unique<TextParserStreamerImpl>(parsers)} {
@@ -186,7 +186,7 @@ CallbackTypeVariant TextParserStreamer::write(std::string delta_text) {
     JsonContainer delta_message;
     // Iterate over all parsers and apply them to the message
     for (auto& parser: m_pimpl->m_parsers) {
-        delta_text = parser->parse(delta_message, delta_text, flushed_tokens);
+        delta_text = parser->parseChunk(delta_message, delta_text, flushed_tokens);
         // Message can be modified inside parser, if parser for example extracted tool calling from message content
     }
     delta_message["content"] = delta_text;

--- a/src/python/py_parsers.cpp
+++ b/src/python/py_parsers.cpp
@@ -13,13 +13,9 @@
 
 namespace py = pybind11;
 
-using ov::genai::IncrementalParser;
 using ov::genai::Parser;
 using ov::genai::ReasoningParser;
-using ov::genai::ReasoningIncrementalParser;
 using ov::genai::DeepSeekR1ReasoningParser;
-using ov::genai::DeepSeekR1ReasoningIncrementalParser;
-using ov::genai::Phi4ReasoningIncrementalParser;
 using ov::genai::Phi4ReasoningParser;
 using ov::genai::JsonContainer;
 using ov::genai::Llama3JsonToolParser;
@@ -33,7 +29,8 @@ namespace {
 
 class ConstructableParser: public Parser {
 public:
-    void parse(JsonContainer& msg) override {
+    void parse(JsonContainer& msg,
+               const std::optional<std::vector<int64_t>>& tokens = std::nullopt) override {
         py::gil_scoped_acquire acquire;
         
         py::function parse_method = py::get_override(static_cast<const Parser*>(this), "parse");
@@ -43,42 +40,48 @@ public:
         
         // Convert JsonContainer to py::dict
         py::dict py_msg = pyutils::json_container_to_py_object(msg);
-        parse_method(py_msg);
+        try {
+            parse_method(py_msg, tokens);
+        } catch (const py::type_error&) {
+            parse_method(py_msg);
+        }
         msg = pyutils::py_object_to_json_container(py_msg);
     }
-};
 
-// ConstructableIncremental and ConstructableBase are used when python overload is called from C++
-// and we need to convert JsonContainer to py::dict and then update back JsonContainer from the py::dict which was modified in Python.
-class ConstructableIncrementalParser: public IncrementalParser {
-public:
-    using IncrementalParser::IncrementalParser;
-    std::string parse(
+    std::string parseChunk(
         JsonContainer& msg,
-        std::string& delta_text, 
+        std::string& delta_text,
         const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt
     ) override {
         py::gil_scoped_acquire acquire;
-        // Convert JsonContainer to py::dict
-        py::dict py_msg = pyutils::json_container_to_py_object(msg);
 
-        py::function parse_method = py::get_override(static_cast<const IncrementalParser*>(this), "parse");
-        if (!parse_method) {
-            OPENVINO_THROW("parse method not implemented in Python subclass");
+        py::function parse_chunk_method = py::get_override(static_cast<const Parser*>(this), "parse_chunk");
+        if (!parse_chunk_method) {
+            parse_chunk_method = py::get_override(static_cast<const Parser*>(this), "parseChunk");
+        }
+        if (!parse_chunk_method) {
+            OPENVINO_THROW("parse_chunk/parseChunk method not implemented in Python subclass");
         }
 
-        auto res = parse_method(py_msg, delta_text, delta_tokens);
+        py::dict py_msg = pyutils::json_container_to_py_object(msg);
+        py::object res;
+        try {
+            res = parse_chunk_method(py_msg, delta_text, delta_tokens);
+        } catch (const py::type_error&) {
+            res = parse_chunk_method(py_msg, delta_text);
+        }
         msg = pyutils::py_object_to_json_container(py_msg);
-        
         return res.cast<std::string>();
     }
 
     void reset() override {
-        PYBIND11_OVERLOAD_PURE(
-            void,
-            IncrementalParser,
-            reset,
-        );
+        py::gil_scoped_acquire acquire;
+
+        py::function reset_method = py::get_override(static_cast<const Parser*>(this), "reset");
+        if (!reset_method) {
+            OPENVINO_THROW("reset method not implemented in Python subclass");
+        }
+        reset_method();
     }
 };
 
@@ -132,7 +135,8 @@ public:
         OPENVINO_ASSERT(!m_parsers.empty(), "Provided vLLM parser does not have supported parsing methods: 'extract_tool_calls' or 'extract_reasoning'");
     }
 
-    void parse(JsonContainer& message) override {
+    void parse(JsonContainer& message,
+               const std::optional<std::vector<int64_t>>& /*tokens*/ = std::nullopt) override {
         py::gil_scoped_acquire acquire;
 
         JsonContainer new_message;
@@ -148,6 +152,14 @@ public:
         }
         message = new_message;
     }
+
+    std::string parseChunk(JsonContainer& /*delta_message*/,
+                           std::string& delta_text,
+                           const std::optional<std::vector<int64_t>>& /*delta_tokens*/ = std::nullopt) override {
+        return delta_text;
+    }
+
+    void reset() override {}
 };
 
 } // namespace
@@ -163,7 +175,21 @@ void init_parsers(py::module_& m) {
                 message.attr("update")(result);
             },
             py::arg("message"),
-            "Parse is called with the full text. Returns a dict with parsed content.");
+            "Parse is called with the full text. Returns a dict with parsed content.")
+        .def("parse_chunk",
+            [](Parser& self,
+               py::dict& delta_message,
+               std::string& delta_text,
+               const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt) {
+                auto msg_cpp = pyutils::py_object_to_json_container(delta_message);
+                auto res = self.parseChunk(msg_cpp, delta_text, delta_tokens);
+                auto result = pyutils::json_container_to_py_object(msg_cpp);
+                delta_message.attr("update")(result);
+                return res;
+            },
+            py::arg("delta_message"), py::arg("delta_text"), py::arg("delta_tokens") = std::nullopt,
+            "Parse is called for every decoded text delta. Returns text to append to output.")
+        .def("reset", &Parser::reset, "Reset the internal state of the parser.");
 
     py::class_<ReasoningParser, std::shared_ptr<ReasoningParser>, Parser>(m, "ReasoningParser")
         .def(py::init<bool, bool, const std::string&, const std::string&>(),
@@ -183,34 +209,12 @@ void init_parsers(py::module_& m) {
 
     py::class_<Llama3PythonicToolParser, std::shared_ptr<Llama3PythonicToolParser>, Parser>(m, "Llama3PythonicToolParser")
         .def(py::init<>());
-    
-    py::class_<IncrementalParser, ConstructableIncrementalParser, std::shared_ptr<IncrementalParser>>(m, "IncrementalParser")
-        .def(py::init<>())
-        .def("parse", [](IncrementalParser& self,
-                         py::dict& delta_message,
-                         std::string& delta_text,
-                         const std::optional<std::vector<int64_t>>& delta_tokens = std::nullopt) {
-            auto msg_cpp = pyutils::py_object_to_json_container(delta_message);
-            auto res = self.parse(msg_cpp, delta_text, delta_tokens);
-            auto result = pyutils::json_container_to_py_object(msg_cpp);
-            delta_message.attr("update")(result);
-            return res;
-        }, py::arg("delta_message"), py::arg("delta_text"), py::arg("delta_tokens") = std::nullopt,
-           "Parse is called every time new text delta is decoded. Returns a string with any additional text to append to the current output.")
-        .def("reset", &IncrementalParser::reset, "Reset the internal state of the parser.");
-    
-    py::class_<ReasoningIncrementalParser, std::shared_ptr<ReasoningIncrementalParser>, IncrementalParser>(m, "ReasoningIncrementalParser")
-        .def(py::init<bool, bool, const std::string&, const std::string&>(),
-             py::arg("expect_open_tag") = true,
-             py::arg("keep_original_content") = true,
-             py::arg("open_tag") = "<think>",
-             py::arg("close_tag") = "</think>");
-    
-    py::class_<Phi4ReasoningIncrementalParser, std::shared_ptr<Phi4ReasoningIncrementalParser>, IncrementalParser>(m, "Phi4ReasoningIncrementalParser")
-        .def(py::init<>());
 
-    py::class_<DeepSeekR1ReasoningIncrementalParser, std::shared_ptr<DeepSeekR1ReasoningIncrementalParser>, IncrementalParser>(m, "DeepSeekR1ReasoningIncrementalParser")
-        .def(py::init<>());
+    // Backward-compatible aliases for legacy incremental parser names.
+    m.attr("IncrementalParser") = m.attr("Parser");
+    m.attr("ReasoningIncrementalParser") = m.attr("ReasoningParser");
+    m.attr("Phi4ReasoningIncrementalParser") = m.attr("Phi4ReasoningParser");
+    m.attr("DeepSeekR1ReasoningIncrementalParser") = m.attr("DeepSeekR1ReasoningParser");
 
     py::class_<VLLMParserWrapper, std::shared_ptr<VLLMParserWrapper>, Parser>(m, "VLLMParserWrapper")
         .def(py::init<py::object>(), py::arg("py_parser"), "Wraps a vLLM parser to be used out of the box in Python.");

--- a/src/python/py_streamers.cpp
+++ b/src/python/py_streamers.cpp
@@ -19,7 +19,7 @@ using ov::genai::CallbackTypeVariant;
 using ov::genai::StreamingStatus;
 using ov::genai::TextStreamer;
 using ov::genai::TextParserStreamer;
-using ov::genai::IncrementalParser;
+using ov::genai::Parser;
 using ov::genai::JsonContainer;
 using ov::genai::Tokenizer;
 
@@ -43,7 +43,7 @@ auto text_parser_streamer_docstring = R"(
 Base class for text streamers which works with parsed messages. In order to use inherit from this class and implement write method which takes a dict as input parameter.
 
 tokenizer: Tokenizer object to decode tokens into text.
-parsers: vector of IncrementalParser to process the text stream incrementally.
+parsers: vector of Parser to process the text stream incrementally.
 )";
 
 class ConstructableStreamer: public StreamerBase {
@@ -133,11 +133,11 @@ void init_streamers(py::module_& m) {
         
     py::class_<TextParserStreamer, ConstructableTextParserStreamer, std::shared_ptr<TextParserStreamer>, TextStreamer>(m, "TextParserStreamer", text_parser_streamer_docstring)
         .def(py::init([](const Tokenizer& tokenizer,
-                         std::vector<std::shared_ptr<IncrementalParser>> parsers) {
+                         std::vector<std::shared_ptr<Parser>> parsers) {
                 return std::make_shared<ConstructableTextParserStreamer>(tokenizer, parsers);
             }),
             py::arg("tokenizer"),
-            py::arg("parsers") = std::vector<std::shared_ptr<IncrementalParser>>(),
+            py::arg("parsers") = std::vector<std::shared_ptr<Parser>>(),
             py::keep_alive<1, 3>())
         
         // If we inherit and implement 'write' in Python and try to call write with text chunks or integer tokens 

--- a/tests/cpp/parser.cpp
+++ b/tests/cpp/parser.cpp
@@ -73,7 +73,7 @@ TEST(ParserTest, test_reasoning_parser_2) {
 
 class DeepSeekR1ReasoningParserTest : public ::testing::Test {
 protected:
-    ov::genai::DeepSeekR1ReasoningIncrementalParser parser;
+    ov::genai::DeepSeekR1ReasoningParser parser;
     JsonContainer msg;
 };
 
@@ -95,7 +95,7 @@ TEST_F(DeepSeekR1ReasoningParserTest, ReasoningContentAccumulatesAcrossCalls) {
     JsonContainer accumulated_msg;
     for (int i = 1; i < input_stream.size(); i++) {
         std::string delta_text = input_stream[i];
-        delta_text = parser.parse(msg, delta_text);
+        delta_text = parser.parseChunk(msg, delta_text);
         accumulated_msg.concatenate(msg);
     }
     ASSERT_EQ(accumulated_msg["reasoning_content"], ref_res);
@@ -105,7 +105,8 @@ TEST(ParserTest, test_custom_parser) {
     // Define a small custom parser derived from Parser
     class CustomParser : public ov::genai::Parser {
     public:
-        void parse(ov::genai::JsonContainer& msg) override {
+        void parse(ov::genai::JsonContainer& msg,
+                   const std::optional<std::vector<int64_t>>& /*tokens*/ = std::nullopt) override {
             // extract "content"
             if (!msg.contains("content"))
                 return;
@@ -129,6 +130,15 @@ TEST(ParserTest, test_custom_parser) {
                 msg["reasoning_content"] = think_text;
             }
         }
+
+        std::string parseChunk(ov::genai::JsonContainer& delta_message,
+                               std::string& delta_text,
+                               const std::optional<std::vector<int64_t>>& /*delta_tokens*/ = std::nullopt) override {
+            (void)delta_message;
+            return delta_text;
+        }
+
+        void reset() override {}
     };
 
     CustomParser parser;
@@ -146,11 +156,16 @@ TEST(ParserTest, CustomParser_AccumulatesBetweenStartStop) {
     using namespace ov::genai;
 
     // Custom incremental parser: mirrors the Python logic
-    class CustomParser : public IncrementalParser {
+    class CustomParser : public Parser {
     public:
         bool main_part_started = false;
 
-        std::string parse(JsonContainer& msg,
+        void parse(JsonContainer& msg,
+                   const std::optional<std::vector<int64_t>>& /*tokens*/ = std::nullopt) override {
+            // Non-incremental parse method (required by base class)
+        }
+
+        std::string parseChunk(JsonContainer& msg,
                           std::string& delta_text,
                           const std::optional<std::vector<int64_t>>& /*delta_tokens*/ = std::nullopt) override {
             // Ensure fields exist (Python test used dict defaults)
@@ -190,7 +205,7 @@ TEST(ParserTest, CustomParser_AccumulatesBetweenStartStop) {
     public:
         using TextParserStreamer::write;
         // Forwarding constructor to base class
-        CustomStreamer(ov::genai::Tokenizer& tok, const std::vector<std::shared_ptr<IncrementalParser>>& parsers)
+        CustomStreamer(const ov::genai::Tokenizer& tok, std::vector<std::shared_ptr<Parser>> parsers)
             : ov::genai::TextParserStreamer(tok, parsers) {}
 
         JsonContainer final_msg;
@@ -201,7 +216,7 @@ TEST(ParserTest, CustomParser_AccumulatesBetweenStartStop) {
     };
 
     Tokenizer tok;
-    std::shared_ptr<IncrementalParser> parser = std::make_shared<CustomParser>();
+    std::shared_ptr<Parser> parser = std::make_shared<CustomParser>();
     CustomStreamer streamer(tok, {parser});
     
     


### PR DESCRIPTION
Refactor tool call parsers to make common class for unary and streaming parsing.
It will have the following advantages:
- one parser configuration on the client regardless of the request type. For streaming there is used `parseChunk` method while in unary processing `parse`
- no difference in usage from TextStreamer perspective - using write method
- reusing method and configuration for unary and streaming implementation
- consistent with vLLM and OVMS implementation making it easier to share parsers
- 

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
