### PR TITLE
[ENH] Optimize LoRA tensor lookup by pre-filtering in constructor

### DIFF
--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -254,7 +254,20 @@ struct LoRAWeightGetterDefault {
     mutable std::set<std::string> used_tensors;
     mutable bool active = false;    // true if operator() was called at least once to filter out the case when this object is temporary object that is not used for tensor queries
 
-    LoRAWeightGetterDefault (const std::map<std::string, TENSOR_TYPE>* lora_tensors, const std::string& prefix) : lora_tensors(lora_tensors), prefix(prefix) {}
+    struct FilteredTensor {
+        std::string original_name;
+        std::string stripped_name;
+        const TENSOR_TYPE* tensor_ptr;
+    };
+    std::vector<FilteredTensor> filtered_tensors;
+
+    LoRAWeightGetterDefault (const std::map<std::string, TENSOR_TYPE>* lora_tensors, const std::string& prefix) : lora_tensors(lora_tensors), prefix(prefix) {
+        for (const auto& pair : *lora_tensors) {
+            if (pair.first.find(prefix) == 0) {
+                filtered_tensors.push_back({pair.first, pair.first.substr(prefix.length()), &pair.second});
+            }
+        }
+    }
 
     std::optional<NODE_TYPE> operator() (const std::string& name) const {
         active = true;
@@ -262,21 +275,17 @@ struct LoRAWeightGetterDefault {
         // TODO: Investigate what is the root cause for this replacement in the name. Customize mapping or change PT FE to produce correct weight names.
         std::replace(name_with_underscores.begin(), name_with_underscores.end(), '.', '_');
         std::vector<std::string> variants{name, name_with_underscores};
-        auto it = std::find_if(lora_tensors->begin(), lora_tensors->end(), [this, variants](const std::pair<std::string, TENSOR_TYPE>& pair) {
-            std::string lora_name = pair.first;
-            // TODO: Make this filtering for prefix once in ctor as a more efficient solution
-            if(lora_name.find(prefix) == 0) {
-                lora_name = lora_name.substr(prefix.length());
-            } else {
-                return false;
-            }
+        auto it = std::find_if(filtered_tensors.begin(), filtered_tensors.end(), [&variants](const FilteredTensor& filtered) {
+            const std::string& lora_name = filtered.stripped_name;
             // TODO: Should it be an exact match instead of substring taking into account that we should provide custom mapper for names?
-            return variants.end() != std::find_if(variants.begin(), variants.end(), [lora_name](const std::string& name) { return name.find(lora_name) != std::string::npos; });
+            return variants.end() != std::find_if(variants.begin(), variants.end(), [&lora_name](const std::string& variant_name) {
+                return variant_name.find(lora_name) != std::string::npos;
+            });
         });
 
-        if(it != lora_tensors->end()) {
-            used_tensors.insert(it->first);
-            return it->second;
+        if(it != filtered_tensors.end()) {
+            used_tensors.insert(it->original_name);
+            return *(it->tensor_ptr);
         }
         return std::nullopt;
     }
@@ -284,11 +293,9 @@ struct LoRAWeightGetterDefault {
     // Return list of LoRA tensors that are dedicated for the model but left unused
     std::list<std::string> get_unused_tensors() const {
         std::list<std::string> unused;
-        for(auto const& tensor: *lora_tensors) {
-            if(tensor.first.find(prefix) == 0) {
-                if(used_tensors.find(tensor.first) == used_tensors.end()) {
-                    unused.push_back(tensor.first);
-                }
+        for(const auto& filtered: filtered_tensors) {
+            if(used_tensors.find(filtered.original_name) == used_tensors.end()) {
+                unused.push_back(filtered.original_name);
             }
         }
         return unused;


### PR DESCRIPTION


<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
This change addresses a TODO comment in `src/cpp/src/lora/adapter.cpp` recommending prefix filtering during object construction.

Instead of performing string matching, `substr` operations, and a full `std::map` scan on every `LoRAWeightGetterDefault::operator()` call, we now filter the tensors in the constructor. We store matching tensors (with their stripped names and stable value pointers) in a `std::vector`, resulting in a faster allocation-free O(k) iteration over only relevant tensors on the hot path. The associated TODO comment was removed.
<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
