### PR TITLE
[llm_bench/wwb] prevent downgrade of optimum-intel version

### DIFF
--- a/tests/python_tests/requirements.txt
+++ b/tests/python_tests/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-diffusers==0.38.0
+diffusers==0.37.1
 optimum-intel @ git+https://github.com/huggingface/optimum-intel.git@140e49a68718ab0025a3b5f02864b9ca9f009558
 pytest==9.1.0
 transformers==5.0.0

--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -12,6 +12,8 @@ diffusers>=0.22.0,<=0.38.0
 # optimum is in dependency list of optimum-intel
 # last supported commit f50a0b326df82d4b05c461a9184a97f616bfa63a
 optimum-intel[nncf]>=1.25.0
+# pin safetensors (<0.8.0) to avoid dependency resolution that downgrades optimum-intel
+safetensors<0.8.0
 packaging>=20.0,<=26.2
 psutil
 timm<=1.0.27

--- a/tools/who_what_benchmark/requirements.txt
+++ b/tools/who_what_benchmark/requirements.txt
@@ -4,6 +4,8 @@ sentence-transformers>=2.2.2,<=5.3.0
 openvino-genai
 # last supported commit f50a0b326df82d4b05c461a9184a97f616bfa63a
 optimum-intel[nncf]>=1.19.0
+# pin safetensors (<0.8.0) to avoid dependency resolution that downgrades optimum-intel
+safetensors<0.8.0
 pandas>=2.0.3,<=3.0.3
 numpy>=1.23.5,<=2.4.6
 tqdm>=4.66.1,<=4.68.2


### PR DESCRIPTION
## Description
In current state of requirements files, pip resolve optimum-intel version with downgrade, even if a higher version is already installed, let's make possibility to install requirements with optimum-intel 2.0

CVS-188702

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
