### PR TITLE
Add error handling to ReAct agent sample tool execution

### DIFF
--- a/samples/python/text_generation/react_sample.py
+++ b/samples/python/text_generation/react_sample.py
@@ -142,6 +142,16 @@ def call_tool(tool_name: str, tool_args: str) -> str:
     else:
         raise NotImplementedError
 
+def execute_tool(tool_name: str, tool_args: str) -> str:
+    try:
+        return call_tool(tool_name, tool_args)
+    except requests.RequestException as e:
+        return f"Tool '{tool_name}' failed: network error - {e}"
+    except (json.JSONDecodeError, ValueError, KeyError) as e:
+        return f"Tool '{tool_name}' failed: invalid arguments - {e}"
+    except Exception as e:
+        return f"Tool '{tool_name}' failed: {e}"
+
 def llm_with_tool(llm_pipe, prompt, history, list_of_tool_info):
     chat_history = [(x["user"], x["bot"]) for x in history] + [(prompt, "")]
     planning_prompt = build_input_text(llm_pipe.get_tokenizer(), chat_history, list_of_tool_info)
@@ -154,7 +164,7 @@ def llm_with_tool(llm_pipe, prompt, history, list_of_tool_info):
         # parse the output to get action
         action, action_input, output = parse_first_tool_call(output)
         if action:
-            observation = call_tool(action, action_input)
+            observation = execute_tool(action, action_input)
             observation_txt = f"\nObservation: = {observation}\nThought:"
             print("\n\n- Getting information from the tool API -", observation_txt, "\n")
             output += observation_txt


### PR DESCRIPTION
## Description

Add error handling to the ReAct agent sample so tool failures are fed back to the LLM as observations instead of crashing the agent.

### Problem

The current `react_sample.py` has no error handling around tool execution. If a tool call fails due to network timeouts, malformed LLM-generated arguments, or unexpected API responses, the agent crashes immediately. This prevents the LLM from reasoning about errors and adjusting its approach.

### Solution

Added an `execute_tool()` wrapper that catches exceptions from `call_tool()` and returns descriptive error strings as observations:

- `requests.RequestException` — network errors (timeouts, DNS failures, HTTP errors)
- `json.JSONDecodeError`, `ValueError`, `KeyError` — malformed tool arguments from LLM
- Generic `Exception` — any other unexpected failure

The error message is appended to the conversation as an observation, allowing the LLM to reason about the failure and potentially retry or adjust.

The happy path is unchanged — when tools succeed, `execute_tool()` transparently returns the same result as `call_tool()`.

Fixes #3508

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code. <!-- The existing test_react_sample.py runs the happy path end-to-end with a real model. The change is transparent on the happy path (execute_tool returns call_tool result when no error). Error scenario tests would require mock infrastructure that does not currently exist in the test suite — can be added as follow-up. -->
- [x] This PR fully addresses the ticket. <!-- Implements proposed solutions 1 and 2 from the issue (error wrapper + agent loop modification). Solutions 3 (validation) and 4 (StructuredOutputConfig) are covered by the exception handling and marked optional in the issue respectively. -->
- [x] I have made corresponding changes to the documentation. <!-- No documentation changes needed — this is a sample code improvement. -->