### PR TITLE
[Samples] Add C samples for RAG pipelines

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ENABLE_SAMPLES)
     add_subdirectory(c/text_generation)
     add_subdirectory(c/whisper_speech_recognition)
     add_subdirectory(c/visual_language_chat)
+    add_subdirectory(c/rag)
 endif()
 
 install(FILES
@@ -48,4 +49,5 @@ install(DIRECTORY
         c/text_generation
         c/whisper_speech_recognition
         c/visual_language_chat
+        c/rag
         DESTINATION samples/c COMPONENT cpp_samples_genai)

--- a/samples/c/rag/CMakeLists.txt
+++ b/samples/c/rag/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+find_package(OpenVINOGenAI REQUIRED
+    PATHS
+        "${CMAKE_BINARY_DIR}"  # Reuse the package from the build.
+        ${OpenVINO_DIR}  # GenAI may be installed alogside OpenVINO.
+    NO_CMAKE_FIND_ROOT_PATH
+)
+
+function(add_sample_executable target_name)
+    add_executable(${target_name} ${target_name}.c)
+    # Specifies that the source file should be compiled as a C source file
+    set_source_files_properties(${target_name}.c PROPERTIES LANGUAGE C)
+    target_link_libraries(${target_name} PRIVATE openvino::genai::c)
+    set_target_properties(${target_name} PROPERTIES
+        # Ensure out-of-box LC_RPATH on macOS with SIP
+        INSTALL_RPATH_USE_LINK_PATH ON)
+    install(TARGETS ${target_name}
+            RUNTIME DESTINATION samples_bin/
+            COMPONENT samples_bin
+            EXCLUDE_FROM_ALL)
+endfunction()
+
+set (SAMPLE_LIST
+    text_rerank_c
+    text_embeddings_c)
+
+foreach(sample IN LISTS SAMPLE_LIST)
+    add_sample_executable(${sample})
+endforeach()

--- a/samples/c/rag/README.md
+++ b/samples/c/rag/README.md
@@ -1,0 +1,51 @@
+# Retrieval Augmented Generation C Samples
+
+This example showcases inference of Text Embedding and Text Rerank Models from C. The application has limited configuration options to encourage the reader to explore and modify the source code. For example, change the device for inference to GPU. The samples feature the C wrappers around `ov::genai::TextEmbeddingPipeline` and `ov::genai::TextRerankPipeline` and use text as an input source.
+
+## Download and Convert the Model and Tokenizers
+
+The `--upgrade-strategy eager` option is needed to ensure `optimum-intel` is upgraded to the latest version.
+
+Install [../../export-requirements.txt](../../export-requirements.txt) to convert a model.
+
+```sh
+pip install --upgrade-strategy eager -r ../../export-requirements.txt
+```
+
+To export text embedding model run Optimum CLI command:
+
+```sh
+optimum-cli export openvino --task feature-extraction --model BAAI/bge-small-en-v1.5 BAAI/bge-small-en-v1.5
+```
+
+To export text reranking model run Optimum CLI command:
+
+```sh
+optimum-cli export openvino --task text-classification --model cross-encoder/ms-marco-MiniLM-L6-v2 cross-encoder/ms-marco-MiniLM-L6-v2
+```
+
+## Run
+
+Follow [Get Started with Samples](https://docs.openvino.ai/2026/get-started/learn-openvino/openvino-samples/get-started-demos.html) to run the sample.
+
+### 1. Text Embeddings Sample (`text_embeddings_c.c`)
+- **Description:**
+  Demonstrates inference of text embedding models using the OpenVINO GenAI C API. Converts input text into vector embeddings for downstream tasks such as retrieval or semantic search.
+- **Run Command:**
+  ```sh
+  text_embeddings_c <MODEL_DIR> "Document 1" "Document 2"
+  ```
+Refer to the [Supported Models](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/#text-embeddings-models) for more details.
+
+### 2. Text Rerank Sample (`text_rerank_c.c`)
+- **Description:**
+  Demonstrates inference of text rerank models using the OpenVINO GenAI C API. Reranks a list of candidate documents based on their relevance to a query using a cross-encoder or reranker model.
+- **Run Command:**
+  ```sh
+  text_rerank_c <MODEL_DIR> '<QUERY>' '<TEXT 1>' ['<TEXT 2>' ...]
+  ```
+
+## Support and Contribution
+- For troubleshooting, please refer to the [troubleshooting](https://openvinotoolkit.github.io/openvino.genai/docs/guides/troubleshooting/) section.
+- To report a bug or request a feature, [create a GitHub issue](https://github.com/openvinotoolkit/openvino.genai/issues).
+- Contributions are welcome! Please see the [Contribution Guide](https://github.com/openvinotoolkit/openvino.genai/blob/master/.github/CONTRIBUTING.md) for details.

--- a/samples/c/rag/text_embeddings_c.c
+++ b/samples/c/rag/text_embeddings_c.c
@@ -1,0 +1,91 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "openvino/genai/c/text_embedding_pipeline.h"
+
+#define CHECK_STATUS(return_status)                                                      \
+    if (return_status != OK) {                                                           \
+        fprintf(stderr, "[ERROR] return status %d, line %d\n", return_status, __LINE__); \
+        goto err;                                                                        \
+    }
+
+static const char* dtype_name(ov_genai_embedding_dtype_e dtype) {
+    switch (dtype) {
+    case OV_GENAI_EMBEDDING_DTYPE_F32:
+        return "f32";
+    case OV_GENAI_EMBEDDING_DTYPE_I8:
+        return "i8";
+    case OV_GENAI_EMBEDDING_DTYPE_U8:
+        return "u8";
+    default:
+        return "?";
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <MODEL_DIR> \"<TEXT 1>\" [\"<TEXT 2>\" ...]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+    const char* model_dir = argv[1];
+    const char** documents = (const char**)&argv[2];
+    size_t documents_count = (size_t)(argc - 2);
+
+    ov_genai_text_embedding_pipeline* pipeline = NULL;
+    ov_genai_embedding_results* docs_embeddings = NULL;
+    ov_genai_embedding_result* query_embedding = NULL;
+    const char* device = "CPU";  // GPU can be used as well
+    int exit_code = EXIT_FAILURE;
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_create(model_dir, device, 2, &pipeline, "pooling_type", "MEAN"));
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_embed_documents(pipeline, documents, documents_count, &docs_embeddings));
+
+    ov_genai_embedding_dtype_e docs_dtype = OV_GENAI_EMBEDDING_DTYPE_F32;
+    size_t docs_count = 0;
+    CHECK_STATUS(ov_genai_embedding_results_get_dtype(docs_embeddings, &docs_dtype));
+    CHECK_STATUS(ov_genai_embedding_results_get_count(docs_embeddings, &docs_count));
+    printf("Documents: %zu embeddings of dtype %s\n", docs_count, dtype_name(docs_dtype));
+    for (size_t i = 0; i < docs_count; ++i) {
+        size_t embedding_size = 0;
+        CHECK_STATUS(ov_genai_embedding_results_get_size_at(docs_embeddings, i, &embedding_size));
+        printf("  [%zu] length=%zu\n", i, embedding_size);
+    }
+
+    CHECK_STATUS(
+        ov_genai_text_embedding_pipeline_embed_query(pipeline, "What is the capital of France?", &query_embedding));
+
+    ov_genai_embedding_dtype_e query_dtype = OV_GENAI_EMBEDDING_DTYPE_F32;
+    size_t query_size = 0;
+    CHECK_STATUS(ov_genai_embedding_result_get_dtype(query_embedding, &query_dtype));
+    CHECK_STATUS(ov_genai_embedding_result_get_size(query_embedding, &query_size));
+    printf("Query embedding: dtype=%s length=%zu\n", dtype_name(query_dtype), query_size);
+
+    if (query_dtype == OV_GENAI_EMBEDDING_DTYPE_F32) {
+        const float* data = NULL;
+        size_t size = 0;
+        CHECK_STATUS(ov_genai_embedding_result_get_data_f32(query_embedding, &data, &size));
+        size_t preview = size < 8 ? size : 8;
+        printf("  first %zu values: [", preview);
+        for (size_t i = 0; i < preview; ++i) {
+            printf("%s%.4f", i == 0 ? "" : ", ", data[i]);
+        }
+        printf("%s]\n", preview < size ? ", ..." : "");
+    }
+
+    exit_code = EXIT_SUCCESS;
+
+err:
+    if (query_embedding)
+        ov_genai_embedding_result_free(query_embedding);
+    if (docs_embeddings)
+        ov_genai_embedding_results_free(docs_embeddings);
+    if (pipeline)
+        ov_genai_text_embedding_pipeline_free(pipeline);
+
+    return exit_code;
+}

--- a/samples/c/rag/text_rerank_c.c
+++ b/samples/c/rag/text_rerank_c.c
@@ -1,0 +1,52 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "openvino/genai/c/text_rerank_pipeline.h"
+
+#define CHECK_STATUS(return_status)                                                      \
+    if (return_status != OK) {                                                           \
+        fprintf(stderr, "[ERROR] return status %d, line %d\n", return_status, __LINE__); \
+        goto err;                                                                        \
+    }
+
+int main(int argc, char* argv[]) {
+    if (argc < 4) {
+        fprintf(stderr, "Usage: %s <MODEL_DIR> \"<QUERY>\" \"<TEXT 1>\" [\"<TEXT 2>\" ...]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+    const char* model_dir = argv[1];
+    const char* query = argv[2];
+    const char** documents = (const char**)&argv[3];
+    size_t documents_count = (size_t)(argc - 3);
+
+    ov_genai_text_rerank_pipeline* pipeline = NULL;
+    ov_genai_text_rerank_result* result = NULL;
+    const char* device = "CPU";  // GPU can be used as well
+    size_t result_size = 0;
+    int exit_code = EXIT_FAILURE;
+
+    // top_n=3 limits the result to the three highest-scoring documents.
+    CHECK_STATUS(ov_genai_text_rerank_pipeline_create(model_dir, device, 2, &pipeline, "top_n", "3"));
+    CHECK_STATUS(ov_genai_text_rerank_pipeline_rerank(pipeline, query, documents, documents_count, &result));
+
+    CHECK_STATUS(ov_genai_text_rerank_result_get_size(result, &result_size));
+    printf("Reranked documents:\n");
+    for (size_t i = 0; i < result_size; ++i) {
+        size_t index = 0;
+        float score = 0.0f;
+        CHECK_STATUS(ov_genai_text_rerank_result_get_item(result, i, &index, &score));
+        printf("Document %zu (score: %.4f): %s\n", index, score, documents[index]);
+    }
+
+    exit_code = EXIT_SUCCESS;
+
+err:
+    if (result)
+        ov_genai_text_rerank_result_free(result);
+    if (pipeline)
+        ov_genai_text_rerank_pipeline_free(pipeline);
+
+    return exit_code;
+}


### PR DESCRIPTION
## Description

Add C samples that exercise the newly added C bindings for the RAG pipelines, matching the C++ samples in `samples/cpp/rag/`.

> **Depends on:** #3855 (TextRerankPipeline C API) and #3856 (TextEmbeddingPipeline C API). This PR is opened as a Draft because it cannot build until both of those merge. I will mark it Ready once they land.

### What's added

| File | Mirrors |
| --- | --- |
| `samples/c/rag/text_rerank_c.c` | `samples/cpp/rag/text_rerank.cpp` |
| `samples/c/rag/text_embeddings_c.c` | `samples/cpp/rag/text_embeddings.cpp` |
| `samples/c/rag/CMakeLists.txt` | `samples/c/text_generation/CMakeLists.txt` (same `add_sample_executable` helper, same install layout) |
| `samples/c/rag/README.md` | `samples/cpp/rag/README.md` (model conversion + run commands) |

Wired into `samples/CMakeLists.txt` for both build (`add_subdirectory`) and `install(DIRECTORY ...)`.

### Behavior

- `text_rerank_c <MODEL_DIR> "<QUERY>" "<TEXT 1>" ["<TEXT 2>" ...]` — creates a TextRerankPipeline with `top_n=3`, calls rerank, and prints `Document <index> (score: <score>): <text>` for each item.
- `text_embeddings_c <MODEL_DIR> "<TEXT 1>" ["<TEXT 2>" ...]` — creates a TextEmbeddingPipeline with `pooling_type=MEAN`, computes batch embeddings (`embed_documents`) and a single query embedding (`embed_query`), prints dtype + length for each, and previews the first 8 float values of the query embedding when dtype is F32.

### Verification

- Both samples compile cleanly as pure C99 with `-Wall -Wextra -Wpedantic` against the headers from #3855 and #3856 (no warnings from sample code; only the existing `ov_common.h` strict-prototypes notice).
- `pre-commit run --files ...` passes on all new files.

CVS-###

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. These samples themselves serve as smoke tests for the C bindings added in #3855 and #3856.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. `samples/c/rag/README.md` is added; it mirrors the structure of `samples/cpp/rag/README.md` (model conversion via `optimum-cli` and run commands).