### PR TITLE
[wwb] Rebuild gt data if exists in run with base model

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -74,7 +74,7 @@ def parse_args():
         default=None,
         help=(
             "CSV file for ground truth outputs. If --base-model is provided, this file will be generated/"
-            "overwritten with --base-model evaluation. If --base-model is not provided, the file must exists."
+            "overwritten with --base-model evaluation. If --base-model is not provided, the file must exist."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Description
the behavior has been updated so that if the gt-data file exists and user run wwb with --base-model and --gt-data, gt-data file will be overwritten.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
