### PR TITLE
Fix grammar and typos across sample READMEs and llm_bench docs

### DIFF
--- a/samples/cpp/text_generation/README.md
+++ b/samples/cpp/text_generation/README.md
@@ -105,7 +105,7 @@ Recommended models: meta-llama/Llama-2-7b-hf, etc
 
 ### 5. Prompt Lookup Decoding LM (`prompt_lookup_decoding_lm`)
 - **Description:**
-[Prompt Lookup decoding](https://github.com/apoorvumang/prompt-lookup-decoding) is [assisted-generation](https://huggingface.co/blog/assisted-generation#understanding-text-generation-latency) technique where the draft model is replaced with simple string matching the prompt to generate candidate token sequences. This method highly effective for input grounded generation (summarization, document QA, multi-turn chat, code editing), where there is high n-gram overlap between LLM input (prompt) and LLM output. This could be entity names, phrases, or code chunks that the LLM directly copies from the input while generating the output. Prompt lookup exploits this pattern to speed up autoregressive decoding in LLMs. This results in significant speedups with no effect on output quality.
+[Prompt Lookup decoding](https://github.com/apoorvumang/prompt-lookup-decoding) is an [assisted-generation](https://huggingface.co/blog/assisted-generation#understanding-text-generation-latency) technique where the draft model is replaced with simple string matching the prompt to generate candidate token sequences. This method is highly effective for input grounded generation (summarization, document QA, multi-turn chat, code editing), where there is high n-gram overlap between LLM input (prompt) and LLM output. This could be entity names, phrases, or code chunks that the LLM directly copies from the input while generating the output. Prompt lookup exploits this pattern to speed up autoregressive decoding in LLMs. This results in significant speedups with no effect on output quality.
 Recommended models: meta-llama/Llama-2-7b-hf, etc
 - **Main Feature:** Specialized prompt-based inference.
 - **Run Command:**
@@ -168,9 +168,9 @@ The sample also demonstrates how to enable user defined encryption for plugin ca
 
 ### 9. LLMs benchmarking sample (`benchmark_genai`)
 - **Description:**
-This sample script demonstrates how to benchmark an LLMs in OpenVINO GenAI. The script includes functionality for warm-up iterations, generating text, and calculating various performance metrics.
+This sample script demonstrates how to benchmark LLMs in OpenVINO GenAI. The script includes functionality for warm-up iterations, generating text, and calculating various performance metrics.
 
-For more information how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
+For more information on how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
 - **Main Feature:** Benchmark model via GenAI
 - **Run Command:**
   ```bash

--- a/samples/cpp/visual_language_chat/README.md
+++ b/samples/cpp/visual_language_chat/README.md
@@ -111,7 +111,7 @@ TPOT: 135.45 ± 4.73 ms/token
 Throughput: 7.38 ± 0.26 tokens/s
 ```
 
-For more information how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
+For more information on how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
 
 ### Troubleshooting
 

--- a/samples/python/image_generation/README.md
+++ b/samples/python/image_generation/README.md
@@ -160,7 +160,7 @@ The sample will create a stable diffusion pipeline such that the text encoder is
 ## Run image to image pipeline
 
 The `image2mage.py` sample demonstrates basic image to image generation pipeline. The difference with text to image pipeline is that final image is denoised from initial image converted to latent space and noised with image noise according to `strength` parameter. `strength` should be in range of `[0., 1.]` where `1.` means initial image is fully noised and it is an equivalent to text to image generation.
-Also, `strength` parameter linearly affects a number of inferenece steps, because lower `strength` values means initial latent already has some structure and it requires less steps to denoise it.
+Also, `strength` parameter linearly affects a number of inference steps, because lower `strength` values means initial latent already has some structure and it requires less steps to denoise it.
 
 To run the sample, download initial image first:
 

--- a/samples/python/text_generation/README.md
+++ b/samples/python/text_generation/README.md
@@ -130,7 +130,7 @@ Recommended models: meta-llama/Llama-2-7b-hf, etc
 
 ### 5. Prompt Lookup Decoding LM (`prompt_lookup_decoding_lm`)
 - **Description:**
-[Prompt Lookup decoding](https://github.com/apoorvumang/prompt-lookup-decoding) is [assisted-generation](https://huggingface.co/blog/assisted-generation#understanding-text-generation-latency) technique where the draft model is replaced with simple string matching the prompt to generate candidate token sequences. This method highly effective for input grounded generation (summarization, document QA, multi-turn chat, code editing), where there is high n-gram overlap between LLM input (prompt) and LLM output. This could be entity names, phrases, or code chunks that the LLM directly copies from the input while generating the output. Prompt lookup exploits this pattern to speed up autoregressive decoding in LLMs. This results in significant speedups with no effect on output quality.
+[Prompt Lookup decoding](https://github.com/apoorvumang/prompt-lookup-decoding) is an [assisted-generation](https://huggingface.co/blog/assisted-generation#understanding-text-generation-latency) technique where the draft model is replaced with simple string matching the prompt to generate candidate token sequences. This method is highly effective for input grounded generation (summarization, document QA, multi-turn chat, code editing), where there is high n-gram overlap between LLM input (prompt) and LLM output. This could be entity names, phrases, or code chunks that the LLM directly copies from the input while generating the output. Prompt lookup exploits this pattern to speed up autoregressive decoding in LLMs. This results in significant speedups with no effect on output quality.
 Recommended models: meta-llama/Llama-2-7b-hf, etc
 - **Main Feature:** Specialized prompt-based inference.
 - **Run Command:**
@@ -187,7 +187,7 @@ LLMPipeline and Tokenizer objects can be initialized directly from the memory bu
 - **Description:**
 This sample script demonstrates how to benchmark LLMs in OpenVINO GenAI. The script includes functionality for warm-up iterations, generating text, and calculating various performance metrics.
 
-For more information how performance metrics are calculated, please follow the [performance-metrics tutorial](../../../src/README.md#performance-metrics).
+For more information on how performance metrics are calculated, please follow the [performance-metrics tutorial](../../../src/README.md#performance-metrics).
 - **Main Feature:** Benchmark model via GenAI
 - **Run Command:**
   ```bash

--- a/samples/python/visual_language_chat/README.md
+++ b/samples/python/visual_language_chat/README.md
@@ -132,7 +132,7 @@ TPOT: 135.45 ± 4.73 ms/token
 Throughput: 7.38 ± 0.26 tokens/s
 ```
 
-For more information how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
+For more information on how performance metrics are calculated please follow [performance-metrics tutorial](../../../src/README.md#performance-metrics).
 
 ### Troubleshooting
 

--- a/tools/llm_bench/README.md
+++ b/tools/llm_bench/README.md
@@ -223,7 +223,7 @@ python benchmark.py -m models/dreamlike_anime_1_0_ov/FP16 -p "cat wizard, gandal
 - `--height`: Generated image height.
 - `--width`: Generated image width.
 - `--num_steps`: Number of inference steps for image generation.
-- `--static_reshape`: Reshape image generation pipeline to specific width & height at pipline creation time.
+- `--static_reshape`: Reshape image generation pipeline to specific width & height at pipeline creation time.
 - `--guidance_scale`: guidance_scale parameter for pipeline, supported via json JSON input only.
 - `--images`: Like a `--media`, path to the directory or single image.
 - `--taylorseer_config`: TaylorSeer cache configuration, supported via JSON string or path to JSON file.


### PR DESCRIPTION
## Description

Fix grammar errors and a typo across multiple sample READMEs and llm_bench documentation.

### Fixes

**`samples/python/text_generation/README.md` and `samples/cpp/text_generation/README.md`**
- "is [assisted-generation] technique" → "is **an** [assisted-generation] technique" — missing article
- "This method highly effective" → "This method **is** highly effective" — missing verb
- "For more information how" → "For more information **on** how" — missing preposition

**`samples/cpp/text_generation/README.md` only**
- "benchmark an LLMs" → "benchmark LLMs" — incorrect article with plural noun (Python version already correct)

**`samples/python/visual_language_chat/README.md` and `samples/cpp/visual_language_chat/README.md`**
- "For more information how" → "For more information **on** how" — same grammar fix

**`samples/python/image_generation/README.md`**
- `inferenece` → `inference` — typo (C++ version was fixed in #3615, Python version was missed)

**`tools/llm_bench/README.md`**
- `pipline` → `pipeline` — typo

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code. <!-- Documentation-only changes, no tests needed. -->
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. <!-- This PR is the documentation change. -->