### PR TITLE
[llm_bench] [wwb] Update torch related deps

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -7,7 +7,7 @@ openvino-tokenizers
 openvino_genai
 # Image processing for VLMs
 pillow==12.1.1
-torch>=2.1.0,<=2.10
+torch>=2.1.0,<=2.11
 transformers[sentencepiece]>=4.40.0,<5.4.0
 diffusers>=0.22.0,<=0.37.0
 # optimum is in dependency list of optimum-intel
@@ -37,7 +37,7 @@ backoff==2.2.1
 # Please, be advised that MiniCPM-o-2_6 requires transformers>=4.50,<=4.51.3
 vector-quantize-pytorch==1.27.20
 vocos==0.1.0
-torchaudio>=2.1.0,<=2.10.0
+torchaudio>=2.1.0,<=2.11.0
 torchcodec==0.7.0; sys_platform == "linux"
-torchvision>=0.16,<=0.25.0
+torchvision>=0.16,<=0.26.0
 soundfile==0.13.1

--- a/tools/who_what_benchmark/requirements.txt
+++ b/tools/who_what_benchmark/requirements.txt
@@ -23,7 +23,7 @@ librosa==0.11.0
 torchcodec<=0.10.0; sys_platform == "linux"
 vocos==0.1.0
 vector-quantize-pytorch==1.27.20
-torchaudio>=2.1.0,<=2.10.0
-torchvision>=0.16,<=0.25.0
+torchaudio>=2.1.0,<=2.11.0
+torchvision>=0.16,<=0.26.0
 # For LoRA adapters
 peft==0.18.1


### PR DESCRIPTION
After recent releases:
- https://pypi.org/project/torch/#history
- https://pypi.org/project/torchaudio/#history
- https://pypi.org/project/torchvision/#history

We are facing issues in validation when installing llm_bench/wwb together with custom optimum-intel, where torch is not as restricted: `"torch>=2.1",`

```
09:08:37  torchvision 0.25.0+cpu requires torch==2.10.0, but you have torch 2.11.0+cpu which is incompatible.
09:08:37  torchaudio 2.10.0+cpu requires torch==2.10.0, but you have torch 2.11.0+cpu which is incompatible.
```