### PR TITLE
Ignore openvinotoolkit/openvino gha updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     open-pull-requests-limit: 3
     ignore:
       # Cannot be updated for the moment, ticket: 184608
-      - dependency-name: "openvinotoolkit/openvino/.github/actions/smart-ci"
       - dependency-name: "openvinotoolkit/openvino"
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     ignore:
       # Cannot be updated for the moment, ticket: 184608
       - dependency-name: "openvinotoolkit/openvino/.github/actions/smart-ci"
+      - dependency-name: "openvinotoolkit/openvino"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

openvino smart-ci still gets updated by dependabot: https://github.com/openvinotoolkit/openvino.genai/pull/3691. Likely because it's recognized as `openvinotoolkit/openvino`. Let's ignore parent dependecy instead.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [NA] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [NA] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
