### PR TITLE
[wwb] Defer annotation eval in custom_code visual-text models

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -387,6 +387,35 @@ def load_visual_text_genai_pipeline(model_dir, device="CPU", ov_config=None, **k
     )
 
 
+def _defer_annotations_in_custom_code(model_id):
+    """Prepend ``from __future__ import annotations`` to .py files in a
+    custom_code model snapshot directory.
+
+    Some Hub repos that ship custom modeling code use type annotations
+    referring to symbols (``List``, ``Optional``, etc.) without the
+    matching ``typing`` import. Without PEP 563, those annotations are
+    evaluated at module import time and break the ``AutoModel`` /
+    dynamic-module fallback path. Prepending the future import defers
+    annotation evaluation to lazy ``typing.get_type_hints()`` calls,
+    which transformers does not perform during model load. Idempotent.
+    """
+    snapshot_dir = Path(model_id)
+    if not snapshot_dir.is_dir():
+        return
+    marker = "from __future__ import annotations"
+    for py_path in snapshot_dir.glob("*.py"):
+        try:
+            text = py_path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if marker in text.splitlines()[:5]:
+            continue
+        try:
+            py_path.write_text(f"{marker}\n{text}")
+        except OSError:
+            pass
+
+
 def load_visual_text_model(
     model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False, **kwargs
 ):
@@ -399,6 +428,13 @@ def load_visual_text_model(
         except Exception:
             config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
             trust_remote_code = True
+
+        # Defer annotation evaluation in custom_code modules to tolerate
+        # third-party modeling files with missing typing imports
+        # (e.g. openbmb/MiniCPM-V-2_6 resampler.py uses ``List[Tensor]``
+        # without ``from typing import List``).
+        if trust_remote_code:
+            _defer_annotations_in_custom_code(model_id)
 
         # force downloading to .cache image_processing file, as it is not happened by default
         if config.model_type.lower() in ["minicpmo"]:


### PR DESCRIPTION
## Summary

- `load_visual_text_model` (`use_hf=True`) prepends `from __future__ import annotations` to every `.py` in a `trust_remote_code=True` snapshot before `from_pretrained`.
- Tolerates third-party modeling code that uses bare typing names (`List`, `Optional`, ...) without the matching import.

## Why

`openbmb/MiniCPM-V-2_6` cannot be loaded today: its `MiniCPMVConfig` is not in any `MODEL_FOR_VISION_2_SEQ_MAPPING` / `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING`, so wwb falls back to `AutoModel.from_pretrained(..., trust_remote_code=True)`. That triggers `modeling_minicpmv.py -> from .resampler import Resampler -> resampler.py:682`, where the function annotation `-> List[Tensor]:` is evaluated at module load. `resampler.py` never does `from typing import List`, so import dies with:

```
NameError: name 'List' is not defined
```

The bug is upstream in the model repo (frozen Feb 2025) and identical regardless of transformers version.

PEP 563 makes annotations strings, deferred to lazy `typing.get_type_hints()` calls — which transformers does not perform during model load. Idempotent injection; no behavior change for correctly annotated models.

## Test plan

- [ ] Run wwb against `openbmb/MiniCPM-V-2_6` with `--hf --model-type visual-text`; confirm GT generation succeeds.
- [ ] Re-run an existing visual-text model (e.g. `MiniCPM-o-2_6`, `Phi-3.5-vision`) to confirm no regression on already-passing models.
- [ ] Verify second invocation does not double-prepend the future import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)