### PR TITLE
Deprecated `start_chat()` / `finish_chat()` API in VLM and CB pipelines

### DIFF
--- a/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
@@ -346,12 +346,22 @@ public:
     /**
     * @brief start chat with keeping history in kv cache.
     * @param system_message optional system message.
+    * @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    * Please, use generate() with ChatHistory argument.
     */
+    OPENVINO_DEPRECATED(
+        "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+        "Please, use generate() with ChatHistory argument.")
     void start_chat(const std::string& system_message = {});
 
     /**
     * @brief finish chat and clear kv cache.
+    * @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    * Please, use generate() with ChatHistory argument.
     */
+    OPENVINO_DEPRECATED(
+        "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+        "Please, use generate() with ChatHistory argument.")
     void finish_chat();
 };
 

--- a/src/cpp/include/openvino/genai/llm_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/llm_pipeline.hpp
@@ -332,8 +332,9 @@ public:
     * @brief start chat with keeping history in kv cache.
     * Turns on keeping KV cache between generate calls.
     * In case if beam search is used, KV cache is kept for the generated sequence with maximal scores.
-    *
     * @param system_message optional system message.
+    * @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    * Please, use generate() with ChatHistory argument.
     */
     OPENVINO_DEPRECATED(
         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
@@ -343,6 +344,8 @@ public:
     /**
     * @brief finish chat and clear kv cache.
     * Turns off keeping KV cache between generate calls.
+    * @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    * Please, use generate() with ChatHistory argument.
     */
     OPENVINO_DEPRECATED(
         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "

--- a/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
@@ -263,9 +263,19 @@ public:
     /// @param system_message Some chat_templates contain system role
     /// in addition to user and assistant roles. Set a message for that
     /// role.
+    /// @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    /// Please, use generate() with ChatHistory argument.
+    OPENVINO_DEPRECATED(
+        "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+        "Please, use generate() with ChatHistory argument.")
     void start_chat(const std::string& system_message="");
 
     /// @brief Deactivate chat mode.
+    /// @deprecated start_chat() / finish_chat() API is deprecated and will be removed in the next major release.
+    /// Please, use generate() with ChatHistory argument.
+    OPENVINO_DEPRECATED(
+        "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+        "Please, use generate() with ChatHistory argument.")
     void finish_chat();
 
     /// @brief Set a custom chat template. Can be used to deactivate

--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -574,10 +574,14 @@ std::vector<VLMDecodedResults> ContinuousBatchingPipeline::generate(
 }
 
 void ContinuousBatchingPipeline::start_chat(const std::string& system_message) {
+    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+               "Please, use generate() with ChatHistory argument.");
     m_impl->finish_chat();
     m_impl->start_chat(system_message);
 }
 
 void ContinuousBatchingPipeline::finish_chat() {
+    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+               "Please, use generate() with ChatHistory argument.");
     m_impl->finish_chat();
 }

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -1009,11 +1009,15 @@ VLMDecodedResults VLMPipeline::generate(
 }
 
 void VLMPipeline::start_chat(const std::string& system_message) {
+    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+               "Please, use generate() with ChatHistory argument.");
     m_pimpl->finish_chat();
     m_pimpl->start_chat(system_message);
 }
 
 void VLMPipeline::finish_chat() {
+    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+               "Please, use generate() with ChatHistory argument.");
     m_pimpl->finish_chat();
 }
 

--- a/src/js/lib/pipelines/llmPipeline.ts
+++ b/src/js/lib/pipelines/llmPipeline.ts
@@ -53,7 +53,8 @@ export class LLMPipeline {
    * Start a chat session with an optional system message.
    * @param systemMessage - Optional system message to initialize chat context.
    * @returns Resolves when chat session is started.
-   * @deprecated startChat is deprecated and will be removed in future releases. Please, use generate() with ChatHistory argument.
+   * @deprecated startChat() / finishChat() API is deprecated and will be removed in the next major release.
+   * Please, use generate() with ChatHistory argument.
    */
   async startChat(systemMessage: string = "") {
     console.warn(
@@ -71,7 +72,8 @@ export class LLMPipeline {
   /**
    * Finish the current chat session and clear chat-related state.
    * @returns Resolves when chat session is finished.
-   * @deprecated finishChat is deprecated and will be removed in future releases. Please, use generate() with ChatHistory argument.
+   * @deprecated startChat() / finishChat() API is deprecated and will be removed in the next major release.
+   * Please, use generate() with ChatHistory argument.
    */
   async finishChat() {
     console.warn(

--- a/src/js/lib/pipelines/vlmPipeline.ts
+++ b/src/js/lib/pipelines/vlmPipeline.ts
@@ -63,8 +63,14 @@ export class VLMPipeline {
    * Start a chat session with an optional system message.
    * @param systemMessage - Optional system message to initialize chat context.
    * @returns Resolves when chat session is started.
+   * @deprecated startChat() / finishChat() API is deprecated and will be removed in the next major release.
+   * Please, use generate() with ChatHistory argument.
    */
   async startChat(systemMessage: string = "") {
+    console.warn(
+      "DEPRECATION WARNING: startChat() / finishChat() API is deprecated and will be removed in the next major release.",
+      "Please, use generate() with ChatHistory argument.",
+    );
     if (!this.pipeline) throw new Error("Pipeline is not initialized");
 
     const startChatPromise = util.promisify(this.pipeline.startChat.bind(this.pipeline));
@@ -75,8 +81,14 @@ export class VLMPipeline {
   /**
    * Finish the current chat session and clear chat-related state.
    * @returns Resolves when chat session is finished.
+   * @deprecated startChat() / finishChat() API is deprecated and will be removed in the next major release.
+   * Please, use generate() with ChatHistory argument.
    */
   async finishChat() {
+    console.warn(
+      "DEPRECATION WARNING: startChat() / finishChat() API is deprecated and will be removed in the next major release.",
+      "Please, use generate() with ChatHistory argument.",
+    );
     if (!this.pipeline) throw new Error("Pipeline is not initialized");
 
     const finishChatPromise = util.promisify(this.pipeline.finishChat.bind(this.pipeline));

--- a/src/python/py_continuous_batching_pipeline.cpp
+++ b/src/python/py_continuous_batching_pipeline.cpp
@@ -564,8 +564,20 @@ void init_continuous_batching_pipeline(py::module_& m) {
         .def("step", &ContinuousBatchingPipeline::step)
         .def("has_non_finished_requests", &ContinuousBatchingPipeline::has_non_finished_requests)
 
-        .def("start_chat", &ContinuousBatchingPipeline::start_chat, py::arg("system_message") = "")
-        .def("finish_chat", &ContinuousBatchingPipeline::finish_chat)
+        .def("start_chat", [](ContinuousBatchingPipeline& pipe, const std::string& system_message) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+                         "Please use generate() with ChatHistory argument.",
+                         1);
+            pipe.start_chat(system_message);
+        }, py::arg("system_message") = "")
+        .def("finish_chat", [](ContinuousBatchingPipeline& pipe) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+                         "Please use generate() with ChatHistory argument.",
+                         1);
+            pipe.finish_chat();
+        })
 
         .def(
             "generate",

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -271,8 +271,20 @@ void init_vlm_pipeline(py::module_& m) {
             kwargs: Device properties
         )")
 
-        .def("start_chat", &ov::genai::VLMPipeline::start_chat, py::arg("system_message") = "")
-        .def("finish_chat", &ov::genai::VLMPipeline::finish_chat)
+        .def("start_chat", [](ov::genai::VLMPipeline& pipe, const std::string& system_message) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+                         "Please use generate() with ChatHistory argument.",
+                         1);
+            pipe.start_chat(system_message);
+        }, py::arg("system_message") = "")
+        .def("finish_chat", [](ov::genai::VLMPipeline& pipe) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
+                         "Please use generate() with ChatHistory argument.",
+                         1);
+            pipe.finish_chat();
+        })
         .def("set_chat_template", &ov::genai::VLMPipeline::set_chat_template, py::arg("chat_template"))
         .def("get_tokenizer", &ov::genai::VLMPipeline::get_tokenizer)
         .def("get_generation_config", &ov::genai::VLMPipeline::get_generation_config, py::return_value_policy::copy)


### PR DESCRIPTION
## Description
This PR deprecates `start_chat()` / `finish_chat()` API in favor of `generate()` with `ChatHistory` in VLM and Continuous Batching pipelines and updates Python and JS bindings.

CVS-170885

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code - **N/A**.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**, docs already include deprecation message.
