### PR TITLE
Fix KV Cache eviction with apply_rotation=True

### DIFF
--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -711,7 +711,7 @@ public:
             m_request.set_tensor("max_context_len", max_context_len);
         }
         if (m_is_use_rotation_inputs) {
-            m_request.set_tensor("rotation_trig_lut", m_cache_rotation_trig_lut);
+            m_request.set_tensor("model_rotation_trig_lut", m_cache_rotation_trig_lut);
             _set_cache_rotation_coefficients(sequence_groups, scheduler_output);
         }
 

--- a/tests/python_tests/test_kv_cache_eviction/test_kv_cache_eviction_1.py
+++ b/tests/python_tests/test_kv_cache_eviction/test_kv_cache_eviction_1.py
@@ -91,17 +91,7 @@ LONGBENCH_CACHE_EVICTION_CONFIG = CacheEvictionConfig(start_size=32, recent_size
     ids=lambda x: x.test_id,
 )
 @pytest.mark.parametrize(
-    "apply_rotation",
-    [
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="with_rotation fail with Port for tensor name rotation_trig_lut was not found. Ticket: 185953"
-            ),
-        ),
-        False,
-    ],
-    ids=["with_rotation", "no_rotation"],
+    "apply_rotation", [True, False], ids=["with_rotation", "no_rotation"]
 )  # rotation should improve similarity
 @pytest.mark.parametrize(
     "use_sparse_attention", [True, False], ids=["with_sparse_attn", "no_sparse_attn"]


### PR DESCRIPTION
## Description
Fix `rotation_trig_lut port not found` error in cache rotation

`ModelRunner` was calling `set_tensor("rotation_trig_lut", ...)` but the OV model exposes the input parameter as "model_rotation_trig_lut" (named by `StateManagementPattern` in OpenVINO transformations). This name mismatch caused a `RuntimeError: Port for tensor name rotation_trig_lut was not found` whenever `CacheEvictionConfig.apply_rotation = True` was set.

**Root cause:** After PR https://github.com/openvinotoolkit/openvino/pull/35500 moved the `SDPAToPagedAttention` call to runtime in `pipeline_impl.cpp`, the discrepancy between the parameter name created by the transformation "model_rotation_trig_lut" and the name used in `model_runner.hpp`: "rotation_trig_lut" became a runtime failure.

**Fix:** Correct the tensor name in `model_runner.hpp` to match what `StateManagementPattern` actually registers as a named model input.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-185953

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
