### PR TITLE
docs(python): add Text2VideoPipeline binding docstrings

### DIFF
--- a/src/python/py_video_generation_pipelines.cpp
+++ b/src/python/py_video_generation_pipelines.cpp
@@ -15,6 +15,77 @@
 namespace py = pybind11;
 namespace pyutils = ov::genai::pybind::utils;
 
+namespace {
+
+auto text2video_pipeline_class_docstring = R"(
+    Text-to-video generation pipeline.
+
+    This pipeline generates videos from text prompts using exported video generation models.
+    Use :meth:`generate` for inference and :meth:`set_generation_config` / :meth:`reshape`
+    to customize generation behavior.
+)";
+
+auto text2video_pipeline_init_docstring = R"(
+    Text2VideoPipeline class constructor.
+
+    :param models_path: Path to a directory with exported text-to-video model files.
+    :type models_path: os.PathLike
+
+    .. note::
+       This constructor does not compile models internally. Call :meth:`compile`
+       (and typically :meth:`reshape`) before invoking :meth:`generate`.
+)";
+
+auto text2video_pipeline_init_with_device_docstring = R"(
+    Text2VideoPipeline class constructor.
+
+    :param models_path: Path to a directory with exported text-to-video model files.
+    :type models_path: os.PathLike
+
+    :param device: Device on which inference will be done (for example, ``CPU`` or ``GPU``).
+    :type device: str
+
+    :param kwargs: Optional OpenVINO device properties.
+    :type kwargs: dict
+
+    This constructor compiles the underlying models for the specified device,
+    so the pipeline is ready for inference immediately after construction and
+    :meth:`compile` does not need to be called explicitly.
+)";
+
+auto text2video_pipeline_generate_docstring = R"(
+    Generates a video from a text prompt.
+
+    :param prompt: Input text prompt.
+    :type prompt: str
+
+    :param kwargs: Optional generation overrides and runtime options.
+        Typical keys include ``negative_prompt``, ``num_frames``, ``height``,
+        ``width``, ``num_inference_steps``, ``guidance_scale``, and ``callback``.
+    :type kwargs: dict
+
+    :return: Video generation output with generated frames and performance metrics.
+    :rtype: VideoGenerationResult
+
+    **Example**
+
+    .. code-block:: python
+
+        import openvino_genai as ov_genai
+
+        pipe = ov_genai.Text2VideoPipeline("./tiny-random-ltx-video", "CPU")
+        result = pipe.generate(
+            "A calm lake at sunrise",
+            num_frames=9,
+            height=32,
+            width=32,
+            num_inference_steps=2,
+        )
+        video = result.video
+)";
+
+} // namespace
+
 void init_video_generation_pipelines(py::module_& m) {
     py::class_<ov::genai::VideoGenerationPerfMetrics, ov::genai::ImageGenerationPerfMetrics>(m, "VideoGenerationPerfMetrics")
         .def(py::init<>());
@@ -37,12 +108,13 @@ void init_video_generation_pipelines(py::module_& m) {
         .def_readonly("video", &ov::genai::VideoGenerationResult::video)
         .def_readonly("perf_metrics", &ov::genai::VideoGenerationResult::performance_stat);
 
-    py::class_<ov::genai::Text2VideoPipeline>(m, "Text2VideoPipeline")
+    py::class_<ov::genai::Text2VideoPipeline>(m, "Text2VideoPipeline", text2video_pipeline_class_docstring)
         .def(py::init([](const std::filesystem::path& models_path) {
                  ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
                  return std::make_unique<ov::genai::Text2VideoPipeline>(models_path);
              }),
-             py::arg("models_path"))
+             py::arg("models_path"),
+             text2video_pipeline_init_docstring)
         .def(
             py::init([](const std::filesystem::path& models_path, const std::string& device, const py::kwargs& kwargs) {
                 ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
@@ -51,7 +123,8 @@ void init_video_generation_pipelines(py::module_& m) {
                                                                        pyutils::kwargs_to_any_map(kwargs));
             }),
             py::arg("models_path"),
-            py::arg("device"))
+            py::arg("device"),
+            text2video_pipeline_init_with_device_docstring)
         .def("get_generation_config",
              &ov::genai::Text2VideoPipeline::get_generation_config,
              py::return_value_policy::copy)
@@ -96,5 +169,6 @@ void init_video_generation_pipelines(py::module_& m) {
                 }
                 return result;
             },
-            py::arg("prompt"));
+            py::arg("prompt"),
+            text2video_pipeline_generate_docstring);
 }


### PR DESCRIPTION
## Description
This PR adds descriptive Python docstrings for `Text2VideoPipeline` bindings to improve `help()` output and IDE tooltips, and to align video pipeline documentation quality with other pipelines.

Fixes #3571

### What Changed
- Updated `src/python/py_video_generation_pipelines.cpp`.
- Added class-level docstring for `Text2VideoPipeline`.
- Added constructor docstrings for:
  - `Text2VideoPipeline(models_path)`
  - `Text2VideoPipeline(models_path, device, **kwargs)`
- Added `generate()` docstring with:
  - argument descriptions (`prompt`, common `kwargs` such as `negative_prompt`, `num_frames`, `height`, `width`, `num_inference_steps`, `guidance_scale`, `callback`)
  - return type description (`VideoGenerationResult`)
  - short usage example

### Notes
- This is a docs-only binding update; no functional/runtime logic changes were introduced.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. (N/A: docs-only binding text change; no behavior changes. Pre-commit checks passed.)
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. (Binding-level Python API docstrings updated in source.)