### PR TITLE
Enable HunYuan (tencent/HY-MT1.5-1.8B) model support

### DIFF
--- a/site/docs/supported-models/_components/llm-models-table/models.ts
+++ b/site/docs/supported-models/_components/llm-models-table/models.ts
@@ -440,6 +440,17 @@ export const LLM_MODELS: LLMModelType[] = [
     ],
   },
   {
+    architecture: 'HunYuanDenseV1ForCausalLM',
+    models: [
+      {
+        name: 'HunYuan',
+        links: [
+          'https://huggingface.co/tencent/HY-MT1.5-1.8B',
+        ],
+      },
+    ],
+  },
+  {
     architecture: 'InternLMForCausalLM',
     models: [
       {

--- a/tools/llm_bench/llm_bench_utils/config_class.py
+++ b/tools/llm_bench/llm_bench_utils/config_class.py
@@ -215,6 +215,7 @@ USE_CASES = {
                 "granite",
                 "granitemoe",
                 "gptj",
+                "hunyuan",
                 "yi-",
                 "lfm2-moe",
                 "afmoe",


### PR DESCRIPTION
## Description

Add support for `tencent/HY-MT1.5-1.8B` (`HunYuanDenseV1ForCausalLM` architecture) to OpenVINO GenAI.

The model architecture `hunyuan_v1_dense` is a Llama-like causal LM (optimum-intel config inherits from `LlamaOpenVINOConfig`). Export and GenAI C++ inference work out of the box — no C++ changes needed. The only code change is registering the `"hunyuan"` model type prefix in llm_bench so the benchmark tool recognizes the model.

**Validation results** (via `check_model.py`):
- Export: PASSED
- llm_bench inference: PASSED (1st token: 40.94 ms, 2nd token: 35.32 ms/token, throughput: 28.31 tokens/s)
- WWB Optimum similarity: **0.9814** (threshold: 0.95)
- WWB GenAI similarity: **0.9572** (threshold: 0.95)

**Changes:**
- `tools/llm_bench/llm_bench_utils/config_class.py` — add `"hunyuan"` to `text_gen` model types
- `site/docs/supported-models/_components/llm-models-table/models.ts` — add `HunYuanDenseV1ForCausalLM` entry to the supported models table

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code. <!-- No new functional test with tiny-random model added for this architecture. The model was validated end-to-end via check_model.py (export + llm_bench + WWB). -->
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. <!-- Supported models table updated with HunYuanDenseV1ForCausalLM entry. -->
