### PR TITLE
Extract win32 av module mock to shared utility (#28)

### DIFF
--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -27,6 +27,8 @@ ov_pipe_model
 ov_continious_batching_pipe
 """
 
+import utils.win32_av_mock  # noqa: F401 - must be imported before transformers
+
 import collections
 from enum import Enum
 from dataclasses import dataclass

--- a/tests/python_tests/test_whisper_pipeline.py
+++ b/tests/python_tests/test_whisper_pipeline.py
@@ -1,17 +1,7 @@
 # Copyright (C) 2023-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
-# win32 fails on ffmpeg DLLs load
-# import transformers.pipeline imports VideoClassificationPipeline which requires PyAV (ffmpeg bindings)
-# wa is to create mock 'av' module to prevent DLLs loading errors
-# ticket: 179943
-if sys.platform == "win32":
-    from types import ModuleType
-
-    sys.modules["av"] = ModuleType("av")
-    sys.modules["av"].__version__ = "0.0.0"
+import utils.win32_av_mock  # noqa: F401 - must be imported before transformers
 
 import openvino_genai as ov_genai
 import functools

--- a/tests/python_tests/utils/win32_av_mock.py
+++ b/tests/python_tests/utils/win32_av_mock.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+# win32 fails on ffmpeg DLLs load
+# import transformers.pipeline imports VideoClassificationPipeline which requires PyAV (ffmpeg bindings)
+# wa is to create mock 'av' module to prevent DLLs loading errors
+# ticket: 179943
+if sys.platform == "win32":
+    from types import ModuleType
+
+    sys.modules["av"] = ModuleType("av")
+    sys.modules["av"].__version__ = "0.0.0"


### PR DESCRIPTION
* Initial plan

* Extract win32 av module mock to shared utils/win32_av_mock.py

Move the win32 ffmpeg DLL mock workaround from test_whisper_pipeline.py into utils/win32_av_mock.py and import it in both test_whisper_pipeline.py and test_vlm_pipeline.py.

Ticket: 179943


Agent-Logs-Url: https://github.com/peterchen-intel/openvino.genai/sessions/804763c3-3b42-4ce9-90da-5a76af00bff1

---------

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
