### PR TITLE
Add pre-commit setup instructions to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,23 @@
 6. Branching policy is aligned with [OpenVINO's policy](https://github.com/openvinotoolkit/openvino/blob/71ee9cc42ec63b3affb2801dbbc4a77e6d8003f6/CONTRIBUTING_PR.md#branching-policy).
 7. Contributions with use of AI must comply with [OpenVINO's AI Usage Policy](https://github.com/openvinotoolkit/openvino/blob/c4f4325c57977c684184e758449d1f8825ebbfd7/AI_USAGE_POLICY.md).
 
+# Code Quality
+This repository uses [pre-commit](https://pre-commit.com/) hooks to catch common issues early (JSON/YAML syntax errors, merge conflict markers, line endings, etc.).
+
+To set up locally:
+
+> **Note for Windows users:** Run `git config core.autocrlf input` first to avoid line-ending conflicts with the hooks.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+After that, checks run automatically on every `git commit`. To run manually on changed files:
+```bash
+pre-commit run --from-ref origin/master --to-ref HEAD
+```
+
 # New feature contribution
 In order to get accepted PR with new features, the following list of items MUST be completed. Otherwise, PR will be rejected.
 1. Proof of Concept (PoC) pipeline including model preparation step using `optimum-intel` and `GenAI` inference implementation.


### PR DESCRIPTION
This PR adds a Code Quality section to CONTRIBUTING.md explaining how to set up and run pre-commit hooks locally. 
Prompted by [this discussion](https://github.com/openvinotoolkit/openvino.genai/pull/3536#pullrequestreview-3990216524)

Helps new contributors discover the tooling upfront rather than first encountering it as a CI failure.

Includes a note for Windows users about core.autocrlf to prevent line-ending conflicts with the mixed-line-ending hook.

cc @Wovchena 

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- Tests have been updated or added to cover the new code. NA
- This PR fully addresses the ticket. NA
- I have made corresponding changes to the documentation.  NA
