### PR TITLE
[Dependabot]: ignore actions/checkout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     ignore:
       # Cannot be updated for the moment, ticket: 184608
       - dependency-name: "openvinotoolkit/openvino/.github/actions/smart-ci"
+      - dependency-name: "actions/checkout"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       - dependency-name: "openvinotoolkit/openvino"
       # Cannot be updated for the moment, ticket: 184715
       - dependency-name: "actions/checkout"
+      # Due to recent trivy security issues to be updated manually
+      - dependency-name: "aquasecurity/trivy-action"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     ignore:
       # Cannot be updated for the moment, ticket: 184608
       - dependency-name: "openvinotoolkit/openvino"
+      # Cannot be updated for the moment, ticket: 184715
       - dependency-name: "actions/checkout"
     groups:
       github-actions:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

SmartCI fails to fetch GenAI repo after actions/checkout update: https://github.com/openvinotoolkit/openvino.genai/actions/runs/24343701284/job/71078797458?pr=3695#step:3:361

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [NA] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [NA] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
