### PR TITLE
Add missing #pragma once to 10 header files

### DIFF
--- a/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
+++ b/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "llm/pipeline_base.hpp"
 
 #include "openvino/genai/continuous_batching_pipeline.hpp"

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 
 #include <limits>
 

--- a/src/cpp/src/sampling/threadpool.hpp
+++ b/src/cpp/src/sampling/threadpool.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <condition_variable>
 #include <functional>
 #include <future>

--- a/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "sampling/sampler.hpp"
 #include "utils.hpp"
 #include "openvino/genai/perf_metrics.hpp"

--- a/src/cpp/src/speech_generation/default_speaker_embedding.hpp
+++ b/src/cpp/src/speech_generation/default_speaker_embedding.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 namespace ov {
 namespace genai {
 

--- a/src/cpp/src/speech_generation/speecht5_tts_model.hpp
+++ b/src/cpp/src/speech_generation/speecht5_tts_model.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <algorithm>
 #include <filesystem>
 #include <openvino/openvino.hpp>

--- a/src/cpp/src/tokenizer/add_second_input_pass.hpp
+++ b/src/cpp/src/tokenizer/add_second_input_pass.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "openvino/pass/manager.hpp"
 #include <nlohmann/json.hpp>
 #include "openvino/core/model.hpp"

--- a/src/cpp/src/tokenizer/chat_template_fallback_map.hpp
+++ b/src/cpp/src/tokenizer/chat_template_fallback_map.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 const std::pair<std::string, std::string> chat_template_fallback_map[] = {
 {
     // THUDM/chatglm3-6b

--- a/src/cpp/src/tokenizer/make_tokenizer_stateful.hpp
+++ b/src/cpp/src/tokenizer/make_tokenizer_stateful.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "openvino/op/constant.hpp"
 #include "openvino/pass/pass.hpp"
 #include "openvino/pass/matcher_pass.hpp"

--- a/src/cpp/src/video_generation/generation_config_utils.hpp
+++ b/src/cpp/src/video_generation/generation_config_utils.hpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "openvino/genai/video_generation/generation_config.hpp"
 
 namespace ov::genai::utils {


### PR DESCRIPTION
## Description

Add missing `#pragma once` include guards to 10 header files. 171 out of 181 headers in `src/cpp/` already use `#pragma once` — these 10 were the only ones missing any include guard.

### Files updated

- `src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.hpp`
- `src/cpp/src/speech_generation/default_speaker_embedding.hpp`
- `src/cpp/src/speech_generation/speecht5_tts_model.hpp`
- `src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp`
- `src/cpp/src/llm/pipeline_stateful.hpp`
- `src/cpp/src/tokenizer/chat_template_fallback_map.hpp`
- `src/cpp/src/tokenizer/make_tokenizer_stateful.hpp`
- `src/cpp/src/tokenizer/add_second_input_pass.hpp`
- `src/cpp/src/sampling/threadpool.hpp`
- `src/cpp/src/video_generation/generation_config_utils.hpp`

No behavioral changes — this only adds the standard include guard consistent with the rest of the codebase.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code. <!-- No behavioral change — adding include guards is a compile-time safeguard only. Existing tests are unaffected. -->
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. <!-- No documentation needed — internal header change only. -->