### PR TITLE
Rename download_gguf_model to download_hf_model in test utilities

### DIFF
--- a/tests/python_tests/samples/test_tools_llm_benchmark.py
+++ b/tests/python_tests/samples/test_tools_llm_benchmark.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from test_utils import run_sample
 from data.models import GGUF_MODEL_LIST
-from utils.hugging_face import download_hf_model
+from utils.hugging_face import download_hf_file
 from conftest import SAMPLES_PY_DIR, convert_model, download_test_content
 
 convert_draft_model = convert_model
@@ -358,7 +358,7 @@ class TestBenchmarkLLM:
     def test_python_tool_llm_benchmark_gguf_format(self, sample_args):
         benchmark_script = SAMPLES_PY_DIR / 'llm_bench/benchmark.py'
         gguf_model = GGUF_MODEL_LIST[0]
-        gguf_full_path = download_hf_model(gguf_model["gguf_model_id"], gguf_model["gguf_filename"])
+        gguf_full_path = download_hf_file(gguf_model["gguf_model_id"], gguf_model["gguf_filename"])
         benchmark_py_command = [
             sys.executable,
             benchmark_script,

--- a/tests/python_tests/samples/test_tools_llm_benchmark.py
+++ b/tests/python_tests/samples/test_tools_llm_benchmark.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from test_utils import run_sample
 from data.models import GGUF_MODEL_LIST
-from utils.hugging_face import download_gguf_model
+from utils.hugging_face import download_hf_model
 from conftest import SAMPLES_PY_DIR, convert_model, download_test_content
 
 convert_draft_model = convert_model
@@ -358,7 +358,7 @@ class TestBenchmarkLLM:
     def test_python_tool_llm_benchmark_gguf_format(self, sample_args):
         benchmark_script = SAMPLES_PY_DIR / 'llm_bench/benchmark.py'
         gguf_model = GGUF_MODEL_LIST[0]
-        gguf_full_path = download_gguf_model(gguf_model["gguf_model_id"], gguf_model["gguf_filename"])
+        gguf_full_path = download_hf_model(gguf_model["gguf_model_id"], gguf_model["gguf_filename"])
         benchmark_py_command = [
             sys.executable,
             benchmark_script,

--- a/tests/python_tests/test_gguf_lora.py
+++ b/tests/python_tests/test_gguf_lora.py
@@ -5,7 +5,7 @@ import pytest
 import sys
 import gc
 import openvino_genai as ov_genai
-from utils.hugging_face import download_gguf_model
+from utils.hugging_face import download_hf_model
 
 # Constants
 # Use OpenVINO IR model (pre-converted) to test GGUF adapter support
@@ -53,7 +53,7 @@ def test_gguf_lora_generation():
     model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
 
     # Download GGUF adapter
-    adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+    adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
     device = "CPU"
 
@@ -123,7 +123,7 @@ class TestGGUFLoRANameConversion:
         This test is faster than full generation tests because it only loads
         the adapter without downloading or running the full model.
         """
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         # Load adapter - this will fail if:
         # 1. GGUF format is not recognized
@@ -152,7 +152,7 @@ class TestGGUFLoRANameConversion:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -202,7 +202,7 @@ class TestGGUFLoRAAlphaScaling:
 
         # Download model and adapter
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -246,7 +246,7 @@ class TestGGUFLoRAAdapterEquality:
         from the same file, which is important for scenarios where multiple pipelines
         need to use the same adapter.
         """
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         # Load adapter twice
         adapter1 = ov_genai.Adapter(str(adapter_path))
@@ -305,7 +305,7 @@ class TestGGUFLoRAIntegration:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -346,7 +346,7 @@ class TestGGUFLoRAIntegration:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_gguf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()

--- a/tests/python_tests/test_gguf_lora.py
+++ b/tests/python_tests/test_gguf_lora.py
@@ -5,7 +5,7 @@ import pytest
 import sys
 import gc
 import openvino_genai as ov_genai
-from utils.hugging_face import download_hf_model
+from utils.hugging_face import download_hf_file
 
 # Constants
 # Use OpenVINO IR model (pre-converted) to test GGUF adapter support
@@ -53,7 +53,7 @@ def test_gguf_lora_generation():
     model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
 
     # Download GGUF adapter
-    adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+    adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
     device = "CPU"
 
@@ -123,7 +123,7 @@ class TestGGUFLoRANameConversion:
         This test is faster than full generation tests because it only loads
         the adapter without downloading or running the full model.
         """
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         # Load adapter - this will fail if:
         # 1. GGUF format is not recognized
@@ -152,7 +152,7 @@ class TestGGUFLoRANameConversion:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -202,7 +202,7 @@ class TestGGUFLoRAAlphaScaling:
 
         # Download model and adapter
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -246,7 +246,7 @@ class TestGGUFLoRAAdapterEquality:
         from the same file, which is important for scenarios where multiple pipelines
         need to use the same adapter.
         """
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         # Load adapter twice
         adapter1 = ov_genai.Adapter(str(adapter_path))
@@ -305,7 +305,7 @@ class TestGGUFLoRAIntegration:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()
@@ -346,7 +346,7 @@ class TestGGUFLoRAIntegration:
         from pathlib import Path
 
         model_path = snapshot_download(repo_id=MODEL_ID, cache_dir=Path.home() / ".cache" / "huggingface" / "hub")
-        adapter_path = download_hf_model(ADAPTER_REPO_ID, ADAPTER_FILENAME)
+        adapter_path = download_hf_file(ADAPTER_REPO_ID, ADAPTER_FILENAME)
 
         device = "CPU"
         config = ov_genai.GenerationConfig()

--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -31,7 +31,7 @@ from data.models import GGUF_MODEL_LIST
 class ModelInfo:
     gguf_model_id: str
     gguf_filename: str
-    gguf_full_path: str
+    gguf_full_path: Path
     dynamic_quantization_group_size: str | None
     opt_model: Any | None
     hf_tokenizer: Any | None
@@ -177,7 +177,6 @@ def test_full_gguf_pipeline(
     gc.collect()
 
     if enable_save_ov_model:
-        gguf_full_path = Path(gguf_full_path)
         ov_pipe_native = create_ov_pipeline(gguf_full_path.parent, pipeline_type=pipeline_type, dynamic_quantization_group_size=dynamic_quantization_group_size)
         res_string_input_3  = ov_pipe_native.generate(prompt, generation_config=ov_generation_config)
         del ov_pipe_native

--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -15,7 +15,7 @@ import openvino_genai as ov_genai
 
 from utils.hugging_face import (
     generation_config_to_hf,
-    download_hf_model,
+    download_hf_file,
     load_hf_model_from_gguf,
     load_hf_tokenizer_from_gguf,
 )
@@ -44,7 +44,7 @@ def model_gguf(request: pytest.FixtureRequest) -> ModelInfo:
     gguf_filename = meta_info["gguf_filename"]
     opt_model = load_hf_model_from_gguf(gguf_model_id, gguf_filename)
     hf_tokenizer = load_hf_tokenizer_from_gguf(gguf_model_id, gguf_filename)
-    gguf_full_path = download_hf_model(gguf_model_id, gguf_filename)
+    gguf_full_path = download_hf_file(gguf_model_id, gguf_filename)
     return ModelInfo(
         gguf_model_id=gguf_model_id,
         gguf_filename=gguf_filename,
@@ -217,7 +217,7 @@ def test_full_gguf_qwen3_pipeline(pipeline_type, model_ids):
     # TODO: Investigate output difference for GGUF models. Ticket: TBD
     res_string_input_1 = "\nOkay, the user is asking why the Sun is yellow. Let me start by recalling what I know about the Sun's color. I remember"
 
-    gguf_full_path = download_hf_model(gguf_model_id, gguf_filename)
+    gguf_full_path = download_hf_file(gguf_model_id, gguf_filename)
     ov_pipe_gguf = create_ov_pipeline(gguf_full_path, pipeline_type=pipeline_type)
     res_string_input_2 = ov_pipe_gguf.generate(prompt, generation_config=ov_generation_config)
 

--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -15,7 +15,7 @@ import openvino_genai as ov_genai
 
 from utils.hugging_face import (
     generation_config_to_hf,
-    download_gguf_model,
+    download_hf_model,
     load_hf_model_from_gguf,
     load_hf_tokenizer_from_gguf,
 )
@@ -44,7 +44,7 @@ def model_gguf(request: pytest.FixtureRequest) -> ModelInfo:
     gguf_filename = meta_info["gguf_filename"]
     opt_model = load_hf_model_from_gguf(gguf_model_id, gguf_filename)
     hf_tokenizer = load_hf_tokenizer_from_gguf(gguf_model_id, gguf_filename)
-    gguf_full_path = download_gguf_model(gguf_model_id, gguf_filename)
+    gguf_full_path = download_hf_model(gguf_model_id, gguf_filename)
     return ModelInfo(
         gguf_model_id=gguf_model_id,
         gguf_filename=gguf_filename,
@@ -217,7 +217,7 @@ def test_full_gguf_qwen3_pipeline(pipeline_type, model_ids):
     # TODO: Investigate output difference for GGUF models. Ticket: TBD
     res_string_input_1 = "\nOkay, the user is asking why the Sun is yellow. Let me start by recalling what I know about the Sun's color. I remember"
 
-    gguf_full_path = download_gguf_model(gguf_model_id, gguf_filename)
+    gguf_full_path = download_hf_model(gguf_model_id, gguf_filename)
     ov_pipe_gguf = create_ov_pipeline(gguf_full_path, pipeline_type=pipeline_type)
     res_string_input_2 = ov_pipe_gguf.generate(prompt, generation_config=ov_generation_config)
 

--- a/tests/python_tests/utils/hugging_face.py
+++ b/tests/python_tests/utils/hugging_face.py
@@ -365,10 +365,10 @@ def download_and_convert_model_class(
     )
 
 
-def download_hf_model(
+def download_hf_file(
     repo_id: str,
     filename: str,
-):
+) -> Path:
     dir_name = sanitize_model_id(repo_id)
     ov_cache_downloaded_dir = get_ov_cache_downloaded_models_dir()
     dest_dir = ov_cache_downloaded_dir / dir_name

--- a/tests/python_tests/utils/hugging_face.py
+++ b/tests/python_tests/utils/hugging_face.py
@@ -365,23 +365,22 @@ def download_and_convert_model_class(
     )
 
 
-def download_gguf_model(
-    gguf_model_id: str,
-    gguf_filename: str,
+def download_hf_model(
+    repo_id: str,
+    filename: str,
 ):
-    gguf_dir_name = sanitize_model_id(gguf_model_id)
+    dir_name = sanitize_model_id(repo_id)
     ov_cache_downloaded_dir = get_ov_cache_downloaded_models_dir()
-    models_path_gguf = ov_cache_downloaded_dir / gguf_dir_name
+    dest_dir = ov_cache_downloaded_dir / dir_name
 
-    manager = AtomicDownloadManager(models_path_gguf)
+    manager = AtomicDownloadManager(dest_dir)
 
     def download_to_temp(temp_path: Path) -> None:
-        retry_request(lambda: hf_hub_download(repo_id=gguf_model_id, filename=gguf_filename, local_dir=temp_path))
+        retry_request(lambda: hf_hub_download(repo_id=repo_id, filename=filename, local_dir=temp_path))
 
     manager.execute(download_to_temp)
 
-    gguf_path = models_path_gguf / gguf_filename
-    return gguf_path
+    return dest_dir / filename
 
 
 def load_hf_model_from_gguf(gguf_model_id, gguf_filename):


### PR DESCRIPTION
## Description
`download_gguf_model` in tests/python_tests/utils/hugging_face.py is a generic file downloader that uses hf_hub_download, it works for any file type, not just GGUF. Renamed it to download_hf_file to reflect its purpose and enable reuse for downloading other file types (e.g. LoRA .safetensors adapters) in upcoming PRs (e.g #3605).

Updated all calls in test_gguf_lora.py, test_gguf_reader.py, and samples/test_tools_llm_benchmark.py.



## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- Tests have been updated or added to cover the new code. NA
- This PR fully addresses the ticket. NA
- I have made corresponding changes to the documentation. NA
