### PR TITLE
[GHA] Add incremental clang-format pre-commit hook for C/C++

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 7. Contributions with use of AI must comply with [OpenVINO's AI Usage Policy](https://github.com/openvinotoolkit/openvino/blob/c4f4325c57977c684184e758449d1f8825ebbfd7/AI_USAGE_POLICY.md).
 
 # Code Quality
-This repository uses [pre-commit](https://pre-commit.com/) hooks to catch common issues early (JSON/YAML syntax errors, merge conflict markers, line endings, etc.).
+This repository uses [pre-commit](https://pre-commit.com/) hooks to catch common issues early (JSON/YAML syntax errors, merge conflict markers, line endings, C/C++ formatting on changed lines, etc.).
 
 To set up locally:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
         additional_dependencies:
           - ruff==0.14.4
           - tomli==2.3.0
+  - repo: local
+    hooks:
+      - id: git-clang-format
+        name: git-clang-format
+        entry: git-clang-format --binary clang-format --extensions=c,cc,cpp,cxx,h,hpp,hxx --style=file
+        language: python
+        additional_dependencies:
+          - clang-format==23.1.0
+        files: \.(c|cc|cpp|cxx|h|hpp|hxx)$
+        pass_filenames: false


### PR DESCRIPTION
This PR adds a clang-format pre-commit hook based on `git-clang-format`, which parses the git diff and passes `--lines start:end` to clang-format, formatting only the touched lines rather than whole files. This was released in clang-format 23.1.0, and was added to LLVM in llvm/llvm-project#188813.

The `--extensions` allowlist on the hook entry is required because `git-clang-format` otherwise forwards every language clang-format supports, so with the codebase's `Cpp`-only .clang-format, a PR touching .js/.json files alongside C++ made clang-format error and the hook abort. Restricting it to C/C++ extensions keeps clang-format out of JS/JSON entirely (JS is formatted by Prettier in src/js; pre-commit only validates JSON via check-json). Per-language `DisableFormat` sections in .clang-format would also work, but make it multi-document YAML, which the existing check-yaml hook rejects.

Validated this on my fork: a misformatted change fails with the diff scoped to touched files only (goyaladitya05/openvino.genai#193), the same change correctly formatted passes (goyaladitya05/openvino.genai#194), and a .json + .cpp change in one PR is handled cleanly (goyaladitya05/openvino.genai#195). Pre-existing drift in untouched files (e.g. chat_history.hpp, imwrite.cpp) is never reported.



## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- Tests have been updated or added to cover the new code. NA
- This PR fully addresses the ticket. NA
- [x] I have made corresponding changes to the documentation. 
