### PR TITLE
Fix StaticWhisperPipeline to work with transformers v5

### DIFF
--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -469,7 +469,9 @@ void add_attention_mask_input(std::shared_ptr<ov::Model> model, bool transform_c
             const auto kAttnMaskPort = 3;
             for (const auto &node : model->get_ops()) {
                 if (ov::is_type<ov::op::v13::ScaledDotProductAttention>(node)) {
-                    if (node->inputs().size() > kAttnMaskPort && ov::is_type<v8::Slice>(node->input(kAttnMaskPort).get_source_output().get_node())) {
+                    if (node->inputs().size() > kAttnMaskPort &&
+                        (ov::is_type<v8::Slice>(node->input(kAttnMaskPort).get_source_output().get_node()) ||
+                         ov::is_type<v1::Select>(node->input(kAttnMaskPort).get_source_output().get_node()))) {
                         self_attn_nodes.push_back(node);
                     } else {
                         cross_attn_nodes.push_back(node);

--- a/tests/python_tests/test_whisper_pipeline_static.py
+++ b/tests/python_tests/test_whisper_pipeline_static.py
@@ -117,7 +117,6 @@ def compare_word_timestamps_results_with_assert(expected, actual_out, ts_toleran
         assert exp_word.end_ts - act_word.end_ts == pytest.approx(0.0, abs=ts_tolerance)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0}], indirect=True)
 def test_static_whisper_generation_compare_stateless(model_descr, sample_from_dataset):
@@ -131,7 +130,6 @@ def test_static_whisper_generation_compare_stateless(model_descr, sample_from_da
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(n=2, language="fr"),
                                                  *get_fixture_params_for_n_whisper_dataset_samples(n=2, language="de"),
@@ -147,7 +145,6 @@ def test_static_whisper_autodetect(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='de', n=3)], indirect=True)
 def test_static_whisper_language_de(model_descr, sample_from_dataset):
@@ -161,7 +158,6 @@ def test_static_whisper_language_de(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='fr', n=3)], indirect=True)
 def test_static_whisper_language_fr(model_descr, sample_from_dataset):
@@ -175,7 +171,6 @@ def test_static_whisper_language_fr(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='ru', n=3)], indirect=True)
 def test_static_whisper_language_ru(model_descr, sample_from_dataset):
@@ -189,7 +184,6 @@ def test_static_whisper_language_ru(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0, "long_form": True}], indirect=True)
 def test_static_whisper_generation_long(model_descr, sample_from_dataset):
@@ -203,7 +197,6 @@ def test_static_whisper_generation_long(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0}], indirect=True)
 def test_static_whisper_stateful_generation_compare_with_cpu(model_descr, sample_from_dataset):
@@ -214,7 +207,6 @@ def test_static_whisper_stateful_generation_compare_with_cpu(model_descr, sample
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(n=2, language="fr"),
                                                  *get_fixture_params_for_n_whisper_dataset_samples(n=2, language="de"),
@@ -227,7 +219,6 @@ def test_static_whisper_stateful_autodetect(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='de', n=3)], indirect=True)
 def test_static_whisper_stateful_language_de(model_descr, sample_from_dataset):
@@ -240,7 +231,6 @@ def test_static_whisper_stateful_language_de(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='fr', n=3)], indirect=True)
 def test_static_whisper_stateful_language_fr(model_descr, sample_from_dataset):
@@ -251,7 +241,6 @@ def test_static_whisper_stateful_language_fr(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [*get_fixture_params_for_n_whisper_dataset_samples(language='ru', n=3)], indirect=True)
 def test_static_whisper_stateful_language_ru(model_descr, sample_from_dataset):
@@ -262,7 +251,6 @@ def test_static_whisper_stateful_language_ru(model_descr, sample_from_dataset):
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0, "long_form": True}], indirect=True)
 def test_static_whisper_stateful_generation_long(model_descr, sample_from_dataset):
@@ -273,7 +261,6 @@ def test_static_whisper_stateful_generation_long(model_descr, sample_from_datase
     compare_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0, "long_form": False}], indirect=True)
 def test_static_whisper_stateful_word_timestamps(model_descr, sample_from_dataset):
@@ -286,7 +273,6 @@ def test_static_whisper_stateful_word_timestamps(model_descr, sample_from_datase
     compare_word_timestamps_results_with_assert(expected, actual_out)
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize(
     "sample_from_multilingual_dataset,language",
@@ -305,7 +291,6 @@ def test_language_detection(model_descr, sample_from_multilingual_dataset, langu
     assert expected.language == actual_out.language == language
 
 
-@pytest.mark.transformers_lower_v5(reason="CVS-185787")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_dataset", [{"language": "en", "sample_id": 0}], indirect=True)
 def test_language_detection_en(model_descr, sample_from_dataset):


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Fix adding attention mask pattern matcher pass for StaticWhisperPipeline to work with transformers v5

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-185787

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
