### PR TITLE
skip test_qwen3_embedding_npu tests

### DIFF
--- a/tests/python_tests/test_rag.py
+++ b/tests/python_tests/test_rag.py
@@ -569,6 +569,7 @@ def test_qwen3_embedding(emb_model, dataset_documents, config):
         ),
     ],
 )
+@pytest.mark.xfail(reason="Ticket - 186607")
 @pytest.mark.xfail(condition=(sys.platform == "darwin"), reason="Ticket - 174635")
 def test_qwen3_embedding_npu(emb_model, dataset_documents, config, chunk_size, threshold, task):
     NPU_FALLBACK_PROPERTIES = {"NPUW_DEVICES": "CPU", "NPUW_F16IC": "False", "NPUW_LLM_PREFILL_CHUNK_SIZE": chunk_size}


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

Skip tests:
```
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config7-chunk_size=16-threshold=0.006-task=embed_documents-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 27.64257526397705 is greater than allowed 0.006
assert np.float64(27.64257526397705) < 0.006
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config8-chunk_size=16-threshold=0.006-task=embed_documents-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 3.3149428367614746 is greater than allowed 0.006
assert np.float64(3.3149428367614746) < 0.006
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config10-chunk_size=16-threshold=7e-05-task=embed_documents-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 0.23100837972015142 is greater than allowed 7e-05
assert np.float64(0.23100837972015142) < 7e-05
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config11-chunk_size=16-threshold=7e-05-task=embed_documents-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 0.03798815608024597 is greater than allowed 7e-05
assert np.float64(0.03798815608024597) < 7e-05
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config13-chunk_size=16-threshold=0.006-task=embed_query-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 27.64257526397705 is greater than allowed 0.006
assert np.float64(27.64257526397705) < 0.006
FAILED tests/python_tests/test_rag.py::test_qwen3_embedding_npu[config14-chunk_size=16-threshold=0.006-task=embed_query-emb_model=Qwen/Qwen3-Embedding-0.6B] - AssertionError: Max error: 3.3149428367614746 is greater than allowed 0.006
assert np.float64(3.3149428367614746) < 0.006
```



## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [NA] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
