### PR TITLE
Fix audio_tokenizer AttributeError

### DIFF
--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -364,12 +364,13 @@ def _get_ov_model(model_id: str) -> str:
         if tokenizer.chat_template is not None and model.config.model_type == "phi3_v":
             # It seems that tiny-random-phi3-vision is saved incorrectly. That line works this around.
             processor.chat_template = tokenizer.chat_template
-        processor.audio_tokenizer = None
         if model_id == "optimum-intel-internal-testing/tiny-random-gemma4":
             # Remove audio_tokenizer to avoid serialization issues (audio inputs are not supported).
             # Setting to None is insufficient because Gemma4Processor.to_dict() still detects
             # the key and calls .name_or_path on a None object.
             processor.__dict__.pop("audio_tokenizer", None)
+        else:
+            processor.audio_tokenizer = None
         processor.save_pretrained(temp_dir)
         model.save_pretrained(temp_dir)
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -364,11 +364,13 @@ def _get_ov_model(model_id: str) -> str:
         if tokenizer.chat_template is not None and model.config.model_type == "phi3_v":
             # It seems that tiny-random-phi3-vision is saved incorrectly. That line works this around.
             processor.chat_template = tokenizer.chat_template
-        processor.audio_tokenizer = None
-        # Remove audio_tokenizer to avoid serialization issues (audio inputs are not supported).
-        # Setting to None is insufficient because Gemma4Processor.to_dict() still detects
-        # the key and calls .name_or_path on a None object.
-        processor.__dict__.pop("audio_tokenizer", None)
+        elif model_id == "optimum-intel-internal-testing/tiny-random-gemma4":
+            # Remove audio_tokenizer to avoid serialization issues (audio inputs are not supported).
+            # Setting to None is insufficient because Gemma4Processor.to_dict() still detects
+            # the key and calls .name_or_path on a None object.
+            processor.__dict__.pop("audio_tokenizer", None)
+        else:
+            processor.audio_tokenizer = None
         processor.save_pretrained(temp_dir)
         model.save_pretrained(temp_dir)
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -364,13 +364,12 @@ def _get_ov_model(model_id: str) -> str:
         if tokenizer.chat_template is not None and model.config.model_type == "phi3_v":
             # It seems that tiny-random-phi3-vision is saved incorrectly. That line works this around.
             processor.chat_template = tokenizer.chat_template
-        elif model_id == "optimum-intel-internal-testing/tiny-random-gemma4":
+        processor.audio_tokenizer = None
+        if model_id == "optimum-intel-internal-testing/tiny-random-gemma4":
             # Remove audio_tokenizer to avoid serialization issues (audio inputs are not supported).
             # Setting to None is insufficient because Gemma4Processor.to_dict() still detects
             # the key and calls .name_or_path on a None object.
             processor.__dict__.pop("audio_tokenizer", None)
-        else:
-            processor.audio_tokenizer = None
         processor.save_pretrained(temp_dir)
         model.save_pretrained(temp_dir)
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -364,7 +364,9 @@ def _get_ov_model(model_id: str) -> str:
         if tokenizer.chat_template is not None and model.config.model_type == "phi3_v":
             # It seems that tiny-random-phi3-vision is saved incorrectly. That line works this around.
             processor.chat_template = tokenizer.chat_template
-        if model_id == "optimum-intel-internal-testing/tiny-random-gemma4":
+        if isinstance(processor, getattr(transformers, "Gemma4Processor", type(None))) or isinstance(
+            processor, getattr(transformers, "Qwen3VLProcessor", type(None))
+        ):
             # Remove audio_tokenizer to avoid serialization issues (audio inputs are not supported).
             # Setting to None is insufficient because Gemma4Processor.to_dict() still detects
             # the key and calls .name_or_path on a None object.


### PR DESCRIPTION
## Description
Updates the VLM pipeline Python test model-conversion helper to avoid an `AttributeError` during `save_pretrained()` caused by Gemma4’s `audio_tokenizer` serialization behavior.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
N/A This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
N/A I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
