### PR TITLE
Add zai-org/GLM-4.7-Flash (Glm4MoeLiteForCausalLM) to supported LLM models

### DIFF
--- a/site/docs/supported-models/_components/llm-models-table/models.ts
+++ b/site/docs/supported-models/_components/llm-models-table/models.ts
@@ -296,6 +296,17 @@ export const LLM_MODELS: LLMModelType[] = [
     ],
   },
   {
+    architecture: 'Glm4MoeLiteForCausalLM',
+    models: [
+      {
+        name: 'GLM-4.7-Flash',
+        links: [
+          'https://huggingface.co/zai-org/GLM-4.7-Flash',
+        ],
+      },
+    ],
+  },
+  {
     architecture: 'GPT2LMHeadModel',
     models: [
       {


### PR DESCRIPTION
## Description

Add `zai-org/GLM-4.7-Flash` to the supported LLM models documentation table. This model uses the `Glm4MoeLiteForCausalLM` architecture (`model_type: glm4_moe_lite`), a Mixture-of-Experts variant of the GLM-4 family introduced by ZhipuAI.

Support for the `glm4_moe_lite` architecture in `optimum-intel` was added in https://github.com/huggingface/optimum-intel/pull/1699.

### Validation Results (tiny model, CPU)

**Export**: `optimum-cli export openvino` with `--task text-generation-with-past` completed successfully.

**llm_bench inference test:**
- 1st token latency: 2.85 ms
- 2nd token latency: 1.64 ms/token
- Throughput: 609.15 tokens/s

**who-what-benchmark accuracy:**
- Optimum backend similarity: 1.0
- GenAI backend similarity: 1.0

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation.