### PR TITLE
Kokoro tts test fix

### DIFF
--- a/tests/python_tests/test_kokoro_pipeline.py
+++ b/tests/python_tests/test_kokoro_pipeline.py
@@ -251,7 +251,6 @@ class TestKokoroPipeline:
 
 
 @pytest.mark.speech_generation
-@pytest.mark.xfail(reason="SafetensorError: Error while serializing: I/O error: (os error 5). CVS-188204")
 class TestKokoroFallback:
     """
     Tests for the OpenVINO G2P fallback mechanism (``phonemize_fallback_model_dir``).

--- a/tests/python_tests/utils/kokoro_test_assets.py
+++ b/tests/python_tests/utils/kokoro_test_assets.py
@@ -284,7 +284,12 @@ def generate_tiny_g2p_model(output_dir: Path) -> Path:
 
     model = BartForConditionalGeneration(config)
     model.eval()
-    model.save_pretrained(str(output_dir))
+
+    # Use PyTorch .bin instead of safetensors here. For some reason,
+    # safetensors serialization can fail in CI trying to write to the
+    # mounted cache path.
+    config.save_pretrained(str(output_dir))
+    torch.save(model.state_dict(), output_dir / "pytorch_model.bin")
 
     generation_config = {
         "_from_model_config": True,


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
In `generate_tiny_g2p_model`, `model.save_pretrained` which tried to produce a safetensor seemed to be flaky, and the tests were failing with:
```
safetensors._safetensors_rust.SafetensorError: Error while serializing: I/O error: Input/output error (os error 5)
```

For some reason, this was flaky for CI runs on Linunx, where the destination folder was on a of mounted cache filesystem. Perhaps we're hitting a corner case in `safetensors_rust` implementation, but swapping this out for a more simple `torch.save` seems to work just fine..

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-188204

## Checklist:
- [X] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [N/A ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [X] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
