### PR TITLE
[EXPERIMENT][WIP] llm: always fall back to SDPA for hybrid models (Qwen3.6-35B-A3B)

### DIFF
--- a/src/cpp/src/llm/pipeline.cpp
+++ b/src/cpp/src/llm/pipeline.cpp
@@ -212,19 +212,18 @@ ov::genai::LLMPipeline::LLMPipeline(
     // PA backend does not support linear attention states (conv/SSM caches).
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)) {
-            GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
-        } else {
-            // Always fall back to SDPA for hybrid models (linear + full attention).
-            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
-            attention_backend = SDPA_BACKEND;
-        }
+        OPENVINO_ASSERT(!utils::strictly_requires_paged_attention(user_properties),
+            "PA backend does not support models with linear attention states (hybrid models). "
+            "Remove 'scheduler_config', speculative-decoding, or 'prompt_lookup' from properties, "
+            "or use a non-hybrid model.");
+        // ATTENTION_BACKEND=PA is a preference; fall back to SDPA for hybrid models.
+        attention_backend = SDPA_BACKEND;
     }
 
     const auto generation_config = utils::from_config_json_if_exists(models_path);
     if (is_npu_requested) {
         m_pimpl = StatefulPipeline::create(model, tokenizer, device, properties, generation_config, models_path);
-    } else if (utils::explicitly_requires_paged_attention(user_properties)) {
+    } else if (utils::strictly_requires_paged_attention(user_properties)) {
         // If CB is invoked explicitly, create CB adapter as is and re-throw in case if internal issues
         auto [device_properties, scheduler_config] = utils::extract_scheduler_config(properties, utils::get_latency_oriented_scheduler_config());
         m_pimpl = std::make_unique<ContinuousBatchingAdapter>(models_path, tokenizer, scheduler_config, device, device_properties);
@@ -268,19 +267,18 @@ ov::genai::LLMPipeline::LLMPipeline(
     // PA backend does not support linear attention states (conv/SSM caches).
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)) {
-            GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
-        } else {
-            // Always fall back to SDPA for hybrid models (linear + full attention).
-            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
-            attention_backend = SDPA_BACKEND;
-        }
+        OPENVINO_ASSERT(!utils::strictly_requires_paged_attention(user_properties),
+            "PA backend does not support models with linear attention states (hybrid models). "
+            "Remove 'scheduler_config', speculative-decoding, or 'prompt_lookup' from properties, "
+            "or use a non-hybrid model.");
+        // ATTENTION_BACKEND=PA is a preference; fall back to SDPA for hybrid models.
+        attention_backend = SDPA_BACKEND;
     }
 
     const auto generation_config = utils::from_config_json_if_exists(models_path);
     if (is_npu_requested) {
         m_pimpl = StatefulPipeline::create(model, tokenizer, device, properties, generation_config, models_path);
-    } else if (utils::explicitly_requires_paged_attention(user_properties)) {
+    } else if (utils::strictly_requires_paged_attention(user_properties)) {
         // If CB is invoked explicitly, create CB adapter as is and re-throw in case if internal issues
         auto [device_properties, scheduler_config] = utils::extract_scheduler_config(properties, utils::get_latency_oriented_scheduler_config());
         m_pimpl = std::make_unique<ContinuousBatchingAdapter>(models_path, scheduler_config, device, device_properties);
@@ -324,13 +322,12 @@ ov::genai::LLMPipeline::LLMPipeline(
     const auto model = utils::singleton_core().read_model(model_str, weights_tensor);
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)) {
-            GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
-        } else {
-            // Always fall back to SDPA for hybrid models (linear + full attention).
-            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
-            attention_backend = SDPA_BACKEND;
-        }
+        OPENVINO_ASSERT(!utils::strictly_requires_paged_attention(user_properties),
+            "PA backend does not support models with linear attention states (hybrid models). "
+            "Remove 'scheduler_config', speculative-decoding, or 'prompt_lookup' from properties, "
+            "or use a non-hybrid model.");
+        // ATTENTION_BACKEND=PA is a preference; fall back to SDPA for hybrid models.
+        attention_backend = SDPA_BACKEND;
     }
 
     if (is_npu_requested) {
@@ -340,7 +337,7 @@ ov::genai::LLMPipeline::LLMPipeline(
             device,
             properties,
             generation_config);
-    } else if (utils::explicitly_requires_paged_attention(user_properties)) {
+    } else if (utils::strictly_requires_paged_attention(user_properties)) {
         // If CB is invoked explicitly, create CB adapter as is and re-throw in case if internal issues
         auto [device_properties, scheduler_config] = utils::extract_scheduler_config(properties, utils::get_latency_oriented_scheduler_config());
         m_pimpl = std::make_unique<ContinuousBatchingAdapter>(model_str, weights_tensor,

--- a/src/cpp/src/llm/pipeline.cpp
+++ b/src/cpp/src/llm/pipeline.cpp
@@ -212,10 +212,11 @@ ov::genai::LLMPipeline::LLMPipeline(
     // PA backend does not support linear attention states (conv/SSM caches).
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)
-            || user_properties.find("ATTENTION_BACKEND") != user_properties.end()) {
+        if (utils::explicitly_requires_paged_attention(user_properties)) {
             GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
         } else {
+            // Always fall back to SDPA for hybrid models (linear + full attention).
+            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
             attention_backend = SDPA_BACKEND;
         }
     }
@@ -267,10 +268,11 @@ ov::genai::LLMPipeline::LLMPipeline(
     // PA backend does not support linear attention states (conv/SSM caches).
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)
-            || user_properties.find("ATTENTION_BACKEND") != user_properties.end()) {
+        if (utils::explicitly_requires_paged_attention(user_properties)) {
             GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
         } else {
+            // Always fall back to SDPA for hybrid models (linear + full attention).
+            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
             attention_backend = SDPA_BACKEND;
         }
     }
@@ -322,10 +324,11 @@ ov::genai::LLMPipeline::LLMPipeline(
     const auto model = utils::singleton_core().read_model(model_str, weights_tensor);
     if (attention_backend == PA_BACKEND && !is_npu_requested
         && utils::has_linear_attention_states(model)) {
-        if (utils::explicitly_requires_paged_attention(user_properties)
-            || user_properties.find("ATTENTION_BACKEND") != user_properties.end()) {
+        if (utils::explicitly_requires_paged_attention(user_properties)) {
             GENAI_WARN("PA backend does not support models with linear attention states. The model may work incorrectly.");
         } else {
+            // Always fall back to SDPA for hybrid models (linear + full attention).
+            // ATTENTION_BACKEND=PA in user_properties is treated as a preference, not a requirement.
             attention_backend = SDPA_BACKEND;
         }
     }

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -793,11 +793,12 @@ SchedulerConfig get_latency_oriented_scheduler_config() {
     return default_config;
 }
 
-bool explicitly_requires_paged_attention(const ov::AnyMap& properties, bool is_npu_requested) {
-    auto attention_backend_it = properties.find("ATTENTION_BACKEND");
-
-    if (properties.find(ov::genai::scheduler_config.name()) != properties.end() ||
-        (attention_backend_it != properties.end() && attention_backend_it->second.as<std::string>() == PA_BACKEND)) {
+bool strictly_requires_paged_attention(const ov::AnyMap& properties, bool is_npu_requested) {
+    // Returns true only when PA is a hard requirement imposed by a feature
+    // (scheduler_config, speculative decoding, prompt lookup).
+    // ATTENTION_BACKEND=PA is deliberately excluded: it is a preference that
+    // can be overridden for models incompatible with PA (e.g. hybrid models).
+    if (properties.find(ov::genai::scheduler_config.name()) != properties.end()) {
         if (is_paged_attention_available()) {
             return true;
         } else {
@@ -822,6 +823,19 @@ bool explicitly_requires_paged_attention(const ov::AnyMap& properties, bool is_n
         }
     }
     return false;
+}
+
+bool explicitly_requires_paged_attention(const ov::AnyMap& properties, bool is_npu_requested) {
+    auto attention_backend_it = properties.find("ATTENTION_BACKEND");
+    if (attention_backend_it != properties.end() &&
+        attention_backend_it->second.as<std::string>() == PA_BACKEND) {
+        if (is_paged_attention_available()) {
+            return true;
+        } else {
+            OPENVINO_THROW("Continuous batching backend requires PagedAttention operation support, which is available on x86_64 or ARM64 platforms only");
+        }
+    }
+    return strictly_requires_paged_attention(properties, is_npu_requested);
 }
 
 void clear_false_prompt_lookup_from_config(ov::AnyMap& properties) {

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -331,6 +331,7 @@ std::pair<ov::AnyMap, SchedulerConfig> extract_scheduler_config(const ov::AnyMap
 
 SchedulerConfig get_latency_oriented_scheduler_config();
 
+bool strictly_requires_paged_attention(const ov::AnyMap& properties, bool is_npu_requested = false);
 bool explicitly_requires_paged_attention(const ov::AnyMap& properties, bool is_npu_requested = false);
 
 std::pair<ov::AnyMap, std::string> extract_attention_backend(const ov::AnyMap& external_properties, bool is_npu_requested = false);


### PR DESCRIPTION
## Description

Fix SDPA fallback for hybrid models (e.g. Qwen3.6-35B-A3B with GatedDeltaNet + full-attention layers) when `ATTENTION_BACKEND=PA` is set.

**Root cause:** `explicitly_requires_paged_attention()` conflated `ATTENTION_BACKEND=PA` (a user preference) with hard PA requirements (scheduler_config / speculative-decoding / prompt_lookup). As a result the hybrid-model SDPA fallback in all three LLMPipeline constructors was dead code — the outer branch always warned and continued with PA, leading to a crash:
```
RuntimeError: Model references undeclared parameters: beam_idx
```

**Fix:** Introduce `strictly_requires_paged_attention()` that checks only scheduler_config, draft_model, and prompt_lookup — not ATTENTION_BACKEND. Update all three LLMPipeline constructors to:
1. Use `OPENVINO_ASSERT(!strictly_requires_paged_attention(...))` for the hybrid-model guard so a truly required PA on a hybrid model fails fast with a clear error (C++ Core Guidelines E.12).
2. Use `strictly_requires_paged_attention()` for the CB-adapter selection so `ATTENTION_BACKEND=PA` alone falls through to the optional try/catch CB path, not the strict always-crash path.

`explicitly_requires_paged_attention()` is preserved (delegates to the new function after the ATTENTION_BACKEND check) so existing callers are unaffected.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- [ ] I have made corresponding changes to the documentation.