### PR TITLE
Fix LoRA separate-mode correctness

### DIFF
--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -505,8 +505,6 @@ public:
                 adapters = updated_adapters;
             }
             // TODO: Add LoRA Adapter support for text encoders
-            // currently not done due to lack of demand
-            // but can be implemented in the future if needed.
             m_transformer->set_adapters(adapters);
         }
     }

--- a/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
+++ b/src/cpp/src/image_generation/stable_diffusion_3_pipeline.hpp
@@ -505,6 +505,8 @@ public:
                 adapters = updated_adapters;
             }
             // TODO: Add LoRA Adapter support for text encoders
+            // currently not done due to lack of demand
+            // but can be implemented in the future if needed.
             m_transformer->set_adapters(adapters);
         }
     }

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -960,6 +960,8 @@ public:
 
         NodeVector lora_variables{lora_weight.A, lora_weight.alpha, lora_weight.B};
 
+        // transpose_input is only set for MatMul nodes; transpose_in_end is only set for Conv nodes.
+        // A node cannot be both, so these two paths are mutually exclusive.
         replacement = tensors_multiplication(activations.get_node_shared_ptr(),
                                              lora_variables,
                                              target,

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -699,11 +699,14 @@ NodePtr tensors_multiplication(NodePtr input,
     }
 
     if (transpose_in_end) {
-        // FIXME: Check the dimensions we really need to move, currently it is hardcoded 2 + 2 dimensions that usually
-        // appears in 2D Convolution case where we need to apply LoRA for the first two dimensions (channels) while
-        // interpreting two last dimensions (spatial )
-        // TODO: Stash transposition constant to reuse
-        auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
+        // Inverse of the permutation applied to activations in the caller: spatial dims back to the end.
+        // e.g. rank=4: {2,3,0,1}, rank=3: {2,0,1}
+        std::vector<int> perm(target_rank);
+        for (int i = 0; i < target_rank - 2; ++i)
+            perm[i] = i + 2;
+        perm[target_rank - 2] = 0;
+        perm[target_rank - 1] = 1;
+        auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(target_rank)}, perm);
         input = std::make_shared<v1::Transpose>(input, transposition);
     } else if (input->get_output_partial_shape(0).rank().get_length() != target_rank) {
         input = unsqueeze(input, target_rank);
@@ -944,10 +947,15 @@ public:
         bool transpose_in_end = false;
 
         // FIXME: Should check rank of activations instead of target rank
-        if(target_rank == 4 && target.get_partial_shape()[target_rank - 3].get_length() > 1) {
-            // FIXME: Check the dimensions we really need to move, currently it is hardcoded 2 + 2 dimensions
-            // FIXME: Stash transposition constant to reuse
-            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
+        if(target_rank >= 3 && target.get_partial_shape()[target_rank - 3].get_length() > 1) {
+            // Permutation moves the two channel dims (last two) to the front and shifts spatial dims back:
+            // e.g. rank=4: {2,3,0,1}, rank=3: {1,2,0}
+            std::vector<int> perm(target_rank);
+            perm[0] = target_rank - 2;
+            perm[1] = target_rank - 1;
+            for (int i = 2; i < target_rank; ++i)
+                perm[i] = i - 2;
+            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(target_rank)}, perm);
             auto transpose = register_new_node<v1::Transpose>(activations, transposition);
             activations = transpose;
             transpose_in_end = true;

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -666,7 +666,8 @@ NodePtr tensors_multiplication(NodePtr input,
                                bool transpose_weights,
                                size_t alpha_pos,
                                size_t A_pos,
-                               bool transpose_in_end) {
+                               bool transpose_in_end,
+                               bool transpose_input = false) {
     const auto target_type = target.get_element_type();
     const auto target_shape = target.get_partial_shape();
     const auto target_rank = target_shape.rank().get_length();
@@ -688,10 +689,9 @@ NodePtr tensors_multiplication(NodePtr input,
                 // TODO: Apply alpha multiplication separately
                 input = std::make_shared<v1::Multiply>(input, normalized);
             } else {  // MatMul for A and B
-                input = std::make_shared<v0::MatMul>(input,
-                                                     normalized,
-                                                     /*transpose_a = */ false,
-                                                     transpose_weights);  // FIXME: verify transpose_a == true
+                // transpose_input applies only to the first matmul (A); subsequent ones (B) are always false
+                bool t_a = (i == A_pos) ? transpose_input : false;
+                input = std::make_shared<v0::MatMul>(input, normalized, t_a, transpose_weights);
             }
         } else {  // used in case of MODE_FUSE
             input = normalized;
@@ -934,8 +934,12 @@ public:
     LoRASeparateTransform(const LoRAWeightByNodeGetter& lora_getter) : LoRATransformBase(lora_getter) {}
 
     bool apply (NodePtr node, const LoRANode& lora_weight) override {
-        auto activations = node->input_value(0);    // FIXME: consider MatMul.transpose_a
+        auto activations = node->input_value(0);
         auto weights_input = node->input_value(1);
+        bool transpose_input = false;
+        if (auto matmul = std::dynamic_pointer_cast<v0::MatMul>(node)) {
+            transpose_input = matmul->get_transpose_a();
+        }
         auto weights_input_type = weights_input.get_element_type();
         NodePtr add_term = nullptr;
         NodePtr replacement = nullptr;
@@ -970,7 +974,8 @@ public:
                                              true,
                                              1, // alpha idx
                                              0, // A idx
-                                             transpose_in_end);
+                                             transpose_in_end,
+                                             transpose_input);
 
         replacement->get_output_tensor(0).add_names(target.get_names());
         for (auto consumer : consumers) {

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -699,6 +699,10 @@ NodePtr tensors_multiplication(NodePtr input,
     }
 
     if (transpose_in_end) {
+        // FIXME: Check the dimensions we really need to move, currently it is hardcoded 2 + 2 dimensions that usually
+        // appears in 2D Convolution case where we need to apply LoRA for the first two dimensions (channels) while
+        // interpreting two last dimensions (spatial )
+        // TODO: Stash transposition constant to reuse
         auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
         input = std::make_shared<v1::Transpose>(input, transposition);
     } else if (input->get_output_partial_shape(0).rank().get_length() != target_rank) {
@@ -946,6 +950,8 @@ public:
         const auto activation_shape = activations.get_partial_shape();
         const auto activation_rank = activation_shape.rank().get_length();
         if(activation_rank == 4 && activation_shape[activation_rank - 3].get_length() > 1) {
+            // FIXME: Check the dimensions we really need to move, currently it is hardcoded 2 + 2 dimensions
+            // FIXME: Stash transposition constant to reuse
             auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
             auto transpose = register_new_node<v1::Transpose>(activations, transposition);
             activations = transpose;

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -946,16 +946,17 @@ public:
         auto consumers = target.get_target_inputs();
         bool transpose_in_end = false;
 
-        // FIXME: Should check rank of activations instead of target rank
-        if(target_rank >= 3 && target.get_partial_shape()[target_rank - 3].get_length() > 1) {
+        const auto activation_shape = activations.get_partial_shape();
+        const auto activation_rank = activation_shape.rank().get_length();
+        if(activation_rank >= 3 && activation_shape[activation_rank - 3].get_length() > 1) {
             // Permutation moves the two channel dims (last two) to the front and shifts spatial dims back:
             // e.g. rank=4: {2,3,0,1}, rank=3: {1,2,0}
-            std::vector<int> perm(target_rank);
-            perm[0] = target_rank - 2;
-            perm[1] = target_rank - 1;
-            for (int i = 2; i < target_rank; ++i)
+            std::vector<int> perm(activation_rank);
+            perm[0] = activation_rank - 2;
+            perm[1] = activation_rank - 1;
+            for (int i = 2; i < activation_rank; ++i)
                 perm[i] = i - 2;
-            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(target_rank)}, perm);
+            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(activation_rank)}, perm);
             auto transpose = register_new_node<v1::Transpose>(activations, transposition);
             activations = transpose;
             transpose_in_end = true;

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -699,14 +699,7 @@ NodePtr tensors_multiplication(NodePtr input,
     }
 
     if (transpose_in_end) {
-        // Inverse of the permutation applied to activations in the caller: spatial dims back to the end.
-        // e.g. rank=4: {2,3,0,1}, rank=3: {2,0,1}
-        std::vector<int> perm(target_rank);
-        for (int i = 0; i < target_rank - 2; ++i)
-            perm[i] = i + 2;
-        perm[target_rank - 2] = 0;
-        perm[target_rank - 1] = 1;
-        auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(target_rank)}, perm);
+        auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
         input = std::make_shared<v1::Transpose>(input, transposition);
     } else if (input->get_output_partial_shape(0).rank().get_length() != target_rank) {
         input = unsqueeze(input, target_rank);
@@ -952,15 +945,8 @@ public:
 
         const auto activation_shape = activations.get_partial_shape();
         const auto activation_rank = activation_shape.rank().get_length();
-        if(activation_rank >= 3 && activation_shape[activation_rank - 3].get_length() > 1) {
-            // Permutation moves the two channel dims (last two) to the front and shifts spatial dims back:
-            // e.g. rank=4: {2,3,0,1}, rank=3: {1,2,0}
-            std::vector<int> perm(activation_rank);
-            perm[0] = activation_rank - 2;
-            perm[1] = activation_rank - 1;
-            for (int i = 2; i < activation_rank; ++i)
-                perm[i] = i - 2;
-            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(activation_rank)}, perm);
+        if(activation_rank == 4 && activation_shape[activation_rank - 3].get_length() > 1) {
+            auto transposition = v0::Constant::create(ov::element::i32, ov::Shape{4}, std::vector<int>{2, 3, 0, 1});
             auto transpose = register_new_node<v1::Transpose>(activations, transposition);
             activations = transpose;
             transpose_in_end = true;


### PR DESCRIPTION
## Description
This PR resolves two // FIXME comments in LoRASeparateTransform::apply and tensors_multiplication in adapter.cpp.

- tensors_multiplication hardcoded transpose_a = false for all LoRA matmuls. For MatMuls with transpose_a = true, the LoRA delta was computed on un-transposed activations while the base op used transposed ones, producing either a shape mismatch at graph validation or a silently wrong result. The flag is now read from the original node via get_transpose_a() and forwarded to the A-matrix step only; the B-matrix step is always false. 

- fixed a minor correctness issue where the conv transposition guard was checking target.get_partial_shape() (the conv output) instead of activations.get_partial_shape() (the tensor actually being transposed). No behavioral change for any currently supported model, as Conv2D input and output are always the same rank, but now correct by construction for any future conv variant where they differ.



## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- Tests have been updated or added to cover the new code. NA
- This PR fully addresses the ticket. NA
- I have made corresponding changes to the documentation. NA
