### PR TITLE
Refine not implemented error

### DIFF
--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -25,10 +25,12 @@
 #include "utils.hpp"
 
 namespace {
-void throw_video_not_implemented() {
-    OPENVINO_THROW_NOT_IMPLEMENTED(
-        "Video preprocessing isn't implemented for this model. Pass frames as independent images."
-    );
+void throw_video_not_implemented(const std::vector<>& videos) {
+    if (!videos.empty()) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(
+            "Video preprocessing isn't implemented for this model. Pass frames as independent images."
+        );
+    }
 }
 }  // anonymous namespace
 
@@ -210,18 +212,15 @@ ov::Tensor InputsEmbedder::IInputsEmbedder::get_inputs_embeds(
     bool recalculate_merged_embeddings,
     const std::vector<size_t>& images_sequence,
     const std::vector<size_t>& videos_sequence,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
-    if (!videos.size()) {
-        return get_inputs_embeds(prompt, images, metrics, recalculate_merged_embeddings, images_sequence);
-    }
-    throw_video_not_implemented();
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
+) {
+    throw_video_not_implemented(videos);
+    return get_inputs_embeds(prompt, images, metrics, recalculate_merged_embeddings, images_sequence);
 }
 
 std::vector<ov::genai::EncodedVideo> InputsEmbedder::IInputsEmbedder::encode_videos(const std::vector<ov::Tensor>& videos) {
-    if (!videos.size()) {
-        return {};
-    }
-    throw_video_not_implemented();
+    throw_video_not_implemented(videos);
+    return {};
 }
 
 NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
@@ -229,11 +228,10 @@ NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
     size_t base_image_id,
     size_t base_video_id,
     const std::vector<EncodedImage>& images,
-    const std::vector<EncodedVideo>& videos) const {
-    if (!videos.size()) {
-        return normalize_prompt(prompt, base_image_id, images);
-    }
-    throw_video_not_implemented();
+    const std::vector<EncodedVideo>& videos
+) const {
+    throw_video_not_implemented(videos);
+    return normalize_prompt(prompt, base_image_id, images);
 }
 
 std::pair<ov::Tensor, ov::Tensor> InputsEmbedder::IInputsEmbedder::get_inputs_embeds_with_token_type_ids(
@@ -253,9 +251,9 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedder::IInputsEmbedder::get_inputs_em
     bool recalculate_merged_embeddings,
     const std::vector<size_t>& image_sequence,
     const std::vector<size_t>& videos_sequence,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
-    OPENVINO_ASSERT(videos.size() == 0U, "The model doesn't support 'videos' preprocessing yet. Please use 'images' instead.");
-
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
+) {
+    throw_video_not_implemented(videos);
     return get_inputs_embeds_with_token_type_ids(prompt, images, metrics, recalculate_merged_embeddings, image_sequence);
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -24,6 +24,14 @@
 
 #include "utils.hpp"
 
+namespace {
+void throw_video_not_implemented() {
+    OPENVINO_THROW_NOT_IMPLEMENTED(
+        "Video preprocessing is't implemented for this model. Input images are processed as separate images."
+    );
+}
+}  // anonymous namespace
+
 namespace ov::genai {
 
 // Base InputsEmbedder class
@@ -206,14 +214,14 @@ ov::Tensor InputsEmbedder::IInputsEmbedder::get_inputs_embeds(
     if (!videos.size()) {
         return get_inputs_embeds(prompt, images, metrics, recalculate_merged_embeddings, images_sequence);
     }
-    OPENVINO_THROW("Current model doesn't support video preprocess currently. Input images are processed as separate images.");
+    throw_video_not_implemented();
 }
 
 std::vector<ov::genai::EncodedVideo> InputsEmbedder::IInputsEmbedder::encode_videos(const std::vector<ov::Tensor>& videos) {
     if (!videos.size()) {
         return {};
     }
-    OPENVINO_THROW("Current model doesn't support video preprocess currently. Input images are processed as separate images.");
+    throw_video_not_implemented();
 }
 
 NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
@@ -225,7 +233,7 @@ NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
     if (!videos.size()) {
         return normalize_prompt(prompt, base_image_id, images);
     }
-    OPENVINO_THROW("Current model doesn't support video preprocess currently. Input images are processed as separate images.");
+    throw_video_not_implemented();
 }
 
 std::pair<ov::Tensor, ov::Tensor> InputsEmbedder::IInputsEmbedder::get_inputs_embeds_with_token_type_ids(

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -254,7 +254,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedder::IInputsEmbedder::get_inputs_em
     const std::vector<size_t>& videos_sequence,
     const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
 ) {
-    throw_video_not_implemented(videos);
+    throw_if_video_not_implemented(videos);
     return get_inputs_embeds_with_token_type_ids(prompt, images, metrics, recalculate_merged_embeddings, image_sequence);
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -25,7 +25,8 @@
 #include "utils.hpp"
 
 namespace {
-void throw_video_not_implemented(const std::vector<>& videos) {
+template <typename VideoType>
+void throw_video_not_implemented(const std::vector<VideoType>& videos) {
     if (!videos.empty()) {
         OPENVINO_THROW_NOT_IMPLEMENTED(
             "Video preprocessing isn't implemented for this model. Pass frames as independent images."

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -26,7 +26,7 @@
 
 namespace {
 template <typename VideoType>
-void throw_video_not_implemented(const std::vector<VideoType>& videos) {
+void throw_if_video_not_implemented(const std::vector<VideoType>& videos) {
     if (!videos.empty()) {
         OPENVINO_THROW_NOT_IMPLEMENTED(
             "Video preprocessing isn't implemented for this model. Pass frames as independent images."
@@ -215,12 +215,12 @@ ov::Tensor InputsEmbedder::IInputsEmbedder::get_inputs_embeds(
     const std::vector<size_t>& videos_sequence,
     const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
 ) {
-    throw_video_not_implemented(videos);
+    throw_if_video_not_implemented(videos);
     return get_inputs_embeds(prompt, images, metrics, recalculate_merged_embeddings, images_sequence);
 }
 
 std::vector<ov::genai::EncodedVideo> InputsEmbedder::IInputsEmbedder::encode_videos(const std::vector<ov::Tensor>& videos) {
-    throw_video_not_implemented(videos);
+    throw_if_video_not_implemented(videos);
     return {};
 }
 
@@ -231,7 +231,7 @@ NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
     const std::vector<EncodedImage>& images,
     const std::vector<EncodedVideo>& videos
 ) const {
-    throw_video_not_implemented(videos);
+    throw_if_video_not_implemented(videos);
     return normalize_prompt(prompt, base_image_id, images);
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -27,7 +27,7 @@
 namespace {
 void throw_video_not_implemented() {
     OPENVINO_THROW_NOT_IMPLEMENTED(
-        "Video preprocessing is't implemented for this model. Input images are processed as separate images."
+        "Video preprocessing isn't implemented for this model. Pass frames as independent images."
     );
 }
 }  // anonymous namespace


### PR DESCRIPTION
## Description
Refines the error handling for video inputs in the Visual Language `InputsEmbedder` by centralizing the “video not supported” exception into a dedicated helper and switching to a not-implemented exception type.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- N/A Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- N/.A This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- N/A I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
