### PR TITLE
fix: replace no-op OPENVINO_ASSERT with OPENVINO_THROW for unsupported type branches

### DIFF
--- a/src/cpp/src/gguf_utils/gguf_quants.cpp
+++ b/src/cpp/src/gguf_utils/gguf_quants.cpp
@@ -248,7 +248,7 @@ void gguf_load_quantized(std::unordered_map<std::string, ov::Tensor>& a,
     } else if (tensor.type == GGUF_TYPE_Q4_K) {
         extract_q4_k_data(tensor, weights, scales, biases);
     } else {
-        OPENVINO_ASSERT("Unsupported tensor type in 'gguf_load_quantized'");
+        OPENVINO_THROW("Unsupported tensor type in 'gguf_load_quantized'");
     }
 
     a.emplace(name, std::move(weights));

--- a/src/cpp/src/image_generation/flux_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux_pipeline.hpp
@@ -140,7 +140,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder");
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");
@@ -199,7 +199,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder", device, *updated_properties);
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -117,7 +117,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder");
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");
@@ -177,7 +177,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder", device, properties);
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");

--- a/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_pipeline.hpp
@@ -62,7 +62,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder");
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");
@@ -107,7 +107,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder", device, *updated_properties);
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");

--- a/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_xl_pipeline.hpp
@@ -55,7 +55,7 @@ public:
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder",
                                                         root_dir / "vae_decoder");
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
         } else {
             OPENVINO_THROW("Unsupported '", vae, "' VAE decoder type");
@@ -142,7 +142,7 @@ public:
             else if (m_pipeline_type == PipelineType::IMAGE_2_IMAGE || m_pipeline_type == PipelineType::INPAINTING) {
                 m_vae = std::make_shared<AutoencoderKL>(root_dir / "vae_encoder", root_dir / "vae_decoder", device, *updated_properties);
             } else {
-                OPENVINO_ASSERT("Unsupported pipeline type");
+                OPENVINO_THROW("Unsupported pipeline type");
             }
             updated_properties.fork().erase(ov::genai::blob_path.name());
         } else {


### PR DESCRIPTION
<img width="713" height="130" alt="image" src="https://github.com/user-attachments/assets/bd554ccb-e79e-49d8-9759-69af6919524b" />
As seen in this screenshot, OPENVINO_ASSERT uses condition to run, in case of the code where i have replaced OPENVINO_ASSERT with OPENVINO_THROW, the string literal is used as a condition rather than a message, and as we know that any non-empty string as a condition is true in C++, the block never executes and hence replaced with OPENVINO_THROW in these error branches which will throw the exception nonetheless.