### PR TITLE
Fix inference error for `gemma-4-31B-it`

### DIFF
--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -312,7 +312,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::get_inputs_embeds_with_t
 }
 
 bool InputsEmbedderGemma4::has_token_type_ids() const {
-    return m_vlm_config.enable_moe_block;
+    return m_vlm_config.use_bidirectional_attention;
 }
 
 ov::Tensor InputsEmbedderGemma4::get_token_type_ids(const ov::Tensor& input_ids) {

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -83,6 +83,9 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
     // gemma4
     read_json_param(parsed, "text_config.enable_moe_block", enable_moe_block);
     read_json_param(parsed, "text_config.hidden_size_per_layer_input", hidden_size_per_layer_input);
+    std::string use_bidirectional_attention_str;
+    read_json_param(parsed, "text_config.use_bidirectional_attention", use_bidirectional_attention_str);
+    use_bidirectional_attention = !use_bidirectional_attention_str.empty();
 }
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -110,6 +110,10 @@ public:
     /// @brief Enables Gemma4 MoE block inference path and related auxiliary inputs such as token_type_ids.
     bool enable_moe_block = false;
 
+    /// @brief Whether the model uses bidirectional attention for vision tokens (e.g. "vision").
+    /// When true, token_type_ids must be provided to build the correct attention mask.
+    bool use_bidirectional_attention = false;
+
     /// @brief Hidden size of Gemma4 per-layer embedding input used during inference.
     size_t hidden_size_per_layer_input = 0;
 


### PR DESCRIPTION
### Details

The `has_token_type_ids()` is an incorrect classifier for attaching `token_type_ids`. The model mentioned in the ticket, `gemma-4-31B-it`, is not an MoE model, but in its config it sets `"use_bidirectional_attention": "vision"`, which uses `token_type_ids`. 

Proof:
Small models do not use `token_type_ids`: `"use_bidirectional_attention": null,`
Gemma4 E2B: [config.json · google/gemma-4-E2B-it at main](https://huggingface.co/google/gemma-4-E2B-it/blob/main/config.json#L137)
Gemma4 E4B: [config.json · google/gemma-4-E4B-it at main](https://huggingface.co/google/gemma-4-E4B-it/blob/main/config.json#L144)
 
But a bigger model, which is NOT an MoE model, has `"use_bidirectional_attention": "vision",`:
Gemma4 31B: [config.json · google/gemma-4-31B-it at main](https://huggingface.co/google/gemma-4-31B-it/blob/main/config.json#L123)
 
Same as the MoE Gemma:
[config.json · google/gemma-4-26B-A4B-it at main](https://huggingface.co/google/gemma-4-26B-A4B-it/blob/main/config.json#L93)

`token_type_ids` is required for bidirectional mask creation. This fix removes the error mentioned in the ticket in my local setup, however there are still accuracy issues when using INT4 model. FP16 works fine for me.

### Ticket

CVS-186483
