### PR TITLE
ignore cache_interval_multiplier for non LM models

### DIFF
--- a/src/cpp/include/openvino/genai/scheduler_config.hpp
+++ b/src/cpp/include/openvino/genai/scheduler_config.hpp
@@ -38,7 +38,7 @@ struct SchedulerConfig {
     // Multiplier used to derive the linear-attention checkpoint interval for prefix caching.
     // The internal cache interval is calculated as KV cache block size * cache_interval_multiplier.
     // When unset, the default value 8 is used for hybrid models with prefix caching.
-    // Explicit values are supported only for models with linear attention cache inputs.
+    // For models without linear attention cache inputs, this parameter is ignored.
     // 0 is valid only when prefix caching is disabled.
     std::optional<std::size_t> cache_interval_multiplier = std::nullopt;
 

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -699,9 +699,6 @@ private:
         OPENVINO_ASSERT(la_manager || config.num_linear_attention_blocks == 0,
                         "SchedulerConfig num_linear_attention_blocks can be set only for models with linear attention cache inputs");
 
-        OPENVINO_ASSERT(la_manager || !config.cache_interval_multiplier.has_value(),
-                        "SchedulerConfig cache_interval_multiplier can be set only for models with linear attention cache inputs");
-
         return {std::move(kv_manager), std::move(la_manager)};
     }
 

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2715,7 +2715,7 @@ class SchedulerConfig:
         cache_interval_multiplier:  optional multiplier used to derive the linear-attention checkpoint interval for prefix caching.
                                     The internal interval is KV cache block size * cache_interval_multiplier.
                                     When unset, the default value 8 is used for hybrid models with prefix caching.
-                                    Explicit values are supported only for models with linear attention cache inputs.
+                                    For models without linear attention cache inputs, this parameter is ignored.
                                     0 is valid only when prefix caching is disabled.
         dynamic_split_fuse:         whether to split prompt / generate to different scheduling phases.
     

--- a/src/python/py_continuous_batching_pipeline.cpp
+++ b/src/python/py_continuous_batching_pipeline.cpp
@@ -117,7 +117,7 @@ auto scheduler_config_docstring = R"(
     cache_interval_multiplier:  optional multiplier used to derive the linear-attention checkpoint interval for prefix caching.
                                 The internal interval is KV cache block size * cache_interval_multiplier.
                                 When unset, the default value 8 is used for hybrid models with prefix caching.
-                                Explicit values are supported only for models with linear attention cache inputs.
+                                For models without linear attention cache inputs, this parameter is ignored.
                                 0 is valid only when prefix caching is disabled.
     dynamic_split_fuse:         whether to split prompt / generate to different scheduling phases.
 

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -309,7 +309,7 @@ TEST(TestCacheOrchestratorHybrid, CreateAcceptsCacheIntervalMultiplierForHybridM
                                               }));
 }
 
-TEST(TestCacheOrchestratorHybrid, CreateRejectsCustomCacheIntervalMultiplierWithoutLinearAttentionCache) {
+TEST(TestCacheOrchestratorHybrid, CreateIgnoresCacheIntervalMultiplierWithoutLinearAttentionCache) {
     ov::Core core;
     ov::InferRequest request = core.compile_model(get_dummy_model(core, /*num_layers=*/3))
                                       .create_infer_request();
@@ -318,12 +318,11 @@ TEST(TestCacheOrchestratorHybrid, CreateRejectsCustomCacheIntervalMultiplierWith
     config.num_kv_blocks = 4;
     config.cache_interval_multiplier = 4;
 
-    EXPECT_THROW(CacheOrchestrator::create(request,
-                                           config,
-                                           [](const std::string&, size_t) {
-                                               return std::numeric_limits<size_t>::max();
-                                           }),
-                 ov::Exception);
+    EXPECT_NO_THROW(CacheOrchestrator::create(request,
+                                              config,
+                                              [](const std::string&, size_t) {
+                                                  return std::numeric_limits<size_t>::max();
+                                              }));
 }
 
 /// @test RequiredTokens_UsesMax

--- a/tests/cpp/scheduler.cpp
+++ b/tests/cpp/scheduler.cpp
@@ -1070,7 +1070,7 @@ TEST(TestScheduler, scheduler_config_zero_cache_interval_multiplier_requires_dis
     EXPECT_EQ(scheduler_config.cache_interval_multiplier.value(), 0);
 }
 
-TEST(TestScheduler, scheduler_config_custom_cache_interval_multiplier_requires_linear_attention_model) {
+TEST(TestScheduler, scheduler_config_custom_cache_interval_multiplier_is_ignored_for_kv_only_model) {
     ov::Core core;
     ov::InferRequest request = core.compile_model(get_dummy_model(core, TEST_NUM_DECODER_LAYERS)).create_infer_request();
     auto get_available_memory = [](const std::string&, size_t) {
@@ -1085,12 +1085,12 @@ TEST(TestScheduler, scheduler_config_custom_cache_interval_multiplier_requires_l
     SchedulerConfig explicit_default_config;
     explicit_default_config.num_kv_blocks = 64;
     explicit_default_config.cache_interval_multiplier = DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER;
-    EXPECT_ANY_THROW(CacheOrchestrator::create(request, explicit_default_config, get_available_memory));
+    EXPECT_NO_THROW(CacheOrchestrator::create(request, explicit_default_config, get_available_memory));
 
     SchedulerConfig custom_interval_config;
     custom_interval_config.num_kv_blocks = 64;
     custom_interval_config.cache_interval_multiplier = TEST_CUSTOM_CACHE_INTERVAL_MULTIPLIER;
-    EXPECT_ANY_THROW(CacheOrchestrator::create(request, custom_interval_config, get_available_memory));
+    EXPECT_NO_THROW(CacheOrchestrator::create(request, custom_interval_config, get_available_memory));
 }
 
 TEST(TestScheduler, hybrid_create_explicit_kv_blocks_derives_single_fixed_linear_attention_block_for_client_scenario) {


### PR DESCRIPTION

## Description
Ignoring the value of cache_interval_multiplier for non LM models. It allows the application to control the default value regardless of the model. Genai library is setting now 8 which is consuming too much memory with prefix caching.
While the value is ignored, the application could set different settings regardless of the model architecture. 
Currently application would need to know if the model is LA but such info is not exposed without full pipeline loading.

CVS-188061

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). 
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket. 
- [x] I have made corresponding changes to the documentation.
