### PR TITLE
[wwb] Update video inputs to avoid big video

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -235,11 +235,16 @@ def prepare_default_data_video(num_samples=None, num_frames=10):
                                       filename=f"{SUBSET}/{SUBSET}_videos_10.tar.gz",
                                       repo_type="dataset")
 
+    # max resolution 1280x720, max size 6MB
+    max_video_size_bytes = 6 * 1024 * 1024
     video_samples = []
     extract_dir = "./videos"
     os.makedirs(extract_dir, exist_ok=True)
     with tarfile.open(videos_arc_path, "r:gz") as tar:
-        all_videos = tar.getnames()
+        all_videos = []
+        for member in tar.getmembers():
+            if member.size < max_video_size_bytes:
+                all_videos.append(member.name)
 
         if len(all_videos) < NUM_SAMPLES:
             logger.warning(f"The required number of samples {NUM_SAMPLES} exceeds the available amount of data {len(all_videos)}."

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -251,7 +251,7 @@ def prepare_default_data_video(num_samples=None, num_frames=10):
                            f"num-samples will be updated to max available: {len(all_videos)}.")
             NUM_SAMPLES = len(all_videos)
 
-        video_samples = random.Random(42).sample(all_videos, NUM_SAMPLES)  # nosec
+        video_samples = random.Random(43).sample(all_videos, NUM_SAMPLES)  # nosec
         for sample in video_samples:
             tar.extract(sample, path=extract_dir)
 


### PR DESCRIPTION
## Description
The max size of the video in default data for `visual-video-text` `--model-type` is 38MB, resolution 2880x1080. Due to big memory loads with qwen2-vl model(CVS-180177) validation is craching on some platforms. We'll limit the video size. Max video size become 6MB. The resolutions of the video in the sample will be: `360x480, 394x480, 640x480 , 640x360 , 480x270 , 480x318 , 1280x720`

Set non-default seed to avoid test with small resolution video, task for reason is created - CVS-186452

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-185026](https://jira.devtools.intel.com/browse/CVS-185026)


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
