### PR TITLE
Remove deprecation prints from C++

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -574,14 +574,10 @@ std::vector<VLMDecodedResults> ContinuousBatchingPipeline::generate(
 }
 
 void ContinuousBatchingPipeline::start_chat(const std::string& system_message) {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_impl->finish_chat();
     m_impl->start_chat(system_message);
 }
 
 void ContinuousBatchingPipeline::finish_chat() {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_impl->finish_chat();
 }

--- a/src/cpp/src/llm/pipeline.cpp
+++ b/src/cpp/src/llm/pipeline.cpp
@@ -411,14 +411,10 @@ ov::genai::Tokenizer ov::genai::LLMPipeline::get_tokenizer() {
 }
 
 void ov::genai::LLMPipeline::start_chat(const std::string& system_message) {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_pimpl->start_chat(system_message);
 }
 
 void ov::genai::LLMPipeline::finish_chat() {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_pimpl->finish_chat();
 }
 

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -1009,15 +1009,11 @@ VLMDecodedResults VLMPipeline::generate(
 }
 
 void VLMPipeline::start_chat(const std::string& system_message) {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_pimpl->finish_chat();
     m_pimpl->start_chat(system_message);
 }
 
 void VLMPipeline::finish_chat() {
-    GENAI_WARN("start_chat() / finish_chat() API is deprecated and will be removed in the next major release. "
-               "Please, use generate() with ChatHistory argument.");
     m_pimpl->finish_chat();
 }
 


### PR DESCRIPTION
## Description
This PR removes `GENAI_WARN` prints with `start_chat()` / `finish_chat()` API deprecation from C++ sources.
This is a follow up for #3889 .

CVS-170885

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code - **N/A**.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**, docs already include deprecation message.
