### PR TITLE
Fix: eos_token_id=0 silently skipped in update_generation_config

### DIFF
--- a/src/cpp/src/generation_config.cpp
+++ b/src/cpp/src/generation_config.cpp
@@ -114,7 +114,7 @@ void GenerationConfig::update_generation_config(const ov::AnyMap& properties) {
     read_anymap_param(properties, "stop_strings", stop_strings);
     read_anymap_param(properties, "include_stop_str_in_output", include_stop_str_in_output);
     read_anymap_param(properties, "stop_token_ids", stop_token_ids);
-    if (eos_token_id > 0) {
+    if (eos_token_id != -1) {
         set_eos_token_id(eos_token_id);
     }
 


### PR DESCRIPTION
## Description

In `GenerationConfig::update_generation_config()`, the condition `if (eos_token_id > 0)` prevents `set_eos_token_id()` from being called when `eos_token_id` is `0`.

Token ID `0` is a valid EOS token for some models (e.g., `Helsinki-NLP/opus-mt-fr-en`). The JSON constructor path (line 96) correctly uses `if (eos_token_id != -1)`, but the AnyMap update path (line 117) incorrectly uses `if (eos_token_id > 0)`. This inconsistency causes models with `eos_token_id=0` to never add it to `stop_token_ids`, potentially causing generation to never terminate.

Changed the condition from `> 0` to `!= -1` to match the JSON constructor behavior.

Fixes #3583

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- [ ] I have made corresponding changes to the documentation.

