### PR TITLE
[OpenVINO] Support Youtu-VL-4B-Instruct with task image-text-to-text

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -15,6 +15,10 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen2_vl": Qwen2VLInputsPreprocessor,
     "qwen2_5_vl": Qwen2VLInputsPreprocessor,
     "qwen2_5_vl_text": Qwen2VLInputsPreprocessor,
+    # Youtu-VL uses a Qwen2-VL-style processor: content-list chat template with
+    # <|vision_start|><|image_pad|><|vision_end|> markers and a
+    # processor(text=..., images=...) call, so the Qwen2-VL preprocessor applies.
+    "youtu_vl": Qwen2VLInputsPreprocessor,
     "llava": LLAVAInputsPreprocessor,
     "gemma3": Gemma3InputsPreprocessor,
     "gemma4_unified": Gemma4UnifiedInputsPreprocessor,

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -431,6 +431,12 @@ def load_visual_text_model(
                         config.audio_processor["config"]["activation_checkpointing"] = ""
                     config._attn_implementation = "sdpa"
                     from_pretrained_kwargs = {"config": config}
+                elif config.model_type == "youtu_vl":
+                    # YoutuVLForConditionalGeneration.__init__ only accepts `config`;
+                    # the legacy `use_flash_attention_2` kwarg is forwarded to the
+                    # constructor and raises TypeError. `_attn_implementation="eager"`
+                    # already disables flash attention, so pass only that.
+                    from_pretrained_kwargs = {"_attn_implementation": "eager"}
                 else:
                     from_pretrained_kwargs = {"_attn_implementation": "eager", "use_flash_attention_2": False}
 


### PR DESCRIPTION
## Description

Enable WhoWhatBenchmark visual-text evaluation for tencent/Youtu-VL-4B-Instruct.

## Reproduce generation

```python
import openvino_genai
from PIL import Image

pipe = openvino_genai.VLMPipeline("output_dir", "CPU")
image = Image.new("RGB", (64, 64), "white")
result = pipe.generate("Describe this image.", image=image, max_new_tokens=10)
print(result.texts[0])
```

## Validation

- WWB Optimum similarity: **Not run**
- WWB GenAI similarity: **Not run**
- First-token latency: **Not run**
- Throughput: **Not run**

## Related model-support PRs

- Optimum Intel: pending

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.

## Changed files

- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py`
- `tools/who_what_benchmark/whowhatbench/model_loaders.py`