### PR TITLE
[wwb] make long prompt by default

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_text.py
+++ b/tools/who_what_benchmark/tests/test_cli_text.py
@@ -58,59 +58,68 @@ target_model_path = convert_text_model(model_id, "opt125m_int8", _convert_int8)
 
 @pytest.mark.skipif((sys.platform == "darwin"), reason='173169')
 def test_text_target_model():
-    run_wwb([
-        "--base-model",
-        base_model_path,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--model-type",
-        "text",
-    ])
+    run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--model-type",
+            "text",
+            "--short-prompt",
+        ]
+    )
 
 
 @pytest.fixture
 def test_text_gt_data(tmp_path):
     temp_file_name = tmp_path / "gt.csv"
-    run_wwb([
-        "--base-model",
-        base_model_path,
-        "--gt-data",
-        temp_file_name,
-        "--dataset",
-        "EleutherAI/lambada_openai,en",
-        "--dataset-field",
-        "text",
-        "--split",
-        "test",
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-    ])
+    run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--gt-data",
+            temp_file_name,
+            "--dataset",
+            "EleutherAI/lambada_openai,en",
+            "--dataset-field",
+            "text",
+            "--split",
+            "test",
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--short-prompt",
+        ]
+    )
     data = pd.read_csv(temp_file_name)
     assert len(data["questions"].values) == 2
 
 
 def test_text_output_directory(tmp_path):
     temp_file_name = tmp_path / "gt.csv"
-    output = run_wwb([
-        "--base-model",
-        base_model_path,
-        "--gt-data",
-        temp_file_name,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--output",
-        tmp_path,
-    ])
+    output = run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--gt-data",
+            temp_file_name,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--output",
+            tmp_path,
+            "--short-prompt",
+        ]
+    )
     assert "Metrics for model" in output
     assert (tmp_path / "metrics_per_question.csv").exists()
     assert (tmp_path / "metrics.csv").exists()
@@ -130,17 +139,20 @@ def test_text_output_directory(tmp_path):
 
 
 def test_text_verbose():
-    output = run_wwb([
-        "--base-model",
-        base_model_path,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--verbose",
-    ])
+    output = run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--short-prompt",
+            "--verbose",
+        ]
+    )
     assert "## Diff:" in output
 
 
@@ -184,17 +196,20 @@ def test_text_hf_model(model_id, tmp_path):
 
 
 def test_text_genai_model():
-    output = run_wwb([
-        "--base-model",
-        base_model_path,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--genai",
-    ])
+    output = run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--genai",
+            "--short-prompt",
+        ]
+    )
     assert "Metrics for model" in output
     assert "## Reference text" not in output
 
@@ -226,21 +241,24 @@ def test_text_genai_cb_model(tmp_path):
         }
         json.dump(config, f)
 
-    output = run_wwb([
-        "--base-model",
-        base_model_path,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--genai",
-        "--cb-config",
-        config_path,
-        "--ov-config",
-        ov_config_path
-    ])
+    output = run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--genai",
+            "--cb-config",
+            config_path,
+            "--ov-config",
+            ov_config_path,
+            "--short-prompt",
+        ]
+    )
     assert "Metrics for model" in output
     assert "## Reference text" not in output
     assert "INFO:whowhatbench.model_loaders:OpenVINO Config: {'KV_CACHE_PRECISION': 'f16', 'ATTENTION_BACKEND': 'PA'}" in output
@@ -255,21 +273,24 @@ def test_text_genai_json_string_config():
     cb_json_string = "{\"max_num_batched_tokens\": 4096}"
     ov_json_string = "{\"KV_CACHE_PRECISION\":\"f16\", \"ATTENTION_BACKEND\": \"PA\"}"
 
-    output = run_wwb([
-        "--base-model",
-        base_model_path,
-        "--target-model",
-        target_model_path,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--genai",
-        "--cb-config",
-        cb_json_string,
-        "--ov-config",
-        ov_json_string
-    ])
+    output = run_wwb(
+        [
+            "--base-model",
+            base_model_path,
+            "--target-model",
+            target_model_path,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--genai",
+            "--cb-config",
+            cb_json_string,
+            "--short-prompt",
+            "--ov-config",
+            ov_json_string,
+        ]
+    )
 
     # Test with WWB log info to make sure the configurations are passed from strings to the GenAI APIs
     assert "INFO:whowhatbench.wwb:cb_config: {'max_num_batched_tokens': 4096}" in output

--- a/tools/who_what_benchmark/tests/test_cli_text.py
+++ b/tools/who_what_benchmark/tests/test_cli_text.py
@@ -157,19 +157,21 @@ def test_text_verbose():
 
 def test_text_language(tmp_path):
     temp_file_name = tmp_path / "gt.csv"
-    run_wwb([
-        "--base-model",
-        "Qwen/Qwen2-0.5B",
-        "--gt-data",
-        temp_file_name,
-        "--num-samples",
-        "2",
-        "--device",
-        "CPU",
-        "--language",
-        "cn",
-        "--short-prompt",
-    ])
+    run_wwb(
+        [
+            "--base-model",
+            "Qwen/Qwen2-0.5B",
+            "--gt-data",
+            temp_file_name,
+            "--num-samples",
+            "2",
+            "--device",
+            "CPU",
+            "--language",
+            "cn",
+            "--short-prompt",
+        ]
+    )
     data = pd.read_csv(temp_file_name)
     assert "马克" in data["prompts"].values[0]
 
@@ -180,18 +182,20 @@ def test_text_language(tmp_path):
 )
 def test_text_hf_model(model_id, tmp_path):
     temp_file_name = tmp_path / "gt.csv"
-    run_wwb([
-        "--base-model",
-        model_id,
-        "--gt-data",
-        temp_file_name,
-        "--num-samples",
-        "1",
-        "--device",
-        "CPU",
-        "--short-prompt",
-        "--hf",
-    ])
+    run_wwb(
+        [
+            "--base-model",
+            model_id,
+            "--gt-data",
+            temp_file_name,
+            "--num-samples",
+            "1",
+            "--device",
+            "CPU",
+            "--short-prompt",
+            "--hf",
+        ]
+    )
     data = pd.read_csv(temp_file_name)
     assert len(data["prompts"].values) == 1
 

--- a/tools/who_what_benchmark/tests/test_cli_text.py
+++ b/tools/who_what_benchmark/tests/test_cli_text.py
@@ -94,7 +94,6 @@ def test_text_gt_data(tmp_path):
             "2",
             "--device",
             "CPU",
-            "--short-prompt",
         ]
     )
     data = pd.read_csv(temp_file_name)
@@ -169,6 +168,7 @@ def test_text_language(tmp_path):
         "CPU",
         "--language",
         "cn",
+        "--short-prompt",
     ])
     data = pd.read_csv(temp_file_name)
     assert "马克" in data["prompts"].values[0]
@@ -189,6 +189,7 @@ def test_text_hf_model(model_id, tmp_path):
         "1",
         "--device",
         "CPU",
+        "--short-prompt",
         "--hf",
     ])
     data = pd.read_csv(temp_file_name)

--- a/tools/who_what_benchmark/whowhatbench/text_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/text_evaluator.py
@@ -38,7 +38,7 @@ class TextEvaluator(BaseEvaluator):
         generation_config_base=None,
         seqs_per_request=None,
         use_chat_template=None,
-        long_prompt=False,
+        long_prompt=True,
         empty_adapters=False,
         num_assistant_tokens=0,
         assistant_confidence_threshold=0.0

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -53,6 +53,8 @@ def parse_args():
         description="This script generates answers for questions from csv file",
     )
 
+    text_def_dataset_group = parser.add_mutually_exclusive_group()
+
     parser.add_argument(
         "--base-model",
         default=None,
@@ -248,10 +250,16 @@ def parse_args():
         default=None,
         help="Weights for LoRA adapters.",
     )
-    parser.add_argument(
+    text_def_dataset_group.add_argument(
         "--long-prompt",
         action='store_true',
-        help="LLMPipeline specific parameter that defines the use of a long context prompt.",
+        help="LLMPipeline specific parameter that defines the use of a long context prompt. "
+        "Deprecated. Kept for backward compatibility, long prompt is not used by default.",
+    )
+    text_def_dataset_group.add_argument(
+        "--short-prompt",
+        action="store_true",
+        help="LLMPipeline specific parameter that defines the use of a short context prompt.",
     )
     parser.add_argument(
         "--empty_adapters",
@@ -814,7 +822,7 @@ def create_evaluator(base_model, args):
                 language=args.language,
                 gen_answer_fn=gen_answer_fn,
                 use_chat_template=use_chat_template,
-                long_prompt=args.long_prompt,
+                long_prompt=(not args.short_prompt),
                 num_assistant_tokens=(
                     int(args.num_assistant_tokens)
                     if args.num_assistant_tokens is not None else 0

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -254,7 +254,7 @@ def parse_args():
         "--long-prompt",
         action='store_true',
         help="LLMPipeline specific parameter that defines the use of a long context prompt. "
-        "Deprecated. Kept for backward compatibility, long prompt is not used by default.",
+        "Deprecated. Kept for backward compatibility, long prompts are used by default.",
     )
     text_def_dataset_group.add_argument(
         "--short-prompt",


### PR DESCRIPTION
## Description
long prompts are defaults for validation now. Move default prompts in wwb to long, --long-prompt has left for backward compatibility, --short-prompt option is introduced for using short prompts.

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
