### PR TITLE
feat: Add Copilot agent instructions (migrated from MEAT)

### DIFF
--- a/.agents/agentic-workflows.agent.md
+++ b/.agents/agentic-workflows.agent.md
@@ -141,3 +141,22 @@ gh aw compile --validate
 - Workflows must be compiled to `.lock.yml` files before running in GitHub Actions
 - **Bash tools are enabled by default** - Don't restrict bash commands unnecessarily since workflows are sandboxed by the AWF
 - Follow security best practices: minimal permissions, explicit network access, no template injection
+
+## Creating Pull Requests
+
+When your work is complete and all tests pass:
+
+1. Create a new branch with a descriptive name: `agent/<short-description>`
+2. Commit all changes with a clear, conventional commit message
+3. Push the branch to the fork
+4. Create a **Draft PR** to the upstream repository using `gh pr create`:
+   ```
+   gh pr create --draft \
+     --title "[Agent] <descriptive title>" \
+     --body "<description of changes, link to related PRs if any>" \
+     --repo <upstream-org>/<repo-name>
+   ```
+5. Add the label `agent-generated` if the label exists
+6. Output the PR URL for tracking
+
+Refer to the [submit-draft-pr](skills/submit-draft-pr.md) skill for detailed instructions.

--- a/.agents/openvino-genai.agent.md
+++ b/.agents/openvino-genai.agent.md
@@ -1,0 +1,336 @@
+---
+name: OpenVINO GenAI Agent
+description: GenAI pipeline specialist. Adds model support in `openvino-genai`, implements the inference pipeline for new model architectures, and writes tests. Acts as a dispatcher: identifies which GenAI pipeline type the model requires, loads the appropriate specialist workflow, and executes it — mirroring the `gh-aw` (GitHub Agentic Workflows) dispatcher pattern used by the openvino.genai project team itself.
+model: claude-sonnet-4.6
+---
+# OpenVINO GenAI Agent
+
+## Role
+
+GenAI pipeline specialist. Adds model support in `openvino-genai`,
+implements the inference pipeline for new model architectures, and writes tests.
+
+Acts as a **dispatcher**: identifies which GenAI pipeline type the model requires,
+loads the appropriate specialist workflow, and executes it — mirroring the
+`gh-aw` (GitHub Agentic Workflows) dispatcher pattern used by the openvino.genai
+project team itself.
+
+## Output
+
+Write all logs, results, and patches to `agent-results/openvino-genai/`.
+
+## Called by
+
+- **Common Orchestrator** (Step 6 — when GenAI reports "model not supported" or
+  GenAI inference fails after successful IR export)
+
+---
+
+## Runner Environment
+
+This agent runs via **GitHub Agentic Workflows** (`@copilot /agent`).
+The GHA job pre-clones the target repository on the runner before triggering this agent.
+
+| Item | Path / Notes |
+|---|---|
+| **Target repo** (`openvinotoolkit/openvino.genai`) | `/tmp/openvino-genai` — already cloned at HEAD, use directly |
+| **HEAD SHA** | Provided in the trigger prompt as `REPO_HEAD` |
+| **MEAT workspace** | `$GITHUB_WORKSPACE` — this repository (read-only; do not modify) |
+| **Skills** | `$GITHUB_WORKSPACE/skills/` |
+
+> Use `/tmp/openvino-genai` directly — **do not re-clone** `openvinotoolkit/openvino.genai`.
+
+---
+
+## Pipeline Type Dispatch
+
+Inspect `model_type` from `config.json` and the error context to determine which
+pipeline applies. Route to the corresponding workflow section below.
+
+| Condition | Pipeline type | Workflow section |
+|---|---|---|
+| Text-only chat/completion model | **LLMPipeline** | § LLM Pipeline |
+| Vision-language inputs (`image_token` in config) | **VLMPipeline** | § VLM Pipeline |
+| High-throughput multi-request serving | **ContinuousBatchingPipeline** | § CB Pipeline |
+| Embeddings (`task=feature-extraction`) | **TextEmbeddingPipeline** | § Embedding Pipeline |
+| Image generation (diffusion model) | **ImageGenerationPipeline** | § Image Gen |
+
+If the model type is not listed in the
+[supported models page](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/),
+proceed with **§ Add New Model Support**.
+
+---
+
+## Execution Model
+
+### Step 0: Bootstrap and Inspect Manifest
+
+```bash
+python scripts/collect_artifacts.py bootstrap --manifest meat_manifest.json | bash
+```
+
+Check manifest for earlier agent outputs:
+- `optimum_intel_patch` present → IR export likely fixed; proceed to inference test
+- `model_ir` present → download cached IR, skip re-export
+- `genai_patch` present → apply and re-test before starting fresh work
+
+### Step 1: Classify Pipeline Need
+
+1. Download `config.json` for the model from HuggingFace.
+2. Look up `architecture` in the
+   [LLM models table](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/)
+   and the
+   [VLM models table](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/).
+3. If **already listed** → the model should work; the issue is likely a config or
+   chat-template bug. Jump to **§ Debug Existing Support**.
+4. If **not listed** → new model support is needed. Continue to Step 2.
+
+### Step 2: Reproduce Failure
+
+```python
+import openvino_genai as ov_genai
+pipe = ov_genai.LLMPipeline(model_ir_path, "CPU")   # or VLMPipeline, etc.
+result = pipe.generate("Hello", max_new_tokens=20)
+print(result)
+```
+
+Capture the exact error: `ValueError`, `RuntimeError`, unsupported op, shape
+mismatch, missing chat template, etc.
+
+### Step 3: Route to Specialist Workflow
+
+#### § LLM Pipeline
+
+Applicable to: `LlamaForCausalLM`, `Qwen2ForCausalLM`, `MistralForCausalLM`,
+most decoder-only transformers.
+
+Key files in `openvino.genai`:
+- `src/cpp/src/llm/` — `pipeline.cpp`, `pipeline_static.cpp`
+- `src/python/py_llm_pipeline.cpp`
+- `tests/python_tests/test_llm_pipeline.py`
+
+Common issues:
+1. **Missing chat template** → add to `tokenizer_config.json` or open PR to genai
+2. **Model signature mismatch** (`input_ids`, `attention_mask`, `beam_idx`,
+   `position_ids`) → the model was exported with non-standard inputs; fix via
+   optimum-intel model patcher
+3. **KV cache shape** → update `GenerationConfig` parameters for the new arch
+
+#### § VLM Pipeline
+
+Applicable to: models with `image_token_id` in config (LLaVA, InternVL,
+Qwen2-VL, Phi-3-Vision, etc.).
+
+Key files:
+- `src/cpp/src/visual_language/` — per-architecture `*.cpp/.hpp` files
+- `tests/python_tests/test_vlm_pipeline.py`
+
+Steps:
+1. Check if a `*ForConditionalGeneration` implementor exists under
+   `src/cpp/src/visual_language/`.
+2. If not: create a new architecture implementation following an existing template
+   (e.g., `llava.cpp`).
+3. Register the new class in the pipeline factory.
+4. Add test case in `test_vlm_pipeline.py`.
+
+#### § CB Pipeline (ContinuousBatchingPipeline)
+
+Key path: `src/cpp/src/scheduler/` and `src/python/py_continuous_batching_pipeline.cpp`.
+
+Usually works for standard architectures. If failing: check `SchedulerConfig`
+and `cache_size` vs model's KV head count.
+
+#### § Embedding Pipeline
+
+For `task=feature-extraction` models. Add to
+`src/cpp/src/rag/text_embedding*`. See `Qwen3` embedding notes in the supported
+models page (requires `--task feature-extraction` during `optimum-cli` conversion).
+
+#### § Image Gen
+
+For diffusion models. Key path: `src/cpp/src/image_generation/`.
+
+#### § Add New Model Support
+
+When the architecture requires a full new pipeline integration:
+
+1. Study the closest existing implementation (find by `architecture` key family).
+2. Create `src/cpp/src/visual_language/<arch>.cpp` (VLM) or extend
+   `src/cpp/src/llm/pipeline.cpp` (LLM).
+3. Register in the factory.
+4. Create or reuse a chat template from HuggingFace `tokenizer_config.json`.
+5. Write integration test (prompt → output, deterministic with `do_sample=False`).
+6. Produce a `git format-patch` patch and post to the tracking issue.
+
+#### § Debug Existing Support
+
+Model is in the supported list but fails at runtime:
+
+1. Check `generation_config.json` parameters.
+2. Check chat template rendering with `tokenizer.apply_chat_template(...)`.
+3. Check whether a newer openvino-genai version fixes the issue (check GitHub
+   releases and open issues).
+4. Minimal repro: swap to the smallest model in the same architecture family
+   listed in the supported models table.
+5. If a regression: `git bisect` the genai repo.
+
+### Step 4: Validate End-to-End
+
+```python
+pipe = ov_genai.LLMPipeline(model_path, "CPU")
+out = pipe.generate("Write hello world in Python.", max_new_tokens=50, do_sample=False)
+assert "print" in out or "hello" in out.lower(), f"Unexpected: {out}"
+```
+
+For VLM: test with a 64×64 white PNG as the image input.
+
+### Step 5: Record Output
+
+```bash
+python scripts/collect_artifacts.py add \
+  --agent openvino-genai --pass 1 \
+  --type patch --component openvino-genai \
+  --artifact-name "genai-patch-${GITHUB_RUN_ID}" \
+  --branch "feature/add-<model_type>-pipeline-support" \
+  --install-cmd "pip install git+https://github.com/openvinotoolkit/openvino.genai@<branch>" \
+  --description "Added <model_type> <pipeline_type> pipeline support"
+```
+
+---
+
+## gh-aw Framework Awareness
+
+The `openvinotoolkit/openvino.genai` repository uses the
+**GitHub Agentic Workflows (`gh-aw`)** framework for internal automation.
+If you need to create, update, or debug a workflow in that repository:
+
+- Workflows live in `.github/workflows/*.md` (natural-language markdown + YAML
+  frontmatter, compiled to `.lock.yml`)
+- Available agent: `.github/agents/agentic-workflows.agent.md` (dispatcher:
+  routes to create / update / debug / upgrade / create-shared-component prompts)
+- CLI: `gh aw init`, `gh aw compile`, `gh aw logs`, `gh aw audit`
+- Workflows run sandboxed in the AWF; `bash` tools are enabled by default
+
+This is relevant if adding GenAI model support requires a new CI workflow (e.g.,
+a nightly inference test for the new model family).
+
+---
+
+## Key References
+
+- openvino-genai repo: https://github.com/openvinotoolkit/openvino.genai
+- Supported models: https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/
+
+## Constraints
+
+- Reports only to Common Orchestrator — does not call other Tier-1 agents.
+- Must include tests for any new model support added.
+- IR export is handled upstream (optimum-intel agent). Receive IR path from manifest;
+  do not re-export unless the manifest shows no `model_ir` entry.
+
+## Output Contract
+
+| Output field | Type | Description |
+|---|---|---|
+| `status` | `success` \| `failed` | Overall result of the GenAI fix attempt |
+| `branch` | string | Name of the fix branch created |
+| `patch_file` | path | Path to the generated GenAI support patch (in `agent-results/openvino-genai/patches/`) |
+| `pipeline_type` | string | One of: `llm`, `vlm`, `cb`, `embedding`, `image_gen` |
+| `description` | string | One-line summary of the pipeline class or config change made |
+| `test_results` | string | Outcome of end-to-end generation validation test |
+| `agent_report` | Markdown file | Run `python scripts/generate_agent_report.py --agent-name "OpenVINO GenAI Agent" --model-id <id> --status <status> --error-context <ctx> --output agent_report.md`. Posted to tracking issue by the workflow. |
+
+---
+
+## Optional: Draft PR
+
+If your context provides a local source path (e.g. `openvino.genai source: /path/to/openvino.genai`)
+and `gh` CLI is available, attempt to open a **draft PR** to the upstream repo after
+completing your implementation:
+
+```bash
+python scripts/create_draft_pr.py \
+  --repo-dir "<source_path>" \
+  --branch   "fix/<descriptive-name>" \
+  --title    "<one-line description>" \
+  --body-file agent-results/openvino-genai/agent_report.md
+```
+
+Skip silently if `gh` is unavailable, not authenticated, or the command fails.
+See `skills/submit-draft-pr.md` for full details.
+
+---
+
+## Checkpoint Protocol
+
+You are given a **120-minute session** (GitHub Actions timeout). Post a checkpoint
+comment to the tracking issue **after completing each numbered step**, not only
+when done or escalating.
+
+This allows:
+- A human to see real-time progress without downloading anything.
+- A re-triggered session to resume exactly where this one left off.
+
+### Checkpoint comment format
+
+Post a GitHub issue comment with this structure after every step:
+
+```markdown
+## ⏱ Checkpoint — Step <N> complete (<model_id>)
+
+| Field | Value |
+|---|---|
+| **Step completed** | `<step name>` |
+| **Outcome** | `success` \| `failed` \| `partial` |
+| **Key finding** | `<one-sentence summary of what was discovered or done>` |
+| **Next step** | `<step name, or "none — done / escalating">` |
+
+<!-- checkpoint {"agent":"openvino_genai_agent","step":"<N>","outcome":"<outcome>","next_step":"<text>"} -->
+```
+
+### Re-trigger resume
+
+When invoked on an issue that already has checkpoint comments from a previous
+run, read them first and:
+1. Find the last `<!-- checkpoint ... -->` marker and its `step` value.
+2. Resume from the step immediately after the last completed one.
+3. Do not repeat already-completed steps.
+4. State explicitly: `Resuming after previous session — continuing from Step <N>`.
+
+---
+
+## Job Communication Protocol
+
+When your work is complete — regardless of outcome — post a comment to the
+tracking issue containing **exactly** this marker on its own line:
+
+    <!-- agent-complete {"agent":"openvino_genai_agent","status":"<STATUS>","next_agent":"common_orchestrator","model_id":"<MODEL_ID>","next_context":"<ONE_LINE_SUMMARY>","iteration":<N>} -->
+
+- `agent`: `"openvino_genai_agent"` (fixed)
+- `status`: `"success"` | `"failed"`
+- `next_agent`: always `"common_orchestrator"` — lets the Common Orchestrator decide the next step
+- `model_id`: the sanitized HuggingFace model ID from your prompt
+- `next_context`: one-line outcome summary (e.g. `"LLM pipeline support added for Qwen3ForCausalLM"` or error description)
+- `iteration`: the `iteration` value from your trigger prompt (pass it through unchanged)
+
+Place your full Markdown report above or below this marker.
+The polling job reads **only** this marker to forward outputs to the orchestrator.
+
+## Creating Pull Requests
+
+When your work is complete and all tests pass:
+
+1. Create a new branch with a descriptive name: `agent/<short-description>`
+2. Commit all changes with a clear, conventional commit message
+3. Push the branch to the fork
+4. Create a **Draft PR** to the upstream repository using `gh pr create`:
+   ```
+   gh pr create --draft \
+     --title "[Agent] <descriptive title>" \
+     --body "<description of changes, link to related PRs if any>" \
+     --repo <upstream-org>/<repo-name>
+   ```
+5. Add the label `agent-generated` if the label exists
+6. Output the PR URL for tracking
+
+Refer to the [submit-draft-pr](skills/submit-draft-pr.md) skill for detailed instructions.

--- a/.agents/skills/submit-draft-pr.md
+++ b/.agents/skills/submit-draft-pr.md
@@ -1,0 +1,107 @@
+---
+name: submit-draft-pr
+description: Optionally create a draft PR to the upstream repo from a local source directory. Used by coding agents when a local source path is available in the context file.
+---
+
+# Skill: Submit Draft PR
+
+> **Optional.** Attempt this only when all of the following are true:
+> - Your context file provides a local source path (e.g. `OpenVINO source code: /path/to/openvino`)
+> - That path is accessible and is a git repository
+> - `gh` CLI is available and authenticated (`gh auth status`)
+>
+> If any condition is not met — **skip silently** and log one line. Do not fail.
+
+---
+
+## When to invoke
+
+After completing your main implementation work and writing results to
+`agent-results/<agent>/`, call this skill to open a **draft PR** from your
+changes to the upstream repo.
+
+This is *in addition to* — never instead of — generating patch files and
+writing results to `agent-results/`.
+
+---
+
+## Steps
+
+### 1. Verify prerequisites
+
+```bash
+# Is gh available and authenticated?
+gh auth status || { echo "[draft-pr] gh not available — skipping"; exit 0; }
+
+# Is the source path a git repo?
+[ -d "${SOURCE_PATH}/.git" ] || { echo "[draft-pr] ${SOURCE_PATH} is not a git repo — skipping"; exit 0; }
+```
+
+### 2. Choose a branch name
+
+Use a descriptive kebab-case branch name derived from the work done:
+
+```
+fix/add-<op-name>-op              # core op or FE op
+fix/add-<pass-name>-transformation
+fix/<model-id>-export             # optimum-intel / tokenizers
+fix/<component>-<short-desc>      # general
+```
+
+### 3. Run the helper script
+
+```bash
+python scripts/create_draft_pr.py \
+  --repo-dir "${SOURCE_PATH}" \
+  --branch   "<branch-name>" \
+  --title    "<one-line description of the fix>" \
+  --body-file agent-results/<agent>/agent_report.md \
+  [--upstream <org/repo>]          # only if auto-detection might fail
+```
+
+The script will:
+1. Detect whether `origin` is a fork or the upstream directly
+2. Ensure a personal fork exists (creates one via `gh repo fork` if needed)
+3. Create the feature branch (or reuse an existing one with the same name)
+4. `git add -A && git commit` any staged/unstaged changes
+5. Push to the fork (`git remote add fork <fork-url>`)
+6. Open a **draft PR** to the upstream repo via `gh pr create --draft`
+7. Print the PR URL on success
+
+### 4. Log the result
+
+After the script runs, record the outcome in `agent-results/<agent>/session.md`:
+
+```
+[draft-pr] PR opened: <pr_url>
+```
+
+or
+
+```
+[draft-pr] Skipped: <reason>
+```
+
+---
+
+## Per-repo upstream table
+
+| Agent | Upstream repo |
+|---|---|
+| transformation, core-opspec, pytorch-fe, cpu, gpu, npu | `openvinotoolkit/openvino` |
+| optimum-intel | `huggingface/optimum-intel` |
+| openvino-tokenizers | `openvinotoolkit/openvino_tokenizers` |
+| openvino-genai | `openvinotoolkit/openvino.genai` |
+
+Pass `--upstream <value>` only when auto-detection from the git remote is likely
+to fail (e.g. the local clone uses an internal mirror URL).
+
+---
+
+## Important constraints
+
+- Always create PRs as **drafts** — never ready-for-review.
+- PR target is the **upstream** repo, not the fork.
+- Do not push to `main`/`master` of any repo.
+- If `git push --force-with-lease` fails (e.g. diverged history), skip and log — do not `--force`.
+- Do not block the agent's completion on PR success — log the failure and continue.

--- a/.agents/skills/wwb/bootstrap-env.md
+++ b/.agents/skills/wwb/bootstrap-env.md
@@ -1,0 +1,119 @@
+---
+name: wwb-bootstrap-env
+description: Set up the environment for WhoWhatBench: install OpenVINO, optimum-intel, and WWB from source; then apply all available patches, branches, and wheels from previous specialist agents.
+---
+
+# Skill: Bootstrap WWB Environment
+
+**Trigger:** Always first. Prepares the full software stack before any WWB step runs.
+Produces `agent-results/wwb/bootstrap.log` and `agent-results/wwb/installed_packages.json`.
+
+---
+
+## Step 1 — Base Installation
+
+Install stable release packages. WWB is always built from the openvino.genai repo
+to get the latest benchmark runner.
+
+```bash
+pip install openvino openvino-tokenizers openvino-genai 2>&1 | tee -a agent-results/wwb/bootstrap.log
+pip install git+https://github.com/huggingface/optimum-intel.git 2>&1 | tee -a agent-results/wwb/bootstrap.log
+pip install torch --extra-index-url https://download.pytorch.org/whl/cpu 2>&1 | tee -a agent-results/wwb/bootstrap.log
+
+# WWB from source — always latest, ensures support for new optimum-intel pipeline_tags
+git clone --depth 1 https://github.com/openvinotoolkit/openvino.genai.git /tmp/ov_genai_repo 2>&1 | tee -a agent-results/wwb/bootstrap.log
+pip install /tmp/ov_genai_repo/tools/who_what_benchmark 2>&1 | tee -a agent-results/wwb/bootstrap.log
+```
+
+## Step 2 — Apply Patches and Branches from agent-results/pipeline_state.json
+
+Parse `agent-results/pipeline_state.json` for all available fixes. Apply in priority order:
+
+### Priority 1 — Pre-built wheels (Package Builder output)
+
+Wheels contain all OV-core patches compiled in. Highest priority.
+
+```python
+import json, os, subprocess
+
+state = {}
+if os.path.exists("agent-results/pipeline_state.json"):
+    state = json.load(open("agent-results/pipeline_state.json"))
+
+wheels_installed = []
+for w in state.get("artifacts", {}).get("wheels", []):
+    path = w.get("path", "")
+    if path and os.path.exists(path):
+        result = subprocess.run(
+            ["pip", "install", path, "--force-reinstall"],
+            capture_output=True, text=True
+        )
+        status = "ok" if result.returncode == 0 else "failed"
+        print(f"[WWB-BOOTSTRAP] wheel {path}: {status}")
+        wheels_installed.append({"path": path, "status": status})
+```
+
+### Priority 2 — install_cmd entries from patch manifest
+
+Captures `pip install git+https://...@branch` commands written by optimum-intel,
+openvino-genai, and tokenizer agents.
+
+```python
+cmds_run = []
+for patch in state.get("artifacts", {}).get("patches", []):
+    cmd = patch.get("install_cmd", "").strip()
+    if not cmd:
+        continue
+    print(f"[WWB-BOOTSTRAP] Applying: {cmd}")
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    status = "ok" if result.returncode == 0 else f"failed ({result.returncode})"
+    print(f"[WWB-BOOTSTRAP]   → {status}")
+    if result.returncode != 0:
+        print(f"[WWB-BOOTSTRAP]   stderr: {result.stderr[:500]}")
+    cmds_run.append({"cmd": cmd, "status": status})
+```
+
+### Priority 3 — OpenVINO core patch files
+
+Core C++ patches can only take effect via a compiled wheel. If a wheel was
+installed in Priority 1, the patches are already included. If no wheel exists,
+log a warning — WWB will use stable OV packages.
+
+```python
+for patch in state.get("artifacts", {}).get("patches", []):
+    if patch.get("component") == "openvino" and not wheels_installed:
+        patch_path = patch.get("path", "")
+        print(f"[WWB-BOOTSTRAP] [WARN] OV core patch detected: {patch_path}")
+        print(f"[WWB-BOOTSTRAP] [WARN] No compiled wheel available. Accuracy may not reflect core fix.")
+        print(f"[WWB-BOOTSTRAP] [WARN] To include core fix: run Package Builder first, then re-run WWB.")
+```
+
+## Step 3 — Record Installed Versions
+
+```python
+import subprocess, json
+
+packages = ["openvino", "optimum-intel", "openvino-genai", "openvino-tokenizers",
+            "torch", "transformers", "who-what-benchmark"]
+installed = {}
+for pkg in packages:
+    result = subprocess.run(
+        ["pip", "show", pkg], capture_output=True, text=True
+    )
+    for line in result.stdout.splitlines():
+        if line.startswith("Version:"):
+            installed[pkg] = line.split(":", 1)[1].strip()
+            break
+    else:
+        installed[pkg] = "not installed"
+
+json.dump(installed, open("agent-results/wwb/installed_packages.json", "w"), indent=2)
+print("[WWB-BOOTSTRAP] Installed packages:")
+for k, v in installed.items():
+    print(f"  {k}: {v}")
+```
+
+---
+
+**On completion:** `agent-results/wwb/installed_packages.json` is ready.
+Proceed to `wwb/locate-model.md`.

--- a/.agents/skills/wwb/generate-gt.md
+++ b/.agents/skills/wwb/generate-gt.md
@@ -1,0 +1,205 @@
+---
+name: wwb-generate-gt
+description: Generate ground-truth reference outputs from the original HuggingFace model. Reuses existing gt.csv if valid. If WWB cannot generate GT for this model, patches WWB sources to add support and retries, or falls back to Analyze-and-Convert for inference samples.
+---
+
+# Skill: Generate Ground Truth
+
+**Trigger:** After `locate-model.md`. Produces `agent-results/wwb/gt.csv`.
+
+---
+
+## Step 1 — Check for Existing GT
+
+```bash
+GT_CSV="agent-results/wwb/gt.csv"
+GT_VALID=false
+
+# Check working dir
+if [ -f "${GT_CSV}" ]; then
+  LINE_COUNT=$(wc -l < "${GT_CSV}")
+  if [ "${LINE_COUNT}" -gt 1 ]; then
+    GT_VALID=true
+    echo "[WWB-GT] Reusing existing gt.csv (${LINE_COUNT} lines)"
+  else
+    echo "[WWB-GT] gt.csv found but empty — regenerating"
+  fi
+fi
+
+# Check analyze-and-convert output
+if [ "${GT_VALID}" = "false" ] && [ -f "agent-results/analyze-and-convert/gt.csv" ]; then
+  AC_LINES=$(wc -l < "agent-results/analyze-and-convert/gt.csv")
+  if [ "${AC_LINES}" -gt 1 ]; then
+    cp "agent-results/analyze-and-convert/gt.csv" "${GT_CSV}"
+    GT_VALID=true
+    echo "[WWB-GT] Reused gt.csv from Analyze-and-Convert (${AC_LINES} lines)"
+  fi
+fi
+```
+
+## Step 2 — Generate GT with WWB
+
+```bash
+if [ "${GT_VALID}" = "false" ]; then
+  MODEL_TYPE=$(cat agent-results/wwb/model_type.txt 2>/dev/null || echo "text")
+  echo "[WWB-GT] Generating ground truth: model=${MODEL_ID} type=${MODEL_TYPE} samples=${NUM_SAMPLES}"
+
+  wwb \
+    --base-model "$MODEL_ID" \
+    --gt-data "${GT_CSV}" \
+    --model-type "${MODEL_TYPE}" \
+    --num-samples "${NUM_SAMPLES:-32}" \
+    --hf \
+    --trust-remote-code \
+    2>&1 | tee agent-results/wwb/wwb_gt.log
+  GT_EXIT=$?
+
+  if [ "${GT_EXIT}" -eq 0 ] && [ -f "${GT_CSV}" ] && [ "$(wc -l < "${GT_CSV}")" -gt 1 ]; then
+    GT_VALID=true
+    echo "[WWB-GT] GT generation successful"
+  else
+    echo "[WWB-GT] GT generation failed (exit ${GT_EXIT})"
+  fi
+fi
+```
+
+## Step 3 — Self-Patch WWB If GT Failed
+
+If GT generation failed, inspect `wwb_gt.log` to determine why and patch WWB sources.
+
+```python
+import re, subprocess, sys
+from pathlib import Path
+
+log = Path("agent-results/wwb/wwb_gt.log").read_text(errors="replace") if Path("agent-results/wwb/wwb_gt.log").exists() else ""
+
+# Detect cause
+CAUSE = "unknown"
+if re.search(r"task.*not.*support|unsupported.*task|pipeline.*not.*found", log, re.I):
+    CAUSE = "unsupported_pipeline_tag"
+elif re.search(r"chat_template|apply_chat_template|TokenizerError", log, re.I):
+    CAUSE = "missing_chat_template"
+elif re.search(r"OutOfMemory|OOM|CUDA out of memory|Cannot allocate", log, re.I):
+    CAUSE = "oom"
+elif re.search(r"ImportError|ModuleNotFoundError", log, re.I):
+    CAUSE = "missing_dependency"
+
+print(f"[WWB-GT] Failure cause: {CAUSE}")
+```
+
+### Patch strategy by cause
+
+**`unsupported_pipeline_tag`** — WWB `who_what_benchmark` does not know this model type.
+Find the WWB source, add a pipeline registration:
+
+```python
+import subprocess, sys
+from pathlib import Path
+
+# Locate WWB source
+result = subprocess.run(["pip", "show", "who-what-benchmark"], capture_output=True, text=True)
+for line in result.stdout.splitlines():
+    if line.startswith("Location:"):
+        wwb_root = Path(line.split(":", 1)[1].strip()) / "who_what_benchmark"
+        break
+else:
+    print("[WWB-GT] Cannot locate WWB source — cannot self-patch")
+    sys.exit(1)
+
+# Read the model factory file and add model type support
+# WWB registers model types in text_evaluation.py or similar
+factory_file = wwb_root / "text_evaluation.py"
+if factory_file.exists():
+    content = factory_file.read_text()
+    print(f"[WWB-GT] Patching WWB source at: {factory_file}")
+    # Append model type alias if not already present
+    model_type = open("agent-results/wwb/model_type.txt").read().strip()
+    # Agent: read the file, understand the registration pattern, add the missing type
+    # The patch should map the model's pipeline_tag to the nearest supported WWB model class
+    print(f"[WWB-GT] Model type to register: {model_type}")
+    print(f"[WWB-GT] Read {factory_file} and extend the class/type registry")
+else:
+    print(f"[WWB-GT] Expected factory file not found at {factory_file}")
+    print("[WWB-GT] List WWB source files:")
+    for f in sorted(wwb_root.rglob("*.py")):
+        print(f"  {f}")
+    print("[WWB-GT] Identify the correct registration point and patch it")
+```
+
+After patching: retry Step 2.
+
+**`missing_chat_template`** — model needs an explicit chat template override:
+
+```bash
+# Add --tokenizer and --chat-template flags and retry
+wwb \
+  --base-model "$MODEL_ID" \
+  --tokenizer "$MODEL_ID" \
+  --gt-data "${GT_CSV}" \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples "${NUM_SAMPLES:-32}" \
+  --hf \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_gt_retry.log
+```
+
+**`oom`** — reduce sample count and retry:
+
+```bash
+echo "[WWB-GT] OOM detected — retrying with 8 samples"
+wwb \
+  --base-model "$MODEL_ID" \
+  --gt-data "${GT_CSV}" \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples 8 \
+  --hf \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_gt_retry.log
+```
+
+**`unknown` / still failing** — fall back to Analyze and Convert:
+
+```
+[WWB-GT] All GT strategies failed. Invoking Analyze and Convert to obtain inference samples.
+```
+
+Invoke Analyze and Convert agent with context:
+> "Generate inference samples for WhoWhatBench ground truth for model `<MODEL_ID>`.
+> Write 32 prompt/response pairs to `agent-results/analyze-and-convert/gt.csv`.
+> Use the model's native tokenizer and standard text-generation pipeline."
+
+After it returns, copy the resulting CSV to `agent-results/wwb/gt.csv` and
+verify it has > 1 line. If still missing, stop with status `blocked` and write:
+
+```json
+{
+  "status": "blocked",
+  "reason": "cannot_generate_gt",
+  "detail": "WWB and Analyze-and-Convert both failed to produce ground truth. Manual inspection required."
+}
+```
+
+## Step 4 — Validate GT
+
+```python
+import csv
+from pathlib import Path
+
+gt_path = Path("agent-results/wwb/gt.csv")
+if not gt_path.exists():
+    print("[WWB-GT] [ERROR] gt.csv missing")
+    raise SystemExit(1)
+
+with open(gt_path, newline="", encoding="utf-8") as f:
+    rows = list(csv.DictReader(f))
+
+print(f"[WWB-GT] gt.csv: {len(rows)} samples")
+if rows:
+    print(f"[WWB-GT] Sample columns: {list(rows[0].keys())}")
+    print(f"[WWB-GT] First prompt:   {str(rows[0])[:120]}")
+```
+
+---
+
+**On completion:** `agent-results/wwb/gt.csv` is valid (>1 line).
+Proceed to `wwb/run-benchmark.md`.

--- a/.agents/skills/wwb/interpret-results.md
+++ b/.agents/skills/wwb/interpret-results.md
@@ -1,0 +1,248 @@
+---
+name: wwb-interpret-results
+description: Parse WWB metrics.csv, compute the similarity score, write commentary with per-sample variance analysis and score-band classification, note which patches/wheels were active, and persist results to agent-results/pipeline_state.json and wwb_result.json.
+---
+
+# Skill: Interpret Results
+
+**Trigger:** After `run-benchmark.md`. Consumes `agent-results/wwb/metrics/metrics.csv`.
+Produces `agent-results/wwb/wwb_result.json` and updates `agent-results/pipeline_state.json`.
+
+---
+
+## Step 1 — Parse Score
+
+```bash
+python scripts/parse_wwb_score.py \
+  agent-results/wwb/metrics/metrics.csv \
+  "${SIMILARITY_THRESHOLD:-0.9}" \
+  2>&1 | tee agent-results/wwb/parse_score.log
+```
+
+If `parse_wwb_score.py` is not available, parse manually:
+
+```python
+import csv, statistics
+from pathlib import Path
+
+metrics_path = Path("agent-results/wwb/metrics/metrics.csv")
+rows = list(csv.DictReader(metrics_path.open(newline="", encoding="utf-8")))
+
+# Detect score column: "similarity", "score", "metric" etc.
+score_col = None
+for col in rows[0].keys():
+    if "similar" in col.lower() or col.lower() in ("score", "metric", "sim"):
+        score_col = col
+        break
+
+if score_col is None:
+    print("[WWB-INTERPRET] Cannot detect score column. Columns:", list(rows[0].keys()))
+    raise SystemExit(1)
+
+scores = []
+for r in rows:
+    try:
+        scores.append(float(r[score_col]))
+    except (ValueError, KeyError):
+        pass
+
+mean_score = statistics.mean(scores) if scores else 0.0
+stdev = statistics.stdev(scores) if len(scores) > 1 else 0.0
+
+print(f"[WWB-INTERPRET] Score column : {score_col}")
+print(f"[WWB-INTERPRET] Samples      : {len(scores)}")
+print(f"[WWB-INTERPRET] Mean score   : {mean_score:.4f}")
+print(f"[WWB-INTERPRET] Std dev      : {stdev:.4f}")
+```
+
+## Step 2 — Score Band Classification
+
+```python
+THRESHOLD = float(open("agent-results/wwb/threshold.txt").read().strip()
+                  if Path("agent-results/wwb/threshold.txt").exists() else "0.9")
+
+if mean_score >= 0.95:
+    band = "strong_pass"
+    band_comment = (
+        f"Score {mean_score:.4f} is well above threshold {THRESHOLD}. "
+        "Accuracy is solid; OV model output closely matches the reference."
+    )
+elif mean_score >= 0.90:
+    band = "pass"
+    band_comment = (
+        f"Score {mean_score:.4f} meets threshold {THRESHOLD}. Acceptable accuracy."
+    )
+elif mean_score >= 0.85:
+    band = "borderline"
+    band_comment = (
+        f"Score {mean_score:.4f} is below threshold {THRESHOLD} but within noise range. "
+        "Re-run with do_sample=False / greedy decoding to rule out non-determinism. "
+        "If score does not improve, investigate logit differences in layers near the end of the model."
+    )
+elif mean_score >= 0.70:
+    band = "low_pass"
+    band_comment = (
+        f"Score {mean_score:.4f} is notably below threshold {THRESHOLD}. "
+        "Likely a systematic accuracy issue, not sampling noise. "
+        "Inspect per-sample failures; check quantization configuration and padding mode."
+    )
+else:
+    band = "accuracy_regression"
+    band_comment = (
+        f"Score {mean_score:.4f} strongly suggests an accuracy regression. "
+        "This is not noise — mean this far below threshold indicates structural mismatch. "
+        "Check: conversion flags, precision settings, graph transformations applied, "
+        "and whether the OV model matches the original architecture exactly."
+    )
+
+passed = mean_score >= THRESHOLD
+print(f"[WWB-INTERPRET] Band    : {band}")
+print(f"[WWB-INTERPRET] Passed  : {passed}")
+print(f"[WWB-INTERPRET] Comment : {band_comment}")
+```
+
+## Step 3 — Per-Sample Variance Analysis
+
+```python
+rows_with_scores = [(i, r, float(r[score_col])) for i, r in enumerate(rows) if r.get(score_col, "").strip()]
+rows_with_scores.sort(key=lambda x: x[2])
+
+# Lowest-scoring samples
+worst_samples = rows_with_scores[:5]
+best_samples = rows_with_scores[-3:]
+
+print("[WWB-INTERPRET] Lowest-scoring samples:")
+for idx, row, sc in worst_samples:
+    prompt_key = next((k for k in row if "prompt" in k.lower() or "question" in k.lower() or "input" in k.lower()), None)
+    prompt_preview = str(row.get(prompt_key, ""))[:80] if prompt_key else "(unknown)"
+    print(f"  [{idx}] score={sc:.4f}  prompt={prompt_preview!r}")
+
+# Check for score variance pattern
+if stdev > 0.15:
+    variance_note = (
+        f"High variance (stdev={stdev:.4f}): scores range widely across samples. "
+        "Specific input patterns may trigger failures — review worst samples above."
+    )
+elif stdev < 0.02 and mean_score < THRESHOLD:
+    variance_note = (
+        f"Low variance (stdev={stdev:.4f}) but below threshold: consistently low scores "
+        "indicate a systemic issue, not outlier samples."
+    )
+else:
+    variance_note = f"Normal variance (stdev={stdev:.4f})."
+
+print(f"[WWB-INTERPRET] Variance note: {variance_note}")
+```
+
+## Step 4 — Note Active Patches / Wheels
+
+```python
+import json
+from pathlib import Path
+
+patches_note = ""
+installed_pkg_path = Path("agent-results/wwb/installed_packages.json")
+if installed_pkg_path.exists():
+    installed = json.loads(installed_pkg_path.read_text())
+    non_standard = {
+        pkg: ver for pkg, ver in installed.items()
+        if "+" in str(ver) or "dev" in str(ver).lower() or "git" in str(ver).lower()
+    }
+    wheel_sources = installed.get("_sources", {})
+    if non_standard or wheel_sources:
+        lines = []
+        if wheel_sources.get("wheels"):
+            lines.append(f"Custom wheels from Package Builder: {wheel_sources['wheels']}")
+        if wheel_sources.get("install_cmd_patches"):
+            lines.append(f"install_cmd patches applied: {wheel_sources['install_cmd_patches']}")
+        for pkg, ver in non_standard.items():
+            lines.append(f"  {pkg}=={ver}")
+        patches_note = "Active non-standard packages: " + "; ".join(lines)
+    else:
+        patches_note = "All packages at standard PyPI releases."
+else:
+    patches_note = "installed_packages.json not found — package context unknown."
+
+print(f"[WWB-INTERPRET] Patches: {patches_note}")
+```
+
+## Step 5 — Write `wwb_result.json`
+
+```python
+import json
+from pathlib import Path
+
+wwb_result = {
+    "status": "passed" if passed else "failed",
+    "score": round(mean_score, 6),
+    "threshold": THRESHOLD,
+    "passed": passed,
+    "band": band,
+    "num_samples": len(scores),
+    "stdev": round(stdev, 6),
+    "commentary": band_comment,
+    "variance_note": variance_note,
+    "patches_context": patches_note,
+    "worst_samples": [
+        {"index": idx, "score": round(sc, 4), "prompt_preview": str(row.get(next(iter(row)), ""))[:100]}
+        for idx, row, sc in worst_samples
+    ],
+}
+
+out_path = Path("agent-results/wwb/wwb_result.json")
+out_path.write_text(json.dumps(wwb_result, indent=2))
+print(f"[WWB-INTERPRET] Written: {out_path}")
+```
+
+## Step 6 — Update `agent-results/pipeline_state.json`
+
+```python
+import json
+from pathlib import Path
+
+state_path = Path("agent-results/pipeline_state.json")
+state = json.loads(state_path.read_text()) if state_path.exists() else {}
+
+state.setdefault("signals", {})
+state["wwb_result"] = {
+    "status": "passed" if passed else "failed",
+    "score": round(mean_score, 6),
+    "threshold": THRESHOLD,
+    "passed": passed,
+    "band": band,
+    "commentary": band_comment,
+}
+state["signals"]["wwb_passed"] = passed
+state["signals"]["wwb_score"] = round(mean_score, 6)
+
+state_path.write_text(json.dumps(state, indent=2))
+print(f"[WWB-INTERPRET] agent-results/pipeline_state.json updated — wwb_passed={passed} score={mean_score:.4f}")
+```
+
+## Step 7 — Final Summary
+
+Print a human-readable summary for the agent log:
+
+```python
+separator = "=" * 60
+print(separator)
+print("WWB RESULT SUMMARY")
+print(separator)
+print(f"  Model      : {MODEL_ID}")
+print(f"  Score      : {mean_score:.4f}  (threshold: {THRESHOLD})")
+print(f"  Result     : {'PASS' if passed else 'FAIL'}  [{band}]")
+print(f"  Samples    : {len(scores)}  (stdev: {stdev:.4f})")
+print()
+print(f"  Commentary : {band_comment}")
+print()
+print(f"  Patches    : {patches_note}")
+print(separator)
+```
+
+---
+
+**On completion:**
+- `agent-results/wwb/wwb_result.json` — machine-readable result with commentary
+- `agent-results/pipeline_state.json` updated with `wwb_result` and `signals.wwb_passed`
+
+The WWB pipeline is complete. Return `wwb_result.json` content as the final agent output.

--- a/.agents/skills/wwb/locate-model.md
+++ b/.agents/skills/wwb/locate-model.md
@@ -1,0 +1,136 @@
+---
+name: wwb-locate-model
+description: Locate the OpenVINO IR model to benchmark — from local filesystem, agent-results/pipeline_state.json, or by re-exporting with current patched packages.
+---
+
+# Skill: Locate OV Model
+
+**Trigger:** After `bootstrap-env.md`. Finds or creates the OV IR to benchmark.
+Produces `OV_MODEL_PATH` (environment variable / shell variable used by subsequent skills).
+
+---
+
+## Step 1 — Check for Existing IR
+
+Search in priority order:
+
+```bash
+OV_MODEL_PATH=""
+
+# 1. Standard local path
+if [ -d "ov_model" ] && [ -f "ov_model/openvino_model.xml" ]; then
+  OV_MODEL_PATH="ov_model"
+  echo "[WWB-LOCATE] Found IR at ov_model/"
+fi
+
+# 2. agent-results/pipeline_state.json → artifacts.model_ir
+if [ -z "${OV_MODEL_PATH}" ] && [ -f "agent-results/pipeline_state.json" ]; then
+  CANDIDATE=$(python3 -c "
+import json, os
+state = json.load(open('agent-results/pipeline_state.json'))
+p = state.get('artifacts', {}).get('model_ir')
+if p and isinstance(p, str) and os.path.isfile(os.path.join(p, 'openvino_model.xml')):
+    print(p)
+" 2>/dev/null)
+  if [ -n "${CANDIDATE}" ]; then
+    OV_MODEL_PATH="${CANDIDATE}"
+    echo "[WWB-LOCATE] Found IR from agent-results/pipeline_state.json at ${OV_MODEL_PATH}"
+  fi
+fi
+
+# 3. analyze-and-convert output directory
+if [ -z "${OV_MODEL_PATH}" ]; then
+  for DIR in agent-results/analyze-and-convert/ov_model_*/; do
+    if [ -f "${DIR}openvino_model.xml" ]; then
+      OV_MODEL_PATH="${DIR}"
+      echo "[WWB-LOCATE] Found IR from analyze-and-convert at ${OV_MODEL_PATH}"
+      break
+    fi
+  done
+fi
+```
+
+## Step 2 — Re-export If No IR Found
+
+If no prior IR exists, export the model now using the fully patched package stack
+from `bootstrap-env.md`. This ensures the benchmark tests the actual fixed state.
+
+```bash
+if [ -z "${OV_MODEL_PATH}" ]; then
+  echo "[WWB-LOCATE] No OV IR found — exporting with current package stack"
+
+  # Detect task
+  TASK=$(python scripts/detect_task.py "$MODEL_ID" 2>/dev/null || echo "text-generation-with-past")
+  echo "[WWB-LOCATE] Detected task: ${TASK}"
+
+  # Export
+  optimum-cli export openvino \
+    --model "$MODEL_ID" \
+    --task "${TASK}" \
+    --weight-format fp16 \
+    --trust-remote-code \
+    ov_model 2>&1 | tee agent-results/wwb/export.log
+
+  EXPORT_EXIT=$?
+  if [ "${EXPORT_EXIT}" -ne 0 ] || [ ! -f "ov_model/openvino_model.xml" ]; then
+    echo "[WWB-LOCATE] [ERROR] Export failed (exit ${EXPORT_EXIT})"
+    echo "[WWB-LOCATE] See agent-results/wwb/export.log for details"
+    echo "[WWB-LOCATE] If export fails with missing ops, ensure the correct patches/wheels are installed"
+    exit 1
+  fi
+
+  OV_MODEL_PATH="ov_model"
+  echo "[WWB-LOCATE] Export succeeded → ${OV_MODEL_PATH}"
+fi
+
+export OV_MODEL_PATH
+echo "[WWB-LOCATE] OV model path: ${OV_MODEL_PATH}"
+```
+
+## Step 3 — Detect Model Type
+
+Determine the `--model-type` argument for WWB based on the model profile
+(produced by `probe-model.md` if available, otherwise from HF metadata).
+
+```python
+import json, os
+
+MODEL_TYPE = "text"  # default
+
+# Try model_profile.json from analyze-and-convert
+for profile_path in [
+    "agent-results/analyze-and-convert/model_profile.json",
+    "agent-results/wwb/model_profile.json",
+]:
+    if os.path.exists(profile_path):
+        profile = json.load(open(profile_path))
+        tag = profile.get("pipeline_tag", "")
+        print(f"[WWB-LOCATE] pipeline_tag from profile: {tag}")
+        break
+else:
+    # Fallback: read from agent-results/pipeline_state.json or HF API
+    tag = ""
+    if os.path.exists("agent-results/pipeline_state.json"):
+        state = json.load(open("agent-results/pipeline_state.json"))
+        tag = state.get("model_info", {}).get("pipeline_tag", "")
+
+MAPPING = {
+    "text-generation":               "text",
+    "text2text-generation":          "text",
+    "image-text-to-text":            "visual-text",
+    "text-to-image":                 "image",
+    "automatic-speech-recognition":  "speech-to-text",
+    "audio-classification":          "speech-to-text",
+}
+MODEL_TYPE = MAPPING.get(tag, "text")
+print(f"[WWB-LOCATE] WWB model type: {MODEL_TYPE}")
+
+# Write for subsequent skills
+with open("agent-results/wwb/model_type.txt", "w") as f:
+    f.write(MODEL_TYPE)
+```
+
+---
+
+**On completion:** `OV_MODEL_PATH` and `agent-results/wwb/model_type.txt` are set.
+Proceed to `wwb/generate-gt.md`.

--- a/.agents/skills/wwb/run-benchmark.md
+++ b/.agents/skills/wwb/run-benchmark.md
@@ -1,0 +1,274 @@
+---
+name: wwb-run-benchmark
+description: Run WhoWhatBench against the OpenVINO IR model using ground-truth CSV. Applies retry strategies for model-type mismatch, OOM, missing tokenizer, and unknown model architectures. Auto-updates WWB from source if the model type is not yet supported by the installed version.
+---
+
+# Skill: Run Benchmark
+
+**Trigger:** After `generate-gt.md`. Consumes `agent-results/wwb/gt.csv` and OV IR path.
+Produces `agent-results/wwb/metrics/metrics.csv`.
+
+---
+
+## Step 1 — Prepare Run Parameters
+
+```python
+import json
+from pathlib import Path
+
+# Read model info
+model_type = (Path("agent-results/wwb/model_type.txt").read_text().strip()
+              if Path("agent-results/wwb/model_type.txt").exists() else "text")
+
+# Find OV IR path
+ov_model_path = None
+if Path("ov_model").is_dir():
+    ov_model_path = "ov_model"
+elif Path("agent-results/pipeline_state.json").exists():
+    state = json.loads(Path("agent-results/pipeline_state.json").read_text())
+    ov_model_path = state.get("artifacts", {}).get("model_ir")
+
+if not ov_model_path:
+    candidates = sorted(Path("agent-results/analyze-and-convert").glob("ov_model_*"))
+    if candidates:
+        ov_model_path = str(candidates[-1])
+
+if not ov_model_path:
+    print("[WWB-BENCH] [ERROR] No OV IR found — cannot run benchmark")
+    raise SystemExit(1)
+
+num_samples = int(os.environ.get("NUM_SAMPLES", "32"))
+gt_csv = "agent-results/wwb/gt.csv"
+output_dir = "agent-results/wwb/metrics"
+
+print(f"[WWB-BENCH] ov_model_path = {ov_model_path}")
+print(f"[WWB-BENCH] model_type    = {model_type}")
+print(f"[WWB-BENCH] num_samples   = {num_samples}")
+print(f"[WWB-BENCH] gt_csv        = {gt_csv}")
+```
+
+## Step 2 — Run WWB (Attempt 1: Primary)
+
+```bash
+MODEL_TYPE=$(cat agent-results/wwb/model_type.txt 2>/dev/null || echo "text")
+OV_MODEL_PATH="<from step 1>"
+
+mkdir -p agent-results/wwb/metrics
+
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --gt-data agent-results/wwb/gt.csv \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples 32 \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_bench.log
+
+BENCH_EXIT=$?
+```
+
+## Step 3 — Diagnose Failure and Retry
+
+Parse `wwb_bench.log` to select the correct retry strategy.
+
+```python
+import re
+from pathlib import Path
+
+log = Path("agent-results/wwb/wwb_bench.log").read_text(errors="replace") if Path("agent-results/wwb/wwb_bench.log").exists() else ""
+metrics_ok = Path("agent-results/wwb/metrics/metrics.csv").exists() and \
+             Path("agent-results/wwb/metrics/metrics.csv").stat().st_size > 0
+
+if metrics_ok:
+    print("[WWB-BENCH] Metrics produced on attempt 1")
+else:
+    # Classify failure
+    if re.search(r"task.*not.*support|unsupported.*task|no.*pipeline.*for|KeyError.*pipeline", log, re.I):
+        STRATEGY = "wrong_model_type"
+    elif re.search(r"OutOfMemory|OOM|CUDA out of memory|Cannot allocate|RuntimeError.*memory", log, re.I):
+        STRATEGY = "oom"
+    elif re.search(r"tokenizer.*not.*found|TokenizerError|cannot.*load.*tokenizer", log, re.I):
+        STRATEGY = "missing_tokenizer"
+    elif re.search(r"AttributeError.*forward|NotImplementedError|pipeline.*not.*implemented", log, re.I):
+        STRATEGY = "unsupported_architecture"
+    else:
+        STRATEGY = "generic_failure"
+    print(f"[WWB-BENCH] Strategy: {STRATEGY}")
+```
+
+### Retry A — Wrong Model Type → Fall Back to `text`
+
+When WWB does not recognize the model's pipeline tag:
+
+```bash
+echo "[WWB-BENCH] Retry A: forcing --model-type text"
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --gt-data agent-results/wwb/gt.csv \
+  --model-type text \
+  --num-samples 32 \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_bench_retryA.log
+```
+
+### Retry B — OOM → Reduce Sample Count
+
+```bash
+echo "[WWB-BENCH] Retry B: OOM — reducing to 8 samples"
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --gt-data agent-results/wwb/gt.csv \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples 8 \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_bench_retryB.log
+```
+
+### Retry C — Missing Tokenizer → Add `--tokenizer`
+
+```bash
+echo "[WWB-BENCH] Retry C: adding explicit --tokenizer"
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --tokenizer "${MODEL_ID}" \
+  --gt-data agent-results/wwb/gt.csv \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples 32 \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_bench_retryC.log
+```
+
+## Step 4 — Auto-Update WWB From Source
+
+If all retries fail with `unsupported_architecture`, `unknown_model_type`, or the error references a missing method or pipeline class, it likely means this model architecture is not yet supported in the installed WWB release.
+
+**Strategy: re-install WWB from openvino.genai HEAD.**
+
+```python
+import subprocess, sys
+from pathlib import Path
+
+# Locate the openvino.genai clone used during bootstrap-env
+genai_repo = None
+for candidate in [
+    "/tmp/ov_genai_repo",
+    "build/ov_genai_repo",
+    str(Path.home() / "ov_genai_repo"),
+]:
+    if Path(candidate).is_dir():
+        genai_repo = candidate
+        break
+
+if not genai_repo:
+    print("[WWB-BENCH] Cloning openvino/openvino.genai for fresh WWB install")
+    result = subprocess.run(
+        ["git", "clone", "--depth=1", "https://github.com/openvinotoolkit/openvino.genai.git", "/tmp/ov_genai_repo"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"[WWB-BENCH] Clone failed: {result.stderr}")
+        sys.exit(1)
+    genai_repo = "/tmp/ov_genai_repo"
+else:
+    print(f"[WWB-BENCH] Pulling latest changes in {genai_repo}")
+    subprocess.run(["git", "-C", genai_repo, "pull", "--rebase"], capture_output=True)
+
+# Re-install WWB from latest source
+result = subprocess.run(
+    ["pip", "install", f"{genai_repo}/tools/who_what_benchmark", "--force-reinstall", "--quiet"],
+    capture_output=True, text=True
+)
+if result.returncode == 0:
+    print("[WWB-BENCH] WWB re-installed from source")
+else:
+    print(f"[WWB-BENCH] Re-install failed: {result.stderr}")
+    sys.exit(1)
+```
+
+After re-installing, retry the full benchmark command (Step 2).
+
+```bash
+echo "[WWB-BENCH] Retry D: using updated WWB from HEAD"
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --gt-data agent-results/wwb/gt.csv \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples "${NUM_SAMPLES:-32}" \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_bench_retryD.log
+```
+
+If Retry D also fails with `unsupported_architecture` or a missing class,
+read the new WWB source files to understand the registration/factory pattern,
+then add support for this model architecture directly in the installed WWB code
+(update the file in site-packages) and retry one final time.
+
+## Step 5 — Self-Patch WWB Source for Unsupported Architecture
+
+```python
+import subprocess
+from pathlib import Path
+
+# Find WWB package location
+result = subprocess.run(["pip", "show", "who-what-benchmark"], capture_output=True, text=True)
+wwb_root = None
+for line in result.stdout.splitlines():
+    if line.startswith("Location:"):
+        wwb_root = Path(line.split(":", 1)[1].strip()) / "who_what_benchmark"
+
+if wwb_root and wwb_root.exists():
+    print("[WWB-BENCH] WWB source files:")
+    for f in sorted(wwb_root.rglob("*.py")):
+        print(f"  {f.relative_to(wwb_root.parent)}")
+    print("[WWB-BENCH] Read the factory/registry file, understand the pattern, then:")
+    print(f"[WWB-BENCH] MODEL_TYPE = {open('agent-results/wwb/model_type.txt').read().strip()}")
+    print("[WWB-BENCH] Add the model type registration and retry Step 2")
+```
+
+## Step 6 — Write Attempt Summary
+
+```python
+import json
+from pathlib import Path
+
+metrics_ok = (
+    Path("agent-results/wwb/metrics/metrics.csv").exists() and
+    Path("agent-results/wwb/metrics/metrics.csv").stat().st_size > 0
+)
+
+summary = {
+    "benchmark_produced_metrics": metrics_ok,
+    "attempts": [],  # fill in based on which log files exist
+}
+
+for label, log_path in [
+    ("primary", "agent-results/wwb/wwb_bench.log"),
+    ("retry_A_text_fallback", "agent-results/wwb/wwb_bench_retryA.log"),
+    ("retry_B_oom", "agent-results/wwb/wwb_bench_retryB.log"),
+    ("retry_C_tokenizer", "agent-results/wwb/wwb_bench_retryC.log"),
+    ("retry_D_updated_wwb", "agent-results/wwb/wwb_bench_retryD.log"),
+]:
+    if Path(log_path).exists():
+        summary["attempts"].append(label)
+
+Path("agent-results/wwb/bench_summary.json").write_text(json.dumps(summary, indent=2))
+print(f"[WWB-BENCH] metrics_ok={metrics_ok}  attempts={summary['attempts']}")
+
+if not metrics_ok:
+    Path("agent-results/wwb/wwb_result.json").write_text(json.dumps({
+        "status": "blocked",
+        "reason": "benchmark_failed_all_retries",
+        "attempts": summary["attempts"],
+        "detail": "No metrics.csv produced after all retry strategies"
+    }, indent=2))
+    raise SystemExit(1)
+```
+
+---
+
+**On completion:** `agent-results/wwb/metrics/metrics.csv` exists and is non-empty.
+Proceed to `wwb/interpret-results.md`.

--- a/.agents/wwb.agent.md
+++ b/.agents/wwb.agent.md
@@ -1,0 +1,416 @@
+---
+name: WWB Agent
+description: Runs WhoWhatBench accuracy evaluation for a model exported to OpenVINO IR. Bootstraps any available patches/branches from optimum-intel, openvino, or openvino-genai before running. Re-invokes Analyze-and-Convert to obtain inference samples if they are missing. Modifies the WWB invocation if the default text pipeline does not work for this model type.
+model: claude-sonnet-4.6
+tools: ['read/readFile', 'write/editFile', 'memory', 'terminal']
+---
+# WWB Agent
+
+## Role
+
+Runs the [WhoWhatBench](https://github.com/openvinotoolkit/openvino.genai/tree/master/tools/who_what_benchmark)
+accuracy benchmark for a HuggingFace model that has been exported to OpenVINO IR.
+
+Measures generation similarity between the original HF model and the OV model.
+If similarity ≥ threshold (default 0.9): pipeline passes.
+If similarity < threshold: reports the score and stops — escalation is handled by the orchestrator.
+
+**Does NOT:** write code, create PRs, or fix model quality issues.
+Its sole purpose is **accurate measurement** and a clear structured result.
+
+## Called by
+
+- **Common Orchestrator** (Step 5 — after successful deploy or specialist fix)
+
+## Agents (callable)
+
+| Agent | When |
+|-------|------|
+| **Analyze and Convert** | Re-run if `gt.csv` is missing and no previous inference samples exist |
+
+---
+
+## Inputs
+
+The context file (or orchestrator prompt) should provide:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `model_id` | yes | HuggingFace model ID, e.g. `Qwen/Qwen3-4B` |
+| `ov_model_path` | no | Local path to the exported OV IR directory (default: `ov_model/`) |
+| `similarity_threshold` | no | Minimum passing score (default: `0.9`) |
+| `num_samples` | no | Number of benchmark samples (default: `32`) |
+| `patches_dir` | no | Path to patches directory (default: `agent-results/openvino-orchestrator/patches/`) |
+| `pipeline_state_path` | no | Path to `agent-results/pipeline_state.json` (default: `agent-results/pipeline_state.json`) |
+
+---
+
+## State
+
+Reads `agent-results/pipeline_state.json` (if present) at startup to discover:
+- `artifacts.patches` — list of patch file paths + `install_cmd` entries
+- `artifacts.wheels` — pre-built wheels from Package Builder
+- `ov_orchestrator.pr_url` — open PR branch URL for OV fork
+- `signals` — any package override URLs
+
+Writes results back to `agent-results/pipeline_state.json` under `wwb_result`:
+```json
+"wwb_result": {
+  "similarity_score": 0.94,
+  "accuracy_ok": true,
+  "threshold": 0.9,
+  "num_samples": 32,
+  "model_type": "text",
+  "patched_packages": ["optimum-intel@fix/qwen3"],
+  "timestamp": "ISO 8601"
+}
+```
+
+Writes `agent-results/wwb/wwb_result.json`:
+```json
+{
+  "similarity_score": 0.94,
+  "accuracy_ok": true,
+  "threshold": 0.9,
+  "num_samples": 32,
+  "patched_packages": [],
+  "gt_csv": "agent-results/wwb/gt.csv",
+  "metrics_csv": "agent-results/wwb/metrics/metrics.csv",
+  "gt_log": "agent-results/wwb/wwb_gt.log",
+  "score_log": "agent-results/wwb/wwb_score.log"
+}
+```
+
+---
+
+## Skills
+
+Execute in order. Each skill produces files consumed by the next.
+
+| Order | Skill file | Purpose |
+|-------|-----------|---------|
+| 1 | `skills/wwb/bootstrap-env.md` | Install packages, apply patches/wheels/branches by priority |
+| 2 | `skills/wwb/locate-model.md` | Find or re-export OV IR; detect WWB model type |
+| 3 | `skills/wwb/generate-gt.md` | Generate GT from HF model; Analyze-and-Convert fallback |
+| 4 | `skills/wwb/run-benchmark.md` | Run WWB; retry strategies; auto-update WWB source if needed |
+| 5 | `skills/wwb/interpret-results.md` | Parse score; write commentary; update agent-results/pipeline_state.json |
+
+---
+
+## Execution Model
+
+> The detailed execution steps live in the skill files listed above.
+> The inline phases below are legacy reference only.
+
+### Phase 0: Bootstrap Environment
+
+Install base packages with stable pinned versions:
+```bash
+pip install openvino openvino-tokenizers openvino-genai
+pip install git+https://github.com/huggingface/optimum-intel.git
+pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Install WWB
+git clone --depth 1 https://github.com/openvinotoolkit/openvino.genai.git /tmp/openvino_genai_repo
+pip install /tmp/openvino_genai_repo/tools/who_what_benchmark
+```
+
+### Phase 1: Bootstrap Patches and Branches
+
+Parse `agent-results/pipeline_state.json` → collect all available fixes in priority order:
+
+**1a. Wheels (highest priority — pre-built with all fixes)**
+```bash
+# Install any wheels from Package Builder first
+for WHEEL_PATH in $(python3 -c "
+import json
+state = json.load(open('agent-results/pipeline_state.json'))
+for w in state.get('artifacts', {}).get('wheels', []):
+    if w.get('path') and os.path.exists(w['path']):
+        print(w['path'])
+" 2>/dev/null); do
+  pip install "${WHEEL_PATH}" --force-reinstall
+  echo "[WWB] Installed wheel: ${WHEEL_PATH}"
+done
+```
+
+**1b. Install commands from patch manifest (optimum-intel, openvino-genai)**
+```bash
+# Read install_cmd from each patch artifact
+python3 -c "
+import json
+state = json.load(open('agent-results/pipeline_state.json'))
+for p in state.get('artifacts', {}).get('patches', []):
+    cmd = p.get('install_cmd', '')
+    if cmd:
+        print(cmd)
+" 2>/dev/null | while read CMD; do
+  echo "[WWB] Applying: ${CMD}"
+  eval "${CMD}"
+done
+```
+
+**1c. Apply patch files for non-pip components (openvino core)**
+```bash
+if [ -d "agent-results/openvino-orchestrator/patches/openvino" ]; then
+  for PATCH in agent-results/openvino-orchestrator/patches/openvino/*.patch; do
+    [ -f "${PATCH}" ] || continue
+    echo "[WWB] Note: OpenVINO core patch detected: ${PATCH}"
+    echo "[WWB] Core patches require a pre-built wheel from Package Builder to take effect."
+    echo "[WWB] If no wheel is available, WWB will use stable release OV packages."
+  done
+fi
+```
+
+Log all installed versions:
+```bash
+echo "[WWB] Installed packages:"
+pip show openvino optimum-intel openvino-genai 2>/dev/null | grep -E "^(Name|Version):"
+```
+
+### Phase 2: Locate or Export OV Model
+
+Check for available OV IR in this order:
+1. `ov_model/` in working directory
+2. Path from `agent-results/pipeline_state.json` → `artifacts.model_ir`
+3. `agent-results/analyze-and-convert/ov_model_*/`
+
+```bash
+OV_MODEL_PATH=""
+if [ -d "ov_model" ] && [ -f "ov_model/openvino_model.xml" ]; then
+  OV_MODEL_PATH="ov_model"
+  echo "[WWB] Using existing OV IR at ov_model/"
+elif [ -f "agent-results/pipeline_state.json" ]; then
+  OV_MODEL_PATH=$(python3 -c "
+import json, os
+state = json.load(open('agent-results/pipeline_state.json'))
+p = state.get('artifacts', {}).get('model_ir')
+print(p if p and os.path.exists(str(p)+'/openvino_model.xml') else '')
+" 2>/dev/null)
+fi
+
+if [ -z "${OV_MODEL_PATH}" ]; then
+  echo "[WWB] No OV IR found — exporting now with current package stack"
+  TASK=$(python scripts/detect_task.py "$MODEL_ID" 2>/dev/null || echo "text-generation-with-past")
+  optimum-cli export openvino \
+    --model "$MODEL_ID" \
+    --task "$TASK" \
+    --weight-format fp16 \
+    --trust-remote-code \
+    ov_model 2>&1 | tee agent-results/wwb/export.log
+  OV_MODEL_PATH="ov_model"
+fi
+```
+
+### Phase 3: Determine Model Type and WWB Args
+
+WWB supports multiple model types. Choose based on the model's `pipeline_tag`:
+
+| `pipeline_tag` | `--model-type` | Notes |
+|---|---|---|
+| `text-generation`, `text2text-generation` | `text` | Default; uses LLM generation |
+| `image-text-to-text` | `visual-text` | Vision-language models |
+| `text-to-image` | `image` | Stable Diffusion variants |
+| `automatic-speech-recognition` | `speech-to-text` | ASR models |
+
+```bash
+MODEL_TYPE=$(python3 -c "
+import json
+try:
+    info = json.load(open('agent-results/analyze-and-convert/model_profile.json'))
+    tag = info.get('pipeline_tag', 'text-generation')
+except Exception:
+    tag = 'text-generation'
+
+mapping = {
+    'text-generation': 'text',
+    'text2text-generation': 'text',
+    'image-text-to-text': 'visual-text',
+    'text-to-image': 'image',
+    'automatic-speech-recognition': 'speech-to-text',
+}
+print(mapping.get(tag, 'text'))
+" 2>/dev/null || echo "text")
+
+echo "[WWB] Model type: ${MODEL_TYPE}"
+```
+
+### Phase 4: Generate Ground Truth from HF Baseline
+
+Check if a valid `gt.csv` already exists (from a previous Analyze-and-Convert run):
+
+```bash
+GT_CSV="agent-results/wwb/gt.csv"
+GT_VALID=false
+
+if [ -f "${GT_CSV}" ]; then
+  LINE_COUNT=$(wc -l < "${GT_CSV}")
+  [ "${LINE_COUNT}" -gt 1 ] && GT_VALID=true
+  echo "[WWB] Reusing existing gt.csv (${LINE_COUNT} lines)"
+fi
+
+# Also check analyze-and-convert output
+if [ "${GT_VALID}" = "false" ] && [ -f "agent-results/analyze-and-convert/gt.csv" ]; then
+  cp "agent-results/analyze-and-convert/gt.csv" "${GT_CSV}"
+  GT_VALID=true
+  echo "[WWB] Reused gt.csv from Analyze-and-Convert"
+fi
+```
+
+If no valid `gt.csv`:
+```bash
+if [ "${GT_VALID}" = "false" ]; then
+  echo "[WWB] Generating ground truth from HF model"
+  wwb \
+    --base-model "$MODEL_ID" \
+    --gt-data "${GT_CSV}" \
+    --model-type "${MODEL_TYPE}" \
+    --num-samples "$NUM_SAMPLES" \
+    --hf \
+    --trust-remote-code \
+    2>&1 | tee agent-results/wwb/wwb_gt.log
+  GT_EXIT=$?
+  if [ "${GT_EXIT}" -ne 0 ]; then
+    echo "[WWB] [WARN] GT generation failed (exit ${GT_EXIT}) — see wwb_gt.log"
+    # Attempt fallback: invoke Analyze and Convert for inference samples
+    _fallback_gt_via_analyze_convert
+  fi
+fi
+```
+
+#### Fallback: GT via Analyze and Convert
+
+If GT generation fails (e.g. model needs custom input format, special tokenizer):
+
+```
+[WWB] GT generation failed. Invoking Analyze and Convert to obtain inference samples.
+```
+
+Invoke the **Analyze and Convert** agent with:
+- `MODEL_ID` set to the model
+- Instruction: "Generate inference samples for WWB ground truth. Write sample prompts and responses to agent-results/analyze-and-convert/gt.csv"
+
+After Analyze and Convert returns, retry GT generation using any prompt file it produced.
+If GT still cannot be generated, stop with:
+```json
+{
+  "status": "blocked",
+  "reason": "cannot_generate_gt",
+  "message": "WWB ground truth generation failed. Model may require custom inference inputs. See wwb_gt.log."
+}
+```
+
+### Phase 5: Run Accuracy Benchmark
+
+```bash
+mkdir -p agent-results/wwb/metrics
+wwb \
+  --target-model "${OV_MODEL_PATH}" \
+  --gt-data "${GT_CSV}" \
+  --model-type "${MODEL_TYPE}" \
+  --num-samples "$NUM_SAMPLES" \
+  --output agent-results/wwb/metrics \
+  --trust-remote-code \
+  2>&1 | tee agent-results/wwb/wwb_score.log || true
+```
+
+#### If WWB command fails (non-zero exit, no metrics.csv)
+
+Common causes and fixes:
+
+**Cause 1: Unknown model type for `--model-type`**
+- Try `--model-type text` as universal fallback.
+- Log: `[WWB] Retrying with --model-type text (fallback)`
+
+**Cause 2: OV model uses custom ops not in stable release**
+- OV core patches are present but no wheel was built.
+- Log: `[WWB] OV core patches detected but no wheel available. Accuracy may be unreliable.`
+- Continue with stable release packages; note in result.
+
+**Cause 3: Missing tokenizer or chat template**
+- Add `--tokenizer "$MODEL_ID"` to the WWB call.
+- Log: `[WWB] Retrying with explicit --tokenizer flag`
+
+**Cause 4: OOM / too many samples**
+- Retry with `--num-samples 8`.
+- Log: `[WWB] OOM detected — retrying with num_samples=8`
+
+For each retry, log the modified command before running.
+
+### Phase 6: Parse Score and Write Result
+
+```bash
+python scripts/parse_wwb_score.py \
+  agent-results/wwb/metrics/metrics.csv \
+  "$SIMILARITY_THRESHOLD" >> /tmp/wwb_outputs.txt
+
+SIMILARITY_SCORE=$(grep "^similarity_score=" /tmp/wwb_outputs.txt | cut -d= -f2)
+ACCURACY_OK=$(grep "^accuracy_ok=" /tmp/wwb_outputs.txt | cut -d= -f2)
+```
+
+Write `agent-results/wwb/wwb_result.json`:
+```python
+import json, datetime
+result = {
+    "similarity_score": float(similarity_score),
+    "accuracy_ok": accuracy_ok == "true",
+    "threshold": float(threshold),
+    "num_samples": int(num_samples),
+    "model_type": model_type,
+    "patched_packages": patched_packages,   # list of "component@branch" strings
+    "gt_csv": "agent-results/wwb/gt.csv",
+    "metrics_csv": "agent-results/wwb/metrics/metrics.csv",
+    "gt_log": "agent-results/wwb/wwb_gt.log",
+    "score_log": "agent-results/wwb/wwb_score.log",
+    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+}
+json.dump(result, open("agent-results/wwb/wwb_result.json", "w"), indent=2)
+```
+
+Update `agent-results/pipeline_state.json` with `wwb_result` block.
+
+Log final result:
+```
+[WWB] similarity_score=0.943 accuracy_ok=true threshold=0.9 model_type=text patched=1
+[WWB] Result: PASS
+```
+or:
+```
+[WWB] similarity_score=0.812 accuracy_ok=false threshold=0.9 model_type=text patched=0
+[WWB] Result: FAIL — escalate to OV Orchestrator
+```
+
+---
+
+## Output
+
+Results are written to `agent-results/wwb/`:
+
+| File | Description |
+|------|-------------|
+| `wwb_result.json` | Structured result with score, pass/fail, metadata |
+| `gt.csv` | Ground truth prompt/response pairs |
+| `metrics/metrics.csv` | Per-sample similarity scores |
+| `wwb_gt.log` | GT generation log |
+| `wwb_score.log` | Benchmark measurement log |
+| `export.log` | Export log (only if OV model was generated by this agent) |
+| `session.md` | Full agent session transcript |
+
+## Creating Pull Requests
+
+When your work is complete and all tests pass:
+
+1. Create a new branch with a descriptive name: `agent/<short-description>`
+2. Commit all changes with a clear, conventional commit message
+3. Push the branch to the fork
+4. Create a **Draft PR** to the upstream repository using `gh pr create`:
+   ```
+   gh pr create --draft \
+     --title "[Agent] <descriptive title>" \
+     --body "<description of changes, link to related PRs if any>" \
+     --repo <upstream-org>/<repo-name>
+   ```
+5. Add the label `agent-generated` if the label exists
+6. Output the PR URL for tracking
+
+Refer to the [submit-draft-pr](skills/submit-draft-pr.md) skill for detailed instructions.


### PR DESCRIPTION
## Summary

This PR migrates Copilot agent and skill instruction files from the central MEAT repository into this repo's new \.agents/\ directory structure.

### What's included
- Agent definitions in \.agents/*.agent.md\`n- Skill instructions in \.agents/skills/*/\`n- Moved \gentic-workflows.agent.md\ from \.github/agents/\ to \.agents/\`n
### Migration source
Original files from internal sandbox
---
_This PR was generated by an automated migration agent._