### PR TITLE
[CI] Skip Kokoro and Gemma3 (PA) failing tests

### DIFF
--- a/tests/python_tests/test_kokoro_pipeline.py
+++ b/tests/python_tests/test_kokoro_pipeline.py
@@ -251,6 +251,7 @@ class TestKokoroPipeline:
 
 
 @pytest.mark.speech_generation
+@pytest.mark.xfail(reason="CVS-188204")
 class TestKokoroFallback:
     """
     Tests for the OpenVINO G2P fallback mechanism (``phonemize_fallback_model_dir``).

--- a/tests/python_tests/test_kokoro_pipeline.py
+++ b/tests/python_tests/test_kokoro_pipeline.py
@@ -251,7 +251,7 @@ class TestKokoroPipeline:
 
 
 @pytest.mark.speech_generation
-@pytest.mark.xfail(reason="CVS-188204")
+@pytest.mark.xfail(reason="SafetensorError: Error while serializing: I/O error: (os error 5). CVS-188204")
 class TestKokoroFallback:
     """
     Tests for the OpenVINO G2P fallback mechanism (``phonemize_fallback_model_dir``).

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -1021,6 +1021,9 @@ def test_vlm_pipeline_start_chat_vs_chat_history(
     ov_pipe_model: VlmModelInfo,
     iteration_images: list[list[PIL.Image]],
 ):
+    if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
+        pytest.xfail("CVS-188205")
+
     ov_pipe = ov_pipe_model.pipeline
 
     generation_config = _setup_generation_config(ov_pipe, do_sample=False, prompt_lookup=ov_pipe_model.prompt_lookup)
@@ -1443,6 +1446,9 @@ def test_vlm_npu_multiple_images(
 def test_vlm_pipeline_chat_streamer_cancel_second_generate(
     request: pytest.FixtureRequest, ov_pipe_model: VlmModelInfo, image_sequence: list[openvino.Tensor]
 ):
+    if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
+        pytest.xfail("CVS-188205")
+
     ov_pipe = ov_pipe_model.pipeline
     callback_questions = [
         "Explain in details 1+1=",

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -1584,6 +1584,9 @@ def test_vlm_pipeline_chat_streamer_cancel_first_generate(
     if "phi" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "SDPA":
         pytest.skip("SDPA is failing for phi models on VLM model reusing")
 
+    if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
+        pytest.xfail("Outputs don't match for Gemma3 with PA. CVS-188205")
+
     ov_pipe = ov_pipe_model.pipeline
     callback_questions = [
         "Why is the Sun yellow?",

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -1022,7 +1022,7 @@ def test_vlm_pipeline_start_chat_vs_chat_history(
     iteration_images: list[list[PIL.Image]],
 ):
     if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
-        pytest.xfail("CVS-188205")
+        pytest.xfail("Outputs don't match for Gemma3 with PA. CVS-188205")
 
     ov_pipe = ov_pipe_model.pipeline
 
@@ -1447,7 +1447,7 @@ def test_vlm_pipeline_chat_streamer_cancel_second_generate(
     request: pytest.FixtureRequest, ov_pipe_model: VlmModelInfo, image_sequence: list[openvino.Tensor]
 ):
     if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
-        pytest.xfail("CVS-188205")
+        pytest.xfail("Outputs don't match for Gemma3 with PA. CVS-188205")
 
     ov_pipe = ov_pipe_model.pipeline
     callback_questions = [


### PR DESCRIPTION
## Description
This PR temporarily skips failing Kokoro and Gemma3 (PA) failing tests on master with ticket references to unblock other PRs.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code - **N/A**.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**.
