### PR TITLE
Timestamps closer to model.generate() in visual_language_generation

### DIFF
--- a/tools/llm_bench/task/visual_language_generation.py
+++ b/tools/llm_bench/task/visual_language_generation.py
@@ -66,7 +66,7 @@ def run_visual_language_generation_optimum(
     mem_consumption.start(num)
     max_gen_tokens = DEFAULT_OUTPUT_TOKEN_SIZE if args['infer_count'] is None else args['infer_count']
     additional_args = model_utils.setup_gen_config_use_custom_args()
-    log.info("%s Text generation start: %s", prefix, datetime.datetime.now().isoformat())
+    log.info("%s[P%s] Text generation start: %s", prefix, prompt_index, datetime.datetime.now().isoformat())
     start = time.perf_counter()
     if args['infer_count'] is not None and args['end_token_stopping'] is False:
         model.generation_config.eos_token_id = None
@@ -90,7 +90,7 @@ def run_visual_language_generation_optimum(
             **additional_args
         )
     end = time.perf_counter()
-    log.info("%s Text generation end: %s", prefix, datetime.datetime.now().isoformat())
+    log.info("%s[P%s] Text generation end: %s", prefix, prompt_index, datetime.datetime.now().isoformat())
     generation_time = end - start
     memory_metrics = mem_consumption.iter_stop_and_collect_data(num)
 
@@ -206,11 +206,11 @@ def run_visual_language_generation_genai(
     if videos:
         kwargs["videos"] = videos
 
-    log.info("%s Text generation start: %s", prefix, datetime.datetime.now().isoformat())
+    log.info("%s[P%s] Text generation start: %s", prefix, prompt_index, datetime.datetime.now().isoformat())
     start = time.perf_counter()
     generation_result = model.generate(prompts[0], generation_config=gen_config, **kwargs)
     end = time.perf_counter()
-    log.info("%s Text generation end: %s", prefix, datetime.datetime.now().isoformat())
+    log.info("%s[P%s] Text generation end: %s", prefix, prompt_index, datetime.datetime.now().isoformat())
     generation_time = end - start
     generated_text = generation_result.texts
     perf_metrics = generation_result.perf_metrics

--- a/tools/llm_bench/task/visual_language_generation.py
+++ b/tools/llm_bench/task/visual_language_generation.py
@@ -66,6 +66,7 @@ def run_visual_language_generation_optimum(
     mem_consumption.start(num)
     max_gen_tokens = DEFAULT_OUTPUT_TOKEN_SIZE if args['infer_count'] is None else args['infer_count']
     additional_args = model_utils.setup_gen_config_use_custom_args()
+    log.info("%s Text generation start: %s", prefix, datetime.datetime.now().isoformat())
     start = time.perf_counter()
     if args['infer_count'] is not None and args['end_token_stopping'] is False:
         model.generation_config.eos_token_id = None
@@ -89,6 +90,7 @@ def run_visual_language_generation_optimum(
             **additional_args
         )
     end = time.perf_counter()
+    log.info("%s Text generation end: %s", prefix, datetime.datetime.now().isoformat())
     generation_time = end - start
     memory_metrics = mem_consumption.iter_stop_and_collect_data(num)
 
@@ -204,9 +206,11 @@ def run_visual_language_generation_genai(
     if videos:
         kwargs["videos"] = videos
 
+    log.info("%s Text generation start: %s", prefix, datetime.datetime.now().isoformat())
     start = time.perf_counter()
     generation_result = model.generate(prompts[0], generation_config=gen_config, **kwargs)
     end = time.perf_counter()
+    log.info("%s Text generation end: %s", prefix, datetime.datetime.now().isoformat())
     generation_time = end - start
     generated_text = generation_result.texts
     perf_metrics = generation_result.perf_metrics


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
The rationale for this change is to enable more accurate power measurements for model.generate() runs.
Changes by file:

- `tools/llm_bench/task/visual_language_generation.py`
Added timestamps closer to model.generate() calls, right before start = time.perf_counter() and after end = time.perf_counter().

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
