### PR TITLE
[tests] Remove skip for gguf tests due to fix in openvino repo

### DIFF
--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -64,8 +64,6 @@ def test_pipelines_with_gguf_generate(
 ):
     if sys.platform == 'darwin':
         pytest.skip(reason="168882: Sporadic segmentation fault failure on MacOS.")
-    if sys.platform == "linux":
-        pytest.skip(reason="CVS-185220")
 
     opt_model = model_gguf.opt_model
     hf_tokenizer = model_gguf.hf_tokenizer
@@ -201,7 +199,6 @@ def test_full_gguf_pipeline(
 )
 @pytest.mark.xfail(condition=(sys.platform == "darwin"), reason="Ticket - 172335")
 @pytest.mark.skipif(sys.platform == "win32", reason="CVS-174065")
-@pytest.mark.skipif(sys.platform == "linux", reason="CVS-185220")
 def test_full_gguf_qwen3_pipeline(pipeline_type, model_ids):
     # Temporal testing solution until transformers starts to support qwen3 in GGUF format
     # Please refer details in issue: https://github.com/huggingface/transformers/issues/38063


### PR DESCRIPTION
## Description
Test was skipped due to error CVS-185220, fix in https://github.com/openvinotoolkit/openvino/pull/35709 . Tests restores here by this pr.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-185220

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
