### PR TITLE
[CB] Sum GPU memory across devices for multi-GPU KV cache validation

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -164,7 +164,15 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
     // Scheduler configuration
     SchedulerConfig normalized_config = scheduler_config;
     size_t total_mem_size;
-    if (execution_device.find("GPU") != std::string::npos) {
+    if (all_gpu_device && execution_devices.size() > 1) {
+        // For multi-GPU setups (e.g. HETERO:GPU.0,GPU.1), sum available
+        // memory across all GPU execution devices so that cache_size can
+        // utilise the combined VRAM instead of being capped by a single GPU.
+        total_mem_size = 0;
+        for (const auto& dev : execution_devices) {
+            total_mem_size += utils::get_available_gpu_memory(dev, m_num_decoder_layers);
+        }
+    } else if (execution_device.find("GPU") != std::string::npos) {
         total_mem_size = utils::get_available_gpu_memory(execution_device, m_num_decoder_layers);
     } else {
         total_mem_size = get_available_cpu_memory();


### PR DESCRIPTION
## Summary

When using `HETERO` pipeline-parallel with multiple GPUs (e.g., `HETERO:GPU.0,GPU.1`), the KV cache memory validation in `pipeline_impl.cpp` only queries the first execution device via `get_available_gpu_memory(execution_devices[0])`. This causes `cache_size` validation to see only one GPU's memory instead of the combined total across all GPUs.

This fix uses the `all_gpu_device` variable (introduced in PR #2227 for pipeline-parallel support) to detect multi-GPU configurations and sum available memory across all execution devices.

## Changes

- `src/cpp/src/continuous_batching/pipeline_impl.cpp`: When `all_gpu_device && execution_devices.size() > 1`, loop over all execution devices and sum `get_available_gpu_memory()` results into `total_mem_size`. Single-GPU and CPU paths are unchanged.

## Example

With 2x Intel Arc Pro B50 (16GB each) and `cache_size=7`:
- **Before**: checks only `GPU.0` → 16GB available (works by luck for small cache sizes, but `cache_size=14` would fail despite 32GB total)
- **After**: sums `GPU.0 + GPU.1` → 32GB available (correct)

## Test environment

- Windows 10 Pro, 2x Intel Arc Pro B50 (16GB VRAM each)
- Driver: 32.0.101.8314
- OVMS 2026.0 with `--target_device "HETERO:GPU.1,GPU.0" --model_distribution_policy "PIPELINE_PARALLEL" --cache_size 7`
- Model: Qwen2.5-7B-Instruct INT8 symmetric

## Related

- PR #2227 — introduced `all_gpu_device` detection and pipeline-parallel support
- PR #2683 — extracted `get_available_gpu_memory()` utility function