### PR TITLE
[Video Generation] Add VAE encoder support to AutoencoderKLLTXVideo

### DIFF
--- a/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
@@ -50,6 +50,8 @@ public:
 
     AutoencoderKLLTXVideo& compile(const std::string& device, const ov::AnyMap& properties = {});
 
+    ov::Tensor encode(const ov::Tensor& video, std::shared_ptr<Generator> generator);
+
     ov::Tensor decode(const ov::Tensor& latent);
 
     const Config& get_config() const;

--- a/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
+++ b/src/cpp/include/openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp
@@ -50,7 +50,7 @@ public:
 
     AutoencoderKLLTXVideo& compile(const std::string& device, const ov::AnyMap& properties = {});
 
-    ov::Tensor encode(const ov::Tensor& video, std::shared_ptr<Generator> generator);
+    ov::Tensor encode(const ov::Tensor& video, std::shared_ptr<Generator> generator = nullptr);
 
     ov::Tensor decode(const ov::Tensor& latent);
 

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -3,7 +3,10 @@
 
 #include "openvino/genai/video_generation/autoencoder_kl_ltx_video.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <numeric>
 
@@ -23,6 +26,76 @@
 using namespace ov::genai;
 
 namespace {
+
+class DiagonalGaussianDistribution {
+public:
+    explicit DiagonalGaussianDistribution(ov::Tensor parameters) : m_params(std::move(parameters)) {
+        OPENVINO_ASSERT(m_params.get_element_type() == ov::element::f32,
+            "DiagonalGaussianDistribution requires f32 encoder output, got ",
+            m_params.get_element_type());
+
+        const ov::Shape& full_shape = m_params.get_shape();
+        OPENVINO_ASSERT(full_shape.size() >= 2, "Parameters tensor rank must be at least 2");
+        OPENVINO_ASSERT(full_shape[1] % 2 == 0, "Channel dimension must be even to split mean and logvar");
+
+        m_channels = full_shape[1] / 2;
+        m_spatial = 1;
+        for (size_t i = 2; i < full_shape.size(); ++i)
+            m_spatial *= full_shape[i];
+
+        ov::Shape std_shape = full_shape;
+        std_shape[1] = m_channels;
+        m_std = ov::Tensor(m_params.get_element_type(), std_shape);
+
+        const float* src = m_params.data<float>();
+        float* std_data = m_std.data<float>();
+        const size_t batch = full_shape[0];
+
+        for (size_t b = 0; b < batch; ++b) {
+            for (size_t c = 0; c < m_channels; ++c) {
+                const size_t lvar_off = (b * full_shape[1] + m_channels + c) * m_spatial;
+                const size_t dst_off  = (b * m_channels + c) * m_spatial;
+                for (size_t s = 0; s < m_spatial; ++s) {
+                    const float logvar = std::min(std::max(src[lvar_off + s], -30.0f), 20.0f);
+                    std_data[dst_off + s] = std::exp(0.5f * logvar);
+                }
+            }
+        }
+    }
+
+    ov::Tensor sample(std::shared_ptr<ov::genai::Generator> generator) const {
+        OPENVINO_ASSERT(generator, "Generator must not be nullptr");
+
+        ov::Shape sample_shape = m_params.get_shape();
+        sample_shape[1] = m_channels;
+        ov::Tensor result = generator->randn_tensor(sample_shape);
+        OPENVINO_ASSERT(result.get_element_type() == ov::element::f32,
+            "Generator::randn_tensor() must return an f32 tensor, got ",
+            result.get_element_type());
+
+        const float* params_data = m_params.data<float>();
+        const float* std_data = m_std.data<float>();
+        float* result_data = result.data<float>();
+        const size_t batch = m_params.get_shape()[0];
+        const size_t full_channels = m_params.get_shape()[1];
+
+        for (size_t b = 0; b < batch; ++b) {
+            for (size_t c = 0; c < m_channels; ++c) {
+                const size_t mean_off = (b * full_channels + c) * m_spatial;
+                const size_t dst_off  = (b * m_channels + c) * m_spatial;
+                for (size_t s = 0; s < m_spatial; ++s) {
+                    result_data[dst_off + s] = params_data[mean_off + s] + std_data[dst_off + s] * result_data[dst_off + s];
+                }
+            }
+        }
+
+        return result;
+    }
+
+private:
+    ov::Tensor m_params, m_std;
+    size_t m_channels, m_spatial;
+};
 
 // for BW compatibility with 2024.6.0
 ov::AnyMap handle_scale_factor(std::shared_ptr<ov::Model> model, const std::string& device, ov::AnyMap properties) {
@@ -120,8 +193,13 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::compile(const std::string& device,
     std::optional<AdapterConfig> unused;
     auto filtered_properties = extract_adapters_from_properties(properties, &unused);
 
-    // TODO: for img2video
-    // if (m_encoder_model) {...}
+    if (m_encoder_model) {
+        ov::CompiledModel encoder_compiled_model = core.compile_model(m_encoder_model, device, handle_scale_factor(m_encoder_model, device, *filtered_properties));
+        ov::genai::utils::print_compiled_model_properties(encoder_compiled_model, "Auto encoder KL LTX video encoder model");
+        OPENVINO_ASSERT(encoder_compiled_model.outputs().size() == 1, "AutoencoderKLLTXVideo encoder model is expected to have a single output");
+        m_encoder_request = encoder_compiled_model.create_infer_request();
+        m_encoder_model.reset();
+    }
 
     ov::CompiledModel decoder_compiled_model = core.compile_model(m_decoder_model, device, handle_scale_factor(m_decoder_model, device, *filtered_properties));
     ov::genai::utils::print_compiled_model_properties(decoder_compiled_model, "Auto encoder KL LTX video decoder model");
@@ -138,12 +216,18 @@ AutoencoderKLLTXVideo& AutoencoderKLLTXVideo::reshape(int64_t batch_size,
                                                       int64_t width) {
     OPENVINO_ASSERT(m_decoder_model, "Model has been already compiled. Cannot reshape already compiled model");
     OPENVINO_ASSERT(height > 0, "Height must be positive");
-    OPENVINO_ASSERT(height % 32 == 0, "Height have to be divisible by 32 but got ", height);
+    OPENVINO_ASSERT(height % 32 == 0, "Height must be divisible by 32 but got ", height);
     OPENVINO_ASSERT(width > 0, "Width must be positive");
-    OPENVINO_ASSERT(width % 32 == 0, "Width have to be divisible by 32 but got ", width);
+    OPENVINO_ASSERT(width % 32 == 0, "Width must be divisible by 32 but got ", width);
 
-    // TODO: for img2video
-    // if (m_encoder_model) {...}
+    if (m_encoder_model) {
+        ov::PartialShape input_shape = m_encoder_model->input(0).get_partial_shape();
+        OPENVINO_ASSERT(input_shape.rank().is_static() && input_shape.rank().get_length() == 5,
+            "AutoencoderKLLTXVideo encoder input must be rank 5 [B, C, F, H, W], got rank ",
+            input_shape.rank());
+        std::map<size_t, ov::PartialShape> idx_to_shape{{0, {batch_size, input_shape[1], num_frames, height, width}}};
+        m_encoder_model->reshape(idx_to_shape);
+    }
 
     int64_t spatial_compression_ratio =
         get_config().patch_size *
@@ -173,6 +257,62 @@ ov::Tensor AutoencoderKLLTXVideo::decode(const ov::Tensor& latent) {
     m_decoder_request.set_input_tensor(latent);
     m_decoder_request.infer();
     return m_decoder_request.get_output_tensor();
+}
+
+ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_ptr<Generator> generator) {
+    OPENVINO_ASSERT(m_encoder_request || m_encoder_model,
+        "AutoencoderKLLTXVideo is created without 'VAE encoder' capability. "
+        "Please, pass 'vae_encoder_path' argument to constructor.");
+    OPENVINO_ASSERT(m_encoder_request,
+        "VAE encoder model must be compiled first. Cannot infer non-compiled model");
+
+    m_encoder_request.set_input_tensor(video);
+    m_encoder_request.infer();
+
+    ov::Tensor output = m_encoder_request.get_output_tensor(), latent;
+
+    const std::string output_name = m_encoder_request.get_compiled_model().outputs()[0].get_any_name();
+    if (output_name == "latent_sample") {
+        // Copy to an owned tensor — get_output_tensor() aliases the infer request's
+        // internal buffer, which would be overwritten on the next encode() call.
+        latent = ov::Tensor(output.get_element_type(), output.get_shape());
+        output.copy_to(latent);
+    } else if (output_name == "latent_parameters") {
+        OPENVINO_ASSERT(generator,
+            "AutoencoderKLLTXVideo::encode requires a non-null generator when encoder output is "
+            "'latent_parameters', because latent sampling is performed from distribution parameters. "
+            "A generator is not required when encoder output is 'latent_sample'.");
+        latent = DiagonalGaussianDistribution(output).sample(generator);
+    } else {
+        OPENVINO_THROW("Unexpected output name for AutoencoderKLLTXVideo encoder '", output_name, "'");
+    }
+
+    // inverse of denormalize_latents used in the decode path
+    const ov::Shape shape = latent.get_shape();
+    OPENVINO_ASSERT(shape.size() == 5, "Encoder output expected to be [B, C, F, H, W]");
+    OPENVINO_ASSERT(latent.get_element_type() == ov::element::f32,
+        "Latent normalization requires f32, got ", latent.get_element_type());
+    const size_t B = shape[0], C = shape[1], spatial = shape[2] * shape[3] * shape[4];
+
+    const auto& mean = m_config.latents_mean_data;
+    const auto& std_data = m_config.latents_std_data;
+    OPENVINO_ASSERT(mean.size() == C && std_data.size() == C,
+        "Config latents_mean/std size (", mean.size(), ") does not match latent channels (", C, ")");
+
+    float* latent_data = latent.data<float>();
+    const float scale = m_config.scaling_factor;
+
+    for (size_t b = 0; b < B; ++b) {
+        for (size_t c = 0; c < C; ++c) {
+            float* ptr = latent_data + (b * C + c) * spatial;
+            const float m = mean[c], s = std_data[c];
+            for (size_t i = 0; i < spatial; ++i) {
+                ptr[i] = (ptr[i] - m) * scale / s;
+            }
+        }
+    }
+
+    return latent;
 }
 
 const AutoencoderKLLTXVideo::Config& AutoencoderKLLTXVideo::get_config() const {

--- a/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
+++ b/src/cpp/src/video_generation/models/autoencoder_kl_ltx_video.cpp
@@ -284,7 +284,7 @@ ov::Tensor AutoencoderKLLTXVideo::encode(const ov::Tensor& video, std::shared_pt
             "A generator is not required when encoder output is 'latent_sample'.");
         latent = DiagonalGaussianDistribution(output).sample(generator);
     } else {
-        OPENVINO_THROW("Unexpected output name for AutoencoderKLLTXVideo encoder '", output_name, "'");
+        OPENVINO_ASSERT(false, "Unexpected output name for AutoencoderKLLTXVideo encoder '", output_name, "'");
     }
 
     // inverse of denormalize_latents used in the decode path

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -389,6 +389,15 @@ class AutoencoderKLLTXVideo:
                         latent (ov.Tensor): Latent video tensor.
                         Returns: Decoded video tensor.
         """
+    def encode(self, video: openvino._pyopenvino.Tensor, generator: Generator = None) -> openvino._pyopenvino.Tensor:
+        """
+                        Encodes a video tensor to latent space.
+                        video (ov.Tensor): Input video tensor [B, C, F, H, W].
+                        generator (Generator, optional): Random generator for sampling from the latent
+                            distribution. Required only when the encoder outputs latent parameters
+                            (mean + logvar); unused when it outputs a latent sample directly.
+                        Returns: Normalized latent tensor.
+        """
     def get_config(self) -> AutoencoderKLLTXVideo.Config:
         ...
     def get_vae_scale_factor(self) -> int:

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -389,7 +389,7 @@ class AutoencoderKLLTXVideo:
                         latent (ov.Tensor): Latent video tensor.
                         Returns: Decoded video tensor.
         """
-    def encode(self, video: openvino._pyopenvino.Tensor, generator: Generator = None) -> openvino._pyopenvino.Tensor:
+    def encode(self, video: openvino._pyopenvino.Tensor, generator: Generator | None = None) -> openvino._pyopenvino.Tensor:
         """
                         Encodes a video tensor to latent space.
                         video (ov.Tensor): Input video tensor [B, C, F, H, W].

--- a/src/python/py_video_generation_models.cpp
+++ b/src/python/py_video_generation_models.cpp
@@ -222,6 +222,23 @@ void init_autoencoder_kl_ltx_video(py::module_& m) {
                 height (int): Video height.
                 width (int): Video width.
             )")
+        .def("encode",
+             [](ov::genai::AutoencoderKLLTXVideo& self,
+                const ov::Tensor& video,
+                std::shared_ptr<ov::genai::Generator> generator) {
+                 py::gil_scoped_release release;
+                 return self.encode(video, generator);
+             },
+             py::arg("video"),
+             py::arg("generator") = py::none(),
+             R"(
+                Encodes a video tensor to latent space.
+                video (ov.Tensor): Input video tensor [B, C, F, H, W].
+                generator (Generator, optional): Random generator for sampling from the latent
+                    distribution. Required only when the encoder outputs latent parameters
+                    (mean + logvar); unused when it outputs a latent sample directly.
+                Returns: Normalized latent tensor.
+            )")
         .def("decode",
              &ov::genai::AutoencoderKLLTXVideo::decode,
              py::call_guard<py::gil_scoped_release>(),

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -300,7 +300,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         generator = ov_genai.CppStdGenerator(42)
         dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
 
-        with pytest.raises(Exception, match="must be compiled first"):
+        with pytest.raises(RuntimeError, match="must be compiled first"):
             vae.encode(dummy, generator)
 
     def test_encode_without_encoder_raises(self, video_generation_model):
@@ -312,7 +312,7 @@ class TestAutoEncoderKLLTXVideoEncoder:
         generator = ov_genai.CppStdGenerator(42)
         dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
 
-        with pytest.raises(Exception, match="without 'VAE encoder' capability"):
+        with pytest.raises(RuntimeError, match="without 'VAE encoder' capability"):
             vae.encode(dummy, generator)
 
     def test_encode_output_shape(self, video_generation_model, require_encoder):

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -362,6 +362,19 @@ class TestAutoEncoderKLLTXVideoEncoder:
         else:
             pytest.skip(f"Unexpected encoder output name '{output_name}'")
 
+    def test_encode_none_generator_raises_for_stochastic_encoder(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+
+        output_name = ov.Core().read_model(str(encoder_path / "openvino_model.xml")).outputs[0].get_any_name()
+        if output_name != "latent_parameters":
+            pytest.skip("Encoder is deterministic (latent_sample) — generator=None is valid")
+
+        video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
+        with pytest.raises(RuntimeError, match="requires a non-null generator"):
+            vae.encode(video, None)
+
 
 class TestText2VideoPipelineAdvanced:
     def test_reshape(self, video_generation_model):

--- a/tests/python_tests/test_video_generation.py
+++ b/tests/python_tests/test_video_generation.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
+import openvino as ov
 import openvino_genai as ov_genai
 
 from utils.constants import get_ov_cache_converted_models_dir
@@ -274,6 +275,92 @@ class TestAutoEncoderKLLTXVideo:
             assert config is not None
             assert hasattr(config, "latent_channels")
             assert hasattr(config, "scaling_factor")
+
+
+class TestAutoEncoderKLLTXVideoEncoder:
+    @pytest.fixture
+    def require_encoder(self, video_generation_model):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        if not encoder_path.exists():
+            pytest.skip("vae_encoder not available in test model")
+        if not decoder_path.exists():
+            pytest.skip("vae_decoder not available in test model")
+
+    def test_constructor_with_encoder(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path))
+        assert vae is not None
+
+    def test_encode_without_compile_raises(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path))  # no compile
+        generator = ov_genai.CppStdGenerator(42)
+        dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+
+        with pytest.raises(Exception, match="must be compiled first"):
+            vae.encode(dummy, generator)
+
+    def test_encode_without_encoder_raises(self, video_generation_model):
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        if not decoder_path.exists():
+            pytest.skip("vae_decoder not available in test model")
+        vae = ov_genai.AutoencoderKLLTXVideo(str(decoder_path))
+        vae.compile("CPU")
+        generator = ov_genai.CppStdGenerator(42)
+        dummy = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+
+        with pytest.raises(Exception, match="without 'VAE encoder' capability"):
+            vae.encode(dummy, generator)
+
+    def test_encode_output_shape(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+        config = vae.get_config()
+        generator = ov_genai.CppStdGenerator(42)
+
+        video = ov.Tensor(np.zeros([1, 3, 9, 32, 32], dtype=np.float32))
+        latent = vae.encode(video, generator)
+
+        assert latent is not None
+        shape = latent.shape
+        assert len(shape) == 5, f"Expected 5D latent [B, C, F, H, W], got shape {shape}"
+        assert shape[0] == 1
+        assert shape[1] == config.latent_channels
+
+    def test_encode_is_deterministic(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+
+        video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
+        latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
+        latent2 = vae.encode(video, ov_genai.CppStdGenerator(42))
+
+        np.testing.assert_array_equal(latent1.data, latent2.data)
+
+    def test_encode_varies_with_seed(self, video_generation_model, require_encoder):
+        encoder_path = Path(video_generation_model) / "vae_encoder"
+        decoder_path = Path(video_generation_model) / "vae_decoder"
+        vae = ov_genai.AutoencoderKLLTXVideo(str(encoder_path), str(decoder_path), "CPU")
+
+        output_name = ov.Core().read_model(str(encoder_path / "openvino_model.xml")).outputs[0].get_any_name()
+
+        video = ov.Tensor(np.ones([1, 3, 9, 32, 32], dtype=np.float32) * 0.5)
+        latent1 = vae.encode(video, ov_genai.CppStdGenerator(42))
+        latent2 = vae.encode(video, ov_genai.CppStdGenerator(99))
+
+        if output_name == "latent_parameters":
+            assert not np.array_equal(latent1.data, latent2.data), (
+                "Different generator seeds should produce different latents"
+            )
+        elif output_name == "latent_sample":
+            np.testing.assert_array_equal(latent1.data, latent2.data)
+        else:
+            pytest.skip(f"Unexpected encoder output name '{output_name}'")
 
 
 class TestText2VideoPipelineAdvanced:


### PR DESCRIPTION
This PR implements `AutoencoderKLLTXVideo::encode()`, enabling Image-to-Video workflows where a conditioning frame is encoded into latent space and passed to the diffusion pipeline. 

This is phase 1 of Image-to-Video support in LTX Video Generation pipeline. 

### Changes

- VAE encoder now compiles and runs. compile() and reshape() had // TODO: for img2video. Both are now implemented.
- encode(video, generator) - takes a [B, C, F, H, W] video tensor, runs the encoder model, and returns a normalized latent ready for the diffusion transformer. Handles both model output variants:
  - latent_parameters - samples z from the predicted distribution
  - latent_sample - uses the output directly (no sampling needed)
- Added 7 tests which cover construction, error messages, output shape, determinism with the same seed, and variation across seeds. Tests that require the encoder skip if `vae_encoder` is not present in the test model.


### Testing

Encode decode roundtrip on an image (512×512, CPU):

| Step | Value |
|---|---|
| Input | [1, 3, 1, 512, 512] |
| Latent | [1, 128, 1, 16, 16] (32× spatial compression) |
| Output | [1, 1, 512, 512, 3] |

<img width="1556" height="536" alt="compare_overture (2)" src="https://github.com/user-attachments/assets/131dc8b0-237d-42bf-8f68-2ae434105243" />




## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. No necessary changes.
