### PR TITLE
[WWB] Create gt and output folders if they don't exist

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_image.py
+++ b/tools/who_what_benchmark/tests/test_cli_image.py
@@ -138,6 +138,8 @@ def test_image_model_genai(model_id, model_type, tmp_path):
             "2",
             "--taylorseer-config",
             '{"disable_cache_after_step": 0}',
+            "--output",
+            tmp_path,
         ]
     )
 

--- a/tools/who_what_benchmark/whowhatbench/registry.py
+++ b/tools/who_what_benchmark/whowhatbench/registry.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 
 # Registry for evaluators
@@ -45,7 +46,9 @@ class Evaluator(ABC):
 
 class BaseEvaluator(Evaluator):
     def dump_gt(self, csv_name: str):
+        Path(csv_name).parent.mkdir(parents=True, exist_ok=True)
         self.gt_data.to_csv(csv_name)
 
     def dump_predictions(self, csv_name: str):
+        Path(csv_name).parent.mkdir(parents=True, exist_ok=True)
         self.predictions.to_csv(csv_name)

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -392,11 +392,8 @@ def check_args(args):
         raise ValueError(f"Speaker embedding file does not exist: {args.speaker_embeddings}")
     if args.gt_data is not None and os.path.isdir(args.gt_data):
         raise ValueError(f"--gt-data must be a file path, not a directory: '{args.gt_data}'")
-    if args.output is not None:
-        if os.path.isfile(args.output):
-            raise ValueError(f"--output must be a directory path, not a file: '{args.output}'")
-        if os.path.splitext(args.output)[1]:
-            raise ValueError(f"--output must be a directory path, not a file: '{args.output}'")
+    if args.output is not None and os.path.isfile(args.output):
+        raise ValueError(f"--output must be a directory path, not a file: '{args.output}'")
 
 
 def load_prompts(args):

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -146,8 +146,8 @@ def parse_args():
     parser.add_argument(
         "--output",
         type=str,
-        default=None,
-        help="Directory name for saving the per sample comparison and metrics in CSV files.",
+        default="wwb_output",
+        help="Directory name for saving the per sample comparison and metrics in CSV files. Defaults to 'wwb_output'.",
     )
     parser.add_argument(
         "--num-samples",

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -390,6 +390,13 @@ def check_args(args):
         raise ValueError("'empty_adapters' mode is not supported for HF Transformers.")
     if args.speaker_embeddings is not None and not os.path.exists(args.speaker_embeddings):
         raise ValueError(f"Speaker embedding file does not exist: {args.speaker_embeddings}")
+    if args.gt_data is not None and os.path.isdir(args.gt_data):
+        raise ValueError(f"--gt-data must be a file path, not a directory: '{args.gt_data}'")
+    if args.output is not None:
+        if os.path.isfile(args.output):
+            raise ValueError(f"--output must be a directory path, not a file: '{args.output}'")
+        if os.path.splitext(args.output)[1]:
+            raise ValueError(f"--output must be a directory path, not a file: '{args.output}'")
 
 
 def load_prompts(args):
@@ -1240,8 +1247,7 @@ def main():
             logger.info(all_metrics)
 
         if args.output:
-            if not os.path.exists(args.output):
-                os.mkdir(args.output)
+            os.makedirs(args.output, exist_ok=True)
             df = pd.DataFrame(all_metrics_per_question)
             df.to_csv(os.path.join(args.output, "metrics_per_question.csv"))
             df = pd.DataFrame(all_metrics)


### PR DESCRIPTION
## Description
Currently, wwb.py would fail to write ground truth data for evaluation if the directory provided to `--gt-data` does not exist. This may be a frustrating result to see after waiting for the model to generate reference results which may take significant amount of time for large models. The same goes for `--output` which writes resulting measurements into the provided folder and may fail if the folder doesn't exist.

Fix this by:
1) Checking if values to these parameters make sense (a file for `--gt-data` and folder a directory path to `--output`)
2) Implicitly creating directories on writing the results if they don't exist

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
