### PR TITLE
feat: Add DeepSeek-V4-Flash to supported LLM models

### DIFF
--- a/site/docs/supported-models/_components/llm-models-table/models.ts
+++ b/site/docs/supported-models/_components/llm-models-table/models.ts
@@ -190,6 +190,17 @@ export const LLM_MODELS: LLMModelType[] = [
     ],
   },
   {
+    architecture: 'DeepseekV4ForCausalLM',
+    models: [
+      {
+        name: 'DeepSeek-V4-Flash',
+        links: [
+          'https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash',
+        ],
+      },
+    ],
+  },
+  {
     architecture: 'ExaoneForCausalLM',
     models: [
       {


### PR DESCRIPTION
## Description

Add deepseek-ai/DeepSeek-V4-Flash to the supported LLM models table. Architecture: DeepseekV4ForCausalLM (model_type: deepseek_v4).

Validation results (CPU): Export OK, llm_bench OK (1st token 4.45ms, 330 tok/s), WWB Optimum similarity 1.0, WWB GenAI similarity 1.0.

## Checklist:
- [x] This PR follows GenAI Contributing guidelines.
- [ ] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation.