### PR TITLE
Bump diffusers 0.37.1 -> 0.38.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,6 +93,8 @@ updates:
       # huggingface-hub is installed for who_what_benchmark only if "llm-test-openvino" extras option is specified
       # newest version of huggingface-hub cause conflict with transformers 4.57.6, which is also defined for this extras
       - dependency-name: "huggingface-hub"
+      # update transformers version is dependent on optimum-intel for now and required more precise changes in repo
+      - dependency-name: "transformers"
     groups:
       pip-dependencies:
         patterns:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -579,7 +579,7 @@ jobs:
             timeout: 45
           - name: 'Whisper Transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tests/python_tests/test_whisper_pipeline.py ./tests/python_tests/test_whisper_pipeline_static.py -m "transformers_lower_v5"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).whisper.test }}
             timeout: 45
@@ -597,7 +597,7 @@ jobs:
             timeout: 90
           - name: 'LLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_llm_pipeline.py tests/python_tests/test_llm_pipeline_static.py tests/python_tests/test_structured_output.py tests/python_tests/test_image_generation.py tests/python_tests/test_image_generation_multi_call.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM.test || fromJSON(needs.smart_ci.outputs.affected_components).Image_generation.test }}
@@ -612,7 +612,7 @@ jobs:
             timeout: 90
           - name: 'VLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_vlm_pipeline.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
@@ -635,7 +635,7 @@ jobs:
             timeout: 60
           - name: 'API tests transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -m "transformers_lower_v5 or transformers_dependent" ./tests/python_tests/test_generation_config.py ./tests/python_tests/test_sampling.py ./tests/python_tests/test_text_streamer.py
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).continuous_batching.test || fromJSON(needs.smart_ci.outputs.affected_components).sampling.test || fromJSON(needs.smart_ci.outputs.affected_components).text_streamer.test }}
@@ -650,13 +650,13 @@ jobs:
             timeout: 120
           - name: 'WWB tests with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tools/who_what_benchmark/tests -m "transformers_dependent or transformers_lower_v5"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).WWB.test }}
             timeout: 120
           - name: 'EAGLE3 speculative decoding tests'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -k "eagle3"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).speculative_decoding.test }}
@@ -669,7 +669,7 @@ jobs:
             timeout: 90
           - name: 'VLM (MiniCPM-o-2_6)'
             cmd: |
-              python -m pip install transformers==4.51.3
+              python -m pip install transformers==4.51.3 diffusers==0.37.1
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "MiniCPM-o-2_6"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
             timeout: 60
@@ -677,7 +677,7 @@ jobs:
             cmd: |
               # Temporary pin: depends on upstream PR #1637 (not merged yet).
               # TODO: replace with official release once available.
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@cba3f3157d18f309f87e3f50f47741582ee645d3
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "videochat"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
@@ -764,7 +764,7 @@ jobs:
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}
             runner: 'aks-linux-4-cores-16gb'
           - name: 'LLM with transformers under 5.0'
-            extra_cmd: 'python -m pip install transformers==4.55.4 && python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76'
+            extra_cmd: 'python -m pip install transformers==4.55.4 diffusers==0.37.1 && python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76'
             marker: 'llm and (transformers_dependent or transformers_lower_v5)'
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}
@@ -993,7 +993,7 @@ jobs:
         if: ${{ fromJSON(needs.smart_ci.outputs.affected_components).llm_bench }}
         run: |
           source ${{ env.INSTALL_DIR }}/setupvars.sh
-          python -m pip install transformers==4.57.0
+          python -m pip install transformers==4.57.6
           python -m pytest -vs ${{ env.SRC_DIR }}/tests/python_tests/samples/test_tools_llm_benchmark.py -m "samples and transformers_lower_v5"
         env:
           SAMPLES_PY_DIR: "${{ env.SRC_DIR }}/tools"
@@ -1148,7 +1148,7 @@ jobs:
           PYTHONPATH: "${{ env.BUILD_DIR }}:"
         run: |
           source ${{ env.INSTALL_DIR }}/setupvars.sh
-          python -m pip install transformers==4.55.4
+          python -m pip install transformers==4.55.4 diffusers==0.37.1
           python3 -m pytest -v ${{ env.SRC_DIR }}/tests/python_tests/test_llm_pipeline.py -m "transformers_lower_v5 or transformers_dependent"
 
   Overall_Status:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -437,7 +437,7 @@ jobs:
             timeout: 120
           - name: 'Whisper Transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_whisper_pipeline.py -m "transformers_lower_v5" -k "not test_smoke[sample_from_dataset0 and not test_whisper_constructors[sample_from_dataset0 and not test_max_new_tokens[sample_from_dataset0 and not test_language_mode[language and not test_task_mode[sample_from_dataset0 and not test_language_autodetect[sample_from_dataset0 and not test_whisper_config_constructor and not test_language_autodetect[sample_from_dataset1 and not test_language_autodetect[sample_from_dataset2 and not test_initial_prompt_hotwords[sample_from_dataset0 and not test_random_sampling[sample_from_dataset0"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).whisper.test }}
@@ -475,7 +475,7 @@ jobs:
             timeout: 120
           - name: 'WWB tests with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tools/who_what_benchmark/tests -m "transformers_dependent or transformers_lower_v5"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).WWB.test }}
             timeout: 120
@@ -543,7 +543,7 @@ jobs:
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}
           - name: 'LLM with transformers under 5.0'
-            extra_cmd: 'python -m pip install transformers==4.55.4'
+            extra_cmd: 'python -m pip install transformers==4.57.6'
             marker: 'llm and (transformers_dependent or transformers_lower_v5)'
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -502,7 +502,7 @@ jobs:
             timeout: 120
           - name: 'Whisper Transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_whisper_pipeline.py ./tests/python_tests/test_whisper_pipeline_static.py -m "transformers_lower_v5" -k "not test_smoke[sample_from_dataset0 and not test_whisper_constructors[sample_from_dataset0 and not test_max_new_tokens[sample_from_dataset0 and not test_language_mode[language and not test_task_mode[sample_from_dataset0 and not test_language_autodetect[sample_from_dataset0 and not test_whisper_config_constructor and not test_language_autodetect[sample_from_dataset1 and not test_language_autodetect[sample_from_dataset2 and not test_initial_prompt_hotwords[sample_from_dataset0 and not test_random_sampling[sample_from_dataset0"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).whisper.test }}
@@ -521,7 +521,7 @@ jobs:
             timeout: 90
           - name: 'LLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pytest -v ./tests/python_tests/test_llm_pipeline.py ./tests/python_tests/test_llm_pipeline_static.py ./tests/python_tests/test_structured_output.py ./tests/python_tests/test_image_generation.py ./tests/python_tests/test_image_generation_multi_call.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM.test || fromJSON(needs.smart_ci.outputs.affected_components).Image_generation.test }}
             timeout: 90
@@ -535,7 +535,7 @@ jobs:
             timeout: 90
           - name: 'VLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_vlm_pipeline.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
@@ -558,7 +558,7 @@ jobs:
             timeout: 60
           - name: 'API tests transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -m "transformers_lower_v5 or transformers_dependent" ./tests/python_tests/test_generation_config.py ./tests/python_tests/test_sampling.py ./tests/python_tests/test_text_streamer.py
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).continuous_batching.test || fromJSON(needs.smart_ci.outputs.affected_components).sampling.test || fromJSON(needs.smart_ci.outputs.affected_components).text_streamer.test }}
@@ -573,13 +573,13 @@ jobs:
             timeout: 120
           - name: 'WWB tests with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tools/who_what_benchmark/tests -m "transformers_dependent or transformers_lower_v5"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).WWB.test }}
             timeout: 120
           - name: 'EAGLE3 speculative decoding tests'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -k "eagle3"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).speculative_decoding.test }}
@@ -592,7 +592,7 @@ jobs:
             timeout: 90
           - name: 'VLM (MiniCPM-o-2_6)'
             cmd: |
-              python -m pip install transformers==4.51.3
+              python -m pip install transformers==4.51.3 diffusers==0.37.1
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "MiniCPM-o-2_6"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
             timeout: 60
@@ -600,7 +600,7 @@ jobs:
             cmd: |
               # Temporary pin: depends on upstream PR #1637 (not merged yet).
               # TODO: replace with official release once available.
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@cba3f3157d18f309f87e3f50f47741582ee645d3
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "videochat"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -668,7 +668,7 @@ jobs:
             timeout: 120
           - name: 'Whisper Transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tests/python_tests/test_whisper_pipeline.py ./tests/python_tests/test_whisper_pipeline_static.py -m "transformers_lower_v5"
             timeout: 120
           - name: 'Cacheopt E2E (Part 1)'
@@ -685,7 +685,7 @@ jobs:
             timeout: 90
           - name: 'LLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pytest -s -v tests/python_tests/test_llm_pipeline.py tests/python_tests/test_llm_pipeline_static.py tests/python_tests/test_structured_output.py tests/python_tests/test_image_generation.py tests/python_tests/test_image_generation_multi_call.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM.test || fromJSON(needs.smart_ci.outputs.affected_components).Image_generation.test }}
             timeout: 90
@@ -699,7 +699,7 @@ jobs:
             timeout: 90
           - name: 'VLM with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_vlm_pipeline.py -m "transformers_lower_v5 or transformers_dependent" --override-ini cache_dir=/mount/caches/pytest/
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
@@ -722,7 +722,7 @@ jobs:
             timeout: 60
           - name: 'API tests transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.55.4 diffusers==0.37.1
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -m "transformers_lower_v5 or transformers_dependent" ./tests/python_tests/test_generation_config.py ./tests/python_tests/test_sampling.py ./tests/python_tests/test_text_streamer.py
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).continuous_batching.test || fromJSON(needs.smart_ci.outputs.affected_components).sampling.test || fromJSON(needs.smart_ci.outputs.affected_components).text_streamer.test }}
@@ -737,13 +737,13 @@ jobs:
             timeout: 120
           - name: 'WWB tests with transformers under 5.0'
             cmd: |
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pytest -v ./tools/who_what_benchmark/tests -m "transformers_dependent or transformers_lower_v5"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).WWB.test }}
             timeout: 120
           - name: 'EAGLE3 speculative decoding tests'
             cmd: |
-              python -m pip install transformers==4.55.4
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76
               python -m pytest -v ./tests/python_tests/test_continuous_batching.py -k "eagle3"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).speculative_decoding.test }}
@@ -756,7 +756,7 @@ jobs:
             timeout: 90
           - name: 'VLM (MiniCPM-o-2_6)'
             cmd: |
-              python -m pip install transformers==4.51.3
+              python -m pip install transformers==4.51.3 diffusers==0.37.1
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "MiniCPM-o-2_6"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
             timeout: 60
@@ -764,7 +764,7 @@ jobs:
             cmd: |
               # Temporary pin: depends on upstream PR #1637 (not merged yet).
               # TODO: replace with official release once available.
-              python -m pip install transformers==4.57.0
+              python -m pip install transformers==4.57.6
               python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@cba3f3157d18f309f87e3f50f47741582ee645d3
               python -m pytest -s -v tests/python_tests/test_vlm_pipeline.py --override-ini cache_dir=/mount/caches/pytest/ -k "videochat"
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).visual_language.test }}
@@ -850,7 +850,7 @@ jobs:
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}
             runner: 'aks-win-16-cores-32gb-test'
           - name: 'LLM with transformers under 5.0'
-            extra_cmd: 'python -m pip install transformers==4.55.4 && python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76'
+            extra_cmd: 'python -m pip install transformers==4.55.4 diffusers==0.37.1 && python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@2c48d6430c265ac259c1b264f3e2c4025cdd7b76'
             marker: 'llm and (transformers_dependent or transformers_lower_v5)'
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).LLM_samples.test }}

--- a/samples/export-requirements.txt
+++ b/samples/export-requirements.txt
@@ -4,7 +4,7 @@ openvino-tokenizers[transformers]~=2026.2.0.0.dev
 https://github.com/huggingface/optimum-intel/archive/f50a0b326df82d4b05c461a9184a97f616bfa63a.tar.gz#egg=optimum-intel
 einops==0.8.2  # For Qwen
 transformers_stream_generator==0.0.5  # For Qwen
-diffusers==0.37.1 # For image generation pipelines
+diffusers==0.38.0 # For image generation pipelines
 timm==1.0.26  # For exporting InternVL2
 # torchvision for visual language models
 torchvision==0.26.0

--- a/tests/python_tests/requirements.txt
+++ b/tests/python_tests/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-diffusers==0.37.1
+diffusers==0.38.0
 https://github.com/huggingface/optimum-intel/archive/f50a0b326df82d4b05c461a9184a97f616bfa63a.tar.gz#egg=optimum-intel
 pytest==9.0.3
 transformers==5.0.0

--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -8,7 +8,7 @@ openvino_genai
 pillow==12.2.0
 torch>=2.1.0,<=2.11
 transformers[sentencepiece]>=4.40.0,<5.4.0
-diffusers>=0.22.0,<=0.37.1
+diffusers>=0.22.0,<=0.38.0
 # optimum is in dependency list of optimum-intel
 # last supported commit f50a0b326df82d4b05c461a9184a97f616bfa63a
 optimum-intel[nncf]>=1.25.0

--- a/tools/who_what_benchmark/requirements.txt
+++ b/tools/who_what_benchmark/requirements.txt
@@ -7,7 +7,7 @@ optimum-intel[nncf]>=1.19.0
 pandas>=2.0.3,<=3.0.2
 numpy>=1.23.5,<=2.4.4
 tqdm>=4.66.1,<=4.67.3
-diffusers>=0.22.0,<=0.37.1
+diffusers>=0.22.0,<=0.38.0
 datasets>=3.6.0,<=4.8.4
 jinja2>=3.1.0,<=3.1.6
 scipy>=1.3.2,<=1.17.1


### PR DESCRIPTION
## Description
diffusers 0.38.0 doesn't work with transformers 4.55, diffusers 0.37.1 will be kept for some actions 

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
