### PR TITLE
Replace `skipif()` back with `xfail()`

### DIFF
--- a/tests/python_tests/test_gguf_reader.py
+++ b/tests/python_tests/test_gguf_reader.py
@@ -196,7 +196,7 @@ def test_full_gguf_pipeline(
         }
     ]
 )
-@pytest.mark.skipif(sys.platform == "darwin", reason="CVS-172335, hangs")
+@pytest.mark.xfail(sys.platform == "darwin", reason="CVS-172335")
 @pytest.mark.skipif(sys.platform == "win32", reason="CVS-174065")
 def test_full_gguf_qwen3_pipeline(pipeline_type, model_ids):
     # Temporal testing solution until transformers starts to support qwen3 in GGUF format


### PR DESCRIPTION
## Description
Adjust the macOS handling for the Qwen3 GGUF pipeline Python test by changing a skipif marker to an xfail, so the test is executed on Darwin but treated as an expected failure.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
N/A Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
N/A This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
N/A I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
