### PR TITLE
[EXPERIMENT][WIP] Add WWB support for Qwen3 VL rerankers

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_reranking.py
+++ b/tools/who_what_benchmark/tests/test_cli_reranking.py
@@ -1,21 +1,40 @@
 # Copyright (C) 2023-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import pytest
-import shutil
 import logging
+import os
+import shutil
+import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import MODELS, convert_model, run_wwb
 from test_cli_image import get_similarity
-from conftest import convert_model, run_wwb
+from whowhatbench.reranking_evaluator import is_qwen3_vl
 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+QWEN3_VL_RERANKER_MODEL_ID = "Qwen/Qwen3-VL-Reranker-2B"
+MODELS.setdefault(
+    "Qwen3-VL-Reranker-2B",
+    {
+        "name": QWEN3_VL_RERANKER_MODEL_ID,
+        "convert_args": ["--trust-remote-code", "--task", "image-text-to-text"],
+    },
+)
+
 
 def remove_artifacts(artifacts_path: Path):
     shutil.rmtree(artifacts_path)
+
+
+def test_is_qwen3_vl():
+    assert is_qwen3_vl(SimpleNamespace(model_type="qwen3_vl"))
+    assert not is_qwen3_vl(SimpleNamespace(model_type="qwen3"))
 
 
 @pytest.mark.wwb_rerank
@@ -127,5 +146,65 @@ def test_reranking_optimum(model_id, threshold, tmp_path):
             "--genai",
         ]
     )
+
+    remove_artifacts(outputs_path)
+
+
+@pytest.mark.wwb_rerank
+@pytest.mark.skipif(
+    os.environ.get("RUN_WWB_LARGE_MODELS", "false").lower() != "true",
+    reason="Large Qwen3-VL reranker test is disabled by default",
+)
+@pytest.mark.xfail(sys.platform == "darwin", reason="Hangs. Ticket 175534", run=False)
+@pytest.mark.xfail(sys.platform == "win32", reason="Ticket 178790", run=False)
+def test_reranking_qwen3vl_optimum(tmp_path):
+    gt_file = tmp_path / "gt.csv"
+    model_path = convert_model(QWEN3_VL_RERANKER_MODEL_ID)
+
+    run_wwb(
+        [
+            "--base-model",
+            QWEN3_VL_RERANKER_MODEL_ID,
+            "--num-samples",
+            "1",
+            "--gt-data",
+            gt_file,
+            "--device",
+            "CPU",
+            "--model-type",
+            "text-reranking",
+            "--hf",
+        ]
+    )
+
+    assert gt_file.exists()
+    assert (tmp_path / "reference").exists()
+
+    outputs_path = tmp_path / "optimum"
+    outputs_optimum = run_wwb(
+        [
+            "--target-model",
+            model_path,
+            "--num-samples",
+            "1",
+            "--gt-data",
+            gt_file,
+            "--device",
+            "CPU",
+            "--model-type",
+            "text-reranking",
+            "--output",
+            outputs_path,
+        ]
+    )
+
+    assert (outputs_path / "target").exists()
+    assert (outputs_path / "target.csv").exists()
+    assert (outputs_path / "metrics_per_question.csv").exists()
+    assert (outputs_path / "metrics.csv").exists()
+    assert "Metrics for model" in outputs_optimum
+
+    similarity = get_similarity(outputs_optimum)
+    assert similarity >= 0.97
 
     remove_artifacts(outputs_path)

--- a/tools/who_what_benchmark/whowhatbench/__main__.py
+++ b/tools/who_what_benchmark/whowhatbench/__main__.py
@@ -1,0 +1,5 @@
+from .wwb import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -23,6 +23,7 @@ from .reranking_evaluator import (
     DEFAULT_TOP_K as RERANK_DEFAULT_TOP_K,
     is_qwen3_causallm,
     is_qwen3,
+    is_qwen3_vl,
 )
 from .utils import (
     apply_peft_adapters,
@@ -688,9 +689,18 @@ def load_reranking_model(model_id, device="CPU", ov_config=None, use_hf=False, u
     except Exception:
         config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
 
+    model_path = Path(model_id)
+    has_openvino_artifacts = model_path.exists() and any(model_path.glob("openvino_*.xml"))
+
     if use_hf:
         logger.info("Using HF Transformers API")
-        if is_qwen3_causallm(config):
+        if is_qwen3_vl(config):
+            from transformers import Qwen3VLForConditionalGeneration
+
+            model = Qwen3VLForConditionalGeneration.from_pretrained(
+                model_id, trust_remote_code=True, **PYTORCH_MODEL_DTYPE_KWARG
+            )
+        elif is_qwen3_causallm(config):
             from transformers import AutoModelForCausalLM
 
             model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=True, **PYTORCH_MODEL_DTYPE_KWARG)
@@ -702,31 +712,51 @@ def load_reranking_model(model_id, device="CPU", ov_config=None, use_hf=False, u
             )
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
+        if is_qwen3_vl(config):
+            raise ValueError("Qwen3-VL rerankers are not supported by the OpenVINO GenAI TextRerankPipeline yet.")
         is_qwen3_model = is_qwen3(config)
         model = load_reranking_genai_pipeline(model_id, device, ov_config, is_qwen3_model)
     else:
         logger.info("Using Optimum API")
-        model_cls = None
-        if is_qwen3_causallm(config):
-            from optimum.intel.openvino import OVModelForCausalLM
-            model_cls = OVModelForCausalLM
-        else:
-            from optimum.intel.openvino import OVModelForSequenceClassification
-            model_cls = OVModelForSequenceClassification
+        if is_qwen3_vl(config):
+            if not has_openvino_artifacts:
+                logger.info("Falling back to HF Transformers API for Qwen3-VL reranker reference model")
+                from transformers import Qwen3VLForConditionalGeneration
 
-        try:
-            model = model_cls.from_pretrained(
-                model_id, device=device, ov_config=ov_config, safety_checker=None,
-            )
-        except ValueError:
-            model = model_cls.from_pretrained(
-                model_id,
-                trust_remote_code=True,
-                use_cache=False,
-                device=device,
-                ov_config=ov_config,
-                safety_checker=None
-            )
+                model = Qwen3VLForConditionalGeneration.from_pretrained(
+                    model_id, trust_remote_code=True, **PYTORCH_MODEL_DTYPE_KWARG
+                )
+            else:
+                from optimum.intel.openvino import OVModelForVisualCausalLM
+
+                model = OVModelForVisualCausalLM.from_pretrained(
+                    model_id, device=device, ov_config=ov_config, trust_remote_code=True
+                )
+        else:
+            model_cls = None
+            if is_qwen3_causallm(config):
+                from optimum.intel.openvino import OVModelForCausalLM
+                model_cls = OVModelForCausalLM
+            else:
+                from optimum.intel.openvino import OVModelForSequenceClassification
+                model_cls = OVModelForSequenceClassification
+
+            try:
+                model = model_cls.from_pretrained(
+                    model_id, device=device, ov_config=ov_config, safety_checker=None,
+                )
+            except ValueError:
+                model = model_cls.from_pretrained(
+                    model_id,
+                    trust_remote_code=True,
+                    use_cache=False,
+                    device=device,
+                    ov_config=ov_config,
+                    safety_checker=None
+                )
+
+    if hasattr(model, "eval"):
+        model.eval()
 
     return model
 

--- a/tools/who_what_benchmark/whowhatbench/reranking_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/reranking_evaluator.py
@@ -27,8 +27,16 @@ def is_qwen3(config):
     return config.model_type == "qwen3"
 
 
+def is_qwen3_vl(config):
+    return config.model_type == "qwen3_vl"
+
+
 def is_qwen3_causallm(config):
     return is_qwen3(config) and "Qwen3ForCausalLM" in config.architectures
+
+
+def is_qwen3_generative_reranker(config):
+    return is_qwen3_causallm(config) or is_qwen3_vl(config)
 
 
 def preprocess_fn(example):
@@ -71,7 +79,7 @@ class RerankingEvaluator(BaseEvaluator):
         self.tokenizer = tokenizer
         self.num_samples = num_samples
         self.generation_fn = gen_rerank_fn
-        self.gt_dir = os.path.dirname(gt_data)
+        self.gt_dir = os.path.dirname(gt_data) if gt_data else os.getcwd()
 
         if base_model:
             self.gt_data = self._generate_data(
@@ -129,25 +137,77 @@ class RerankingEvaluator(BaseEvaluator):
         qwen3_passages = [f"<Document>: {doc}{suffix}" for doc in passages]
         return qwen3_query, qwen3_passages
 
+    def _apply_qwen3_vl_template(self, query, passages):
+        task = "Given a web search query, retrieve relevant passages that answer the query"
+        system_prompt = (
+            "Judge whether the Document meets the requirements based on the Query and the Instruct provided. "
+            'Note that the answer can only be "yes" or "no".'
+        )
+
+        return [
+            [
+                {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": f"<Instruct>: {task}"},
+                        {"type": "text", "text": "<Query>:"},
+                        {"type": "text", "text": query},
+                        {"type": "text", "text": "\n<Document>:"},
+                        {"type": "text", "text": passage},
+                    ],
+                },
+            ]
+            for passage in passages
+        ]
+
     def _generate_data(self, model, gen_answer_fn=None, result_dir="reference"):
         def default_gen_answer(model, tokenizer, query, passages):
             # post/pre processing for qwen models added according to transformers Qwen3-Embedding-0.6B model card:
             # https://huggingface.co/Qwen/Qwen3-Reranker-0.6B#transformers-usage
             if is_qwen3(model.config):
                 pairs = [f"{query}{passage}" for passage in passages]
-                input_data = tokenizer(pairs, padding=True, truncation=True, max_length=DEFAULT_MAX_LENGTH_QWEN, return_tensors="pt", padding_side="left")
+                input_data = tokenizer(
+                    pairs,
+                    padding=True,
+                    truncation=True,
+                    max_length=DEFAULT_MAX_LENGTH_QWEN,
+                    return_tensors="pt",
+                    padding_side="left",
+                )
+            elif is_qwen3_vl(model.config):
+                tokenizer.tokenizer.padding_side = "left"
+                pairs = self._apply_qwen3_vl_template(query, passages)
+                rendered_inputs = tokenizer.apply_chat_template(pairs, tokenize=False, add_generation_prompt=True)
+                input_data = tokenizer(
+                    text=rendered_inputs,
+                    images=None,
+                    videos=None,
+                    truncation=False,
+                    padding=False,
+                    do_resize=False,
+                )
+                padded_inputs = tokenizer.tokenizer.pad(
+                    {"input_ids": input_data["input_ids"]},
+                    padding=True,
+                    return_tensors="pt",
+                    max_length=DEFAULT_MAX_LENGTH_QWEN,
+                )
+                for key, value in padded_inputs.items():
+                    input_data[key] = value
             else:
                 tokenizer_kwargs = {"truncation": True, "padding": True, "max_length": DEFAULT_MAX_LENGTH}
                 inputs = [query] * len(passages)
                 input_data = tokenizer(inputs, passages, return_tensors="pt", **tokenizer_kwargs)
 
             with torch.no_grad():
-                outputs = model(**input_data).logits
+                outputs = torch.as_tensor(model(**input_data).logits)
 
-            if is_qwen3_causallm(model.config):
+            if is_qwen3_generative_reranker(model.config):
                 batch_scores = outputs[:, -1, :]
-                token_false_id = tokenizer.convert_tokens_to_ids("no")
-                token_true_id = tokenizer.convert_tokens_to_ids("yes")
+                qwen_tokenizer = tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
+                token_false_id = qwen_tokenizer.convert_tokens_to_ids("no")
+                token_true_id = qwen_tokenizer.convert_tokens_to_ids("yes")
                 true_vector = batch_scores[:, token_true_id]
                 false_vector = batch_scores[:, token_false_id]
                 batch_scores = torch.stack([false_vector, true_vector], dim=1)
@@ -158,7 +218,7 @@ class RerankingEvaluator(BaseEvaluator):
                     scores = outputs[:, 1]
                 else:
                     scores = outputs.flatten()
-                scores = scipy.special.expit(scores)
+                scores = torch.as_tensor(scipy.special.expit(scores))
             ordered_scores = []
             for index, (score, _) in enumerate(zip(scores, passages)):
                 ordered_scores.append(np.array([index, score.to(torch.float32).cpu().numpy()]))

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -25,6 +25,14 @@ from whowhatbench.utils import get_json_config
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+MODEL_TYPE_ALIASES = {
+    "reranking": "text-reranking",
+}
+
+
+def normalize_model_type(model_type: str) -> str:
+    return MODEL_TYPE_ALIASES.get(model_type, model_type)
+
 
 def pruning_ratio_type(value: str) -> int:
     ivalue = int(value)
@@ -104,6 +112,7 @@ def parse_args():
             "image-inpainting",
             "text-embedding",
             "text-reranking",
+            "reranking",
         ],
         default="text",
         help="Indicates the model type: text - for causal text generation, visual-text - for Visual Language Models with image inputs, "
@@ -373,7 +382,9 @@ def parse_args():
         help="Max numbers of tokens to generate, excluding the number of tokens in the prompt; the value must be greater than 0.",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.model_type = normalize_model_type(args.model_type)
+    return args
 
 
 def check_args(args):
@@ -780,7 +791,7 @@ def create_evaluator(base_model, args):
     # config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
     # task = TasksManager.infer_task_from_model(config._name_or_path)
     # TODO: Add logic to auto detect task based on model_id (TaskManager does not work for locally saved models)
-    task = args.model_type
+    task = normalize_model_type(args.model_type)
 
     try:
         EvaluatorCLS = EVALUATOR_REGISTRY[task]
@@ -916,9 +927,13 @@ def create_evaluator(base_model, args):
                 batch_size=args.embeds_batch_size,
             )
         elif task == "text-reranking":
+            reranking_tokenizer = load_tokenizer(args)
+            reranking_processor, reranking_config = load_processor(args)
+            if reranking_config is not None and reranking_config.model_type == "qwen3_vl":
+                reranking_tokenizer = reranking_processor
             return EvaluatorCLS(
                 base_model=base_model,
-                tokenizer=load_tokenizer(args),
+                tokenizer=reranking_tokenizer,
                 gt_data=args.gt_data,
                 test_data=prompts,
                 num_samples=args.num_samples,


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary
- add WWB CLI support for `python -m whowhatbench` and `--model-type reranking`
- load `Qwen/Qwen3-VL-Reranker-2B` reference runs with HF and OV targets with `OVModelForVisualCausalLM`
- add Qwen3-VL reranker scoring/template handling in the reranking evaluator
- keep GenAI reranking path explicit as unsupported for Qwen3-VL rerankers

## Validation
- `python -m whowhatbench --model-type reranking --base-model Qwen/Qwen3-VL-Reranker-2B --target-model /opt/home/mlukasze/meat/dev/Qwen-Qwen3-VL-Reranker-2B/ov_model --device CPU --num-samples 32 --gt-data ./wwb_cpu_32/gt.csv --output ./wwb_cpu_32`
  - similarity: `0.9999255442936572`
- `python -m whowhatbench --model-type reranking --base-model Qwen/Qwen3-VL-Reranker-2B --target-model /opt/home/mlukasze/meat/dev/Qwen-Qwen3-VL-Reranker-2B/ov_model --device GPU --num-samples 32 --gt-data ./wwb_gpu_32/gt.csv --output ./wwb_gpu_32`
  - similarity: `0.980200625069964`
