### PR TITLE
[feat] ReAct sample: robust tool error handling and failure-path tests

### DIFF
--- a/samples/python/text_generation/react_sample.py
+++ b/samples/python/text_generation/react_sample.py
@@ -8,7 +8,6 @@ import openvino_genai
 import urllib.parse
 import json
 import json5
-import os
 
 TOOL_DESC = """{name_for_model}: Call this tool to interact with the {name_for_human} API. What is the {name_for_human} API useful for? {description_for_model} Parameters: {parameters}"""
 
@@ -242,9 +241,6 @@ def main():
 
     device = 'CPU'  # GPU can be used as well
     llm_model_path = args.model_dir
-
-    if not os.path.exists(llm_model_path):
-        raise RuntimeError(f"Model path does not exist: {llm_model_path}")
 
     llm_pipe = openvino_genai.LLMPipeline(llm_model_path, device)
     llm_config = openvino_genai.GenerationConfig()

--- a/samples/python/text_generation/react_sample.py
+++ b/samples/python/text_generation/react_sample.py
@@ -115,7 +115,7 @@ def parse_first_tool_call(text):
     return tool_name, tool_args, text
 
 def _tool_error(tool_name: str, message: str) -> str:
-    return json.dumps({"tool": tool_name, "error": message}, ensure_ascii=False)
+    return json.dumps({"tool": tool_name, "error": message})
 
 def _strip_wrapping_parentheses(text: str) -> str:
     stripped = text.strip()

--- a/samples/python/text_generation/react_sample.py
+++ b/samples/python/text_generation/react_sample.py
@@ -8,6 +8,7 @@ import openvino_genai
 import urllib.parse
 import json
 import json5
+import os
 
 TOOL_DESC = """{name_for_model}: Call this tool to interact with the {name_for_human} API. What is the {name_for_human} API useful for? {description_for_model} Parameters: {parameters}"""
 
@@ -114,9 +115,30 @@ def parse_first_tool_call(text):
         text = text[:k]
     return tool_name, tool_args, text
 
+def _tool_error(tool_name: str, message: str) -> str:
+    return json.dumps({"tool": tool_name, "error": message}, ensure_ascii=False)
+
+def _parse_tool_args(tool_name: str, tool_args: str):
+    try:
+        parsed_args = json5.loads(tool_args)
+    except Exception as ex:
+        return None, _tool_error(tool_name, f"Failed to parse tool arguments: {ex}")
+
+    if not isinstance(parsed_args, dict):
+        return None, _tool_error(tool_name, "Tool arguments must be a JSON object")
+
+    return parsed_args, None
+
 def call_tool(tool_name: str, tool_args: str) -> str:
     if tool_name == "get_weather":
-        city_name = json5.loads(tool_args)["city_name"]
+        parsed_args, parse_error = _parse_tool_args(tool_name, tool_args)
+        if parse_error:
+            return parse_error
+
+        city_name = parsed_args.get("city_name")
+        if not isinstance(city_name, str) or not city_name.strip():
+            return _tool_error(tool_name, "Missing or invalid required argument: city_name")
+
         key_selection = {
             "current_condition": [
                 "temp_C",
@@ -126,35 +148,69 @@ def call_tool(tool_name: str, tool_args: str) -> str:
                 "observation_time",
             ],
         }
-        resp = requests.get(f"https://wttr.in/{city_name}?format=j1")
-        resp.raise_for_status()
-        resp = resp.json()
-        ret = {k: {_v: resp[k][0][_v] for _v in v} for k, v in key_selection.items()}
+
+        try:
+            response = requests.get(f"https://wttr.in/{city_name}?format=j1", timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as ex:
+            return _tool_error(tool_name, f"Weather request failed: {ex}")
+
+        try:
+            response_payload = response.json()
+        except ValueError as ex:
+            return _tool_error(tool_name, f"Weather response is not valid JSON: {ex}")
+
+        current_condition = response_payload.get("current_condition")
+        if not isinstance(current_condition, list) or not current_condition or not isinstance(current_condition[0], dict):
+            return _tool_error(tool_name, "Weather response has unexpected structure")
+
+        weather = current_condition[0]
+        ret = {
+            k: {_v: weather.get(_v, "") for _v in v}
+            for k, v in key_selection.items()
+        }
         return json.dumps(ret, ensure_ascii=False)
     elif tool_name == "generate_image":
         tool_args = tool_args.replace("(", "").replace(")", "")
-        prompt = json5.loads(tool_args)["prompt"]
+        parsed_args, parse_error = _parse_tool_args(tool_name, tool_args)
+        if parse_error:
+            return parse_error
+
+        prompt = parsed_args.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return _tool_error(tool_name, "Missing or invalid required argument: prompt")
+
         prompt = urllib.parse.quote(prompt)
         return json.dumps(
             {"image_url": f"https://image.pollinations.ai/prompt/{prompt}"},
             ensure_ascii=False,
         )
     else:
-        raise NotImplementedError
+        return _tool_error(tool_name, "Unsupported tool")
 
-def llm_with_tool(llm_pipe, prompt, history, list_of_tool_info):
+def llm_with_tool(llm_pipe, prompt, history, list_of_tool_info, max_steps=8):
     chat_history = [(x["user"], x["bot"]) for x in history] + [(prompt, "")]
     planning_prompt = build_input_text(llm_pipe.get_tokenizer(), chat_history, list_of_tool_info)
 
     text = ""
-    while True:
+    for _ in range(max_steps):
         # llm pipe output based planning_prompt and the text (previous output)
         llm_config = llm_pipe.get_generation_config()
-        output = llm_pipe.generate(planning_prompt + text, llm_config, streamer)
+        try:
+            output = llm_pipe.generate(planning_prompt + text, llm_config, streamer)
+        except Exception as ex:
+            output = f"\nObservation: = {_tool_error('llm_generate', f'LLM generation failed: {ex}')}\nThought:"
+            text += output
+            break
+
         # parse the output to get action
         action, action_input, output = parse_first_tool_call(output)
         if action:
-            observation = call_tool(action, action_input)
+            try:
+                observation = call_tool(action, action_input)
+            except Exception as ex:
+                observation = _tool_error(action, f"Unexpected tool execution failure: {ex}")
+
             observation_txt = f"\nObservation: = {observation}\nThought:"
             print("\n\n- Getting information from the tool API -", observation_txt, "\n")
             output += observation_txt
@@ -162,6 +218,8 @@ def llm_with_tool(llm_pipe, prompt, history, list_of_tool_info):
         else:
             text += output
             break
+    else:
+        text += f"\nObservation: = {_tool_error('llm_with_tool', 'Reached max tool-calling steps')}\n"
 
     history.append({"user": prompt, "bot": text})
     return text, history
@@ -178,6 +236,9 @@ def main():
 
     device = 'CPU'  # GPU can be used as well
     llm_model_path = args.model_dir
+
+    if not os.path.exists(llm_model_path):
+        raise RuntimeError(f"Model path does not exist: {llm_model_path}")
 
     llm_pipe = openvino_genai.LLMPipeline(llm_model_path, device)
     llm_config = openvino_genai.GenerationConfig()

--- a/samples/python/text_generation/react_sample.py
+++ b/samples/python/text_generation/react_sample.py
@@ -118,6 +118,12 @@ def parse_first_tool_call(text):
 def _tool_error(tool_name: str, message: str) -> str:
     return json.dumps({"tool": tool_name, "error": message}, ensure_ascii=False)
 
+def _strip_wrapping_parentheses(text: str) -> str:
+    stripped = text.strip()
+    if len(stripped) >= 2 and stripped[0] == "(" and stripped[-1] == ")":
+        return stripped[1:-1].strip()
+    return stripped
+
 def _parse_tool_args(tool_name: str, tool_args: str):
     try:
         parsed_args = json5.loads(tool_args)
@@ -171,7 +177,7 @@ def call_tool(tool_name: str, tool_args: str) -> str:
         }
         return json.dumps(ret, ensure_ascii=False)
     elif tool_name == "generate_image":
-        tool_args = tool_args.replace("(", "").replace(")", "")
+        tool_args = _strip_wrapping_parentheses(tool_args)
         parsed_args, parse_error = _parse_tool_args(tool_name, tool_args)
         if parse_error:
             return parse_error

--- a/tests/python_tests/samples/test_react_sample_error_handling.py
+++ b/tests/python_tests/samples/test_react_sample_error_handling.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+import requests
+import pytest
+
+from conftest import SAMPLES_PY_DIR
+
+
+@pytest.fixture(scope="module")
+def react_module():
+    module_path = SAMPLES_PY_DIR / "text_generation/react_sample.py"
+    spec = importlib.util.spec_from_file_location("react_sample", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.samples
+@pytest.mark.agent
+def test_call_tool_handles_invalid_json_args(react_module):
+    result = react_module.call_tool("get_weather", "not-json")
+    payload = json.loads(result)
+    assert payload["tool"] == "get_weather"
+    assert "Failed to parse tool arguments" in payload["error"]
+
+
+@pytest.mark.samples
+@pytest.mark.agent
+def test_call_tool_handles_missing_required_argument(react_module):
+    result = react_module.call_tool("get_weather", "{}")
+    payload = json.loads(result)
+    assert payload["tool"] == "get_weather"
+    assert "Missing or invalid required argument: city_name" == payload["error"]
+
+
+@pytest.mark.samples
+@pytest.mark.agent
+def test_call_tool_handles_unsupported_tool(react_module):
+    result = react_module.call_tool("unknown_tool", "{}")
+    payload = json.loads(result)
+    assert payload["tool"] == "unknown_tool"
+    assert payload["error"] == "Unsupported tool"
+
+
+@pytest.mark.samples
+@pytest.mark.agent
+def test_call_tool_handles_weather_request_exception(monkeypatch, react_module):
+    def _raise_request_exception(*args, **kwargs):
+        raise requests.RequestException("network unavailable")
+
+    monkeypatch.setattr(react_module.requests, "get", _raise_request_exception)
+    result = react_module.call_tool("get_weather", '{"city_name":"London"}')
+    payload = json.loads(result)
+    assert payload["tool"] == "get_weather"
+    assert "Weather request failed" in payload["error"]
+
+
+class _FakeTokenizer:
+    def apply_chat_template(self, messages, add_generation_prompt=True):
+        return "PROMPT\n"
+
+
+class _FakeLLMPipeline:
+    def __init__(self):
+        self._outputs = [
+            "\nAction: get_weather\nAction Input: not-json\nObservation:",
+            "Final Answer: fallback response",
+        ]
+
+    def get_tokenizer(self):
+        return _FakeTokenizer()
+
+    def get_generation_config(self):
+        return object()
+
+    def generate(self, prompt, config, streamer):
+        if self._outputs:
+            return self._outputs.pop(0)
+        return "Final Answer: done"
+
+
+@pytest.mark.samples
+@pytest.mark.agent
+def test_llm_with_tool_continues_after_tool_error(react_module):
+    fake_pipe = _FakeLLMPipeline()
+    text, history = react_module.llm_with_tool(
+        fake_pipe,
+        prompt="question",
+        history=[],
+        list_of_tool_info=react_module.tools,
+        max_steps=4,
+    )
+
+    assert "Failed to parse tool arguments" in text
+    assert "Final Answer: fallback response" in text
+    assert len(history) == 1

--- a/tests/python_tests/samples/test_react_sample_error_handling.py
+++ b/tests/python_tests/samples/test_react_sample_error_handling.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util

--- a/tests/python_tests/samples/test_react_sample_error_handling.py
+++ b/tests/python_tests/samples/test_react_sample_error_handling.py
@@ -22,6 +22,7 @@ def react_module():
 
 @pytest.mark.samples
 @pytest.mark.agent
+@pytest.mark.llm
 def test_call_tool_handles_invalid_json_args(react_module):
     result = react_module.call_tool("get_weather", "not-json")
     payload = json.loads(result)
@@ -31,6 +32,7 @@ def test_call_tool_handles_invalid_json_args(react_module):
 
 @pytest.mark.samples
 @pytest.mark.agent
+@pytest.mark.llm
 def test_call_tool_handles_missing_required_argument(react_module):
     result = react_module.call_tool("get_weather", "{}")
     payload = json.loads(result)
@@ -40,6 +42,7 @@ def test_call_tool_handles_missing_required_argument(react_module):
 
 @pytest.mark.samples
 @pytest.mark.agent
+@pytest.mark.llm
 def test_call_tool_handles_unsupported_tool(react_module):
     result = react_module.call_tool("unknown_tool", "{}")
     payload = json.loads(result)
@@ -49,6 +52,7 @@ def test_call_tool_handles_unsupported_tool(react_module):
 
 @pytest.mark.samples
 @pytest.mark.agent
+@pytest.mark.llm
 def test_call_tool_handles_weather_request_exception(monkeypatch, react_module):
     def _raise_request_exception(*args, **kwargs):
         raise requests.RequestException("network unavailable")
@@ -86,6 +90,7 @@ class _FakeLLMPipeline:
 
 @pytest.mark.samples
 @pytest.mark.agent
+@pytest.mark.llm
 def test_llm_with_tool_continues_after_tool_error(react_module):
     fake_pipe = _FakeLLMPipeline()
     text, history = react_module.llm_with_tool(

--- a/tests/python_tests/samples/test_react_sample_error_handling.py
+++ b/tests/python_tests/samples/test_react_sample_error_handling.py
@@ -13,6 +13,7 @@ from conftest import SAMPLES_PY_DIR
 def react_module():
     module_path = SAMPLES_PY_DIR / "text_generation/react_sample.py"
     spec = importlib.util.spec_from_file_location("react_sample", module_path)
+    assert spec is not None, f"Failed to load module spec from {module_path}"
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Description
This PR hardens the Python ReAct sample so tool-calling failures are surfaced as observations instead of terminating execution.

Scope of change:
- Updated `samples/python/text_generation/react_sample.py`.
- Added model-free failure-path tests in `tests/python_tests/samples/test_react_sample_error_handling.py`.

Implemented improvements:
- Added safe tool-argument parsing and validation for required fields.
- Added structured error payloads for tool failures.
- Added timeout and robust error handling for weather API request/response parsing.
- Replaced unsupported-tool hard exception with safe error observation.
- Hardened tool loop with guarded error handling and max-step protection.
- Added model path existence validation before pipeline initialization.

Motivation:
- The sample previously assumed happy-path behavior for tool args and API calls.
- Real agentic workflows require resilience to malformed tool input, network failures, and unexpected API payloads.


Fixes #3508 

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code.
Added tests:
  - `tests/python_tests/samples/test_react_sample_error_handling.py`
Covered scenarios:
  - invalid JSON tool args
  - missing required argument
  - unsupported tool
  - weather request exception (mocked)
  - loop continuation after tool error (fake pipeline)
Executed:
  - `.venv\Scripts\python -m pytest tests\python_tests\samples\test_react_sample_error_handling.py -q`
  - Result: `5 passed`
- [x] This PR fully addresses the ticket.
- [ ] I have made corresponding changes to the documentation.
- [x]No public API/documentation changes are required for this PR.
