### PR TITLE
[VLM] Eliminate redundant deep copy of lm_extra_inputs in CB pipeline for Qwen3-VL

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -371,7 +371,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[0].get_shape()[1], 0));
 
-        lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
+        lm_extra_inputs_list.push_back(m_inputs_embedder->get_lm_extra_inputs());
 
         auto end_get_inputs_embeds = std::chrono::steady_clock::now();
         vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
@@ -638,7 +638,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(uint64_t re
     std::optional<ov::Tensor> token_type_ids;
     // FIXME prompt_ids is not populated for VLM prompt lookup with add_request API
     std::optional<ov::Tensor> prompt_ids;
-    std::unordered_map<std::string, ov::Tensor> lm_extra_inputs;
     {
         std::lock_guard<std::mutex> lock(m_embeddings_mutex);
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
@@ -650,9 +649,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(uint64_t re
         } else {
             inputs = m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, metrics, true, image_sequence);
         }
-        lm_extra_inputs = deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs());
+        return add_request(request_id, inputs, sampling_params, token_type_ids, prompt_ids, m_inputs_embedder->get_lm_extra_inputs());
     }
-    return add_request(request_id, inputs, sampling_params, token_type_ids, prompt_ids, lm_extra_inputs);
 }
 
 GenerationHandle
@@ -682,7 +680,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
     std::optional<ov::Tensor> token_type_ids;
     // FIXME prompt_ids is not populated for VLM prompt lookup with add_request API
     std::optional<ov::Tensor> prompt_ids;
-    std::unordered_map<std::string, ov::Tensor> lm_extra_inputs;
     {
         std::lock_guard<std::mutex> lock(m_embeddings_mutex);
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
@@ -691,9 +688,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
 
         const auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, 0, 0, encoded_images, encoded_videos);
         inputs = m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, encoded_videos, metrics, true, image_sequence, video_sequence);
-        lm_extra_inputs = deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs());
+        return add_request(request_id, inputs, std::move(sampling_params), token_type_ids, prompt_ids, m_inputs_embedder->get_lm_extra_inputs());
     }
-    return add_request(request_id, inputs, std::move(sampling_params), token_type_ids, prompt_ids, lm_extra_inputs);
 }
 
 void ContinuousBatchingPipeline::IContinuousBatchingPipeline::stream_tokens(


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
### Details
   - In the continuous batching (CB) pipeline, `lm_extra_inputs` (containing tensors like `deepstack_visual_embeds` ~60MB for Qwen3-VL) was being deep-copied via `deep_copy_tensors_map()` before being passed to **SequenceGroup**. However, **SequenceGroup** already performs its own deep copy internally, making the first copy completely redundant.
   - This PR removes the redundant copy by passing the result of the existing `get_lm_extra_inputs()` directly to **SequenceGroup**. Since `ov::Tensor` is reference-counted, this only bumps refcounts — **SequenceGroup**'s internal `tensor.copy_to(...)` then produces the owned copy, all under the same `m_embeddings_mutex` that protects the embedder state.
### Changes
   - Chat single-prompt path and both `add_request()` overloads: drop `deep_copy_tensors_map(...)` and pass `get_lm_extra_inputs()` directly.
   - Non-chat batch loops: retain `deep_copy_tensors_map()`, where subsequent iterations may reuse the same vision-merger `InferRequest` and overwrite aliased tensor buffers before the list is consumed.
   - No new API; no model-specific class changes.
### Impact
   - **Qwen3-VL**: eliminates the redundant ~60MB deep copy (`deepstack_visual_embeds` **[3, 2048, 2560]** float32) per image request, improving 1st token latency by ~3.5%.
   - **Other VLM models**: no functional change — the base `get_lm_extra_inputs()` returns an empty map.
   - **Non-CB pipeline** (`pipeline.cpp`): unchanged, still uses `get_lm_extra_inputs()` by const reference
  
<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
Ticket: [CVS-184031](https://jira.devtools.intel.com/browse/CVS-184031)

<!-- Remove if not applicable -->

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
