### PR TITLE
Kczarnec malloc trim in memory monitor cooldown

### DIFF
--- a/tools/llm_bench/README.md
+++ b/tools/llm_bench/README.md
@@ -343,9 +343,9 @@ python benchmark.py -m models/llama-2-7b-chat/ -p "What is openvino?" -n 2 --tas
 ```
 
 **Parameters:**
-- `-mc, --memory_consumption`: Enables memory usage information collection mode. If the value is 1, output the maximum memory consumption in warm-up iterations. If the value is 2, output the maximum memory consumption in all iterations.
+- `-mc, --memory_consumption`: Enables memory usage information collection mode. If the value is 1, output the maximum memory consumption in warm-up iterations. If the value is 2, output the maximum memory consumption in all iterations. Then 3 means separated process, warm-up only, 4 - separated process with all iterations.
 - `--memory_consumption_interval`: Interval sampling for memory consumption check in seconds, smaller value will lead to more precised memory consumption, but may affects performance.
-- `--memory_consumption_cooldown`: Time for relaxing before workload, it allows to deallocate system resources.
+- `--memory_consumption_cooldown`: Time for relaxing before workload, it allows to deallocate system resources by portable heap-trimming helper.
 - `-mc_dir, --memory_consumption_dir`: Path to store memory consumption logs and chart.
 
 ## 9. Additional Resources

--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -133,13 +133,12 @@ def get_argparser():
         default=0,
         required=False,
         type=int,
-        help="Enables memory usage monitoring mode. For 0 monitoring is off. Use 1 to track memory consumption"
-        " during model compilation and warm-up iteration, 2 to track across all iterations, or 3 to track in"
-        " separate process over model compilation and warm-up, and respectively 4 for the whole benchmarking,"
-        "as well as 5 for monitor memory in cooldown phases only."
-        " Warning: Concurrent memory consumption and performance benchmarking is not recommended. Performance"
-        " impact can be reduced by using longer --memory_consumption_cooldown and --memory_consumption_interval"
-        " values, though a degradation is unavoidable.",
+        help="Enables memory usage monitoring mode. 0 = off (default). "
+        "1 = thread, warm-up only; 2 = thread, all iterations; "
+        "3 = separate process, warm-up only; 4 = separate process, all iterations. "
+        "Warning: concurrent memory and performance benchmarking is not recommended. "
+        "Performance impact can be reduced with longer --memory_consumption_cooldown "
+        "and --memory_consumption_interval values, though some degradation is unavoidable.",
     )
     parser.add_argument(
         "--memory_consumption_cooldown",

--- a/tools/llm_bench/llm_bench_utils/memory_monitor.py
+++ b/tools/llm_bench/llm_bench_utils/memory_monitor.py
@@ -31,10 +31,56 @@ import logging as log
 import traceback
 import json
 import sys
+import ctypes
+import ctypes.util
 
 
 # CUSTOM FIX TO AVOID ISSUE: RuntimeError: main thread is not in main loop.
 matplotlib.use("Agg")
+
+# ── portable malloc_trim ──────────────────────────────────────────────────────
+def _load_libc():
+    """Load the C standard library portably (Linux / macOS). Returns None on Windows."""
+    if sys.platform == "win32":
+        return None
+    lib = ctypes.CDLL(None)          # fast path: already mapped into the process
+    if not hasattr(lib, "malloc_trim"):
+        name = ctypes.util.find_library("c")
+        lib = ctypes.CDLL(name) if name else None
+    return lib
+
+_libc = _load_libc()
+
+def malloc_trim() -> bool:
+    """
+    Release free heap memory back to the OS in the current (main) process.
+    - Linux / glibc : malloc_trim(0) — returns free heap pages to the OS
+    - Windows       : HeapCompact()  — coalesces / decommits all process heaps
+    Returns True if memory was trimmed, False otherwise.
+    Safe to call at any time — only touches already-freed memory.
+    """
+    if sys.platform == "win32":
+        try:
+            kernel32 = ctypes.windll.kernel32
+            count = kernel32.GetProcessHeaps(0, None)
+            HeapsArray = ctypes.c_void_p * count
+            heaps = HeapsArray()
+            kernel32.GetProcessHeaps(count, heaps)
+            trimmed = False
+            for heap in heaps:
+                if kernel32.HeapCompact(heap, 0):
+                    trimmed = True
+            return trimmed
+        except OSError:
+            return False
+
+    if _libc is None or not hasattr(_libc, "malloc_trim"):
+        return False
+    _libc.malloc_trim.restype  = ctypes.c_int
+    _libc.malloc_trim.argtypes = [ctypes.c_size_t]
+    return bool(_libc.malloc_trim(0))
+# ─────────────────────────────────────────────────────────────────────────────
+
 
 
 class MonitorLevel(Enum):
@@ -170,6 +216,8 @@ class MemoryMonitorHandler:
         if self.mmh:
             self.mmh.update_marker("cooldown")
             log.info(f"MemoryMonitor: {label}: {self.cooldown}")
+        trimmed = malloc_trim()
+        log.info(f"MemoryMonitor: malloc_trim: {trimmed}")
         time.sleep(self.cooldown)
 
     def iter_stop_and_collect_data(self, iter_num, dict_format=True):

--- a/tools/llm_bench/llm_bench_utils/memory_monitor.py
+++ b/tools/llm_bench/llm_bench_utils/memory_monitor.py
@@ -57,12 +57,16 @@ _libc = _load_libc()
 
 def drop_caches():
     os.sync()
-    cache_path = "/proc/sys/vm/drop_caches"
+    if sys.platform != "linux":
+        return False
+
     try:
-        with open(cache_path, "w") as f:
+        cache_path = "/proc/sys/vm/drop_caches"
+        with open(cache_path, "w", encoding="utf-8") as f:
             f.write("3")
-    except PermissionError:
-        os.system("sudo echo 3 > /proc/sys/vm/drop_caches")
+        return True
+    except (FileNotFoundError, PermissionError, OSError):
+        return False
 
 
 def malloc_trim() -> bool:
@@ -138,7 +142,7 @@ class MonitorMode(Enum):
 
     @classmethod
     def from_code(cls, code: int):
-        """Create MonitorMode from integer code 0-5"""
+        """Create MonitorMode from integer code 0-4"""
         modes = [
             cls.NO_MONITORING,
             cls.THREAD_WARMUP,
@@ -1063,7 +1067,7 @@ class MemoryMarkerHandler:
         self.marker_queue = multiprocessing.Queue(maxsize=1000)
         self.s_event = multiprocessing.Event()
 
-        time.sleep(max(cooldown, 1))  # needed for some machines
+        time.sleep(max(cooldown or 0, 1))  # needed for some machines
         pargs = self.marker_queue, parent_pid, interval, report_path, mode, cooldown, self.s_event
         self.background_process = mProcess(target=self.background_worker, args=pargs, daemon=True)
         self.background_process.start()

--- a/tools/llm_bench/llm_bench_utils/memory_monitor.py
+++ b/tools/llm_bench/llm_bench_utils/memory_monitor.py
@@ -38,18 +38,32 @@ import ctypes.util
 # CUSTOM FIX TO AVOID ISSUE: RuntimeError: main thread is not in main loop.
 matplotlib.use("Agg")
 
+
 # ── portable malloc_trim ──────────────────────────────────────────────────────
 def _load_libc():
     """Load the C standard library portably (Linux / macOS). Returns None on Windows."""
     if sys.platform == "win32":
         return None
-    lib = ctypes.CDLL(None)          # fast path: already mapped into the process
+    # fast path: already mapped into the process
+    lib = ctypes.CDLL(None)
     if not hasattr(lib, "malloc_trim"):
         name = ctypes.util.find_library("c")
         lib = ctypes.CDLL(name) if name else None
     return lib
 
+
 _libc = _load_libc()
+
+
+def drop_caches():
+    os.sync()
+    cache_path = "/proc/sys/vm/drop_caches"
+    try:
+        with open(cache_path, "w") as f:
+            f.write("3")
+    except PermissionError:
+        os.stsem("sudo echo 3 > /proc/sys/vm/drop_caches")
+
 
 def malloc_trim() -> bool:
     """
@@ -62,6 +76,12 @@ def malloc_trim() -> bool:
     if sys.platform == "win32":
         try:
             kernel32 = ctypes.windll.kernel32
+            import ctypes.wintypes as _wt
+
+            kernel32.GetProcessHeaps.argtypes = [_wt.DWORD, ctypes.c_void_p]
+            kernel32.GetProcessHeaps.restype = _wt.DWORD
+            kernel32.HeapCompact.argtypes = [ctypes.c_void_p, _wt.DWORD]
+            kernel32.HeapCompact.restype = ctypes.c_size_t  # SIZE_T - avoids int overflow
             count = kernel32.GetProcessHeaps(0, None)
             HeapsArray = ctypes.c_void_p * count
             heaps = HeapsArray()
@@ -73,21 +93,31 @@ def malloc_trim() -> bool:
             return trimmed
         except OSError:
             return False
+    else:
+        drop_caches()
 
     if _libc is None or not hasattr(_libc, "malloc_trim"):
         return False
-    _libc.malloc_trim.restype  = ctypes.c_int
+    _libc.malloc_trim.restype = ctypes.c_int
     _libc.malloc_trim.argtypes = [ctypes.c_size_t]
     return bool(_libc.malloc_trim(0))
-# ─────────────────────────────────────────────────────────────────────────────
 
+
+@lru_cache
+def system_memory_warning():
+    # Log once
+    log.warning(
+        "Please note that MemoryType.SYSTEM in general is affected by other processes that change RAM availability."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 class MonitorLevel(Enum):
     DISABLED = 0
     WARMUP = 1
     FULL = 2
-    IDLE = 3
 
 
 class MonitorType(Enum):
@@ -101,7 +131,6 @@ class MonitorMode(Enum):
     THREAD_FULL = (MonitorLevel.FULL, MonitorType.THREAD)
     PROCESS_WARMUP = (MonitorLevel.WARMUP, MonitorType.PROCESS)
     PROCESS_FULL = (MonitorLevel.FULL, MonitorType.PROCESS)
-    PROCESS_IDLE = (MonitorLevel.IDLE, MonitorType.PROCESS)
 
     def __init__(self, monitor_level, monitor_type):
         self.monitor_level = monitor_level
@@ -116,10 +145,9 @@ class MonitorMode(Enum):
             cls.THREAD_FULL,
             cls.PROCESS_WARMUP,
             cls.PROCESS_FULL,
-            cls.PROCESS_IDLE,
         ]
-        if not 0 <= code <= 5:
-            raise ValueError(f"Invalid memory monitor mode: {code}. Must be 0-5")
+        if not 0 <= code <= 4:
+            raise ValueError(f"Invalid memory monitor mode: {code}. Must be 0-4")
         return modes[code]
 
     @property
@@ -142,10 +170,6 @@ class MonitorMode(Enum):
     def is_enabled(self) -> bool:
         return self.monitor_level != MonitorLevel.DISABLED
 
-    @property
-    def is_idle(self) -> bool:
-        return self.monitor_level == MonitorLevel.IDLE
-
 
 class MemoryMonitorHandler:
     def __init__(self, args):
@@ -153,7 +177,7 @@ class MemoryMonitorHandler:
         self.mth = MemThreadHandler(args) if self.mode.is_thread else None
         self.mmh = None
         if self.mode.is_process:
-            self.mmh = MemoryMarkerHandler(args, self.mode.is_idle)
+            self.mmh = MemoryMarkerHandler(args)
         self.cooldown = args.memory_consumption_cooldown
         self.last_iter_number = None
 
@@ -235,7 +259,6 @@ class MemoryMonitorHandler:
         self.stop_and_collect_data(dir_name)
         return self.mth.get_data(dict_format)
 
-
 ######################################################
 # Memory Monitoring (in separate thread)
 
@@ -259,14 +282,6 @@ class MemoryUnit(Enum):
     KB = "KB"  # Kilobyte
     MB = "MB"  # Megabyte
     GB = "GB"  # Gigabyte
-
-
-@lru_cache
-def system_memory_warning():
-    # Log once
-    log.warning(
-        "Please note that MemoryType.SYSTEM in general is affected by other processes that change RAM availability."
-    )
 
 
 class MemoryMonitor:
@@ -698,7 +713,6 @@ def _subtract_first_element(data):
     data[0] = 0
     return data
 
-
 ######################################################
 # Memory Marker Monitoring (in separate process)
 
@@ -956,30 +970,6 @@ class MemoryMarkerMonitor(list):
             print(f"Error checking markers: {e}")
         return False
 
-    def idle_loop(self, metadata):
-        count_error = 0
-        while not self.should_stop:
-            before_marker = self.marker
-            if self.check_for_markers():
-                print("Memory worker: Received stop signal")
-                break
-
-            if before_marker != "cooldown" and self.marker == "cooldown":
-                try:
-                    self.collect_samples(before_marker)
-                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-                    print("Memory worker: Target process no longer accessible")
-                    break
-                except Exception as e:
-                    print(f"Error collecting samples: {e}")
-                    count_error += 1
-
-            self.sampling_sleep()
-            if count_error > 3:
-                print("Memory worker: too many errors: stop!")
-                break
-        self.write_final_results(metadata)
-
     def loop(self, metadata):
         count_error = 0
         while not self.should_stop:
@@ -1063,7 +1053,7 @@ class MemoryMarkerMonitor(list):
 
 
 class MemoryMarkerHandler:
-    def __init__(self, args, is_idle=False):
+    def __init__(self, args):
         mode = args.memory_consumption
         cooldown = args.memory_consumption_cooldown
         interval = args.memory_consumption_interval
@@ -1074,7 +1064,7 @@ class MemoryMarkerHandler:
         self.s_event = multiprocessing.Event()
 
         time.sleep(max(cooldown, 1))  # needed for some machines
-        pargs = self.marker_queue, parent_pid, interval, report_path, mode, cooldown, self.s_event, is_idle
+        pargs = self.marker_queue, parent_pid, interval, report_path, mode, cooldown, self.s_event
         self.background_process = mProcess(target=self.background_worker, args=pargs, daemon=True)
         self.background_process.start()
         self.update_marker("start")
@@ -1131,7 +1121,7 @@ class MemoryMarkerHandler:
                 time.sleep(0.1)
 
     @staticmethod
-    def background_worker(conn, pid, interval, path, mode, cooldown, s_event, is_idle):
+    def background_worker(conn, pid, interval, path, mode, cooldown, s_event):
         try:
             mmm = MemoryMarkerMonitor(conn, pid, interval, path)
         except Exception:
@@ -1154,10 +1144,7 @@ class MemoryMarkerHandler:
             print("Could not set event: %s", exc)
 
         try:
-            if is_idle:
-                mmm.idle_loop(metadata)
-            else:
-                mmm.loop(metadata)
+            mmm.loop(metadata)
             conn.close()
             log.info("Memory monitor background worker stopped")
         except Exception as e:

--- a/tools/llm_bench/llm_bench_utils/memory_monitor.py
+++ b/tools/llm_bench/llm_bench_utils/memory_monitor.py
@@ -62,7 +62,7 @@ def drop_caches():
         with open(cache_path, "w") as f:
             f.write("3")
     except PermissionError:
-        os.stsem("sudo echo 3 > /proc/sys/vm/drop_caches")
+        os.system("sudo echo 3 > /proc/sys/vm/drop_caches")
 
 
 def malloc_trim() -> bool:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
## `llm_bench`: memory monitor — add `malloc_trim` and remove idle mode

### Add portable `malloc_trim` (`memory_monitor.py`)

Introduces a portable heap-trimming helper that releases free memory back to the OS from the **main (benchmark) process** during each cooldown phase.

**New additions:**
- `_load_libc()` — resolves the C standard library at runtime without hard-coding `libc.so.6`:
  - Linux/glibc: uses `ctypes.CDLL(None)` (already mapped into the process)
  - Linux/musl / other: falls back to `ctypes.util.find_library("c")`
  - Windows: skipped (handled separately)
- `malloc_trim() -> bool` — cross-platform memory release:
  - **Linux/glibc**: calls `malloc_trim(0)` to return free heap pages to the OS
  - **Windows**: iterates all process heaps via `GetProcessHeaps` + `HeapCompact`
  - **macOS / musl / unsupported**: returns `False` silently, no crash
- `activate_cooldown()`: add a call to `malloc_trim()` + log output. The call runs unconditionally (outside `if self.mmh:`) so it always acts on the main process heap regardless of monitoring mode.

**Why it matters:** glibc retains freed memory in its internal pool by default. Calling `malloc_trim(0)` after a model unload or between benchmark iterations forces the OS to reclaim those pages, giving cleaner baseline readings in subsequent measurements.

---

### Remove idle mode (`memory_monitor.py`, `benchmark.py`)

The idle/cooldown-only monitoring mode (`-mc 5`) has been removed. It was the least-used mode and added unnecessary branching in the background worker.

**Removed:**
- `MonitorLevel.IDLE = 3` enum value
- `MonitorMode.PROCESS_IDLE` enum member
- `MonitorMode.is_idle` property
- `MemoryMarkerMonitor.idle_loop()` method
- `is_idle` parameter from `MemoryMarkerHandler.__init__()`, `pargs` tuple, and `background_worker()` signature
- `if is_idle: mmm.idle_loop(…) else:` branch in `background_worker` — now unconditionally calls `mmm.loop()`

**Valid mode range updated:** `0–5` → `0–4`

**`benchmark.py` help text updated** to reflect the current four modes:
```
0 = off (default)
1 = thread, warm-up only
2 = thread, all iterations
3 = separate process, warm-up only
4 = separate process, all iterations
```



## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
