### PR TITLE
[C API] Add C bindings for TextEmbeddingPipeline

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ENABLE_SAMPLES)
     add_subdirectory(c/text_generation)
     add_subdirectory(c/whisper_speech_recognition)
     add_subdirectory(c/visual_language_chat)
+    add_subdirectory(c/rag)
 endif()
 
 install(FILES
@@ -49,4 +50,5 @@ install(DIRECTORY
         c/text_generation
         c/whisper_speech_recognition
         c/visual_language_chat
+        c/rag
         DESTINATION samples/c COMPONENT cpp_samples_genai)

--- a/samples/c/rag/CMakeLists.txt
+++ b/samples/c/rag/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+find_package(OpenVINOGenAI REQUIRED
+    PATHS
+        "${CMAKE_BINARY_DIR}"  # Reuse the package from the build.
+        ${OpenVINO_DIR}  # GenAI may be installed alogside OpenVINO.
+    NO_CMAKE_FIND_ROOT_PATH
+)
+
+function(add_sample_executable target_name)
+    add_executable(${target_name} ${target_name}.c)
+    # Specifies that the source file should be compiled as a C source file
+    set_source_files_properties(${target_name}.c PROPERTIES LANGUAGE C)
+    target_link_libraries(${target_name} PRIVATE openvino::genai::c)
+    set_target_properties(${target_name} PROPERTIES
+        # Ensure out-of-box LC_RPATH on macOS with SIP
+        INSTALL_RPATH_USE_LINK_PATH ON)
+    install(TARGETS ${target_name}
+            RUNTIME DESTINATION samples_bin/
+            COMPONENT samples_bin
+            EXCLUDE_FROM_ALL)
+endfunction()
+
+set (SAMPLE_LIST
+    text_embeddings_c)
+
+foreach(sample IN LISTS SAMPLE_LIST)
+    add_sample_executable(${sample})
+endforeach()

--- a/samples/c/rag/README.md
+++ b/samples/c/rag/README.md
@@ -1,0 +1,37 @@
+# Retrieval Augmented Generation C Samples
+
+This example showcases inference of Retrieval Augmented Generation models from C. The application has limited configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The samples feature C wrappers around `ov::genai::TextEmbeddingPipeline` (and, in a future PR, `ov::genai::TextRerankPipeline`) and use text as an input source.
+
+## Download and Convert the Model and Tokenizers
+
+The `--upgrade-strategy eager` option is needed to ensure `optimum-intel` is upgraded to the latest version.
+
+Install [../../export-requirements.txt](../../export-requirements.txt) to convert a model.
+
+```sh
+pip install --upgrade-strategy eager -r ../../export-requirements.txt
+```
+
+To export text embedding model run Optimum CLI command:
+
+```sh
+optimum-cli export openvino --task feature-extraction --model BAAI/bge-small-en-v1.5 BAAI/bge-small-en-v1.5
+```
+
+## Run
+
+Follow [Get Started with Samples](https://docs.openvino.ai/2026/get-started/learn-openvino/openvino-samples/get-started-demos.html) to run the sample.
+
+### Text Embeddings Sample (`text_embeddings_c.c`)
+- **Description:**
+  Demonstrates inference of text embedding models using the OpenVINO GenAI C API. Converts input text into vector embeddings for downstream tasks such as retrieval or semantic search.
+- **Run Command:**
+  ```sh
+  text_embeddings_c <MODEL_DIR> "Document 1" "Document 2"
+  ```
+Refer to the [Supported Models](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/#text-embeddings-models) for more details.
+
+## Support and Contribution
+- For troubleshooting, please refer to the [troubleshooting](https://openvinotoolkit.github.io/openvino.genai/docs/guides/troubleshooting/) section.
+- To report a bug or request a feature, [create a GitHub issue](https://github.com/openvinotoolkit/openvino.genai/issues).
+- Contributions are welcome! Please see the [Contribution Guide](https://github.com/openvinotoolkit/openvino.genai/blob/master/.github/CONTRIBUTING.md) for details.

--- a/samples/c/rag/text_embeddings_c.c
+++ b/samples/c/rag/text_embeddings_c.c
@@ -1,0 +1,91 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "openvino/genai/c/text_embedding_pipeline.h"
+
+#define CHECK_STATUS(return_status)                                                      \
+    if (return_status != OK) {                                                           \
+        fprintf(stderr, "[ERROR] return status %d, line %d\n", return_status, __LINE__); \
+        goto err;                                                                        \
+    }
+
+static const char* dtype_name(ov_genai_embedding_dtype_e dtype) {
+    switch (dtype) {
+    case OV_GENAI_EMBEDDING_DTYPE_F32:
+        return "f32";
+    case OV_GENAI_EMBEDDING_DTYPE_I8:
+        return "i8";
+    case OV_GENAI_EMBEDDING_DTYPE_U8:
+        return "u8";
+    default:
+        return "?";
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <MODEL_DIR> \"<TEXT 1>\" [\"<TEXT 2>\" ...]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+    const char* model_dir = argv[1];
+    const char** documents = (const char**)&argv[2];
+    size_t documents_count = (size_t)(argc - 2);
+
+    ov_genai_text_embedding_pipeline* pipeline = NULL;
+    ov_genai_embedding_results* docs_embeddings = NULL;
+    ov_genai_embedding_result* query_embedding = NULL;
+    const char* device = "CPU";  // GPU can be used as well
+    int exit_code = EXIT_FAILURE;
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_create(model_dir, device, 2, &pipeline, "pooling_type", "MEAN"));
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_embed_documents(pipeline, documents, documents_count, &docs_embeddings));
+
+    ov_genai_embedding_dtype_e docs_dtype = OV_GENAI_EMBEDDING_DTYPE_F32;
+    size_t docs_count = 0;
+    CHECK_STATUS(ov_genai_embedding_results_get_dtype(docs_embeddings, &docs_dtype));
+    CHECK_STATUS(ov_genai_embedding_results_get_count(docs_embeddings, &docs_count));
+    printf("Documents: %zu embeddings of dtype %s\n", docs_count, dtype_name(docs_dtype));
+    for (size_t i = 0; i < docs_count; ++i) {
+        size_t embedding_size = 0;
+        CHECK_STATUS(ov_genai_embedding_results_get_size_at(docs_embeddings, i, &embedding_size));
+        printf("  [%zu] length=%zu\n", i, embedding_size);
+    }
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_embed_query(pipeline, "What is the capital of France?", &query_embedding));
+
+    ov_genai_embedding_dtype_e query_dtype = OV_GENAI_EMBEDDING_DTYPE_F32;
+    size_t query_size = 0;
+    CHECK_STATUS(ov_genai_embedding_result_get_dtype(query_embedding, &query_dtype));
+    CHECK_STATUS(ov_genai_embedding_result_get_size(query_embedding, &query_size));
+    printf("Query embedding: dtype=%s length=%zu\n", dtype_name(query_dtype), query_size);
+
+    if (query_dtype == OV_GENAI_EMBEDDING_DTYPE_F32) {
+        const float* data = NULL;
+        size_t size = 0;
+        CHECK_STATUS(ov_genai_embedding_result_get_data_f32(query_embedding, &data, &size));
+        size_t preview = size < 8 ? size : 8;
+        printf("  first %zu values: [", preview);
+        for (size_t i = 0; i < preview; ++i) {
+            printf("%s%.4f", i == 0 ? "" : ", ", data[i]);
+        }
+        printf("%s]\n", preview < size ? ", ..." : "");
+    }
+
+    exit_code = EXIT_SUCCESS;
+
+err:
+    if (query_embedding)
+        ov_genai_embedding_result_free(query_embedding);
+    if (docs_embeddings)
+        ov_genai_embedding_results_free(docs_embeddings);
+    if (pipeline)
+        ov_genai_text_embedding_pipeline_free(pipeline);
+
+    return exit_code;
+}

--- a/src/c/include/openvino/genai/c/text_embedding_pipeline.h
+++ b/src/c/include/openvino/genai/c/text_embedding_pipeline.h
@@ -1,0 +1,293 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/**
+ * @brief This is a header file for OpenVINO GenAI C API, which is a C wrapper for ov::genai::TextEmbeddingPipeline
+ * class.
+ *
+ * @file text_embedding_pipeline.h
+ */
+
+#pragma once
+#include "openvino/c/ov_common.h"
+#include "openvino/genai/c/visibility.h"
+
+/**
+ * @enum ov_genai_embedding_dtype_e
+ * @brief Element type of an embedding tensor.
+ */
+typedef enum {
+    OV_GENAI_EMBEDDING_DTYPE_F32 = 0,  ///< IEEE 754 binary32 (float)
+    OV_GENAI_EMBEDDING_DTYPE_I8 = 1,   ///< signed 8-bit integer
+    OV_GENAI_EMBEDDING_DTYPE_U8 = 2,   ///< unsigned 8-bit integer
+} ov_genai_embedding_dtype_e;
+
+/**
+ * @struct ov_genai_embedding_result
+ * @brief type define ov_genai_embedding_result from ov_genai_embedding_result_opaque
+ *
+ * Holds a single embedding vector returned by embed_query.
+ */
+typedef struct ov_genai_embedding_result_opaque ov_genai_embedding_result;
+
+/**
+ * @brief Release the memory allocated by ov_genai_embedding_result.
+ * @param result A pointer to the ov_genai_embedding_result to free memory.
+ */
+OPENVINO_GENAI_C_EXPORTS void ov_genai_embedding_result_free(ov_genai_embedding_result* result);
+
+/**
+ * @brief Get the element type of the embedding.
+ * @param result A pointer to the ov_genai_embedding_result instance.
+ * @param dtype A pointer to ov_genai_embedding_dtype_e which receives the element type.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_result_get_dtype(const ov_genai_embedding_result* result,
+                                                                         ov_genai_embedding_dtype_e* dtype);
+
+/**
+ * @brief Get the number of elements (vector length) in the embedding.
+ * @param result A pointer to the ov_genai_embedding_result instance.
+ * @param size A pointer to size_t which receives the number of elements.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_result_get_size(const ov_genai_embedding_result* result,
+                                                                        size_t* size);
+
+/**
+ * @brief Borrow the raw float32 buffer of the embedding.
+ *
+ * The returned pointer is owned by the result object and is invalidated when the result is freed.
+ *
+ * @param result A pointer to the ov_genai_embedding_result instance.
+ * @param data Receives a pointer to the underlying float buffer.
+ * @param size Receives the number of float elements.
+ * @return ov_status_e A status code, return OK(0) if successful. Returns INVALID_C_PARAM(-2) if the embedding dtype is
+ * not F32.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_result_get_data_f32(const ov_genai_embedding_result* result,
+                                                                            const float** data,
+                                                                            size_t* size);
+
+/**
+ * @brief Borrow the raw int8 buffer of the embedding.
+ *
+ * The returned pointer is owned by the result object and is invalidated when the result is freed.
+ *
+ * @param result A pointer to the ov_genai_embedding_result instance.
+ * @param data Receives a pointer to the underlying int8 buffer.
+ * @param size Receives the number of int8 elements.
+ * @return ov_status_e A status code, return OK(0) if successful. Returns INVALID_C_PARAM(-2) if the embedding dtype is
+ * not I8.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_result_get_data_i8(const ov_genai_embedding_result* result,
+                                                                           const int8_t** data,
+                                                                           size_t* size);
+
+/**
+ * @brief Borrow the raw uint8 buffer of the embedding.
+ *
+ * The returned pointer is owned by the result object and is invalidated when the result is freed.
+ *
+ * @param result A pointer to the ov_genai_embedding_result instance.
+ * @param data Receives a pointer to the underlying uint8 buffer.
+ * @param size Receives the number of uint8 elements.
+ * @return ov_status_e A status code, return OK(0) if successful. Returns INVALID_C_PARAM(-2) if the embedding dtype is
+ * not U8.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_result_get_data_u8(const ov_genai_embedding_result* result,
+                                                                           const uint8_t** data,
+                                                                           size_t* size);
+
+/**
+ * @struct ov_genai_embedding_results
+ * @brief type define ov_genai_embedding_results from ov_genai_embedding_results_opaque
+ *
+ * Holds a batch of embedding vectors returned by embed_documents. All inner vectors share the same dtype.
+ */
+typedef struct ov_genai_embedding_results_opaque ov_genai_embedding_results;
+
+/**
+ * @brief Release the memory allocated by ov_genai_embedding_results.
+ * @param results A pointer to the ov_genai_embedding_results to free memory.
+ */
+OPENVINO_GENAI_C_EXPORTS void ov_genai_embedding_results_free(ov_genai_embedding_results* results);
+
+/**
+ * @brief Get the element type of the batch (shared by all inner vectors).
+ * @param results A pointer to the ov_genai_embedding_results instance.
+ * @param dtype A pointer to ov_genai_embedding_dtype_e which receives the element type.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_dtype(const ov_genai_embedding_results* results,
+                                                                          ov_genai_embedding_dtype_e* dtype);
+
+/**
+ * @brief Get the number of embedding vectors in the batch.
+ * @param results A pointer to the ov_genai_embedding_results instance.
+ * @param count A pointer to size_t which receives the number of embeddings.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_count(const ov_genai_embedding_results* results,
+                                                                          size_t* count);
+
+/**
+ * @brief Get the number of elements in the i-th embedding vector.
+ * @param results A pointer to the ov_genai_embedding_results instance.
+ * @param i Index of the inner vector. Must be less than the value returned by ov_genai_embedding_results_get_count().
+ * @param size A pointer to size_t which receives the number of elements.
+ * @return ov_status_e A status code, return OK(0) if successful. Returns OUT_OF_BOUNDS(-6) if i is out of range.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_size_at(const ov_genai_embedding_results* results,
+                                                                            size_t i,
+                                                                            size_t* size);
+
+/**
+ * @brief Borrow the raw float32 buffer of the i-th embedding vector.
+ *
+ * The returned pointer is owned by the results object and is invalidated when the results are freed.
+ *
+ * @param results A pointer to the ov_genai_embedding_results instance.
+ * @param i Index of the inner vector.
+ * @param data Receives a pointer to the float buffer.
+ * @param size Receives the number of float elements.
+ * @return ov_status_e A status code, return OK(0) if successful. Returns INVALID_C_PARAM(-2) if dtype is not F32, or
+ * OUT_OF_BOUNDS(-6) if i is out of range.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_data_f32_at(
+    const ov_genai_embedding_results* results,
+    size_t i,
+    const float** data,
+    size_t* size);
+
+/**
+ * @brief Borrow the raw int8 buffer of the i-th embedding vector.
+ *
+ * The returned pointer is owned by the results object and is invalidated when the results are freed.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_data_i8_at(
+    const ov_genai_embedding_results* results,
+    size_t i,
+    const int8_t** data,
+    size_t* size);
+
+/**
+ * @brief Borrow the raw uint8 buffer of the i-th embedding vector.
+ *
+ * The returned pointer is owned by the results object and is invalidated when the results are freed.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e ov_genai_embedding_results_get_data_u8_at(
+    const ov_genai_embedding_results* results,
+    size_t i,
+    const uint8_t** data,
+    size_t* size);
+
+/**
+ * @struct ov_genai_text_embedding_pipeline
+ * @brief type define ov_genai_text_embedding_pipeline from ov_genai_text_embedding_pipeline_opaque
+ */
+typedef struct ov_genai_text_embedding_pipeline_opaque ov_genai_text_embedding_pipeline;
+
+/**
+ * @brief Construct ov_genai_text_embedding_pipeline.
+ *
+ * Initializes a ov_genai_text_embedding_pipeline instance from the specified model directory and device. Optional
+ * property parameters can be passed as key-value pairs.
+ *
+ * Recognized embedding-specific config keys (passed as strings, converted internally):
+ *   - "max_length"         : size_t, maximum tokens passed to the model
+ *   - "pad_to_max_length"  : "true" or "false"
+ *   - "padding_side"       : "left" or "right"
+ *   - "batch_size"         : size_t, fixed model batch (used for database population)
+ *   - "pooling_type"       : "CLS", "MEAN" or "LAST_TOKEN"
+ *   - "normalize"          : "true" or "false" (L2 normalization of embeddings)
+ *   - "query_instruction"  : string, instruction prepended to query inputs
+ *   - "embed_instruction"  : string, instruction prepended to document inputs
+ * Any other key is treated as an OpenVINO plugin property and forwarded as a string.
+ *
+ * @param models_path Path to the directory containing the model files.
+ * @param device Name of a device to load a model to.
+ * @param property_args_size How many properties args will be passed, each property contains 2 args: key and value.
+ * @param pipe A pointer to the newly created ov_genai_text_embedding_pipeline.
+ * @param ... Optional pack of pairs: <const char* property_key, const char* property_value>.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ *
+ * @example
+ * ov_genai_text_embedding_pipeline_create(model_path, "CPU", 0, &pipe);
+ * ov_genai_text_embedding_pipeline_create(model_path, "CPU", 2, &pipe, "pooling_type", "MEAN");
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_create(const char* models_path,
+                                        const char* device,
+                                        const size_t property_args_size,
+                                        ov_genai_text_embedding_pipeline** pipe,
+                                        ...);
+
+/**
+ * @brief Release the memory allocated by ov_genai_text_embedding_pipeline.
+ * @param pipe A pointer to the ov_genai_text_embedding_pipeline to free memory.
+ */
+OPENVINO_GENAI_C_EXPORTS void ov_genai_text_embedding_pipeline_free(ov_genai_text_embedding_pipeline* pipe);
+
+/**
+ * @brief Compute embeddings for a list of documents.
+ *
+ * @param pipe A pointer to the ov_genai_text_embedding_pipeline instance.
+ * @param texts An array of null-terminated document strings.
+ * @param texts_count Number of elements in `texts`.
+ * @param results A pointer to the newly created ov_genai_embedding_results.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_embed_documents(ov_genai_text_embedding_pipeline* pipe,
+                                                 const char** texts,
+                                                 size_t texts_count,
+                                                 ov_genai_embedding_results** results);
+
+/**
+ * @brief Asynchronously compute embeddings for a list of documents.
+ *
+ * Only one async call can be active on the pipeline at a time. The caller must follow this with
+ * ov_genai_text_embedding_pipeline_wait_embed_documents() to retrieve the result.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_start_embed_documents_async(ov_genai_text_embedding_pipeline* pipe,
+                                                             const char** texts,
+                                                             size_t texts_count);
+
+/**
+ * @brief Wait for the result of a previously started asynchronous embed_documents.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_wait_embed_documents(ov_genai_text_embedding_pipeline* pipe,
+                                                      ov_genai_embedding_results** results);
+
+/**
+ * @brief Compute embedding for a single query.
+ *
+ * @param pipe A pointer to the ov_genai_text_embedding_pipeline instance.
+ * @param text A null-terminated query string.
+ * @param result A pointer to the newly created ov_genai_embedding_result.
+ * @return ov_status_e A status code, return OK(0) if successful.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_embed_query(ov_genai_text_embedding_pipeline* pipe,
+                                             const char* text,
+                                             ov_genai_embedding_result** result);
+
+/**
+ * @brief Asynchronously compute embedding for a single query.
+ *
+ * Only one async call can be active on the pipeline at a time. The caller must follow this with
+ * ov_genai_text_embedding_pipeline_wait_embed_query() to retrieve the result.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_start_embed_query_async(ov_genai_text_embedding_pipeline* pipe, const char* text);
+
+/**
+ * @brief Wait for the result of a previously started asynchronous embed_query.
+ */
+OPENVINO_GENAI_C_EXPORTS ov_status_e
+ov_genai_text_embedding_pipeline_wait_embed_query(ov_genai_text_embedding_pipeline* pipe,
+                                                  ov_genai_embedding_result** result);

--- a/src/c/src/text_embedding_pipeline.cpp
+++ b/src/c/src/text_embedding_pipeline.cpp
@@ -1,0 +1,389 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/genai/c/text_embedding_pipeline.h"
+
+#include <stdarg.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "openvino/genai/rag/text_embedding_pipeline.hpp"
+#include "types_c.h"
+
+namespace {
+
+bool parse_bool(const std::string& s, bool& out) {
+    if (s == "true" || s == "True" || s == "TRUE" || s == "1") {
+        out = true;
+        return true;
+    }
+    if (s == "false" || s == "False" || s == "FALSE" || s == "0") {
+        out = false;
+        return true;
+    }
+    return false;
+}
+
+bool parse_pooling(const std::string& s, ov::genai::TextEmbeddingPipeline::PoolingType& out) {
+    if (s == "CLS") {
+        out = ov::genai::TextEmbeddingPipeline::PoolingType::CLS;
+        return true;
+    }
+    if (s == "MEAN") {
+        out = ov::genai::TextEmbeddingPipeline::PoolingType::MEAN;
+        return true;
+    }
+    if (s == "LAST_TOKEN") {
+        out = ov::genai::TextEmbeddingPipeline::PoolingType::LAST_TOKEN;
+        return true;
+    }
+    return false;
+}
+
+// Splits the variadic property pack into embedding-specific Config keys (typed) and pass-through plugin properties
+// (kept as strings).
+ov_status_e split_embedding_properties(va_list args_ptr,
+                                       size_t property_size,
+                                       ov::AnyMap& config_properties,
+                                       ov::AnyMap& plugin_properties) {
+    for (size_t i = 0; i < property_size; ++i) {
+        const char* key_cstr = va_arg(args_ptr, const char*);
+        const char* value_cstr = va_arg(args_ptr, const char*);
+        if (!key_cstr || !value_cstr) {
+            return ov_status_e::INVALID_C_PARAM;
+        }
+        std::string key(key_cstr);
+        std::string value(value_cstr);
+        if (key == "max_length" || key == "batch_size") {
+            config_properties[key] = static_cast<size_t>(std::stoull(value));
+        } else if (key == "pad_to_max_length" || key == "normalize") {
+            bool b = false;
+            if (!parse_bool(value, b)) {
+                return ov_status_e::INVALID_C_PARAM;
+            }
+            config_properties[key] = b;
+        } else if (key == "padding_side" || key == "query_instruction" || key == "embed_instruction") {
+            config_properties[key] = value;
+        } else if (key == "pooling_type") {
+            ov::genai::TextEmbeddingPipeline::PoolingType pt;
+            if (!parse_pooling(value, pt)) {
+                return ov_status_e::INVALID_C_PARAM;
+            }
+            config_properties[key] = pt;
+        } else {
+            plugin_properties[key] = value;
+        }
+    }
+    return ov_status_e::OK;
+}
+
+std::vector<std::string> to_string_vector(const char** texts, size_t count) {
+    std::vector<std::string> out;
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        out.emplace_back(texts[i] ? texts[i] : "");
+    }
+    return out;
+}
+
+ov_status_e wrap_result(ov::genai::EmbeddingResult&& value, ov_genai_embedding_result** out) {
+    std::unique_ptr<ov_genai_embedding_result> r = std::make_unique<ov_genai_embedding_result>();
+    r->value = std::move(value);
+    *out = r.release();
+    return ov_status_e::OK;
+}
+
+ov_status_e wrap_results(ov::genai::EmbeddingResults&& value, ov_genai_embedding_results** out) {
+    std::unique_ptr<ov_genai_embedding_results> r = std::make_unique<ov_genai_embedding_results>();
+    r->value = std::move(value);
+    *out = r.release();
+    return ov_status_e::OK;
+}
+
+ov_genai_embedding_dtype_e dtype_of(const ov::genai::EmbeddingResult& v) {
+    if (std::holds_alternative<std::vector<float>>(v)) {
+        return OV_GENAI_EMBEDDING_DTYPE_F32;
+    }
+    if (std::holds_alternative<std::vector<int8_t>>(v)) {
+        return OV_GENAI_EMBEDDING_DTYPE_I8;
+    }
+    return OV_GENAI_EMBEDDING_DTYPE_U8;
+}
+
+ov_genai_embedding_dtype_e dtype_of(const ov::genai::EmbeddingResults& v) {
+    if (std::holds_alternative<std::vector<std::vector<float>>>(v)) {
+        return OV_GENAI_EMBEDDING_DTYPE_F32;
+    }
+    if (std::holds_alternative<std::vector<std::vector<int8_t>>>(v)) {
+        return OV_GENAI_EMBEDDING_DTYPE_I8;
+    }
+    return OV_GENAI_EMBEDDING_DTYPE_U8;
+}
+
+template <typename T>
+ov_status_e get_data_single(const ov_genai_embedding_result* result, const T** data, size_t* size) {
+    if (!result || !data || !size) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    const auto* vec = std::get_if<std::vector<T>>(&result->value);
+    if (!vec) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    *data = vec->data();
+    *size = vec->size();
+    return ov_status_e::OK;
+}
+
+template <typename T>
+ov_status_e get_data_at(const ov_genai_embedding_results* results, size_t i, const T** data, size_t* size) {
+    if (!results || !data || !size) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    const auto* outer = std::get_if<std::vector<std::vector<T>>>(&results->value);
+    if (!outer) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    if (i >= outer->size()) {
+        return ov_status_e::OUT_OF_BOUNDS;
+    }
+    *data = (*outer)[i].data();
+    *size = (*outer)[i].size();
+    return ov_status_e::OK;
+}
+
+}  // namespace
+
+// ---- single embedding ----
+
+void ov_genai_embedding_result_free(ov_genai_embedding_result* result) {
+    if (result) {
+        delete result;
+    }
+}
+
+ov_status_e ov_genai_embedding_result_get_dtype(const ov_genai_embedding_result* result,
+                                                ov_genai_embedding_dtype_e* dtype) {
+    if (!result || !dtype) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    *dtype = dtype_of(result->value);
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_embedding_result_get_size(const ov_genai_embedding_result* result, size_t* size) {
+    if (!result || !size) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    *size = std::visit([](const auto& v) { return v.size(); }, result->value);
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_embedding_result_get_data_f32(const ov_genai_embedding_result* result,
+                                                   const float** data,
+                                                   size_t* size) {
+    return get_data_single<float>(result, data, size);
+}
+
+ov_status_e ov_genai_embedding_result_get_data_i8(const ov_genai_embedding_result* result,
+                                                  const int8_t** data,
+                                                  size_t* size) {
+    return get_data_single<int8_t>(result, data, size);
+}
+
+ov_status_e ov_genai_embedding_result_get_data_u8(const ov_genai_embedding_result* result,
+                                                  const uint8_t** data,
+                                                  size_t* size) {
+    return get_data_single<uint8_t>(result, data, size);
+}
+
+// ---- batch embeddings ----
+
+void ov_genai_embedding_results_free(ov_genai_embedding_results* results) {
+    if (results) {
+        delete results;
+    }
+}
+
+ov_status_e ov_genai_embedding_results_get_dtype(const ov_genai_embedding_results* results,
+                                                 ov_genai_embedding_dtype_e* dtype) {
+    if (!results || !dtype) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    *dtype = dtype_of(results->value);
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_embedding_results_get_count(const ov_genai_embedding_results* results, size_t* count) {
+    if (!results || !count) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    *count = std::visit([](const auto& v) { return v.size(); }, results->value);
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_embedding_results_get_size_at(const ov_genai_embedding_results* results, size_t i, size_t* size) {
+    if (!results || !size) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    ov_status_e status = ov_status_e::OK;
+    std::visit(
+        [&](const auto& v) {
+            if (i >= v.size()) {
+                status = ov_status_e::OUT_OF_BOUNDS;
+                return;
+            }
+            *size = v[i].size();
+        },
+        results->value);
+    return status;
+}
+
+ov_status_e ov_genai_embedding_results_get_data_f32_at(const ov_genai_embedding_results* results,
+                                                       size_t i,
+                                                       const float** data,
+                                                       size_t* size) {
+    return get_data_at<float>(results, i, data, size);
+}
+
+ov_status_e ov_genai_embedding_results_get_data_i8_at(const ov_genai_embedding_results* results,
+                                                      size_t i,
+                                                      const int8_t** data,
+                                                      size_t* size) {
+    return get_data_at<int8_t>(results, i, data, size);
+}
+
+ov_status_e ov_genai_embedding_results_get_data_u8_at(const ov_genai_embedding_results* results,
+                                                      size_t i,
+                                                      const uint8_t** data,
+                                                      size_t* size) {
+    return get_data_at<uint8_t>(results, i, data, size);
+}
+
+// ---- pipeline ----
+
+ov_status_e ov_genai_text_embedding_pipeline_create(const char* models_path,
+                                                    const char* device,
+                                                    const size_t property_args_size,
+                                                    ov_genai_text_embedding_pipeline** pipe,
+                                                    ...) {
+    if (!models_path || !device || !pipe || property_args_size % 2 != 0) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        ov::AnyMap config_properties;
+        ov::AnyMap plugin_properties;
+        va_list args_ptr;
+        va_start(args_ptr, pipe);
+        ov_status_e split_status =
+            split_embedding_properties(args_ptr, property_args_size / 2, config_properties, plugin_properties);
+        va_end(args_ptr);
+        if (split_status != ov_status_e::OK) {
+            return split_status;
+        }
+        ov::genai::TextEmbeddingPipeline::Config config(config_properties);
+        std::unique_ptr<ov_genai_text_embedding_pipeline> _pipe =
+            std::make_unique<ov_genai_text_embedding_pipeline>();
+        _pipe->object = std::make_shared<ov::genai::TextEmbeddingPipeline>(std::filesystem::path(models_path),
+                                                                           std::string(device),
+                                                                           config,
+                                                                           plugin_properties);
+        *pipe = _pipe.release();
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+void ov_genai_text_embedding_pipeline_free(ov_genai_text_embedding_pipeline* pipe) {
+    if (pipe) {
+        delete pipe;
+    }
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_embed_documents(ov_genai_text_embedding_pipeline* pipe,
+                                                             const char** texts,
+                                                             size_t texts_count,
+                                                             ov_genai_embedding_results** results) {
+    if (!pipe || !(pipe->object) || !results || (texts_count > 0 && !texts)) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        std::vector<std::string> docs = to_string_vector(texts, texts_count);
+        auto value = pipe->object->embed_documents(docs);
+        return wrap_results(std::move(value), results);
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_start_embed_documents_async(ov_genai_text_embedding_pipeline* pipe,
+                                                                         const char** texts,
+                                                                         size_t texts_count) {
+    if (!pipe || !(pipe->object) || (texts_count > 0 && !texts)) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        std::vector<std::string> docs = to_string_vector(texts, texts_count);
+        pipe->object->start_embed_documents_async(docs);
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_wait_embed_documents(ov_genai_text_embedding_pipeline* pipe,
+                                                                  ov_genai_embedding_results** results) {
+    if (!pipe || !(pipe->object) || !results) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        auto value = pipe->object->wait_embed_documents();
+        return wrap_results(std::move(value), results);
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_embed_query(ov_genai_text_embedding_pipeline* pipe,
+                                                         const char* text,
+                                                         ov_genai_embedding_result** result) {
+    if (!pipe || !(pipe->object) || !text || !result) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        auto value = pipe->object->embed_query(std::string(text));
+        return wrap_result(std::move(value), result);
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_start_embed_query_async(ov_genai_text_embedding_pipeline* pipe,
+                                                                     const char* text) {
+    if (!pipe || !(pipe->object) || !text) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        pipe->object->start_embed_query_async(std::string(text));
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+    return ov_status_e::OK;
+}
+
+ov_status_e ov_genai_text_embedding_pipeline_wait_embed_query(ov_genai_text_embedding_pipeline* pipe,
+                                                              ov_genai_embedding_result** result) {
+    if (!pipe || !(pipe->object) || !result) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        auto value = pipe->object->wait_embed_query();
+        return wrap_result(std::move(value), result);
+    } catch (...) {
+        return ov_status_e::UNKNOW_EXCEPTION;
+    }
+}

--- a/src/c/src/types_c.h
+++ b/src/c/src/types_c.h
@@ -10,6 +10,7 @@
 #include "openvino/genai/visual_language/pipeline.hpp"
 #include "openvino/genai/chat_history.hpp"
 #include "openvino/genai/json_container.hpp"
+#include "openvino/genai/rag/text_embedding_pipeline.hpp"
 
 #define GET_PROPERTY_FROM_ARGS_LIST                                                                            \
     std::string property_key = va_arg(args_ptr, char*);                                                        \
@@ -145,4 +146,28 @@ struct ov_genai_chat_history_opaque {
  */
 struct ov_genai_json_container_opaque {
     std::shared_ptr<ov::genai::JsonContainer> object;
+};
+
+/**
+ * @struct ov_genai_text_embedding_pipeline_opaque
+ * @brief This is an interface of ov::genai::TextEmbeddingPipeline
+ */
+struct ov_genai_text_embedding_pipeline_opaque {
+    std::shared_ptr<ov::genai::TextEmbeddingPipeline> object;
+};
+
+/**
+ * @struct ov_genai_embedding_result_opaque
+ * @brief Holds a single embedding vector returned by ov::genai::TextEmbeddingPipeline::embed_query.
+ */
+struct ov_genai_embedding_result_opaque {
+    ov::genai::EmbeddingResult value;
+};
+
+/**
+ * @struct ov_genai_embedding_results_opaque
+ * @brief Holds a batch of embedding vectors returned by ov::genai::TextEmbeddingPipeline::embed_documents.
+ */
+struct ov_genai_embedding_results_opaque {
+    ov::genai::EmbeddingResults value;
 };


### PR DESCRIPTION
## Description

Expose `ov::genai::TextEmbeddingPipeline` through the C API so it can be consumed from C and from languages without a stable C++ ABI (Rust, Go, etc.). The wrapper is a thin pass-through over the existing C++ implementation, mirroring the pattern already used for `LLMPipeline`, `VLMPipeline`, and `WhisperPipeline`.

This is the second half of bringing the RAG pipelines to the C API; the first half (TextRerankPipeline) is in #3855. The two PRs are independent — either can land first, the other will rebase.

### What's added

- New header: `src/c/include/openvino/genai/c/text_embedding_pipeline.h`
- New impl:   `src/c/src/text_embedding_pipeline.cpp`
- Three opaque types registered in `src/c/src/types_c.h`: pipeline, single embedding result, batch embedding results.

API surface:

| Category | Functions |
| --- | --- |
| Pipeline | `ov_genai_text_embedding_pipeline_{create,free}` |
| Sync inference | `ov_genai_text_embedding_pipeline_embed_query`, `ov_genai_text_embedding_pipeline_embed_documents` |
| Async inference | `start_embed_query_async` / `wait_embed_query`, `start_embed_documents_async` / `wait_embed_documents` |
| Single result accessors | `ov_genai_embedding_result_{free,get_dtype,get_size,get_data_f32,get_data_i8,get_data_u8}` |
| Batch result accessors | `ov_genai_embedding_results_{free,get_dtype,get_count,get_size_at,get_data_f32_at,get_data_i8_at,get_data_u8_at}` |

### Handling the variant return type

The C++ side returns `std::variant<vector<float>, vector<int8_t>, vector<uint8_t>>` (for quantized embeddings). On the C side this is exposed as:
- `ov_genai_embedding_dtype_e` enum with `F32`, `I8`, `U8` variants
- per-dtype borrow accessors (`get_data_f32`, `get_data_i8`, `get_data_u8`)
- mismatched accessor returns `INVALID_C_PARAM`; the caller is expected to query `get_dtype` first.

The returned `data` pointer borrows from the result/results object and is invalidated on `_free`.

### Config keys

Recognized in the variadic property pack and forwarded to `ov::genai::TextEmbeddingPipeline::Config`:
- `max_length`, `batch_size` (size_t)
- `pad_to_max_length`, `normalize` (bool)
- `padding_side`, `query_instruction`, `embed_instruction` (string)
- `pooling_type` ("CLS", "MEAN", "LAST_TOKEN")

Any unknown key is treated as a plugin property and forwarded to `ov::Core` as a string.

### What's intentionally **not** in this PR

- C sample (`samples/c/rag/text_embedding.c`) and C unit tests — happy to add in a follow-up if reviewers prefer that split.
- Documentation page under `site/` — same reasoning.

No CMake changes are required: `src/c/CMakeLists.txt` already globs `src/*.cpp`, and `src/cpp/CMakeLists.txt` installs `src/c/include/` via `install(DIRECTORY ...)`.

CVS-###

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code. Intentionally deferred to a follow-up PR; see "What's intentionally not in this PR" above. Locally verified that the wrapper compiles cleanly with `-Wall -Wextra` (no warnings from new code), the header is consumable from pure C99 with `-Wpedantic`, and all 21 new symbols are exported with proper `extern "C"` linkage.
- [x] This PR fully addresses the ticket. Sample and tests are explicitly tracked as follow-ups.
- [ ] I have made corresponding changes to the documentation. Will land alongside the C sample in a follow-up PR.