### PR TITLE
[VLM] Remove min image height/width limitation for Qwen-VL models

### DIFF
--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -261,9 +261,6 @@ std::shared_ptr<ov::Model> patch_preprocess_into_model(const std::shared_ptr<ov:
 namespace qwen2_vl_utils {
 
 ImageSize smart_resize(size_t height, size_t width, size_t factor, size_t min_pixels, size_t max_pixels) {
-    if (height < factor || width < factor) {
-        OPENVINO_THROW("Height (" + std::to_string(height) + ") and width (" + std::to_string(width) + ") must be greater than factor (" + std::to_string(factor) + ")");
-    }
     if (std::max(height, width) / std::min(height, width) > 200) {
         OPENVINO_THROW("Absolute aspect ratio must be smaller than 200");
     }


### PR DESCRIPTION
## Description
This PR removes min image height/width limitation for Qwen-VL models.
Previously when Qwen2-VL was enabled, it was aligned with transformers image processing, which had the same image size limitation - `height/width < factor` (see https://github.com/huggingface/transformers/blob/v4.50.0/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py#L68-L69 ).
Newer transformers don't have this limitation anymore.

CVS-185929
CVS-184760

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**.
