### PR TITLE
[wwb] Force dtype float32 for models loaded with diffusers

### DIFF
--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -301,9 +301,9 @@ def load_text2image_model(
 
         logger.info("Using HF Transformers API")
         try:
-            model = DiffusionPipeline.from_pretrained(model_id)
+            model = DiffusionPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
         except Exception:
-            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True)
+            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -517,7 +517,7 @@ def load_imagetext2image_model(
         from diffusers import AutoPipelineForImage2Image
 
         logger.info("Using HF Transformers API")
-        model = AutoPipelineForImage2Image.from_pretrained(model_id, trust_remote_code=True)
+        model = AutoPipelineForImage2Image.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         model = load_image2image_genai_pipeline(model_id, device, ov_config)
@@ -564,7 +564,7 @@ def load_inpainting_model(
         from diffusers import AutoPipelineForInpainting
 
         logger.info("Using HF Transformers API")
-        model = AutoPipelineForInpainting.from_pretrained(model_id, trust_remote_code=True)
+        model = AutoPipelineForInpainting.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         model = load_inpainting_genai_pipeline(model_id, device, ov_config)
@@ -741,9 +741,9 @@ def load_text2video_model(model_id, device="CPU", ov_config=None, use_hf=False, 
 
         logger.info("Using HF Transformers API")
         try:
-            model = LTXPipeline.from_pretrained(model_id)
+            model = LTXPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
         except ValueError:
-            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True)
+            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)


### PR DESCRIPTION
## Description
transformers load model in "auto" model type depending on the data type in HuggingFace, diffusers is still force torch.float32 for models. As a result, we have text_encoder(s) in torch.float16, and a transformer/vae in torch.float32. When several models in pipeline has different type it leads to error like this:
RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float

Let's cast all models to one type.

[CVS-189083](https://jira.devtools.intel.com/browse/CVS-189083)
[CVS-189081](https://jira.devtools.intel.com/browse/CVS-189081)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
