### PR TITLE
[samples] Move encrypted_model_vlm from minicpmv to qwen3

### DIFF
--- a/samples/cpp/visual_language_chat/README.md
+++ b/samples/cpp/visual_language_chat/README.md
@@ -1,6 +1,6 @@
 # C++ visual language chat
 
-This example showcases inference of Visual language models (VLMs). The application doesn't have many configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The sample features `ov::genai::VLMPipeline` and runs the simplest deterministic greedy sampling algorithm. There is also a Jupyter [notebook](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/minicpm-v-multimodal-chatbot) which provides an example of Visual-language assistant.
+This example showcases inference of Visual language models (VLMs). The application doesn't have many configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The sample features `ov::genai::VLMPipeline` and runs the simplest deterministic greedy sampling algorithm. There is also a Jupyter [notebook](https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/qwen3-vl/qwen3-vl.ipynb) which provides an example of Visual-language assistant.
 
 
 The following are sample files:
@@ -18,7 +18,7 @@ It's not required to install [../../export-requirements.txt](../../export-requir
 
 ```sh
 pip install --upgrade-strategy eager -r ../../requirements.txt
-optimum-cli export openvino --model openbmb/MiniCPM-V-2_6 --trust-remote-code MiniCPM-V-2_6
+optimum-cli export openvino --model Qwen/Qwen3-VL-2B-Instruct --trust-remote-code Qwen3-VL-2B-Instruct
 ```
 
 Follow [Get Started with Samples](https://docs.openvino.ai/2026/get-started/learn-openvino/openvino-samples/get-started-demos.html) to run samples.
@@ -27,7 +27,7 @@ Follow [Get Started with Samples](https://docs.openvino.ai/2026/get-started/lear
 
 [This image](https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11) can be used as a sample image.
 
-`visual_language_chat miniCPM-V-2_6 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
+`visual_language_chat Qwen3-VL-2B-Instruct 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
 
 Discrete GPUs (dGPUs) usually provide better performance compared to CPUs. It is recommended to run larger models on a dGPU with 32GB+ RAM. For example, the model `llava-hf/llava-v1.6-mistral-7b-hf` can benefit from being run on a dGPU. Modify the source code to change the device for inference to the `GPU`.
 
@@ -37,7 +37,7 @@ Refer to the [Supported Models](https://openvinotoolkit.github.io/openvino.genai
 
 This sample runs generation twice for the same prompt and image: first with LoRA adapter applied, then without any adapters (base model).
 
-Export `Qwen/Qwen2.5-VL-7B-Instruct` to OpenVINO as [described above for MiniCPM-V](#download-and-convert-the-model-and-tokenizers), then download LoRA `Mouad2004/qwen2.5-vl-lora-diagrams`:
+Export `Qwen/Qwen2.5-VL-7B-Instruct` to OpenVINO as [described above](#download-and-convert-the-model-and-tokenizers), then download LoRA `Mouad2004/qwen2.5-vl-lora-diagrams`:
 
 ```sh
 wget -O adapter_model.safetensors \
@@ -97,7 +97,7 @@ benchmark_vlm [OPTIONS]
 ### Output:
 
 ```
-benchmark_vlm -m miniCPM-V-2_6 -i 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg -n 3
+benchmark_vlm -m Qwen3-VL-2B-Instruct -i 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg -n 3
 ```
 
 ```

--- a/samples/cpp/visual_language_chat/encrypted_model_vlm.cpp
+++ b/samples/cpp/visual_language_chat/encrypted_model_vlm.cpp
@@ -78,6 +78,7 @@ int main(int argc, char* argv[]) try {
     std::filesystem::path models_path = argv[1];
     ov::genai::ModelsMap models_map;
 
+    static const std::regex model_name_regex = std::regex("^openvino_|_model$");
     for (const auto& entry : std::filesystem::directory_iterator(models_path)) {
         if (entry.path().extension() != ".xml")
             continue;
@@ -88,7 +89,7 @@ int main(int argc, char* argv[]) try {
         if (!std::filesystem::exists(bin_file))
             continue;
 
-        std::string model_name = std::regex_replace(stem, std::regex("^openvino_|_model$"), "");
+        std::string model_name = std::regex_replace(stem, model_name_regex, "");
         models_map.emplace(model_name, decrypt_model(models_path, stem + ".xml", stem + ".bin"));
     }
 

--- a/samples/cpp/visual_language_chat/encrypted_model_vlm.cpp
+++ b/samples/cpp/visual_language_chat/encrypted_model_vlm.cpp
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <regex>
 
 #include "load_image.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
@@ -77,14 +78,18 @@ int main(int argc, char* argv[]) try {
     std::filesystem::path models_path = argv[1];
     ov::genai::ModelsMap models_map;
 
-    std::map<std::string, std::string> model_name_to_file_map = {
-        {"language", "openvino_language_model"},
-        {"resampler", "openvino_resampler_model"},
-        {"text_embeddings", "openvino_text_embeddings_model"},
-        {"vision_embeddings", "openvino_vision_embeddings_model"}};
+    for (const auto& entry : std::filesystem::directory_iterator(models_path)) {
+        if (entry.path().extension() != ".xml")
+            continue;
+        const std::string stem = entry.path().stem().string();
+        if (stem.find("tokenizer") != std::string::npos)
+            continue;
+        const std::filesystem::path bin_file = entry.path().parent_path() / (stem + ".bin");
+        if (!std::filesystem::exists(bin_file))
+            continue;
 
-    for (const auto& [model_name, file_name] : model_name_to_file_map) {
-        models_map.emplace(model_name, decrypt_model(models_path, file_name + ".xml", file_name + ".bin"));
+        std::string model_name = std::regex_replace(stem, std::regex("^openvino_|_model$"), "");
+        models_map.emplace(model_name, decrypt_model(models_path, stem + ".xml", stem + ".bin"));
     }
 
     ov::genai::Tokenizer tokenizer = decrypt_tokenizer(models_path);

--- a/samples/python/visual_language_chat/README.md
+++ b/samples/python/visual_language_chat/README.md
@@ -1,6 +1,6 @@
 # Python vlm_chat_sample that supports VLM models
 
-This example showcases inference of text-generation Vision Language Models (VLMs): `miniCPM-V-2_6` and other models with the same signature. The application doesn't have many configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The sample features `openvino_genai.VLMPipeline` and configures it for the chat scenario. There is also a Jupyter [notebook](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/minicpm-v-multimodal-chatbot) which provides an example of Visual-language assistant.
+This example showcases inference of text-generation Vision Language Models (VLMs): `Qwen3-VL-2B-Instruct` and other models with the same signature. The application doesn't have many configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The sample features `openvino_genai.VLMPipeline` and configures it for the chat scenario. There is also a Jupyter [notebook](https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/qwen3-vl/qwen3-vl.ipynb) which provides an example of Visual-language assistant.
 
 The following are sample files:
  - [`visual_language_chat.py`](./visual_language_chat.py) demonstrates basic usage of the VLM pipeline which supports accelerated inference using prompt lookup decoding.
@@ -22,7 +22,7 @@ pip install --upgrade-strategy eager -r ../../export-requirements.txt
 Then, run the export with Optimum CLI:
 
 ```sh
-optimum-cli export openvino --model openbmb/MiniCPM-V-2_6 --trust-remote-code MiniCPM-V-2_6
+optimum-cli export openvino --model Qwen/Qwen3-VL-2B-Instruct --trust-remote-code Qwen3-VL-2B-Instruct
 ```
 
 Alternatively, you can do it in Python code:
@@ -32,12 +32,12 @@ from optimum.exporters.openvino.convert import export_tokenizer
 from optimum.intel import OVModelForVisualCausalLM
 from transformers import AutoTokenizer
 
-output_dir = "MiniCPM-V-2_6"
+output_dir = "Qwen3-VL-2B-Instruct"
 
-model = OVModelForVisualCausalLM.from_pretrained("openbmb/MiniCPM-V-2_6", export=True, trust_remote_code=True)
+model = OVModelForVisualCausalLM.from_pretrained("Qwen/Qwen3-VL-2B-Instruct", export=True, trust_remote_code=True)
 model.save_pretrained(output_dir)
 
-tokenizer = AutoTokenizer.from_pretrained("openbmb/MiniCPM-V-2_6")
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-VL-2B-Instruct")
 export_tokenizer(tokenizer, output_dir)
 ```
 
@@ -47,7 +47,7 @@ Install [deployment-requirements.txt](../../deployment-requirements.txt) via `pi
 
 [This image](https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11) can be used as a sample image.
 
-`python visual_language_chat.py ./miniCPM-V-2_6/ 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
+`python visual_language_chat.py ./Qwen3-VL-2B-Instruct/ 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg`
 
 See https://github.com/openvinotoolkit/openvino.genai/blob/master/src/README.md#supported-models for the list of supported models.
 
@@ -55,7 +55,7 @@ See https://github.com/openvinotoolkit/openvino.genai/blob/master/src/README.md#
 
 This sample runs generation twice for the same prompt and image: first with LoRA adapter(s) applied, then without any adapters (base model).
 
-Export `Qwen/Qwen2.5-VL-7B-Instruct` to OpenVINO as [described above for MiniCPM-V](#download-and-convert-the-model-and-tokenizers), then download LoRA `Mouad2004/qwen2.5-vl-lora-diagrams`:
+Export `Qwen/Qwen2.5-VL-7B-Instruct` to OpenVINO as [described above](#download-and-convert-the-model-and-tokenizers), then download LoRA `Mouad2004/qwen2.5-vl-lora-diagrams`:
 
 ```sh
 wget -O adapter_model.safetensors \
@@ -118,7 +118,7 @@ python benchmark_vlm.py [OPTIONS]
 ### Output:
 
 ```
-python benchmark_vlm.py -m miniCPM-V-2_6 -i 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg -n 3
+python benchmark_vlm.py -m Qwen3-VL-2B-Instruct -i 319483352-d5fbbd1a-d484-415c-88cb-9986625b7b11.jpg -n 3
 ```
 
 ```

--- a/samples/python/visual_language_chat/encrypted_model_vlm.py
+++ b/samples/python/visual_language_chat/encrypted_model_vlm.py
@@ -94,18 +94,18 @@ def get_config_for_cache_encryption():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('model_dir')
-    parser.add_argument('image_dir', help="Image file or dir with images")
-    parser.add_argument('prompt', help="Prompt text")
+    parser.add_argument("model_dir")
+    parser.add_argument("image_dir", help="Image file or dir with images")
+    parser.add_argument("prompt", help="Prompt text")
     args = parser.parse_args()
 
     models_map = dict()
-    for xlm_file in Path(args.model_dir).glob("*.xml"):
-        bin_file = xlm_file.with_suffix(".bin")
-        if "tokenizer" in xlm_file.name or not bin_file.exists():
+    for xml_file in Path(args.model_dir).glob("*.xml"):
+        bin_file = xml_file.with_suffix(".bin")
+        if "tokenizer" in xml_file.name or not bin_file.exists():
             continue
-        model, weights = decrypt_model(args.model_dir, xlm_file.name, bin_file.name)
-        model_name = xlm_file.stem.removeprefix("openvino_").removesuffix("_model")
+        model, weights = decrypt_model(args.model_dir, xml_file.name, bin_file.name)
+        model_name = xml_file.stem.removeprefix("openvino_").removesuffix("_model")
         models_map[model_name] = (model, weights)
 
     tokenizer = read_tokenizer(args.model_dir)

--- a/samples/python/visual_language_chat/encrypted_model_vlm.py
+++ b/samples/python/visual_language_chat/encrypted_model_vlm.py
@@ -99,15 +99,13 @@ def main():
     parser.add_argument('prompt', help="Image file or dir with images")
     args = parser.parse_args()
 
-    model_name_to_file_map = {
-        ('language', 'openvino_language_model'),
-        ('resampler', 'openvino_resampler_model'),
-        ('text_embeddings', 'openvino_text_embeddings_model'),
-        ('vision_embeddings', 'openvino_vision_embeddings_model')}
-
     models_map = dict()
-    for model_name, file_name in model_name_to_file_map:
-        model, weights = decrypt_model(args.model_dir, file_name + '.xml', file_name + '.bin')
+    for xlm_file in Path(args.model_dir).glob("*.xml"):
+        bin_file = xlm_file.with_suffix(".bin")
+        if "tokenizer" in xlm_file.name or not bin_file.exists():
+            continue
+        model, weights = decrypt_model(args.model_dir, xlm_file.name, bin_file.name)
+        model_name = xlm_file.stem.removeprefix("openvino_").removesuffix("_model")
         models_map[model_name] = (model, weights)
 
     tokenizer = read_tokenizer(args.model_dir)

--- a/samples/python/visual_language_chat/encrypted_model_vlm.py
+++ b/samples/python/visual_language_chat/encrypted_model_vlm.py
@@ -96,7 +96,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('model_dir')
     parser.add_argument('image_dir', help="Image file or dir with images")
-    parser.add_argument('prompt', help="Image file or dir with images")
+    parser.add_argument('prompt', help="Prompt text")
     args = parser.parse_args()
 
     models_map = dict()

--- a/tests/python_tests/samples/conftest.py
+++ b/tests/python_tests/samples/conftest.py
@@ -185,6 +185,10 @@ MODELS: Dict[str, Dict[str, Any]] = {
         "name": "optimum-intel-internal-testing/stable-diffusion-3-tiny-random",
         "convert_args": ["--trust-remote-code", "--weight-format", "fp16"],
     },
+    "tiny-random-qwen3-vl": {
+        "name": "optimum-intel-internal-testing/tiny-random-qwen3-vl",
+        "convert_args": ["--trust-remote-code", "--task", "image-text-to-text"],
+    },
 }
 
 TEST_FILES = {

--- a/tests/python_tests/samples/test_encrypted_model_vlm.py
+++ b/tests/python_tests/samples/test_encrypted_model_vlm.py
@@ -13,14 +13,11 @@ from test_utils import run_sample
 class TestEncryptedVLM:
     @pytest.mark.llm
     @pytest.mark.samples
-    @pytest.mark.transformers_lower_v5(
-        reason="Samples is configured for minicpmv, but support for this architecture are deprecating for transformers >= v5 by optimum-intel"
-    )
     @pytest.mark.skipif(
         sys.platform == "darwin" and platform.machine() == "arm64",
         reason="Only supported on X64 or ARM with SVE support",
     )
-    @pytest.mark.parametrize("convert_model", ["tiny-random-minicpmv-2_6"], indirect=True)
+    @pytest.mark.parametrize("convert_model", ["tiny-random-qwen3-vl"], indirect=True)
     @pytest.mark.parametrize("sample_args", ["Describe the images."])
     @pytest.mark.parametrize("download_test_content", ["images/image.png"], indirect=True)
     @pytest.mark.parametrize("generate_test_content", ["images/lines.png"], indirect=True)


### PR DESCRIPTION
## Description
minicpmv is required older version of transformers, but sample encrypted_model_vlm is targets to that model. This PR change minicmpv to qwen3.


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
