### PR TITLE
Skip Mac GGUF tests

### DIFF
--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -122,7 +122,7 @@ def test_pipelines_with_gguf_generate(
     ids=["regular_prompt", "only_special_tokens", "multiple_special_tokens", "special_tokens_with_text"],
 )
 @pytest.mark.parametrize("model_gguf", GGUF_MODEL_LIST, indirect=True)
-@pytest.mark.skipif(sys.platform == "darwin", reason="CVS-168882: Sporadic segmentation fault failure and hanging")
+@pytest.mark.skipif(sys.platform == "darwin", reason="CVS-168882: sporadic segmentation fault")
 @pytest.mark.skipif(sys.platform == "win32", reason="CVS-174065")
 @pytest.mark.xfail(sys.platform == "linux", reason="CVS-179725")
 def test_full_gguf_pipeline(
@@ -196,7 +196,7 @@ def test_full_gguf_pipeline(
         }
     ]
 )
-@pytest.mark.xfail(condition=(sys.platform == "darwin"), reason="Ticket - 172335")
+@pytest.mark.skipif(sys.platform == "darwin", reason="CVS-172335, hangs")
 @pytest.mark.skipif(sys.platform == "win32", reason="CVS-174065")
 def test_full_gguf_qwen3_pipeline(pipeline_type, model_ids):
     # Temporal testing solution until transformers starts to support qwen3 in GGUF format

--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -122,6 +122,7 @@ def test_pipelines_with_gguf_generate(
     ids=["regular_prompt", "only_special_tokens", "multiple_special_tokens", "special_tokens_with_text"],
 )
 @pytest.mark.parametrize("model_gguf", GGUF_MODEL_LIST, indirect=True)
+@pytest.mark.skipif(sys.platform == "darwin", reason="CVS-168882: Sporadic segmentation fault failure and hanging")
 @pytest.mark.skipif(sys.platform == "win32", reason="CVS-174065")
 @pytest.mark.xfail(sys.platform == "linux", reason="CVS-179725")
 def test_full_gguf_pipeline(
@@ -130,8 +131,6 @@ def test_full_gguf_pipeline(
     enable_save_ov_model: bool,
     prompt: str,
 ):
-    if sys.platform == 'darwin':
-        pytest.skip(reason="168882: Sporadic segmentation fault failure on MacOS.")
     gguf_model_id = model_gguf.gguf_model_id
     gguf_full_path = model_gguf.gguf_full_path
     opt_model = model_gguf.opt_model


### PR DESCRIPTION
## Description
1. Move a macOS-specific skip from runtime (pytest.skip inside the test body) to collection-time (@pytest.mark.skipif) for the GGUF full pipeline test.
2. `xfail()` -> `skipif()` to prevent hanging

Note, all GGUF Mac tests are skipped now

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
N/A Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
N/A This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
N/A I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
