### PR TITLE
Fix CVS-189485

### DIFF
--- a/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
@@ -180,11 +180,9 @@ protected:
     std::map<uint64_t, GenerationHandle> m_draft_generations;
 
     void reset_generate_metrics() {
-        m_sd_metrics = SpeculativeDecodingMetrics();
         m_perf_metrics = ov::genai::SDPerModelsPerfMetrics();
-        RawPerfMetrics draft_metrics;
-        draft_metrics.m_inference_durations = {{ MicroSeconds(0.0f) }};
-        m_draft_pipeline->raw_perf_metrics = std::move(draft_metrics);
+        m_draft_pipeline->raw_perf_metrics = RawPerfMetrics{};
+        m_draft_pipeline->raw_perf_metrics.m_inference_durations = {{ MicroSeconds(0.0f) }};
     }
 
     void drop_requests();

--- a/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
@@ -182,8 +182,9 @@ protected:
     void reset_generate_metrics() {
         m_sd_metrics = SpeculativeDecodingMetrics();
         m_perf_metrics = ov::genai::SDPerModelsPerfMetrics();
-        m_draft_pipeline->raw_perf_metrics = RawPerfMetrics{};
-        m_draft_pipeline->raw_perf_metrics.m_inference_durations = {{ MicroSeconds(0.0f) }};
+        RawPerfMetrics draft_metrics;
+        draft_metrics.m_inference_durations = {{ MicroSeconds(0.0f) }};
+        m_draft_pipeline->raw_perf_metrics = std::move(draft_metrics);
     }
 
     void drop_requests();


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
This PR adjusts metric reset behavior in speculative decoding fast draft strategy to avoid clearing SD logical statistics at generate reset time.
m_sd_metrics is a debugging and diagnostic metric collector specifically for speculative decoding. Statistics are printed and cleaned up once per step only when the environment variable is set to >warning. Now we get statistics of main and draft models from m_perf_metrics. So the reset for m_sd_metrics here is not needed and can be removed.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-189485

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
