### PR TITLE
Add denoising_process C++ and Python samples

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,6 +90,7 @@
 - 'samples/cpp/image_generation/**/*'
 - 'samples/python/image_generation/**/*'
 - 'tests/python_tests/samples/test_benchmark_image_gen.py'
+- 'tests/python_tests/samples/test_denoising_process.py'
 - 'tests/python_tests/samples/test_heterogeneous_stable_diffusion.py'
 - 'tests/python_tests/samples/test_text2image.py'
 - 'tests/python_tests/samples/test_image2image.py'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -813,6 +813,11 @@ jobs:
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).Image_generation_samples.test }}
             runner: 'aks-linux-4-cores-16gb'
+          - name: 'tiny_random_latent_consistency'
+            marker: 'tiny_random_latent_consistency'
+            cmd: 'tests/python_tests/samples'
+            run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).Image_generation_samples.test }}
+            runner: 'aks-linux-4-cores-16gb'
           # Test hangs on Linux. Ticket: 181387
           # - name: 'VLM'
           #   marker: 'vlm'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -932,6 +932,11 @@ jobs:
             cmd: 'tests/python_tests/samples'
             run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).Image_generation_samples.test }}
             runner: 'aks-win-8-cores-16gb-test'
+          - name: 'tiny_random_latent_consistency'
+            marker: 'tiny_random_latent_consistency'
+            cmd: 'tests/python_tests/samples'
+            run_condition: ${{ fromJSON(needs.smart_ci.outputs.affected_components).Image_generation_samples.test }}
+            runner: 'aks-win-8-cores-16gb-test'
           - name: 'Rag'
             marker: 'rag'
             cmd: 'tests/python_tests/samples'

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -37,6 +37,7 @@ install(DIRECTORY
 install(DIRECTORY
             python/text_generation
             python/image_generation
+            python/video_generation
             python/speech_generation
             python/visual_language_chat
             python/whisper_speech_recognition

--- a/samples/cpp/fetch_opencv.cmake
+++ b/samples/cpp/fetch_opencv.cmake
@@ -77,6 +77,36 @@ function(ov_genai_link_opencv target_name)
                 INSTALL_RPATH "@loader_path/../lib"
                 INSTALL_RPATH_USE_LINK_PATH ON)
         endif()
+
+        # Windows: deploy fetched OpenCV runtime DLLs alongside sample executables
+        # in samples_bin/. Windows has no rpath, so install/samples_bin/<exe> can
+        # only resolve its OpenCV dependencies via the loader search path. The
+        # function is invoked by multiple sample CMakeLists.txt files; guard with
+        # a GLOBAL property so the install rules are emitted exactly once.
+        if(WIN32)
+            get_property(_ov_genai_opencv_dlls_installed GLOBAL
+                PROPERTY OV_GENAI_OPENCV_RUNTIME_DLLS_INSTALLED)
+            if(NOT _ov_genai_opencv_dlls_installed)
+                foreach(component IN LISTS required_components)
+                    install(FILES "$<TARGET_FILE:opencv_${component}>"
+                            DESTINATION samples_bin/
+                            COMPONENT samples_bin
+                            EXCLUDE_FROM_ALL)
+                endforeach()
+                # FFmpeg backend plugin: prebuilt DLL OpenCV places next to
+                # opencv_videoio with no CMake target. TARGET_FILE_DIR keeps the
+                # path tied to the OpenCV build layout and config, with no
+                # version-suffix or absolute-path assumptions.
+                install(FILES
+                            "$<TARGET_FILE_DIR:opencv_videoio>/opencv_videoio_ffmpeg_64.dll"
+                        DESTINATION samples_bin/
+                        COMPONENT samples_bin
+                        EXCLUDE_FROM_ALL
+                        OPTIONAL)
+                set_property(GLOBAL PROPERTY
+                    OV_GENAI_OPENCV_RUNTIME_DLLS_INSTALLED TRUE)
+            endif()
+        endif()
     else()
         set(opencv_targets ${OpenCV_LIBS})
         if(OpenCV_INCLUDE_DIRS)

--- a/samples/cpp/fetch_opencv.cmake
+++ b/samples/cpp/fetch_opencv.cmake
@@ -78,35 +78,10 @@ function(ov_genai_link_opencv target_name)
                 INSTALL_RPATH_USE_LINK_PATH ON)
         endif()
 
-        # Windows: deploy fetched OpenCV runtime DLLs alongside sample executables
-        # in samples_bin/. Windows has no rpath, so install/samples_bin/<exe> can
-        # only resolve its OpenCV dependencies via the loader search path. The
-        # function is invoked by multiple sample CMakeLists.txt files; guard with
-        # a GLOBAL property so the install rules are emitted exactly once.
-        if(WIN32)
-            get_property(_ov_genai_opencv_dlls_installed GLOBAL
-                PROPERTY OV_GENAI_OPENCV_RUNTIME_DLLS_INSTALLED)
-            if(NOT _ov_genai_opencv_dlls_installed)
-                foreach(component IN LISTS required_components)
-                    install(FILES "$<TARGET_FILE:opencv_${component}>"
-                            DESTINATION samples_bin/
-                            COMPONENT samples_bin
-                            EXCLUDE_FROM_ALL)
-                endforeach()
-                # FFmpeg backend plugin: prebuilt DLL OpenCV places next to
-                # opencv_videoio with no CMake target. TARGET_FILE_DIR keeps the
-                # path tied to the OpenCV build layout and config, with no
-                # version-suffix or absolute-path assumptions.
-                install(FILES
-                            "$<TARGET_FILE_DIR:opencv_videoio>/opencv_videoio_ffmpeg_64.dll"
-                        DESTINATION samples_bin/
-                        COMPONENT samples_bin
-                        EXCLUDE_FROM_ALL
-                        OPTIONAL)
-                set_property(GLOBAL PROPERTY
-                    OV_GENAI_OPENCV_RUNTIME_DLLS_INSTALLED TRUE)
-            endif()
-        endif()
+        # Signal to callers that OpenCV was built from source via FetchContent,
+        # so target-scoped CMake can emit any runtime deployment rules it needs
+        # (e.g., installing the fetched DLLs next to a Windows sample EXE).
+        set_property(GLOBAL PROPERTY OV_GENAI_FETCHED_OPENCV TRUE)
     else()
         set(opencv_targets ${OpenCV_LIBS})
         if(OpenCV_INCLUDE_DIRS)

--- a/samples/cpp/image_generation/CMakeLists.txt
+++ b/samples/cpp/image_generation/CMakeLists.txt
@@ -12,6 +12,7 @@ file(DOWNLOAD https://raw.githubusercontent.com/nothings/stb/f75e8d1cad7d90d72ef
      EXPECTED_HASH MD5=27932e6fb3a2f26aee2fc33f2cb4e696)
 
 include(FetchContent)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../fetch_opencv.cmake)
 
 if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
@@ -34,6 +35,34 @@ set_target_properties(text2image PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH ON)
 
 install(TARGETS text2image
+        RUNTIME DESTINATION samples_bin/
+        COMPONENT samples_bin
+        EXCLUDE_FROM_ALL)
+
+# create denoising_process sample executable
+
+add_executable(denoising_process denoising_process.cpp ../video_generation/imwrite_video.cpp)
+
+target_include_directories(denoising_process PRIVATE
+    ${CMAKE_BINARY_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../video_generation")
+ov_genai_link_opencv(denoising_process core imgproc videoio imgcodecs)
+target_link_libraries(denoising_process PRIVATE openvino::genai indicators::indicators)
+
+if(UNIX AND NOT APPLE)
+    set_target_properties(denoising_process PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib")
+elseif(APPLE)
+    set_target_properties(denoising_process PROPERTIES
+        INSTALL_RPATH "@loader_path/../lib")
+endif()
+
+set_target_properties(denoising_process PROPERTIES
+    # Ensure out of box LC_RPATH on macOS with SIP
+    INSTALL_RPATH_USE_LINK_PATH ON)
+
+install(TARGETS denoising_process
         RUNTIME DESTINATION samples_bin/
         COMPONENT samples_bin
         EXCLUDE_FROM_ALL)

--- a/samples/cpp/image_generation/CMakeLists.txt
+++ b/samples/cpp/image_generation/CMakeLists.txt
@@ -50,17 +50,25 @@ target_include_directories(denoising_process PRIVATE
 ov_genai_link_opencv(denoising_process core imgproc videoio imgcodecs)
 target_link_libraries(denoising_process PRIVATE openvino::genai indicators::indicators)
 
-if(UNIX AND NOT APPLE)
-    set_target_properties(denoising_process PROPERTIES
-        INSTALL_RPATH "$ORIGIN/../lib")
-elseif(APPLE)
-    set_target_properties(denoising_process PROPERTIES
-        INSTALL_RPATH "@loader_path/../lib")
-endif()
-
 set_target_properties(denoising_process PROPERTIES
     # Ensure out of box LC_RPATH on macOS with SIP
     INSTALL_RPATH_USE_LINK_PATH ON)
+
+# Windows: when OpenCV was built from source via FetchContent, deploy the
+# component DLLs next to denoising_process.exe in samples_bin/. The Windows
+# loader has no rpath, and install/samples_bin/ is not on PATH at runtime
+# unless the user puts it there. Skipped when find_package found a system
+# OpenCV, since those installs ship their own runtime path.
+get_property(_ov_genai_opencv_fetched GLOBAL PROPERTY OV_GENAI_FETCHED_OPENCV)
+if(WIN32 AND _ov_genai_opencv_fetched)
+    install(FILES "$<TARGET_FILE:opencv_core>"
+                  "$<TARGET_FILE:opencv_imgproc>"
+                  "$<TARGET_FILE:opencv_imgcodecs>"
+                  "$<TARGET_FILE:opencv_videoio>"
+            DESTINATION samples_bin/
+            COMPONENT samples_bin
+            EXCLUDE_FROM_ALL)
+endif()
 
 install(TARGETS denoising_process
         RUNTIME DESTINATION samples_bin/

--- a/samples/cpp/image_generation/README.md
+++ b/samples/cpp/image_generation/README.md
@@ -4,6 +4,7 @@ Examples in this folder showcase inference of text to image models like Stable D
 
 There are several sample files:
  - [`text2image.cpp`](./text2image.cpp) demonstrates basic usage of the text to image pipeline
+ - [`denoising_process.cpp`](./denoising_process.cpp) demonstrates how to use the callback latent argument with `Text2ImagePipeline::decode()` to render an intermediate image per inference step and save the denoising trajectory as a video
  - [`text2image_concurrency.cpp`](./text2image_concurrency.cpp) demonstrates concurrent usage of the text to image pipeline to create multiple images with different prompts
  - [`lora_text2image.cpp`](./lora_text2image.cpp) shows how to apply LoRA adapters to the pipeline
  - [`taylorseer_text2image.cpp`](./taylorseer_text2image.cpp) demonstrates text to image generation with TaylorSeer caching optimization for improved performance. Flux and StableDiffusion3 models are supported.
@@ -75,6 +76,20 @@ ov::Tensor image = pipe.generate(prompt,
    ov::genai::callback(callback)
 );
 ```
+
+## Visualize the text-to-image denoising trajectory as a video
+
+The `denoising_process.cpp` sample demonstrates how to capture the latent at every denoising step from the generation callback, decode it with `Text2ImagePipeline::decode()`, and write the full denoising trajectory as a video. It reuses the `save_video` helper from `samples/cpp/video_generation/`.
+
+The usage of this sample is:
+
+`./denoising_process <MODEL_DIR> '<PROMPT>'`
+
+For example:
+
+`./denoising_process ./dreamlike_anime_1_0_ov/FP16 'cyberpunk cityscape like Tokyo New York with tall buildings at dusk golden hour cinematic lighting'`
+
+The sample writes `denoising_process.avi` in the current working directory. Each video frame is the decoded image of the latent after a single denoising step, so the last frame approximates the final generated image.
 
 ## Run with optional LoRA adapters
 

--- a/samples/cpp/image_generation/denoising_process.cpp
+++ b/samples/cpp/image_generation/denoising_process.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+
+#include "imwrite_video.hpp"
+#include "openvino/genai/image_generation/text2image_pipeline.hpp"
+#include "progress_bar.hpp"
+
+int32_t main(int32_t argc, char* argv[]) try {
+    OPENVINO_ASSERT(argc == 3, "Usage: ", argv[0], " <MODEL_DIR> '<PROMPT>'");
+
+    const std::string models_path = argv[1], prompt = argv[2];
+    const std::string device = "CPU";  // GPU can be used as well
+
+    constexpr size_t rng_seed = 42;
+    constexpr size_t num_inference_steps = 20;
+    constexpr int64_t image_width = 512;
+    constexpr int64_t image_height = 512;
+    constexpr size_t channels = 3;
+    constexpr float fps = 5.0f;
+
+    ov::genai::Text2ImagePipeline pipe(models_path, device);
+
+    ov::Tensor frames(ov::element::u8,
+                      ov::Shape{1,
+                                num_inference_steps,
+                                static_cast<size_t>(image_height),
+                                static_cast<size_t>(image_width),
+                                channels});
+    uint8_t* frames_data = frames.data<uint8_t>();
+    const size_t frame_bytes = static_cast<size_t>(image_height) * static_cast<size_t>(image_width) * channels;
+
+    auto denoising_callback = [&](size_t step, size_t num_steps, ov::Tensor& latent) -> bool {
+        OPENVINO_ASSERT(step < num_inference_steps,
+                        "Denoising callback step ",
+                        step,
+                        " is out of range for ",
+                        num_inference_steps,
+                        " inference steps");
+        const ov::Tensor decoded = pipe.decode(latent);
+        std::memcpy(frames_data + step * frame_bytes, decoded.data<const uint8_t>(), frame_bytes);
+        progress_bar(step, num_steps, latent);
+        return false;
+    };
+
+    pipe.generate(prompt,
+                  ov::genai::width(image_width),
+                  ov::genai::height(image_height),
+                  ov::genai::num_inference_steps(num_inference_steps),
+                  ov::genai::num_images_per_prompt(1),
+                  ov::genai::rng_seed(rng_seed),
+                  ov::genai::callback(denoising_callback));
+
+    save_video("denoising_process.avi", frames, fps);
+
+    return EXIT_SUCCESS;
+} catch (const std::exception& error) {
+    try {
+        std::cerr << error.what() << '\n';
+    } catch (const std::ios_base::failure&) {
+    }
+    return EXIT_FAILURE;
+} catch (...) {
+    try {
+        std::cerr << "Non-exception object thrown\n";
+    } catch (const std::ios_base::failure&) {
+    }
+    return EXIT_FAILURE;
+}

--- a/samples/cpp/video_generation/imwrite_video.cpp
+++ b/samples/cpp/video_generation/imwrite_video.cpp
@@ -33,7 +33,7 @@ void save_video(const std::string& filename,
         }
 
         const int fourcc = cv::VideoWriter::fourcc('M', 'J', 'P', 'G');
-        cv::VideoWriter writer(out, fourcc, static_cast<double>(fps), cv::Size(W, H), true);
+        cv::VideoWriter writer(out, cv::CAP_OPENCV_MJPEG, fourcc, static_cast<double>(fps), cv::Size(W, H), true);
         if (!writer.isOpened())
             throw std::runtime_error("VideoWriter failed to open: " + out);
 

--- a/samples/python/image_generation/README.md
+++ b/samples/python/image_generation/README.md
@@ -4,6 +4,7 @@ Examples in this folder showcase inference of text to image models like Stable D
 
 There are several sample files:
  - [`text2image.py`](./text2image.py) demonstrates basic usage of the text to image pipeline
+ - [`denoising_process.py`](./denoising_process.py) demonstrates how to use the callback latent argument with `Text2ImagePipeline.decode()` to render an intermediate image per inference step and save the denoising trajectory as a video
  - [`lora_text2image.py`](./lora_text2image.py) shows how to apply LoRA adapters to the pipeline
  - [`taylorseer_text2image.py`](./taylorseer_text2image.py) demonstrates text to image generation with TaylorSeer caching optimization for improved performance. Flux and StableDiffusion3 models are supported.
  - [`heterogeneous_stable_diffusion.py`](./heterogeneous_stable_diffusion.py) shows how to assemble a heterogeneous text2image pipeline from individual subcomponents (scheduler, text encoder, unet, vae decoder)
@@ -89,6 +90,20 @@ image = pipe.generate(
    callback = callback
 )
 ```
+
+## Visualize the text-to-image denoising trajectory as a video
+
+The `denoising_process.py` sample demonstrates how to capture the latent at every denoising step from the generation callback, decode it with `Text2ImagePipeline.decode()`, and write the full denoising trajectory as a video. It reuses the `save_video` helper from `samples/python/video_generation/`.
+
+The usage of this sample is:
+
+`python denoising_process.py <MODEL_DIR> '<PROMPT>'`
+
+For example:
+
+`python denoising_process.py ./dreamlike_anime_1_0_ov/FP16 'cyberpunk cityscape like Tokyo New York with tall buildings at dusk golden hour cinematic lighting'`
+
+The sample writes `denoising_process.avi` in the current working directory. Each video frame is the decoded image of the latent after a single denoising step, so the last frame approximates the final generated image.
 
 ## Run with optional LoRA adapters
 

--- a/samples/python/image_generation/denoising_process.py
+++ b/samples/python/image_generation/denoising_process.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import openvino as ov
+import openvino_genai
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "video_generation"))
+from video_utils import save_video
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_dir")
+    parser.add_argument("prompt")
+    args = parser.parse_args()
+
+    rng_seed = 42
+    num_inference_steps = 20
+    image_width = 512
+    image_height = 512
+    fps = 5
+
+    device = "CPU"  # GPU can be used as well
+    pipe = openvino_genai.Text2ImagePipeline(args.model_dir, device)
+
+    frames = np.zeros((1, num_inference_steps, image_height, image_width, 3), dtype=np.uint8)
+
+    def callback(step, num_steps, latent):
+        decoded = pipe.decode(latent)
+        frames[0, step] = decoded.data[0]
+        print(f"Step {step + 1}/{num_steps}")
+        return False
+
+    pipe.generate(
+        args.prompt,
+        width=image_width,
+        height=image_height,
+        num_inference_steps=num_inference_steps,
+        num_images_per_prompt=1,
+        rng_seed=rng_seed,
+        callback=callback,
+    )
+
+    save_video("denoising_process.avi", ov.Tensor(frames), fps)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/video_generation/video_utils.py
+++ b/samples/python/video_generation/video_utils.py
@@ -16,7 +16,9 @@ def save_video(filename: str, video_tensor, fps: int = 25):
             output_path = f"{base}_b{b}.{ext}"
 
         fourcc = cv2.VideoWriter_fourcc(*"MJPG")
-        writer = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+        writer = cv2.VideoWriter(output_path, cv2.CAP_OPENCV_MJPEG, fourcc, fps, (width, height))
+        if not writer.isOpened():
+            raise RuntimeError(f"VideoWriter failed to open: {output_path}")
 
         for f in range(num_frames):
             frame_bgr = cv2.cvtColor(video_data[b, f], cv2.COLOR_RGB2BGR)

--- a/tests/python_tests/pytest.ini
+++ b/tests/python_tests/pytest.ini
@@ -29,6 +29,7 @@ markers =
     transformers_dependent
     stable_diffusion_3_tiny_random
     tiny_random_flux
+    tiny_random_latent_consistency
     eagle3_decoding
 
 addopts = -m "not real_models and not nightly"

--- a/tests/python_tests/samples/test_denoising_process.py
+++ b/tests/python_tests/samples/test_denoising_process.py
@@ -2,38 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-from pathlib import Path
 
-import cv2
-import numpy as np
 import pytest
 
 from conftest import SAMPLES_PY_DIR, SAMPLES_CPP_DIR
-from test_utils import run_sample
-
-# Must match the constants hardcoded in the denoising_process samples.
-NUM_INFERENCE_STEPS = 20
-IMAGE_HEIGHT = 512
-IMAGE_WIDTH = 512
-CHANNELS = 3
-EXPECTED_VIDEO_SHAPE = (NUM_INFERENCE_STEPS, IMAGE_HEIGHT, IMAGE_WIDTH, CHANNELS)
-
-
-def _read_video_frames(path: Path) -> np.ndarray:
-    cap = cv2.VideoCapture(str(path))
-    try:
-        assert cap.isOpened(), f"OpenCV failed to open {path}"
-        frames = []
-        while True:
-            ok, frame = cap.read()
-            if not ok:
-                break
-            frames.append(frame)
-    finally:
-        cap.release()
-
-    assert frames, f"Could not read any frames from {path}"
-    return np.stack(frames)
+from test_utils import run_sample, compare_videos
 
 
 class TestDenoisingProcess:
@@ -66,18 +39,9 @@ class TestDenoisingProcess:
         assert py_video.exists(), f"Python sample did not produce {py_video}"
         assert cpp_video.exists(), f"C++ sample did not produce {cpp_video}"
 
-        # Both samples write MJPG AVIs via cv::CAP_OPENCV_MJPEG, so the OpenCV-built-in
-        # encoder produces reproducible frames independent of any system FFmpeg/GStreamer.
-        py_frames = _read_video_frames(py_video)
-        cpp_frames = _read_video_frames(cpp_video)
-        assert py_frames.shape == EXPECTED_VIDEO_SHAPE, (
-            f"Python AVI shape {py_frames.shape}, expected {EXPECTED_VIDEO_SHAPE}"
-        )
-        assert cpp_frames.shape == EXPECTED_VIDEO_SHAPE, (
-            f"C++ AVI shape {cpp_frames.shape}, expected {EXPECTED_VIDEO_SHAPE}"
-        )
-        assert py_frames.dtype == np.uint8
-        assert cpp_frames.dtype == np.uint8
-        assert np.array_equal(py_frames, cpp_frames), (
+        # Both samples write MJPG AVIs via cv::CAP_OPENCV_MJPEG, so the OpenCV
+        # built-in encoder produces reproducible frames independent of any
+        # system FFmpeg/GStreamer backend.
+        assert compare_videos(py_video, cpp_video), (
             "Decoded denoising-process video frames produced by the Python and C++ samples are not exactly equal"
         )

--- a/tests/python_tests/samples/test_denoising_process.py
+++ b/tests/python_tests/samples/test_denoising_process.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from conftest import SAMPLES_PY_DIR, SAMPLES_CPP_DIR
+from test_utils import run_sample
+
+# Must match the constants hardcoded in the denoising_process samples.
+NUM_INFERENCE_STEPS = 20
+IMAGE_HEIGHT = 512
+IMAGE_WIDTH = 512
+CHANNELS = 3
+EXPECTED_VIDEO_SHAPE = (NUM_INFERENCE_STEPS, IMAGE_HEIGHT, IMAGE_WIDTH, CHANNELS)
+
+
+def _read_video_frames(path: Path) -> np.ndarray:
+    cap = cv2.VideoCapture(str(path))
+    try:
+        assert cap.isOpened(), f"OpenCV failed to open {path}"
+        frames = []
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            frames.append(frame)
+    finally:
+        cap.release()
+
+    assert frames, f"Could not read any frames from {path}"
+    return np.stack(frames)
+
+
+class TestDenoisingProcess:
+    PROMPT = "cyberpunk cityscape with neon lights"
+
+    @pytest.mark.samples
+    @pytest.mark.tiny_random_latent_consistency
+    @pytest.mark.parametrize(
+        "convert_model, sample_args",
+        [
+            pytest.param("tiny-random-latent-consistency", PROMPT),
+        ],
+        indirect=["convert_model"],
+    )
+    def test_sample_denoising_process(self, convert_model, sample_args, tmp_path):
+        py_script = SAMPLES_PY_DIR / "image_generation" / "denoising_process.py"
+        cpp_sample = SAMPLES_CPP_DIR / "denoising_process"
+
+        py_cwd = tmp_path / "py"
+        cpp_cwd = tmp_path / "cpp"
+        py_cwd.mkdir()
+        cpp_cwd.mkdir()
+
+        run_sample([sys.executable, str(py_script), convert_model, sample_args], cwd=str(py_cwd))
+        run_sample([str(cpp_sample), convert_model, sample_args], cwd=str(cpp_cwd))
+
+        py_video = py_cwd / "denoising_process.avi"
+        cpp_video = cpp_cwd / "denoising_process.avi"
+
+        assert py_video.exists(), f"Python sample did not produce {py_video}"
+        assert cpp_video.exists(), f"C++ sample did not produce {cpp_video}"
+
+        # Both samples write MJPG AVIs via cv::CAP_OPENCV_MJPEG, so the OpenCV-built-in
+        # encoder produces reproducible frames independent of any system FFmpeg/GStreamer.
+        py_frames = _read_video_frames(py_video)
+        cpp_frames = _read_video_frames(cpp_video)
+        assert py_frames.shape == EXPECTED_VIDEO_SHAPE, (
+            f"Python AVI shape {py_frames.shape}, expected {EXPECTED_VIDEO_SHAPE}"
+        )
+        assert cpp_frames.shape == EXPECTED_VIDEO_SHAPE, (
+            f"C++ AVI shape {cpp_frames.shape}, expected {EXPECTED_VIDEO_SHAPE}"
+        )
+        assert py_frames.dtype == np.uint8
+        assert cpp_frames.dtype == np.uint8
+        assert np.array_equal(py_frames, cpp_frames), (
+            "Decoded denoising-process video frames produced by the Python and C++ samples are not exactly equal"
+        )

--- a/tests/python_tests/samples/test_taylorseer.py
+++ b/tests/python_tests/samples/test_taylorseer.py
@@ -5,11 +5,10 @@ import pytest
 import sys
 import numpy as np
 from pathlib import Path
-import cv2
 from PIL import Image
 
 from conftest import SAMPLES_PY_DIR, SAMPLES_CPP_DIR
-from test_utils import run_sample
+from test_utils import run_sample, compare_videos
 
 
 def compare_images(image_path1: Path, image_path2: Path) -> bool:
@@ -19,39 +18,6 @@ def compare_images(image_path1: Path, image_path2: Path) -> bool:
         arr2 = np.array(img2)
 
         return arr1.shape == arr2.shape and np.array_equal(arr1, arr2)
-
-
-def compare_videos(video_path1: Path, video_path2: Path) -> bool:
-    """Compare two videos frame by frame for exact match."""
-    cap1 = cv2.VideoCapture(str(video_path1))
-    cap2 = cv2.VideoCapture(str(video_path2))
-
-    if not cap1.isOpened() or not cap2.isOpened():
-        return False
-
-    frame_count1 = int(cap1.get(cv2.CAP_PROP_FRAME_COUNT))
-    frame_count2 = int(cap2.get(cv2.CAP_PROP_FRAME_COUNT))
-
-    if frame_count1 != frame_count2:
-        cap1.release()
-        cap2.release()
-        return False
-
-    try:
-        for _ in range(frame_count1):
-            ret1, frame1 = cap1.read()
-            ret2, frame2 = cap2.read()
-
-            if not ret1 or not ret2:
-                return False
-
-            if frame1.shape != frame2.shape or not np.array_equal(frame1, frame2):
-                return False
-
-        return True
-    finally:
-        cap1.release()
-        cap2.release()
 
 
 class TestTaylorSeerText2Image:

--- a/tests/python_tests/samples/test_utils.py
+++ b/tests/python_tests/samples/test_utils.py
@@ -4,6 +4,10 @@ from conftest import logger
 import os
 import subprocess # nosec B404
 import time
+from pathlib import Path
+
+import cv2
+import numpy as np
 
 PA_FALLBACK_WARNING = (
     "[WARNING] Paged Attention backend initialization failed. Falling back to SDPA backend. "
@@ -15,6 +19,33 @@ def normalize_sample_output(output: str) -> str:
     if PA_FALLBACK_WARNING not in output:
         return output
     return output.replace(PA_FALLBACK_WARNING, "").strip()
+
+
+def compare_videos(video_path1: Path, video_path2: Path) -> bool:
+    """Compare two videos frame by frame for exact match."""
+    cap1 = cv2.VideoCapture(str(video_path1))
+    cap2 = cv2.VideoCapture(str(video_path2))
+
+    try:
+        if not cap1.isOpened() or not cap2.isOpened():
+            return False
+
+        while True:
+            ret1, frame1 = cap1.read()
+            ret2, frame2 = cap2.read()
+
+            if not ret1 and not ret2:
+                return True
+
+            if ret1 != ret2:
+                return False
+
+            if frame1.shape != frame2.shape or not np.array_equal(frame1, frame2):
+                return False
+    finally:
+        cap1.release()
+        cap2.release()
+
 
 def run_sample(
     command: list[str],


### PR DESCRIPTION
 ## Description

  Adds two new `denoising_process` samples under
  `samples/{cpp,python}/image_generation/` that visualize the
  text-to-image denoising trajectory as a video. Each sample captures
   the latent at every step from the `Text2ImagePipeline` generation
  callback, decodes it via `Text2ImagePipeline::decode(latent)`, and
  writes the per-step decoded frames as an MJPG AVI using the
  existing `save_video` helper. The last frame approximates the final
   generated image.


  ## Changes

  - **C++ sample**
  `samples/cpp/image_generation/denoising_process.cpp`: built from
  `text2image.cpp`; same hardcoded `num_inference_steps=20`,
  `width=512`, `height=512` as `text2image.cpp`; `rng_seed=42` for
  reproducibility; the existing `progress_bar` callback is retained
  for progress reporting; `pipe.decode(latent)` is invoked inside the
   callback to accumulate per-step decoded frames;
  `denoising_process.avi` is emitted via the existing `save_video`
  helper from `samples/cpp/video_generation/`.
  - **Python sample**
  `samples/python/image_generation/denoising_process.py`: mirrors the
   C++ sample's structure and parameters; reuses the existing
  `video_utils.save_video` helper from
  `samples/python/video_generation/` via a `sys.path` insert.
  - **Shared `save_video` helpers** 
  (`samples/cpp/video_generation/imwrite_video.cpp`, 
  `samples/python/video_generation/video_utils.py`): now pass 
  `cv::CAP_OPENCV_MJPEG` / `cv2.CAP_OPENCV_MJPEG` to 
  `cv::VideoWriter` explicitly, so the C++ and Python sides request 
  OpenCV's MJPEG backend explicitly rather than depending on
  whichever MJPEG backend OpenCV auto-selects per language and per
  build.
  - **README updates** in 
  `samples/{cpp,python}/image_generation/README.md` describing the 
  new sample and its output.
  - **New test** 
  `tests/python_tests/samples/test_denoising_process.py`: runs both 
  samples with `tiny-random-latent-consistency` at the sample's 
  hardcoded settings, decodes the produced `.avi` files via 
  `cv2.VideoCapture`, and asserts the decoded frame arrays are 
  exactly equal via `np.array_equal`.
  - **CI plumbing**: new `tiny_random_latent_consistency` marker in 
  `tests/python_tests/pytest.ini`; new sample-tests matrix row of the
   same name in `.github/workflows/linux.yml` and 
  `.github/workflows/windows.yml` gated on 
  `affected_components.Image_generation_samples.test`; new entry for 
  `test_denoising_process.py` under the Image generation samples
  category in `.github/labeler.yml`.

  ## Model choice for the test

  The test uses `tiny-random-latent-consistency`, following the 
  precedent set by `tests/python_tests/samples/test_taylorseer.py`, 
  which uses `tiny-random-flux` and `stable-diffusion-3-tiny-random` 
  for exact Python-vs-C++ image and video equality assertions. The 
  fixture is already declared in both 
  `tests/python_tests/conftest.py` and
  `tests/python_tests/samples/conftest.py`. The marker and CI matrix
  row mirror the existing `dreamlike_anime_1_0` and
  `LCM_Dreamshaper_v7_int8_ov` sample-test rows.

  ## Validation

  - [x] Sample built via the in-repo 
  `samples/cpp/image_generation/CMakeLists.txt`.
  - [x] Python sample standalone run emits `Step 1/20` … `Step 20/20`
   and writes `denoising_process.avi`.
  - [x] C++ sample standalone run advances `Generation step 1 / 20` …
   `20 / 20` via `indicators` and writes `denoising_process.avi`.
  - [x] Targeted pytest on `tiny-random-latent-consistency`: `1 
  passed in 204.33s (0:03:24)`, exact decoded-frame equality between 
  the Python- and C++-produced AVIs.
  - [x] Visual smoke on a real model (`LCM_Dreamshaper_v7-int8-ov`) at the finalized sample defaults (`num_inference_steps=20`, `512×512`, `rng_seed=42`): both Python and C++ samples completed; each emitted 20/20 callback/progress steps; each produced a 20-frame `(20, 512, 512, 3)` `uint8` AVI with a nonzero final frame and a plausible denoising trajectory; `np.array_equal(py_frames, cpp_frames) == True` on the decoded frames.
  - [x] `pre-commit run --from-ref origin/master --to-ref HEAD` and 
  `pre-commit run --files <all 11 changed files>` both pass.
  - [x] `git diff --check` clean.
  - [ ] Linux + Windows CI green on the new 
  `tiny_random_latent_consistency` matrix row.

  ## Notes

  - JS sample for `denoising_process` is intentionally out of scope 
  per the task spec ("two samples in total — C++ and Python"). 
  Existing `samples/js/image_generation/text2image.js` is unchanged.
  - macOS CI does not currently include an image-generation 
  sample-tests matrix row (`mac.yml` covers LLM, Whisper, Rag, Speech
   generation only). This PR preserves that convention.

  ## Checklist

  - [x] This PR follows [GenAI Contributing 
  guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=c
  ontributing-ov-file#contributing).
  - [x] Tests have been updated or added to cover the new code.
  - [x] This PR fully addresses the requested sample task.
  - [x] I have made corresponding changes to the documentation.