### PR TITLE
Add system prompt support to chat and visual language chat samples

### DIFF
--- a/samples/cpp/text_generation/README.md
+++ b/samples/cpp/text_generation/README.md
@@ -52,7 +52,7 @@ Recommended models: meta-llama/Llama-2-7b-chat-hf, TinyLlama/TinyLlama-1.1B-Chat
 - **Main Feature:** Real-time chat-like text generation.
 - **Run Command:**
   ```bash
-  ./chat_sample <MODEL_DIR>
+  ./chat_sample <MODEL_DIR> [DEVICE] [--system_prompt "prompt text"]
   ```
 #### Missing chat template
 If you encounter an exception indicating a missing "chat template" when launching the `ov::genai::LLMPipeline` in chat mode, it likely means the model was not tuned for chat functionality. To work this around, manually add the chat template to tokenizer_config.json of your model or update it using call `pipe.get_tokenizer().set_chat_template(new_chat_template)`.

--- a/samples/cpp/text_generation/chat_sample.cpp
+++ b/samples/cpp/text_generation/chat_sample.cpp
@@ -4,14 +4,30 @@
 #include "openvino/genai/llm_pipeline.hpp"
 
 int main(int argc, char* argv[]) try {
-    if (argc < 2 || argc > 3) {
-        throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR> <DEVICE>");
-    }
-    std::string prompt;
-    std::string models_path = argv[1];
+    std::string models_path;
+    std::string device = "CPU";  // GPU, NPU can be used as well
+    std::string system_prompt;
 
-    // Default device is CPU; can be overridden by the second argument
-    std::string device = (argc == 3) ? argv[2] : "CPU";  // GPU, NPU can be used as well
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--system_prompt" || arg == "-sys") {
+            if (i + 1 < argc) {
+                system_prompt = argv[++i];
+            } else {
+                throw std::runtime_error("Error: --system_prompt requires a value.");
+            }
+        } else if (models_path.empty()) {
+            models_path = arg;
+        } else {
+            device = arg;
+        }
+    }
+
+    if (models_path.empty()) {
+        throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR> [DEVICE] [--system_prompt \"prompt text\"]");
+    }
+
+    std::string prompt;
     ov::genai::LLMPipeline pipe(models_path, device);
     
     ov::genai::GenerationConfig config;
@@ -24,6 +40,9 @@ int main(int argc, char* argv[]) try {
     };
 
     ov::genai::ChatHistory chat_history;
+    if (!system_prompt.empty()) {
+        chat_history.push_back({{"role", "system"}, {"content", system_prompt}});
+    }
 
     std::cout << "question:\n";
     while (std::getline(std::cin, prompt)) {

--- a/samples/cpp/visual_language_chat/README.md
+++ b/samples/cpp/visual_language_chat/README.md
@@ -27,7 +27,7 @@ Follow [Get Started with Samples](https://docs.openvino.ai/2026/get-started/lear
 
 [This image](https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11) can be used as a sample image.
 
-`visual_language_chat miniCPM-V-2_6 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
+`visual_language_chat miniCPM-V-2_6 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg [DEVICE] [PROMPT_LOOKUP] [--system_prompt "prompt text"]`
 
 Discrete GPUs (dGPUs) usually provide better performance compared to CPUs. It is recommended to run larger models on a dGPU with 32GB+ RAM. For example, the model `llava-hf/llava-v1.6-mistral-7b-hf` can benefit from being run on a dGPU. Modify the source code to change the device for inference to the `GPU`.
 

--- a/samples/cpp/visual_language_chat/visual_language_chat.cpp
+++ b/samples/cpp/visual_language_chat/visual_language_chat.cpp
@@ -11,16 +11,39 @@ ov::genai::StreamingStatus print_subword(std::string&& subword) {
 }
 
 int main(int argc, char* argv[]) try {
-    if (argc < 3 || argc > 5) {
-        throw std::runtime_error(std::string{"Usage "} + argv[0] + " <MODEL_DIR> <IMAGE_FILE OR DIR_WITH_IMAGES> [DEVICE] [PROMPT_LOOKUP]");
+    std::string model_dir;
+    std::string image_dir;
+    std::string device = "CPU";
+    std::string lookup = "false";
+    std::string system_prompt;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--system_prompt" || arg == "-sys") {
+            if (i + 1 < argc) {
+                system_prompt = argv[++i];
+            } else {
+                throw std::runtime_error("Error: --system_prompt requires a value.");
+            }
+        } else if (model_dir.empty()) {
+            model_dir = arg;
+        } else if (image_dir.empty()) {
+            image_dir = arg;
+        } else if (device == "CPU") {
+            device = arg;
+        } else {
+            lookup = arg;
+        }
     }
 
-    std::vector<ov::Tensor> rgbs = utils::load_images(argv[2]);
+    if (model_dir.empty() || image_dir.empty()) {
+        throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR> <IMAGE_FILE OR DIR_WITH_IMAGES> [DEVICE] [PROMPT_LOOKUP] [--system_prompt \"prompt text\"]");
+    }
+
+    std::vector<ov::Tensor> rgbs = utils::load_images(image_dir);
 
     // GPU and NPU can be used as well.
     // Note: If NPU is selected, only language model will be run on NPU
-    std::string device = (argc >= 4) ? argv[3] : "CPU";
-    std::string lookup = (argc == 5) ? argv[4] : "false";
     bool prompt_lookup = (lookup == "true");
     // Prompt lookup decoding in VLM pipeline enforces ContinuousBatching backend
     ov::AnyMap properties = {ov::genai::prompt_lookup(prompt_lookup)};
@@ -30,7 +53,7 @@ int main(int argc, char* argv[]) try {
         properties.insert({ov::cache_dir("vlm_cache")});
     }
 
-    ov::genai::VLMPipeline pipe(argv[1], device, properties);
+    ov::genai::VLMPipeline pipe(model_dir, device, properties);
 
     ov::genai::GenerationConfig generation_config;
     generation_config.max_new_tokens = 100;
@@ -44,6 +67,9 @@ int main(int argc, char* argv[]) try {
     std::string prompt;
 
     ov::genai::ChatHistory history;
+    if (!system_prompt.empty()) {
+        history.push_back({{"role", "system"}, {"content", system_prompt}});
+    }
     
     std::cout << "question:\n";
     std::getline(std::cin, prompt);

--- a/samples/python/text_generation/README.md
+++ b/samples/python/text_generation/README.md
@@ -77,7 +77,7 @@ Recommended models: meta-llama/Llama-2-7b-chat-hf, TinyLlama/TinyLlama-1.1B-Chat
 - **Main Feature:** Real-time chat-like text generation.
 - **Run Command:**
   ```bash
-  python chat_sample.py model_dir
+  python chat_sample.py model_dir [device] [--system_prompt "prompt text"]
   ```
 #### Missing chat template
 If you encounter an exception indicating a missing "chat template" when launching the `ov::genai::LLMPipeline` in chat mode, it likely means the model was not tuned for chat functionality. To work this around, manually add the chat template to tokenizer_config.json of your model or update it using call `pipe.get_tokenizer().set_chat_template(new_chat_template)`.

--- a/samples/python/text_generation/chat_sample.py
+++ b/samples/python/text_generation/chat_sample.py
@@ -16,6 +16,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("model_dir", help="Path to the model directory")
     parser.add_argument("device", nargs="?", default="CPU", help="Device to run the model on (default: CPU)")
+    parser.add_argument("--system_prompt", "-sys", help="Optional system prompt to set the assistant persona")
     args = parser.parse_args()
 
     device = args.device
@@ -25,6 +26,8 @@ def main():
     config.max_new_tokens = 100
 
     chat_history = openvino_genai.ChatHistory()
+    if args.system_prompt:
+        chat_history.append({"role": "system", "content": args.system_prompt})
     while True:
         try:
             prompt = input("question:\n")

--- a/samples/python/visual_language_chat/README.md
+++ b/samples/python/visual_language_chat/README.md
@@ -47,7 +47,7 @@ Install [deployment-requirements.txt](../../deployment-requirements.txt) via `pi
 
 [This image](https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11) can be used as a sample image.
 
-`python visual_language_chat.py ./miniCPM-V-2_6/ 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
+`python visual_language_chat.py ./miniCPM-V-2_6/ 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg [device] [prompt_lookup] [--system_prompt "prompt text"]`
 
 See https://github.com/openvinotoolkit/openvino.genai/blob/master/src/README.md#supported-models for the list of supported models.
 

--- a/samples/python/visual_language_chat/visual_language_chat.py
+++ b/samples/python/visual_language_chat/visual_language_chat.py
@@ -55,6 +55,7 @@ def main():
     parser.add_argument(
         "prompt_lookup", nargs="?", default="false", help="Enable prompt lookup decoding (default: false)"
     )
+    parser.add_argument("--system_prompt", "-sys", help="Optional system prompt to set the assistant persona")
     args = parser.parse_args()
 
     rgbs = read_images(args.image_dir)
@@ -80,6 +81,8 @@ def main():
         config.max_ngram_size = 3
 
     history = openvino_genai.ChatHistory()
+    if args.system_prompt:
+        history.append({"role": "system", "content": args.system_prompt})
     prompt = input('question:\n')
     history.append({"role": "user", "content": prompt})
     decoded_results = pipe.generate(history, images=rgbs, generation_config=config, streamer=streamer)


### PR DESCRIPTION
## Description
This PR introduces the ability for users to pass a system prompt to set the persona/context of the assistant in both the text generation and visual language modeling chat samples.

## Changes included
- Added `--system_prompt` / `-sys` argument to both C++ and Python chat samples:
  - `samples/cpp/text_generation/chat_sample.cpp`
  - `samples/cpp/visual_language_chat/visual_language_chat.cpp`
  - `samples/python/text_generation/chat_sample.py`
  - `samples/python/visual_language_chat/visual_language_chat.py`

- When provided, a system role message is prepended to the `ChatHistory` before the first user prompt, allowing users to customize the assistant's persona.

- Updated C++ samples to use flexible argument parsing instead of rigid positional `argc` checks:
  - Maintains backward compatibility with the old positional argument structure
  - Adds seamless support for the new optional flag

## Fixes
- Fixes #(issue)

## Checklist
- [x] This PR follows GenAI Contributing guidelines  
- [x] This PR fully addresses the ticket  
- [x] I have made corresponding changes to the documentation  