### PR TITLE
[VLM] Optimize get_interpolated_pos_embeds in Qwen3-VL

### DIFF
--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -259,9 +259,11 @@ ov::Tensor create_visual_pos_masks(
     return result;
 }
 
-bool check_vision_pos_embeds_env() {
+// Returns true when the user requested the C++ fallback path via the
+// VISION_POS_EMBEDS=CPP environment variable. Otherwise the default (patched model) is used.
+bool is_cpp_pos_embeds_fallback_requested() {
     const char* env = std::getenv("VISION_POS_EMBEDS");
-    return !(env && std::string(env) == "CPP");
+    return env && std::string(env) == "CPP";
 }
 
 /**
@@ -331,7 +333,7 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const std::string& device,
     const ov::AnyMap device_config
 ) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config),
-    m_use_patched_pos_model(check_vision_pos_embeds_env()) {
+    m_use_patched_pos_model(!is_cpp_pos_embeds_fallback_requested()) {
     auto pos_model = utils::singleton_core().read_model(
         model_dir / "openvino_vision_embeddings_pos_model.xml");
     if (m_use_patched_pos_model) {
@@ -355,7 +357,7 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const std::string& device,
     const ov::AnyMap device_config
 ) : InputsEmbedderQwen2VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config),
-    m_use_patched_pos_model(check_vision_pos_embeds_env()) {
+    m_use_patched_pos_model(!is_cpp_pos_embeds_fallback_requested()) {
     const auto& [pos_model_str, pos_weights] = 
         utils::get_model_weights_pair(models_map, "vision_embeddings_pos");
     auto pos_model = utils::singleton_core().read_model(pos_model_str, pos_weights);

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -5,6 +5,10 @@
 #include "utils.hpp"
 #include "logger.hpp"
 
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_sum.hpp"
+
 namespace ov::genai {
 
 namespace {
@@ -242,6 +246,49 @@ ov::Tensor create_visual_pos_masks(
     return result;
 }
 
+bool check_vision_preprocess_env() {
+    const char* env = std::getenv("VISION_PREPROCESS");
+    return !(env && std::string(env) == "CPP");
+}
+
+/**
+ * @brief Patches vision_embeddings_pos model to perform weighted sum internally.
+ *
+ * Original: input [4, N] → model → [4, N, D] (then CPU weighted sum)
+ * Patched:  input [4, N] + weights [4, N] → model → [4, N, D] → Unsqueeze+Multiply+ReduceSum → [N, D]
+ */
+std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
+    const std::shared_ptr<ov::Model>& model_org
+) {
+    auto results = model_org->get_results();
+    OPENVINO_ASSERT(results.size() == 1u, "Expected single output from vision_embeddings_pos model");
+    auto orig_output = results[0]->input_value(0); // [4, N, D]
+
+    // New parameter: weights [4, N]
+    auto weights_param = std::make_shared<ov::op::v0::Parameter>(
+        ov::element::f32, ov::PartialShape{4, -1});
+    weights_param->set_friendly_name("weights");
+    weights_param->output(0).get_tensor().set_names({"weights"});
+
+    // Unsqueeze weights: [4, N] → [4, N, 1]
+    auto axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+    auto unsqueezed = std::make_shared<ov::op::v0::Unsqueeze>(weights_param, axis_const);
+
+    // Multiply: [4, N, D] * [4, N, 1] → [4, N, D]
+    auto multiplied = std::make_shared<ov::op::v1::Multiply>(orig_output, unsqueezed);
+
+    // ReduceSum over axis 0: [4, N, D] → [N, D]
+    auto reduce_axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    auto summed = std::make_shared<ov::op::v1::ReduceSum>(multiplied, reduce_axis, false);
+
+    auto new_result = std::make_shared<ov::op::v0::Result>(summed);
+
+    auto params = model_org->get_parameters();
+    params.push_back(weights_param);
+
+    return std::make_shared<ov::Model>(ov::ResultVector{new_result}, params);
+}
+
 } // namespace
 
 EncodedVideo VisionEncoderQwen3VL::encode_frames(const std::vector<ov::Tensor>& frames) {
@@ -258,6 +305,10 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
 ) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config) {
     auto pos_model = utils::singleton_core().read_model(
         model_dir / "openvino_vision_embeddings_pos_model.xml");
+    m_use_patched_pos_model = check_vision_preprocess_env();
+    if (m_use_patched_pos_model) {
+        pos_model = patch_weighted_sum_into_pos_model(pos_model);
+    }
     auto pos_compiled = utils::singleton_core().compile_model(pos_model, device, device_config);
     
     m_ireq_queue_vision_embeddings_pos = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
@@ -279,6 +330,10 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const auto& [pos_model_str, pos_weights] = 
         utils::get_model_weights_pair(models_map, "vision_embeddings_pos");
     auto pos_model = utils::singleton_core().read_model(pos_model_str, pos_weights);
+    m_use_patched_pos_model = check_vision_preprocess_env();
+    if (m_use_patched_pos_model) {
+        pos_model = patch_weighted_sum_into_pos_model(pos_model);
+    }
     auto pos_compiled = utils::singleton_core().compile_model(pos_model, device, device_config);
     
     m_ireq_queue_vision_embeddings_pos = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
@@ -367,32 +422,42 @@ ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
     ov::InferRequest& vision_embeddings_pos = infer_request_guard.get();
 
     vision_embeddings_pos.set_tensor("input", indices);
-    vision_embeddings_pos.infer();
-    ov::Tensor pos_embeds = vision_embeddings_pos.get_output_tensor();
 
-    size_t num_positions = pos_embeds.get_shape()[1];
-    size_t embed_dim = pos_embeds.get_shape()[2];
+    ov::Tensor weighted_sum;
+    if (m_use_patched_pos_model) {
+        // Patched model: pass weights, get [N, D] directly from GPU
+        vision_embeddings_pos.set_tensor("weights", weights);
+        vision_embeddings_pos.infer();
+        weighted_sum = vision_embeddings_pos.get_output_tensor();
+    } else {
+        // Original model: get [4, N, D], do CPU weighted sum
+        vision_embeddings_pos.infer();
+        ov::Tensor pos_embeds = vision_embeddings_pos.get_output_tensor();
 
-    // Weighted sum over 4 corners
-    ov::Tensor weighted_sum{ov::element::f32, {num_positions, embed_dim}};
-    float* weighted_sum_data = weighted_sum.data<float>();
-    std::fill_n(weighted_sum_data, num_positions * embed_dim, 0.0f);
+        size_t num_positions = pos_embeds.get_shape()[1];
+        size_t embed_dim = pos_embeds.get_shape()[2];
 
-    const float* pos_embeds_data = pos_embeds.data<const float>();
-    const float* weights_data = weights.data<const float>();
-    
-    // Apply weights and sum: pos_embeds * weights[:, :, None], then sum over dim 0
-    for (size_t corner = 0; corner < 4; ++corner) {
-        for (size_t pos = 0; pos < num_positions; ++pos) {
-            float w = weights_data[corner * num_positions + pos];
-            const float* src = pos_embeds_data + (corner * num_positions + pos) * embed_dim;
-            float* dst = weighted_sum_data + pos * embed_dim;
-            for (size_t d = 0; d < embed_dim; ++d) {
-                dst[d] += w * src[d];
+        // Weighted sum over 4 corners
+        weighted_sum = ov::Tensor{ov::element::f32, {num_positions, embed_dim}};
+        float* weighted_sum_data = weighted_sum.data<float>();
+        std::fill_n(weighted_sum_data, num_positions * embed_dim, 0.0f);
+
+        const float* pos_embeds_data = pos_embeds.data<const float>();
+        const float* weights_data = weights.data<const float>();
+
+        // Apply weights and sum: pos_embeds * weights[:, :, None], then sum over dim 0
+        for (size_t corner = 0; corner < 4; ++corner) {
+            for (size_t pos = 0; pos < num_positions; ++pos) {
+                float w = weights_data[corner * num_positions + pos];
+                const float* src = pos_embeds_data + (corner * num_positions + pos) * embed_dim;
+                float* dst = weighted_sum_data + pos * embed_dim;
+                for (size_t d = 0; d < embed_dim; ++d) {
+                    dst[d] += w * src[d];
+                }
             }
         }
     }
-    
+
     size_t spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
     return permute_with_spatial_merge(weighted_sum, grids_thw, spatial_merge_size);
 }

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -108,68 +108,65 @@ std::pair<ov::Tensor, ov::Tensor> get_position_interpolation_indices_and_weights
     const std::vector<std::array<size_t, 3>>& grids_thw,
     size_t num_grid_per_side
 ) {
-    std::vector<std::vector<int64_t>> indices_list(4);
-    std::vector<std::vector<float>> weights_list(4);
-    
+    // Pre-compute total positions to allocate tensors directly
+    size_t total_positions = 0;
+    for (const auto& grid_thw : grids_thw) {
+        total_positions += grid_thw[0] * grid_thw[1] * grid_thw[2];
+    }
+
+    ov::Tensor indices{ov::element::i64, {4, total_positions}};
+    ov::Tensor weights{ov::element::f32, {4, total_positions}};
+    int64_t* indices_data = indices.data<int64_t>();
+    float* weights_data = weights.data<float>();
+    size_t pos_offset = 0;
+
     for (const auto& grid_thw : grids_thw) {
         const auto [t, h, w] = grid_thw;
-        
+
         // Create linearly spaced indices for h and w
         std::vector<float> h_idxs(h), w_idxs(w);
         const float h_scale = h > 1 ? static_cast<float>(num_grid_per_side - 1) / (h - 1) : 0.0f;
         const float w_scale = w > 1 ? static_cast<float>(num_grid_per_side - 1) / (w - 1) : 0.0f;
-        
+
         for (size_t i = 0; i < h; ++i) {
             h_idxs[i] = static_cast<float>(i) * h_scale;
         }
         for (size_t i = 0; i < w; ++i) {
             w_idxs[i] = static_cast<float>(i) * w_scale;
         }
-        
+
         // Compute floor/ceil indices and interpolation weights
+        const int64_t grid_max = static_cast<int64_t>(num_grid_per_side - 1);
         for (size_t ti = 0; ti < t; ++ti) {
             for (size_t hi = 0; hi < h; ++hi) {
                 const int64_t h_floor = static_cast<int64_t>(h_idxs[hi]);
-                const int64_t h_ceil = std::min(h_floor + 1, static_cast<int64_t>(num_grid_per_side - 1));
+                const int64_t h_ceil = std::min(h_floor + 1, grid_max);
                 const float dh = h_idxs[hi] - static_cast<float>(h_floor);
+                const int64_t h_floor_row = h_floor * num_grid_per_side;
+                const int64_t h_ceil_row = h_ceil * num_grid_per_side;
                 
                 for (size_t wi = 0; wi < w; ++wi) {
                     const int64_t w_floor = static_cast<int64_t>(w_idxs[wi]);
-                    const int64_t w_ceil = std::min(w_floor + 1, static_cast<int64_t>(num_grid_per_side - 1));
+                    const int64_t w_ceil = std::min(w_floor + 1, grid_max);
                     const float dw = w_idxs[wi] - static_cast<float>(w_floor);
-                    
+
                     // 4 corners: (floor,floor), (floor,ceil), (ceil,floor), (ceil,ceil)
-                    indices_list[0].push_back(h_floor * num_grid_per_side + w_floor);
-                    indices_list[1].push_back(h_floor * num_grid_per_side + w_ceil);
-                    indices_list[2].push_back(h_ceil * num_grid_per_side + w_floor);
-                    indices_list[3].push_back(h_ceil * num_grid_per_side + w_ceil);
-                    
+                    indices_data[0 * total_positions + pos_offset] = h_floor_row + w_floor;
+                    indices_data[1 * total_positions + pos_offset] = h_floor_row + w_ceil;
+                    indices_data[2 * total_positions + pos_offset] = h_ceil_row + w_floor;
+                    indices_data[3 * total_positions + pos_offset] = h_ceil_row + w_ceil;
+
                     // Bilinear weights
-                    weights_list[0].push_back((1.0f - dh) * (1.0f - dw));
-                    weights_list[1].push_back((1.0f - dh) * dw);
-                    weights_list[2].push_back(dh * (1.0f - dw));
-                    weights_list[3].push_back(dh * dw);
+                    weights_data[0 * total_positions + pos_offset] = (1.0f - dh) * (1.0f - dw);
+                    weights_data[1 * total_positions + pos_offset] = (1.0f - dh) * dw;
+                    weights_data[2 * total_positions + pos_offset] = dh * (1.0f - dw);
+                    weights_data[3 * total_positions + pos_offset] = dh * dw;
+                    ++pos_offset;
                 }
             }
         }
     }
-    
-    const size_t total_positions = indices_list[0].size();
-    ov::Tensor indices{ov::element::i64, {4, total_positions}};
-    ov::Tensor weights{ov::element::f32, {4, total_positions}};
-    
-    int64_t* indices_data = indices.data<int64_t>();
-    float* weights_data = weights.data<float>();
-    
-    for (size_t corner = 0; corner < 4; ++corner) {
-        std::memcpy(indices_data + corner * total_positions,
-                    indices_list[corner].data(),
-                    total_positions * sizeof(int64_t));
-        std::memcpy(weights_data + corner * total_positions,
-                    weights_list[corner].data(),
-                    total_positions * sizeof(float));
-    }
-    
+
     return {indices, weights};
 }
 
@@ -189,18 +186,19 @@ ov::Tensor permute_with_spatial_merge(
     const size_t num_positions = pos_embeds.get_shape()[0];
     const size_t embed_dim = pos_embeds.get_shape()[1];
     const float* pos_embeds_data = pos_embeds.data<const float>();
-    
-    std::vector<float> permuted_data;
-    permuted_data.reserve(num_positions * embed_dim);
-    
-    size_t offset = 0;
+    const size_t embed_bytes = embed_dim * sizeof(float);
+
+    ov::Tensor result{ov::element::f32, {num_positions, embed_dim}};
+    float* dst_data = result.data<float>();
+    size_t dst_offset = 0;
+    size_t src_offset = 0;
+
     for (const auto& grid_thw : grids_thw) {
         const auto [t, h, w] = grid_thw;
         const size_t hw = h * w;
-        
         const size_t merge_h = h / spatial_merge_size;
         const size_t merge_w = w / spatial_merge_size;
-        
+
         for (size_t ti = 0; ti < t; ++ti) {
             for (size_t mhi = 0; mhi < merge_h; ++mhi) {
                 for (size_t mwi = 0; mwi < merge_w; ++mwi) {
@@ -208,22 +206,19 @@ ov::Tensor permute_with_spatial_merge(
                         for (size_t swi = 0; swi < spatial_merge_size; ++swi) {
                             const size_t src_h = mhi * spatial_merge_size + shi;
                             const size_t src_w = mwi * spatial_merge_size + swi;
-                            const size_t src_idx = offset + ti * hw + src_h * w + src_w;
-                            
-                            const float* src = pos_embeds_data + src_idx * embed_dim;
-                            permuted_data.insert(permuted_data.end(), src, src + embed_dim);
+                            const size_t src_idx = src_offset + ti * hw + src_h * w + src_w;
+
+                            std::memcpy(dst_data + dst_offset * embed_dim,
+                                        pos_embeds_data + src_idx * embed_dim,
+                                        embed_bytes);
+                            ++dst_offset;
                         }
                     }
                 }
             }
         }
-        offset += t * hw;
+        src_offset += t * hw;
     }
-    
-    const size_t permuted_len = permuted_data.size() / embed_dim;
-    ov::Tensor result{ov::element::f32, {permuted_len, embed_dim}};
-    std::memcpy(result.data<float>(), permuted_data.data(), permuted_data.size() * sizeof(float));
-    
     return result;
 }
 

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -197,7 +197,7 @@ void permute_with_spatial_merge_and_add(
     const size_t embed_dim = pos_embeds.get_shape()[1];
     const float* pos_embeds_data = pos_embeds.data<const float>();
 
-    OPENVINO_ASSERT(spatial_merge_size > 0, "spatial_merge_size must be positive, got 0");
+    OPENVINO_ASSERT(spatial_merge_size > 0, "spatial_merge_size must be positive, got ", spatial_merge_size);
 
     size_t dst_offset = 0;
     size_t src_offset = 0;

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -5,9 +5,11 @@
 #include "utils.hpp"
 #include "logger.hpp"
 
-#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/add.hpp"
 #include "openvino/op/multiply.hpp"
-#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
 
 namespace ov::genai {
 
@@ -144,7 +146,7 @@ std::pair<ov::Tensor, ov::Tensor> get_position_interpolation_indices_and_weights
                 const float dh = h_idxs[hi] - static_cast<float>(h_floor);
                 const int64_t h_floor_row = h_floor * num_grid_per_side;
                 const int64_t h_ceil_row = h_ceil * num_grid_per_side;
-                
+
                 for (size_t wi = 0; wi < w; ++wi) {
                     const int64_t w_floor = static_cast<int64_t>(w_idxs[wi]);
                     const int64_t w_ceil = std::min(w_floor + 1, grid_max);
@@ -241,16 +243,17 @@ ov::Tensor create_visual_pos_masks(
     return result;
 }
 
-bool check_vision_preprocess_env() {
-    const char* env = std::getenv("VISION_PREPROCESS");
+bool check_vision_pos_embeds_env() {
+    const char* env = std::getenv("VISION_POS_EMBEDS");
     return !(env && std::string(env) == "CPP");
 }
 
 /**
- * @brief Patches vision_embeddings_pos model to perform weighted sum internally.
+ * @brief Patches vision_embeddings_pos model to perform weighted sum on device.
  *
  * Original: input [4, N] → model → [4, N, D] (then CPU weighted sum)
- * Patched:  input [4, N] + weights [4, N] → model → [4, N, D] → Unsqueeze+Multiply+ReduceSum → [N, D]
+ * Patched:  input [4, N] + weights [4, N] → model → [4, N, D]
+ *           → per-corner Multiply [N,D]×[N,1] → sequential Add → [N, D]
  */
 std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
     const std::shared_ptr<ov::Model>& model_org
@@ -259,29 +262,37 @@ std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
     OPENVINO_ASSERT(results.size() == 1u, "Expected single output from vision_embeddings_pos model");
     auto orig_output = results[0]->input_value(0); // [4, N, D]
 
-    // New parameter: weights [4, N]
     auto weights_param = std::make_shared<ov::op::v0::Parameter>(
         ov::element::f32, ov::PartialShape{4, -1});
     weights_param->set_friendly_name("weights");
     weights_param->output(0).get_tensor().set_names({"weights"});
 
-    // Unsqueeze weights: [4, N] → [4, N, 1]
-    auto axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
-    auto unsqueezed = std::make_shared<ov::op::v0::Unsqueeze>(weights_param, axis_const);
+    constexpr size_t num_corners = 4;
+    auto axis0 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    auto sq_axis0 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    auto unsq_axis1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
 
-    // Multiply: [4, N, D] * [4, N, 1] → [4, N, D]
-    auto multiplied = std::make_shared<ov::op::v1::Multiply>(orig_output, unsqueezed);
+    // Split pos_embeds [4,N,D] → 4×[N,D] and weights [4,N] → 4×[N,1]
+    auto split_e = std::make_shared<ov::op::v1::Split>(orig_output, axis0, num_corners);
+    auto split_w = std::make_shared<ov::op::v1::Split>(weights_param, axis0, num_corners);
 
-    // ReduceSum over axis 0: [4, N, D] → [N, D]
-    auto reduce_axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
-    auto summed = std::make_shared<ov::op::v1::ReduceSum>(multiplied, reduce_axis, false);
+    // Per-corner: Squeeze → Multiply → sequential Add
+    ov::Output<ov::Node> summed;
+    for (size_t i = 0; i < num_corners; ++i) {
+        auto embed = std::make_shared<ov::op::v0::Squeeze>(split_e->output(i), sq_axis0);     // [N, D]
+        auto weight = std::make_shared<ov::op::v0::Unsqueeze>(
+            std::make_shared<ov::op::v0::Squeeze>(split_w->output(i), sq_axis0), unsq_axis1); // [N, 1]
+        auto weighted = std::make_shared<ov::op::v1::Multiply>(embed, weight);                // [N, D]
 
-    auto new_result = std::make_shared<ov::op::v0::Result>(summed);
+        summed = (i == 0) ? weighted->output(0)
+                          : std::make_shared<ov::op::v1::Add>(summed, weighted)->output(0);
+    }
 
     auto params = model_org->get_parameters();
     params.push_back(weights_param);
 
-    return std::make_shared<ov::Model>(ov::ResultVector{new_result}, params);
+    return std::make_shared<ov::Model>(
+        ov::ResultVector{std::make_shared<ov::op::v0::Result>(summed)}, params);
 }
 
 } // namespace
@@ -300,7 +311,7 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
 ) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config) {
     auto pos_model = utils::singleton_core().read_model(
         model_dir / "openvino_vision_embeddings_pos_model.xml");
-    m_use_patched_pos_model = check_vision_preprocess_env();
+    m_use_patched_pos_model = check_vision_pos_embeds_env();
     if (m_use_patched_pos_model) {
         pos_model = patch_weighted_sum_into_pos_model(pos_model);
     }
@@ -325,7 +336,7 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const auto& [pos_model_str, pos_weights] = 
         utils::get_model_weights_pair(models_map, "vision_embeddings_pos");
     auto pos_model = utils::singleton_core().read_model(pos_model_str, pos_weights);
-    m_use_patched_pos_model = check_vision_preprocess_env();
+    m_use_patched_pos_model = check_vision_pos_embeds_env();
     if (m_use_patched_pos_model) {
         pos_model = patch_weighted_sum_into_pos_model(pos_model);
     }
@@ -410,9 +421,9 @@ ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
 ) {
     const size_t num_grid_per_side = static_cast<size_t>(
         std::sqrt(static_cast<double>(m_vlm_config.vision_config_num_position_embeddings)));
-    
+
     auto [indices, weights] = get_position_interpolation_indices_and_weights(grids_thw, num_grid_per_side);
-    
+
     CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(m_ireq_queue_vision_embeddings_pos.get());
     ov::InferRequest& vision_embeddings_pos = infer_request_guard.get();
 

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -5,11 +5,17 @@
 #include "utils.hpp"
 #include "logger.hpp"
 
+#include <cstdlib>
+
 #include "openvino/op/add.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/unsqueeze.hpp"
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
 
 namespace ov::genai {
 
@@ -144,8 +150,8 @@ std::pair<ov::Tensor, ov::Tensor> get_position_interpolation_indices_and_weights
                 const int64_t h_floor = static_cast<int64_t>(h_idxs[hi]);
                 const int64_t h_ceil = std::min(h_floor + 1, grid_max);
                 const float dh = h_idxs[hi] - static_cast<float>(h_floor);
-                const int64_t h_floor_row = h_floor * num_grid_per_side;
-                const int64_t h_ceil_row = h_ceil * num_grid_per_side;
+                const int64_t h_floor_row = h_floor * static_cast<int64_t>(num_grid_per_side);
+                const int64_t h_ceil_row = h_ceil * static_cast<int64_t>(num_grid_per_side);
 
                 for (size_t wi = 0; wi < w; ++wi) {
                     const int64_t w_floor = static_cast<int64_t>(w_idxs[wi]);
@@ -168,6 +174,8 @@ std::pair<ov::Tensor, ov::Tensor> get_position_interpolation_indices_and_weights
             }
         }
     }
+    OPENVINO_ASSERT(pos_offset == total_positions,
+        "Position offset mismatch: expected ", total_positions, ", got ", pos_offset);
 
     return {indices, weights};
 }
@@ -200,6 +208,10 @@ ov::Tensor permute_with_spatial_merge(
         const size_t hw = h * w;
         const size_t merge_h = h / spatial_merge_size;
         const size_t merge_w = w / spatial_merge_size;
+        OPENVINO_ASSERT(
+            h % spatial_merge_size == 0 && w % spatial_merge_size == 0,
+            "permute_with_spatial_merge expects h and w divisible by spatial_merge_size. "
+            "Got h=", h, ", w=", w, ", spatial_merge_size=", spatial_merge_size);
 
         for (size_t ti = 0; ti < t; ++ti) {
             for (size_t mhi = 0; mhi < merge_h; ++mhi) {
@@ -221,6 +233,10 @@ ov::Tensor permute_with_spatial_merge(
         }
         src_offset += t * hw;
     }
+    OPENVINO_ASSERT(
+        dst_offset == num_positions,
+        "permute_with_spatial_merge wrote ", dst_offset,
+        " positions, but num_positions is ", num_positions);
     return result;
 }
 
@@ -308,10 +324,10 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const std::filesystem::path& model_dir,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config) {
+) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config),
+    m_use_patched_pos_model(check_vision_pos_embeds_env()) {
     auto pos_model = utils::singleton_core().read_model(
         model_dir / "openvino_vision_embeddings_pos_model.xml");
-    m_use_patched_pos_model = check_vision_pos_embeds_env();
     if (m_use_patched_pos_model) {
         pos_model = patch_weighted_sum_into_pos_model(pos_model);
     }
@@ -332,11 +348,11 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const std::filesystem::path& config_dir_path,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen2VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {
+) : InputsEmbedderQwen2VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config),
+    m_use_patched_pos_model(check_vision_pos_embeds_env()) {
     const auto& [pos_model_str, pos_weights] = 
         utils::get_model_weights_pair(models_map, "vision_embeddings_pos");
     auto pos_model = utils::singleton_core().read_model(pos_model_str, pos_weights);
-    m_use_patched_pos_model = check_vision_pos_embeds_env();
     if (m_use_patched_pos_model) {
         pos_model = patch_weighted_sum_into_pos_model(pos_model);
     }
@@ -431,7 +447,7 @@ ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
 
     ov::Tensor weighted_sum;
     if (m_use_patched_pos_model) {
-        // Patched model: pass weights, get [N, D] directly from GPU
+        // Patched model: pass weights, get [N, D] directly on device
         vision_embeddings_pos.set_tensor("weights", weights);
         vision_embeddings_pos.infer();
         weighted_sum = vision_embeddings_pos.get_output_tensor();

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -6,6 +6,7 @@
 #include "logger.hpp"
 
 #include <cstdlib>
+#include <cstring>
 
 #include "openvino/op/add.hpp"
 #include "openvino/op/multiply.hpp"
@@ -263,7 +264,7 @@ ov::Tensor create_visual_pos_masks(
 // VISION_POS_EMBEDS=CPP environment variable. Otherwise the default (patched model) is used.
 bool is_cpp_pos_embeds_fallback_requested() {
     const char* env = std::getenv("VISION_POS_EMBEDS");
-    return env && std::string(env) == "CPP";
+    return env && std::strcmp(env, "CPP") == 0;
 }
 
 /**

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -181,73 +181,11 @@ std::pair<ov::Tensor, ov::Tensor> get_position_interpolation_indices_and_weights
 }
 
 /**
- * @brief Reorders position embeddings according to spatial merge pattern in vision encoder.
- * 
- * @param pos_embeds Interpolated position embeddings [num_positions, embed_dim]
- * @param grids_thw Grid dimensions for permutation
- * @param spatial_merge_size Spatial merge size from processor config
- * @return Permuted position embeddings [num_merged_positions, embed_dim]
- */
-ov::Tensor permute_with_spatial_merge(
-    const ov::Tensor& pos_embeds,
-    const std::vector<std::array<size_t, 3>>& grids_thw,
-    size_t spatial_merge_size
-) {
-    const size_t num_positions = pos_embeds.get_shape()[0];
-    const size_t embed_dim = pos_embeds.get_shape()[1];
-    const float* pos_embeds_data = pos_embeds.data<const float>();
-    const size_t embed_bytes = embed_dim * sizeof(float);
-
-    ov::Tensor result{ov::element::f32, {num_positions, embed_dim}};
-    float* dst_data = result.data<float>();
-    size_t dst_offset = 0;
-    size_t src_offset = 0;
-
-    for (const auto& grid_thw : grids_thw) {
-        const auto [t, h, w] = grid_thw;
-        const size_t hw = h * w;
-        const size_t merge_h = h / spatial_merge_size;
-        const size_t merge_w = w / spatial_merge_size;
-        OPENVINO_ASSERT(
-            h % spatial_merge_size == 0 && w % spatial_merge_size == 0,
-            "permute_with_spatial_merge expects h and w divisible by spatial_merge_size. "
-            "Got h=", h, ", w=", w, ", spatial_merge_size=", spatial_merge_size);
-
-        for (size_t ti = 0; ti < t; ++ti) {
-            for (size_t mhi = 0; mhi < merge_h; ++mhi) {
-                for (size_t mwi = 0; mwi < merge_w; ++mwi) {
-                    for (size_t shi = 0; shi < spatial_merge_size; ++shi) {
-                        for (size_t swi = 0; swi < spatial_merge_size; ++swi) {
-                            const size_t src_h = mhi * spatial_merge_size + shi;
-                            const size_t src_w = mwi * spatial_merge_size + swi;
-                            const size_t src_idx = src_offset + ti * hw + src_h * w + src_w;
-
-                            std::memcpy(dst_data + dst_offset * embed_dim,
-                                        pos_embeds_data + src_idx * embed_dim,
-                                        embed_bytes);
-                            ++dst_offset;
-                        }
-                    }
-                }
-            }
-        }
-        src_offset += t * hw;
-    }
-    OPENVINO_ASSERT(
-        dst_offset == num_positions,
-        "permute_with_spatial_merge wrote ", dst_offset,
-        " positions, but num_positions is ", num_positions);
-    return result;
-}
-
-/**
  * @brief Fused permute + in-place addition: permutes position embeddings according to
  *        spatial merge pattern and adds them directly into the destination tensor.
  *
- * Equivalent to:
- *   auto permuted = permute_with_spatial_merge(pos_embeds, grids_thw, spatial_merge_size);
- *   for (i) dst[i] += permuted[i];
- * but avoids allocating the intermediate tensor and makes a single pass.
+ * Reorders [num_positions, embed_dim] position embeddings by the spatial merge pattern
+ * and adds each row into the corresponding dst row, avoiding an intermediate tensor.
  */
 void permute_with_spatial_merge_and_add(
     const ov::Tensor& pos_embeds,
@@ -258,6 +196,8 @@ void permute_with_spatial_merge_and_add(
     const size_t num_positions = pos_embeds.get_shape()[0];
     const size_t embed_dim = pos_embeds.get_shape()[1];
     const float* pos_embeds_data = pos_embeds.data<const float>();
+
+    OPENVINO_ASSERT(spatial_merge_size > 0, "spatial_merge_size must be positive, got 0");
 
     size_t dst_offset = 0;
     size_t src_offset = 0;
@@ -337,6 +277,12 @@ std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
     auto results = model_org->get_results();
     OPENVINO_ASSERT(results.size() == 1u, "Expected single output from vision_embeddings_pos model");
     auto orig_output = results[0]->input_value(0); // [4, N, D]
+
+    const ov::PartialShape& out_pshape = orig_output.get_partial_shape();
+    OPENVINO_ASSERT(out_pshape.rank().is_static() && out_pshape.rank().get_length() == 3,
+        "vision_embeddings_pos output must be rank-3 [4, N, D], got rank ", out_pshape.rank());
+    OPENVINO_ASSERT(!out_pshape[0].is_static() || out_pshape[0].get_length() == 4,
+        "vision_embeddings_pos output dim 0 must be 4, got ", out_pshape[0]);
 
     auto weights_param = std::make_shared<ov::op::v0::Parameter>(
         ov::element::f32, ov::PartialShape{4, -1});
@@ -542,6 +488,13 @@ void InputsEmbedderQwen3VL::add_interpolated_pos_embeds(
     }
 
     size_t spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
+
+    OPENVINO_ASSERT(concatenated_embeds.get_element_type() == ov::element::f32,
+        "concatenated_embeds must be f32, got ", concatenated_embeds.get_element_type());
+    OPENVINO_ASSERT(concatenated_embeds.get_shape() == weighted_sum.get_shape(),
+        "concatenated_embeds shape ", concatenated_embeds.get_shape(),
+        " does not match weighted_sum shape ", weighted_sum.get_shape());
+
     permute_with_spatial_merge_and_add(weighted_sum, concatenated_embeds.data<float>(), grids_thw, spatial_merge_size);
 }
 

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -241,6 +241,66 @@ ov::Tensor permute_with_spatial_merge(
 }
 
 /**
+ * @brief Fused permute + in-place addition: permutes position embeddings according to
+ *        spatial merge pattern and adds them directly into the destination tensor.
+ *
+ * Equivalent to:
+ *   auto permuted = permute_with_spatial_merge(pos_embeds, grids_thw, spatial_merge_size);
+ *   for (i) dst[i] += permuted[i];
+ * but avoids allocating the intermediate tensor and makes a single pass.
+ */
+void permute_with_spatial_merge_and_add(
+    const ov::Tensor& pos_embeds,
+    float* dst_data,
+    const std::vector<std::array<size_t, 3>>& grids_thw,
+    size_t spatial_merge_size
+) {
+    const size_t num_positions = pos_embeds.get_shape()[0];
+    const size_t embed_dim = pos_embeds.get_shape()[1];
+    const float* pos_embeds_data = pos_embeds.data<const float>();
+
+    size_t dst_offset = 0;
+    size_t src_offset = 0;
+
+    for (const auto& grid_thw : grids_thw) {
+        const auto [t, h, w] = grid_thw;
+        const size_t hw = h * w;
+        const size_t merge_h = h / spatial_merge_size;
+        const size_t merge_w = w / spatial_merge_size;
+        OPENVINO_ASSERT(
+            h % spatial_merge_size == 0 && w % spatial_merge_size == 0,
+            "permute_with_spatial_merge_and_add expects h and w divisible by spatial_merge_size. "
+            "Got h=", h, ", w=", w, ", spatial_merge_size=", spatial_merge_size);
+
+        for (size_t ti = 0; ti < t; ++ti) {
+            for (size_t mhi = 0; mhi < merge_h; ++mhi) {
+                for (size_t mwi = 0; mwi < merge_w; ++mwi) {
+                    for (size_t shi = 0; shi < spatial_merge_size; ++shi) {
+                        for (size_t swi = 0; swi < spatial_merge_size; ++swi) {
+                            const size_t src_h = mhi * spatial_merge_size + shi;
+                            const size_t src_w = mwi * spatial_merge_size + swi;
+                            const size_t src_idx = src_offset + ti * hw + src_h * w + src_w;
+
+                            const float* src = pos_embeds_data + src_idx * embed_dim;
+                            float* dst = dst_data + dst_offset * embed_dim;
+                            for (size_t d = 0; d < embed_dim; ++d) {
+                                dst[d] += src[d];
+                            }
+                            ++dst_offset;
+                        }
+                    }
+                }
+            }
+        }
+        src_offset += t * hw;
+    }
+    OPENVINO_ASSERT(
+        dst_offset == num_positions,
+        "permute_with_spatial_merge_and_add wrote ", dst_offset,
+        " positions, but num_positions is ", num_positions);
+}
+
+/**
  * @brief Create visual position mask from input_ids by finding vision pad tokens.
  * @return Boolean tensor [batch, seq_len] with true at vision token positions
  */
@@ -432,8 +492,9 @@ void InputsEmbedderQwen3VL::expand_video_tags_in_prompt(
     }
 }
 
-ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
-    const std::vector<std::array<size_t, 3>>& grids_thw
+void InputsEmbedderQwen3VL::add_interpolated_pos_embeds(
+    const std::vector<std::array<size_t, 3>>& grids_thw,
+    ov::Tensor& concatenated_embeds
 ) {
     const size_t num_grid_per_side = static_cast<size_t>(
         std::sqrt(static_cast<double>(m_vlm_config.vision_config_num_position_embeddings)));
@@ -481,7 +542,7 @@ ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
     }
 
     size_t spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
-    return permute_with_spatial_merge(weighted_sum, grids_thw, spatial_merge_size);
+    permute_with_spatial_merge_and_add(weighted_sum, concatenated_embeds.data<float>(), grids_thw, spatial_merge_size);
 }
 
 std::pair<ov::Tensor, ov::Tensor> InputsEmbedderQwen3VL::run_video_image_embeddings_merger(
@@ -506,13 +567,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderQwen3VL::run_video_image_embeddi
         reordered_images_grid_thw.begin(), reordered_images_grid_thw.end());
     
     if (!combined_grid_thw.empty()) {
-        ov::Tensor pos_embeds = get_interpolated_pos_embeds(combined_grid_thw);
-        
-        float* concatenated_embeds_data = concatenated_embeds.data<float>();
-        const float* pos_embeds_data = pos_embeds.data<const float>();
-        for (size_t i = 0; i < concatenated_embeds.get_size(); ++i) {
-            concatenated_embeds_data[i] += pos_embeds_data[i];
-        }
+        add_interpolated_pos_embeds(combined_grid_thw, concatenated_embeds);
     }
     
     ov::Tensor rotary_pos_emb = get_rotary_pos_emb(combined_grid_thw);

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -86,12 +86,13 @@ protected:
         const std::vector<size_t>& videos_sequence) override;
 
     /**
-     * @brief Computes interpolated position embeddings.
+     * @brief Computes interpolated position embeddings and adds them in-place.
      * 
      * Calculates position interpolation indices and weights, runs vision_embeddings_pos model,
-     * applies bilinear interpolation weights, sums corners, permutes for spatial merge.
+     * applies bilinear interpolation weights, sums corners, permutes for spatial merge,
+     * and adds the result directly into concatenated_embeds (fused permute + addition).
      */
-    ov::Tensor get_interpolated_pos_embeds(const std::vector<std::array<size_t, 3>>& grids_thw);
+    void add_interpolated_pos_embeds(const std::vector<std::array<size_t, 3>>& grids_thw, ov::Tensor& concatenated_embeds);
 
     std::vector<std::array<size_t, 3>> get_vision_grid_thw_for_position_ids(
         const std::vector<std::array<size_t, 3>>& images_grid_thw,

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -59,7 +59,8 @@ public:
 protected:
     // Vision embeddings position model
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_pos;
-    
+    bool m_use_patched_pos_model = false;
+
     // Cached extra inputs for language model
     std::unordered_map<std::string, ov::Tensor> m_lm_extra_inputs{
         {"deepstack_visual_embeds", ov::Tensor()},

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -59,6 +59,8 @@ public:
 protected:
     // Vision embeddings position model
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_pos;
+    // Controlled by VISION_POS_EMBEDS env var: default uses patched model (device-side weighted sum);
+    // set VISION_POS_EMBEDS=CPP to force C++ fallback path.
     bool m_use_patched_pos_model = false;
 
     // Cached extra inputs for language model

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -59,8 +59,10 @@ public:
 protected:
     // Vision embeddings position model
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_pos;
-    // Set to true in constructor when VISION_POS_EMBEDS != "CPP" (patched model)
-    bool m_use_patched_pos_model = false;
+    // By default the vision_embeddings_pos model is patched to perform the weighted sum on the
+    // device (faster, deterministic on GPU). Setting the VISION_POS_EMBEDS=CPP environment
+    // variable disables the patch and falls back to a C++ weighted sum on the host.
+    bool m_use_patched_pos_model = true;
 
     // Cached extra inputs for language model
     std::unordered_map<std::string, ov::Tensor> m_lm_extra_inputs{

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -59,8 +59,7 @@ public:
 protected:
     // Vision embeddings position model
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_pos;
-    // Controlled by VISION_POS_EMBEDS env var: default uses patched model (device-side weighted sum);
-    // set VISION_POS_EMBEDS=CPP to force C++ fallback path.
+    // Set to true in constructor when VISION_POS_EMBEDS != "CPP" (patched model)
     bool m_use_patched_pos_model = false;
 
     // Cached extra inputs for language model

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2933,34 +2933,41 @@ def test_video_metadata_sampling_continuous_batching(
     _compare_outputs_for_video_sampling(*outputs_add_request_api)
 
 
-@pytest.mark.parametrize("backend", ATTENTION_BACKEND)
-def test_vision_pos_embeds_modes_equivalence(cat_tensor, backend):
+@pytest.mark.parametrize(
+    "ov_pipe_model",
+    [("optimum-intel-internal-testing/tiny-random-qwen3-vl", b) for b in ATTENTION_BACKEND],
+    ids=lambda p: f"{p[0]}/{p[1]}",
+    indirect=["ov_pipe_model"],
+)
+def test_vision_pos_embeds_modes_equivalence(ov_pipe_model: VlmModelInfo, cat_tensor):
     """Test that VISION_POS_EMBEDS=CPP (CPU fallback) and default (patched model)
     produce identical results for Qwen3-VL."""
-    model_id = "optimum-intel-internal-testing/tiny-random-qwen3-vl"
-    model_path = _get_ov_model(model_id)
+    # Default-mode pipeline comes from the module-scoped fixture (env var unset
+    # at construction time => patched model, device-side weighted sum).
+    ov_pipe_default = ov_pipe_model.pipeline
 
     gen_config = GenerationConfig()
     gen_config.max_new_tokens = 20
     gen_config.do_sample = False
 
-    # Default mode: patched model (device-side weighted sum)
-    prev_val = os.environ.pop("VISION_POS_EMBEDS", None)
-    try:
-        ov_pipe_default = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
-        result_default = ov_pipe_default.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
-    finally:
-        if prev_val is not None:
-            os.environ["VISION_POS_EMBEDS"] = prev_val
+    result_default = ov_pipe_default.generate(
+        PROMPTS[0], images=[cat_tensor], generation_config=gen_config
+    )
 
-    # CPP mode: CPU fallback weighted sum
+    # CPP mode: CPU fallback weighted sum. Build a fresh pipeline with the env
+    # var set, since VISION_POS_EMBEDS is read in the InputsEmbedder constructor.
+    prev_val = os.environ.get("VISION_POS_EMBEDS")
     os.environ["VISION_POS_EMBEDS"] = "CPP"
     try:
-        ov_pipe_cpp = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
-        result_cpp = ov_pipe_cpp.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
+        model_path = _get_ov_model(ov_pipe_model.model_id)
+        ov_pipe_cpp = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=ov_pipe_model.ov_backend)
+        result_cpp = ov_pipe_cpp.generate(
+            PROMPTS[0], images=[cat_tensor], generation_config=gen_config
+        )
     finally:
-        os.environ.pop("VISION_POS_EMBEDS", None)
-        if prev_val is not None:
+        if prev_val is None:
+            os.environ.pop("VISION_POS_EMBEDS", None)
+        else:
             os.environ["VISION_POS_EMBEDS"] = prev_val
 
     assert result_default.texts[0] == result_cpp.texts[0], (

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2950,9 +2950,7 @@ def test_vision_pos_embeds_modes_equivalence(ov_pipe_model: VlmModelInfo, cat_te
     gen_config.max_new_tokens = 20
     gen_config.do_sample = False
 
-    result_default = ov_pipe_default.generate(
-        PROMPTS[0], images=[cat_tensor], generation_config=gen_config
-    )
+    result_default = ov_pipe_default.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
 
     # CPP mode: CPU fallback weighted sum. Build a fresh pipeline with the env
     # var set, since VISION_POS_EMBEDS is read in the InputsEmbedder constructor.
@@ -2961,9 +2959,7 @@ def test_vision_pos_embeds_modes_equivalence(ov_pipe_model: VlmModelInfo, cat_te
     try:
         model_path = _get_ov_model(ov_pipe_model.model_id)
         ov_pipe_cpp = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=ov_pipe_model.ov_backend)
-        result_cpp = ov_pipe_cpp.generate(
-            PROMPTS[0], images=[cat_tensor], generation_config=gen_config
-        )
+        result_cpp = ov_pipe_cpp.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
     finally:
         if prev_val is None:
             os.environ.pop("VISION_POS_EMBEDS", None)

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2931,3 +2931,42 @@ def test_video_metadata_sampling_continuous_batching(
             outputs_add_request_api.append(tokenizer.decode(result.generated_ids))
 
     _compare_outputs_for_video_sampling(*outputs_add_request_api)
+
+
+@pytest.mark.skipif(
+    is_transformers_version("<", "4.57.0"),
+    reason="Qwen3-VL requires transformers >= 4.57.0",
+)
+@pytest.mark.parametrize("backend", ATTENTION_BACKEND)
+def test_vision_pos_embeds_modes_equivalence(cat_tensor, backend):
+    """Test that VISION_POS_EMBEDS=CPP (CPU fallback) and default (patched model)
+    produce identical results for Qwen3-VL."""
+    model_id = "optimum-intel-internal-testing/tiny-random-qwen3-vl"
+    model_path = _get_ov_model(model_id)
+
+    # Default mode: patched model (device-side weighted sum)
+    prev_val = os.environ.pop("VISION_POS_EMBEDS", None)
+    try:
+        ov_pipe_default = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
+        gen_config_default = _setup_generation_config(ov_pipe_default, max_new_tokens=20, do_sample=False)
+        result_default = ov_pipe_default.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config_default)
+    finally:
+        if prev_val is not None:
+            os.environ["VISION_POS_EMBEDS"] = prev_val
+
+    # CPP mode: CPU fallback weighted sum
+    os.environ["VISION_POS_EMBEDS"] = "CPP"
+    try:
+        ov_pipe_cpp = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
+        gen_config_cpp = _setup_generation_config(ov_pipe_cpp, max_new_tokens=20, do_sample=False)
+        result_cpp = ov_pipe_cpp.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config_cpp)
+    finally:
+        os.environ.pop("VISION_POS_EMBEDS", None)
+        if prev_val is not None:
+            os.environ["VISION_POS_EMBEDS"] = prev_val
+
+    assert result_default.texts[0] == result_cpp.texts[0], (
+        f"VISION_POS_EMBEDS modes produced different results.\n"
+        f"Default (patched model): '{result_default.texts[0]}'\n"
+        f"CPP (CPU fallback):      '{result_cpp.texts[0]}'"
+    )

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2933,10 +2933,6 @@ def test_video_metadata_sampling_continuous_batching(
     _compare_outputs_for_video_sampling(*outputs_add_request_api)
 
 
-@pytest.mark.skipif(
-    is_transformers_version("<", "4.57.0"),
-    reason="Qwen3-VL requires transformers >= 4.57.0",
-)
 @pytest.mark.parametrize("backend", ATTENTION_BACKEND)
 def test_vision_pos_embeds_modes_equivalence(cat_tensor, backend):
     """Test that VISION_POS_EMBEDS=CPP (CPU fallback) and default (patched model)
@@ -2944,12 +2940,15 @@ def test_vision_pos_embeds_modes_equivalence(cat_tensor, backend):
     model_id = "optimum-intel-internal-testing/tiny-random-qwen3-vl"
     model_path = _get_ov_model(model_id)
 
+    gen_config = GenerationConfig()
+    gen_config.max_new_tokens = 20
+    gen_config.do_sample = False
+
     # Default mode: patched model (device-side weighted sum)
     prev_val = os.environ.pop("VISION_POS_EMBEDS", None)
     try:
         ov_pipe_default = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
-        gen_config_default = _setup_generation_config(ov_pipe_default, max_new_tokens=20, do_sample=False)
-        result_default = ov_pipe_default.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config_default)
+        result_default = ov_pipe_default.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
     finally:
         if prev_val is not None:
             os.environ["VISION_POS_EMBEDS"] = prev_val
@@ -2958,8 +2957,7 @@ def test_vision_pos_embeds_modes_equivalence(cat_tensor, backend):
     os.environ["VISION_POS_EMBEDS"] = "CPP"
     try:
         ov_pipe_cpp = VLMPipeline(model_path, "CPU", ATTENTION_BACKEND=backend)
-        gen_config_cpp = _setup_generation_config(ov_pipe_cpp, max_new_tokens=20, do_sample=False)
-        result_cpp = ov_pipe_cpp.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config_cpp)
+        result_cpp = ov_pipe_cpp.generate(PROMPTS[0], images=[cat_tensor], generation_config=gen_config)
     finally:
         os.environ.pop("VISION_POS_EMBEDS", None)
         if prev_val is not None:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Optimizes the `get_interpolated_pos_embeds` path in Qwen3-VL by moving the weighted sum computation onto the device and eliminating unnecessary memory allocations
 - Patch weighted sum into the vision embeddings pos model
   - `patch_weighted_sum_into_pos_model` appends OV ops after the model output: per-corner `Split->Squeeze->Multiply->sequential Add`, producing [N,D] directly on device
   - Controlled by `VISION_POS_EMBEDS=CPP` env var (independent of existing `VISION_PREPROCESS`)
 - Optimize `get_position_interpolation_indices_and_weights`
   - Replace 4x `std::vector<int64_t>` + `4x std::vector<float>` with direct `ov::Tensor` allocation and indexing
   - Eliminate intermediate vector growth and final `std::memcpy` stage
   - Pre-compute `grid_max`, `h_floor_row`, `h_ceil_row` to reduce repeated multiplications
 - Optimize `permute_with_spatial_merge`
   - Replace s`td::vector<float>` with insert() + final `std::memcpy` with direct `ov::Tensor` allocation with per-row `std::memcpy`
   - Eliminate vector reallocation
 - Fuse `permute_with_spatial_merge` + `pos_embeds_addition` into single pass
   - Add `permute_with_spatial_merge_and_add()` that permutes position embeddings and adds them in-place to `concatenated_embeds` in a single traversal (dst[d] += src[d])
   - Rename `get_interpolated_pos_embeds` → `add_interpolated_pos_embeds` (takes `concatenated_embeds` by reference, returns void)
   - Eliminates ~12MB intermediate tensor allocation and a separate element-wise addition loop over ~3M floats

Ticket: [CVS-182790](https://jira.devtools.intel.com/browse/CVS-182790)
Average 1st token latency (1024x2048 image + 3K input tokens -> generate 128 tokens):
```
CPP vision_pos_embeds                 (GPU)  584.04 ms
OV vision_pos_embeds                  (GPU)  557.12 ms   
+ eliminating unnecessary mem alloc
```
WWB results with image input (--model-type visual-text):
```
genai: 2026.2.0.0-3009-b706e3031f6                                   (GPU)  0.869841
genai: 2026.2.0.0-3016-1d29eb04f24-opt_get_interpolated_pos_embeds   (GPU)  0.863346  
```
WWB results with video input (--model-type visual-video-text):
```
genai: 2026.2.0.0-3009-b706e3031f6                                   (GPU)  0.612858
genai: 2026.2.0.0-3016-1d29eb04f24-opt_get_interpolated_pos_embeds   (GPU)  0.606366
```

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
