### PR TITLE
[CB] Fix high VRAM and empty-output for hybrid SSM models with prefix caching (#3968, #4047)

### DIFF
--- a/site/docs/concepts/optimization-techniques/hybrid-attention-models-cache.md
+++ b/site/docs/concepts/optimization-techniques/hybrid-attention-models-cache.md
@@ -54,7 +54,7 @@ Relevant settings:
 When `enable_prefix_caching=true`, linear-attention cache switches to paged checkpointing mode.
 Instead of allocating one fixed state block per sequence, the runtime stores checkpoints every derived cache interval.
 The interval is calculated as `kv_block_size * cache_interval_multiplier` tokens.
-If `cache_interval_multiplier` is unset, the default multiplier is `8` for hybrid models with prefix caching.
+If `cache_interval_multiplier` is unset, the multiplier is derived adaptively from the model's linear-attention state size so that one checkpoint costs roughly one KV block (and is never smaller than the baseline of `8`). This keeps the recurrent-state cache of large hybrid SSM models from exhausting the cache budget on long prompts. Larger values reduce linear-attention memory at the cost of coarser prefix-cache reuse.
 
 Relevant settings:
 

--- a/src/cpp/include/openvino/genai/scheduler_config.hpp
+++ b/src/cpp/include/openvino/genai/scheduler_config.hpp
@@ -37,7 +37,10 @@ struct SchedulerConfig {
 
     // Multiplier used to derive the linear-attention checkpoint interval for prefix caching.
     // The internal cache interval is calculated as KV cache block size * cache_interval_multiplier.
-    // When unset, the default value 8 is used for hybrid models with prefix caching.
+    // When unset, the multiplier is derived adaptively from the model's linear-attention state
+    // size so one checkpoint costs roughly one KV block (>= the default of 8); this prevents the
+    // recurrent-state cache of large hybrid SSM models from exhausting the cache budget on long
+    // prompts. Larger values reduce memory at the cost of coarser prefix-cache reuse.
     // For models without linear attention cache inputs, this parameter is ignored.
     // 0 is valid only when prefix caching is disabled.
     std::optional<std::size_t> cache_interval_multiplier = std::nullopt;

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -737,7 +737,7 @@ private:
             return 0;
         }
         OPENVINO_ASSERT(kv_manager,
-                        "SchedulerConfig cache_interval_multiplier requires KV cache inputs when prefix caching is enabled");
+                        "Prefix caching for hybrid (linear-attention) models requires the model to expose KV cache inputs, but no KV cache manager is registered");
         const size_t kv_block_size = kv_manager->get_block_size();
 
         // An explicit user multiplier is always honoured.

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -689,7 +689,12 @@ public:
     static size_t adaptive_cache_interval_multiplier(size_t la_block_bytes, size_t kv_block_bytes) {
         size_t multiplier = DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER;
         if (kv_block_bytes > 0) {
-            const size_t ratio = (la_block_bytes + kv_block_bytes - 1) / kv_block_bytes;  // ceil
+            // ceil(la_block_bytes / kv_block_bytes) computed via division + remainder to avoid
+            // the intermediate-addition overflow of (la_block_bytes + kv_block_bytes - 1).
+            size_t ratio = la_block_bytes / kv_block_bytes;
+            if (la_block_bytes % kv_block_bytes != 0) {
+                ++ratio;
+            }
             multiplier = std::max(multiplier, ratio);
         }
         return std::min(multiplier, MAX_ADAPTIVE_CACHE_INTERVAL_MULTIPLIER);
@@ -742,6 +747,11 @@ private:
 
         const size_t multiplier = adaptive_cache_interval_multiplier(la_manager->get_block_size_in_bytes(),
                                                                      kv_manager->get_block_size_in_bytes());
+        // Keep the same overflow guard as SchedulerConfig::get_cache_interval() for consistency.
+        OPENVINO_ASSERT(multiplier == 0 ||
+                            kv_block_size <= std::numeric_limits<std::size_t>::max() / multiplier,
+                        "Derived cache_interval_multiplier is too large for KV cache block size. multiplier: ",
+                        multiplier, ", kv_block_size: ", kv_block_size);
         return kv_block_size * multiplier;
     }
 

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -672,6 +672,29 @@ public:
         return m_use_per_layer_kv_block_indices;
     }
 
+    // Upper bound for the auto-derived linear-attention checkpoint multiplier.
+    // Caps how coarse prefix-cache reuse can get for very large recurrent states.
+    static constexpr size_t MAX_ADAPTIVE_CACHE_INTERVAL_MULTIPLIER = 256;
+
+    // Derive the linear-attention checkpoint multiplier used when the user did not set one.
+    //
+    // A linear-attention checkpoint stores the full recurrent state (tens of MiB for large
+    // hybrid SSM models). Checkpointing every block_size tokens (multiplier 1) makes the LA
+    // state cache dwarf the KV cache and exhaust the cache budget on long prompts, which in
+    // turn makes long-prompt requests unschedulable. Size the interval so one LA checkpoint
+    // costs roughly one KV block (multiplier ~= la_block_bytes / kv_block_bytes), keeping
+    // LA-state overhead comparable to the KV cache regardless of model. Clamp to
+    // [default, MAX] so small-state models keep fine-grained prefix reuse and huge-state
+    // models do not get an unbounded interval.
+    static size_t adaptive_cache_interval_multiplier(size_t la_block_bytes, size_t kv_block_bytes) {
+        size_t multiplier = DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER;
+        if (kv_block_bytes > 0) {
+            const size_t ratio = (la_block_bytes + kv_block_bytes - 1) / kv_block_bytes;  // ceil
+            multiplier = std::max(multiplier, ratio);
+        }
+        return std::min(multiplier, MAX_ADAPTIVE_CACHE_INTERVAL_MULTIPLIER);
+    }
+
 private:
     bool has_registered_types() const {
         return !m_cache_managers.empty();
@@ -710,7 +733,16 @@ private:
         }
         OPENVINO_ASSERT(kv_manager,
                         "SchedulerConfig cache_interval_multiplier requires KV cache inputs when prefix caching is enabled");
-        return config.get_cache_interval(kv_manager->get_block_size());
+        const size_t kv_block_size = kv_manager->get_block_size();
+
+        // An explicit user multiplier is always honoured.
+        if (config.cache_interval_multiplier.has_value()) {
+            return config.get_cache_interval(kv_block_size);
+        }
+
+        const size_t multiplier = adaptive_cache_interval_multiplier(la_manager->get_block_size_in_bytes(),
+                                                                     kv_manager->get_block_size_in_bytes());
+        return kv_block_size * multiplier;
     }
 
     /**

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -459,6 +459,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                                     lm_extra_inputs_list);
     for (size_t i = 0; i < prompts.size(); i++) {
         auto result = encoded_results[i];
+        utils::assert_request_was_scheduled(result.m_status);
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -458,8 +458,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                                     original_prompt_ids_list,
                                                                     lm_extra_inputs_list);
     for (size_t i = 0; i < prompts.size(); i++) {
+        utils::assert_request_was_scheduled(encoded_results[i].m_status, encoded_results[i].m_request_id);
         auto result = encoded_results[i];
-        utils::assert_request_was_scheduled(result.m_status, result.m_request_id);
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;
@@ -632,8 +632,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     results.reserve(encoded_results.size());
 
     for (size_t i = 0; i < encoded_results.size(); ++i) {
+        utils::assert_request_was_scheduled(encoded_results.at(i).m_status, encoded_results.at(i).m_request_id);
         auto result = encoded_results.at(i);
-        utils::assert_request_was_scheduled(result.m_status, result.m_request_id);
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -633,6 +633,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
     for (size_t i = 0; i < encoded_results.size(); ++i) {
         auto result = encoded_results.at(i);
+        utils::assert_request_was_scheduled(result.m_status, result.m_request_id);
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -459,7 +459,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                                     lm_extra_inputs_list);
     for (size_t i = 0; i < prompts.size(); i++) {
         auto result = encoded_results[i];
-        utils::assert_request_was_scheduled(result.m_status);
+        utils::assert_request_was_scheduled(result.m_status, result.m_request_id);
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -641,17 +641,6 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
 
         result.m_status = generations[request_id]->get_status();
 
-        // A request whose prompt cannot fit the cache is dropped by the scheduler and finishes
-        // with GenerationStatus::IGNORED (out of memory). Returning an empty result silently
-        // hides this from the caller; surface it as an actionable error instead.
-        OPENVINO_ASSERT(result.m_status != GenerationStatus::IGNORED,
-                        "Request ", request_id, " was dropped because its prompt (",
-                        request->get_prompt_len(),
-                        " tokens) does not fit in the available cache (out of memory). "
-                        "Increase cache_size / num_kv_blocks, reduce the prompt length, or for "
-                        "hybrid (linear-attention) models raise cache_interval_multiplier to lower "
-                        "per-token cache usage.");
-
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
         perf_metrics.raw_metrics.generate_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -641,6 +641,17 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
 
         result.m_status = generations[request_id]->get_status();
 
+        // A request whose prompt cannot fit the cache is dropped by the scheduler and finishes
+        // with GenerationStatus::IGNORED (out of memory). Returning an empty result silently
+        // hides this from the caller; surface it as an actionable error instead.
+        OPENVINO_ASSERT(result.m_status != GenerationStatus::IGNORED,
+                        "Request ", request_id, " was dropped because its prompt (",
+                        request->get_prompt_len(),
+                        " tokens) does not fit in the available cache (out of memory). "
+                        "Increase cache_size / num_kv_blocks, reduce the prompt length, or for "
+                        "hybrid (linear-attention) models raise cache_interval_multiplier to lower "
+                        "per-token cache usage.");
+
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
         perf_metrics.raw_metrics.generate_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));

--- a/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
+++ b/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
@@ -113,6 +113,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (GenerationResult& res : generated) {
+            utils::assert_request_was_scheduled(res.m_status);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_replies));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));
@@ -172,6 +173,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (GenerationResult& res : generated) {
+            utils::assert_request_was_scheduled(res.m_status);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_replies));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));
@@ -274,6 +276,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (EncodedGenerationResult& res : generated) {
+            utils::assert_request_was_scheduled(res.m_status);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_tokens));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));

--- a/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
+++ b/src/cpp/src/llm/pipeline_continuous_batching_adapter.hpp
@@ -113,7 +113,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (GenerationResult& res : generated) {
-            utils::assert_request_was_scheduled(res.m_status);
+            utils::assert_request_was_scheduled(res.m_status, res.m_request_id);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_replies));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));
@@ -173,7 +173,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (GenerationResult& res : generated) {
-            utils::assert_request_was_scheduled(res.m_status);
+            utils::assert_request_was_scheduled(res.m_status, res.m_request_id);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_replies));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));
@@ -276,7 +276,7 @@ public:
         std::vector<float> plain_scores;
         std::vector<GenerationFinishReason> plain_finish_reasons;
         for (EncodedGenerationResult& res : generated) {
-            utils::assert_request_was_scheduled(res.m_status);
+            utils::assert_request_was_scheduled(res.m_status, res.m_request_id);
             OPENVINO_ASSERT(res.m_status == GenerationStatus::FINISHED || res.m_status == GenerationStatus::STOP || res.m_status == GenerationStatus::CANCEL, "Got unfinished GenerationStatus");
             std::move(res.m_generation_ids.begin(), res.m_generation_ids.end(), std::back_inserter(plain_tokens));
             std::move(res.m_scores.begin(), res.m_scores.end(), std::back_inserter(plain_scores));

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -55,6 +55,18 @@ struct GenerationFinishInfo
     GenerationStatus streaming_finish_status;
 };
 
+// A request finishes with GenerationStatus::IGNORED when the scheduler could not fit it within
+// the available cache budget (out of memory) - this can happen for the prompt or later during
+// generation under overall cache pressure. Call sites that discard GenerationStatus (and would
+// otherwise return an empty result) should use this to surface an actionable error instead.
+inline void assert_request_was_scheduled(GenerationStatus status) {
+    OPENVINO_ASSERT(status != GenerationStatus::IGNORED,
+                    "Request was dropped by the scheduler because it did not fit in the available cache budget "
+                    "(out of memory). Increase cache_size / num_kv_blocks, reduce the prompt or generation length, "
+                    "or for hybrid (linear-attention) models raise cache_interval_multiplier to lower per-token "
+                    "cache usage.");
+}
+
 Tensor init_attention_mask(const Tensor& position_ids);
 
 void initialize_position_ids(ov::Tensor& position_ids, const ov::Tensor& attention_mask, int64_t start_pos = 0);

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -59,12 +59,13 @@ struct GenerationFinishInfo
 // the available cache budget (out of memory) - this can happen for the prompt or later during
 // generation under overall cache pressure. Call sites that discard GenerationStatus (and would
 // otherwise return an empty result) should use this to surface an actionable error instead.
-inline void assert_request_was_scheduled(GenerationStatus status) {
+// request_id identifies which request was dropped when several are generated together.
+inline void assert_request_was_scheduled(GenerationStatus status, uint64_t request_id) {
     OPENVINO_ASSERT(status != GenerationStatus::IGNORED,
-                    "Request was dropped by the scheduler because it did not fit in the available cache budget "
-                    "(out of memory). Increase cache_size / num_kv_blocks, reduce the prompt or generation length, "
-                    "or for hybrid (linear-attention) models raise cache_interval_multiplier to lower per-token "
-                    "cache usage.");
+                    "Request ", request_id, " was dropped by the scheduler because it did not fit in the "
+                    "available cache budget (out of memory). Increase cache_size / num_kv_blocks, reduce the "
+                    "prompt or generation length, or for hybrid (linear-attention) models raise "
+                    "cache_interval_multiplier to lower per-token cache usage.");
 }
 
 Tensor init_attention_mask(const Tensor& position_ids);

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -3118,7 +3118,11 @@ class SchedulerConfig:
                                     Only applicable for models with linear attention cache inputs.
         cache_interval_multiplier:  optional multiplier used to derive the linear-attention checkpoint interval for prefix caching.
                                     The internal interval is KV cache block size * cache_interval_multiplier.
-                                    When unset, the default value 8 is used for hybrid models with prefix caching.
+                                    When unset, the multiplier is derived adaptively from the model's linear-attention
+                                    state size so one checkpoint costs roughly one KV block (>= the default of 8); this
+                                    prevents the recurrent-state cache of large hybrid SSM models from exhausting the
+                                    cache budget on long prompts. Larger values reduce memory at the cost of coarser
+                                    prefix-cache reuse.
                                     For models without linear attention cache inputs, this parameter is ignored.
                                     0 is valid only when prefix caching is disabled.
         dynamic_split_fuse:         whether to split prompt / generate to different scheduling phases.

--- a/src/python/py_continuous_batching_pipeline.cpp
+++ b/src/python/py_continuous_batching_pipeline.cpp
@@ -116,7 +116,11 @@ auto scheduler_config_docstring = R"(
                                 Only applicable for models with linear attention cache inputs.
     cache_interval_multiplier:  optional multiplier used to derive the linear-attention checkpoint interval for prefix caching.
                                 The internal interval is KV cache block size * cache_interval_multiplier.
-                                When unset, the default value 8 is used for hybrid models with prefix caching.
+                                When unset, the multiplier is derived adaptively from the model's linear-attention
+                                state size so one checkpoint costs roughly one KV block (>= the default of 8); this
+                                prevents the recurrent-state cache of large hybrid SSM models from exhausting the
+                                cache budget on long prompts. Larger values reduce memory at the cost of coarser
+                                prefix-cache reuse.
                                 For models without linear attention cache inputs, this parameter is ignored.
                                 0 is valid only when prefix caching is disabled.
     dynamic_split_fuse:         whether to split prompt / generate to different scheduling phases.

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -306,6 +306,31 @@ TEST(TestCacheOrchestratorHybrid, CreateAcceptsCacheIntervalMultiplierForHybridM
                                               }));
 }
 
+TEST(TestCacheOrchestratorHybrid, AdaptiveCacheIntervalMultiplierScalesWithStateSize) {
+    using ov::genai::CacheOrchestrator;
+    // Small LA state relative to a KV block keeps the default multiplier (fine-grained reuse).
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/1024, /*kv=*/4096),
+              DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER);
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/4096, /*kv=*/4096),
+              DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER);
+
+    // Large recurrent state (e.g. hybrid SSM): multiplier grows ~ la/kv so one LA
+    // checkpoint costs about one KV block, instead of exhausting the cache budget.
+    // 51 MiB LA state vs 512 KiB KV block -> ratio ~102.
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/size_t(51) * 1024 * 1024,
+                                                                    /*kv=*/size_t(512) * 1024),
+              102u);
+
+    // Clamped to the upper bound for very large states.
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/size_t(4096) * 1024 * 1024,
+                                                                    /*kv=*/size_t(64) * 1024),
+              CacheOrchestrator::MAX_ADAPTIVE_CACHE_INTERVAL_MULTIPLIER);
+
+    // Degenerate kv block size falls back to the default multiplier (no divide-by-zero).
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/1024, /*kv=*/0),
+              DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER);
+}
+
 TEST(TestCacheOrchestratorHybrid, CreateIgnoresCacheIntervalMultiplierWithoutLinearAttentionCache) {
     ov::Core core;
     ov::InferRequest request = core.compile_model(get_dummy_model(core, /*num_layers=*/3))

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -329,6 +329,25 @@ TEST(TestCacheOrchestratorHybrid, AdaptiveCacheIntervalMultiplierScalesWithState
     // Degenerate kv block size falls back to the default multiplier (no divide-by-zero).
     EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(/*la=*/1024, /*kv=*/0),
               DEFAULT_LINEAR_ATTENTION_CACHE_INTERVAL_MULTIPLIER);
+
+    // A near-max LA block size must not overflow the ceil-division and still clamps to MAX.
+    EXPECT_EQ(CacheOrchestrator::adaptive_cache_interval_multiplier(
+                  /*la=*/std::numeric_limits<size_t>::max(), /*kv=*/4096),
+              CacheOrchestrator::MAX_ADAPTIVE_CACHE_INTERVAL_MULTIPLIER);
+}
+
+// The OOM-drop (GenerationStatus::IGNORED) surfaces an actionable error at the call sites that
+// would otherwise discard the status (CB adapter overloads and the VLM result conversion).
+TEST(TestCacheOrchestratorHybrid, AssertRequestWasScheduledThrowsOnIgnored) {
+    // IGNORED == request dropped by the scheduler (out of cache budget) -> must throw.
+    EXPECT_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::IGNORED),
+                 ov::Exception);
+
+    // All terminal/active states that represent real results must pass through untouched.
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::FINISHED));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::STOP));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::CANCEL));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::RUNNING));
 }
 
 TEST(TestCacheOrchestratorHybrid, CreateIgnoresCacheIntervalMultiplierWithoutLinearAttentionCache) {

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -339,15 +339,16 @@ TEST(TestCacheOrchestratorHybrid, AdaptiveCacheIntervalMultiplierScalesWithState
 // The OOM-drop (GenerationStatus::IGNORED) surfaces an actionable error at the call sites that
 // would otherwise discard the status (CB adapter overloads and the VLM result conversion).
 TEST(TestCacheOrchestratorHybrid, AssertRequestWasScheduledThrowsOnIgnored) {
+    constexpr uint64_t request_id = 7;
     // IGNORED == request dropped by the scheduler (out of cache budget) -> must throw.
-    EXPECT_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::IGNORED),
+    EXPECT_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::IGNORED, request_id),
                  ov::Exception);
 
     // All terminal/active states that represent real results must pass through untouched.
-    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::FINISHED));
-    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::STOP));
-    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::CANCEL));
-    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::RUNNING));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::FINISHED, request_id));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::STOP, request_id));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::CANCEL, request_id));
+    EXPECT_NO_THROW(ov::genai::utils::assert_request_was_scheduled(GenerationStatus::RUNNING, request_id));
 }
 
 TEST(TestCacheOrchestratorHybrid, CreateIgnoresCacheIntervalMultiplierWithoutLinearAttentionCache) {


### PR DESCRIPTION
## Summary

Fixes high VRAM usage and empty-output failures for hybrid SSM/attention models (Qwen3.5/3.6) under Continuous Batching with prefix caching.

- Fixes openvinotoolkit/openvino.genai#3968 (high memory on Qwen3.5)
- Fixes openvinotoolkit/openvino.genai#4047 (prefix caching returns 0 tokens on long prompts)

These turned out to be the **same root cause**.

## Root cause

Hybrid models checkpoint the **full recurrent (linear-attention/SSM) state** every `cache_interval` tokens for prefix caching. The interval defaulted to `kv_block_size * cache_interval_multiplier` with a fixed multiplier of 8. For large recurrent states (e.g. Qwen3.5-9B: ~51 MiB of FP32 state per checkpoint), checkpointing every ~128 tokens makes the linear-attention cache dwarf the KV cache and exhaust the cache budget on long prompts:

- **#3968**: VRAM is dominated by hundreds of full-state checkpoints (a 54k-token prompt ≈ 21 GiB of LA state at the old default).
- **#4047**: once the budget is exceeded the prompt becomes unschedulable, the scheduler drops the request, and the synchronous `generate()` returned it as an empty result with no error — so users saw 0 generated tokens, but only with prefix caching enabled.

(For #4047 specifically: a one-line repro on `OpenVINO/Qwen3.5-9B-int8-ov` returns 0 tokens at 28k/55k prompts with `enable_prefix_caching=True` and normal output with it off.)

## Changes

**1. Adaptive linear-attention checkpoint interval** (`cache_orchestrator.hpp`, `scheduler_config.hpp`)

When the user does not set `cache_interval_multiplier`, derive it from the model's state sizes:
`multiplier = clamp(ceil(la_block_bytes / kv_block_bytes), 8, 256)`, so one linear-attention checkpoint costs roughly one KV block and LA-state overhead stays comparable to the KV cache regardless of model. An explicitly set multiplier is still honoured; models without linear-attention inputs are unaffected. Adds a unit test for the derivation.

**2. Surface out-of-memory drops as a clear error** (`pipeline_impl.cpp`)

An OOM-dropped request finishes with `GenerationStatus::IGNORED`; the synchronous `generate()` returned that as an empty result. Now it raises an actionable error naming the request, its prompt length, and the knobs to adjust (`cache_size` / `num_kv_blocks` / prompt length / `cache_interval_multiplier`). `IGNORED` is only ever set on out-of-memory, so normal completion / stop / cancel paths are unaffected.

## Validation

Built from source (OpenVINO 2026.3, Windows/MSVC) and tested on **CPU** (Ryzen 9 9950X3D) and **GPU** (Intel Arc Pro B70) with `OpenVINO/Qwen3.5-9B-int8-ov`.

| Scenario (prefix caching ON, default config) | Before | After |
|---|---|---|
| ~2k prompt | 80 tokens | 80 tokens |
| ~28k prompt | **0 tokens** | **80 tokens** (matches non-cached baseline) |
| ~55k prompt | **0 tokens** | **80 tokens** (matches non-cached baseline) |
| ~55k output determinism (3x repeat) | n/a | identical |
| genuine OOM (tiny budget) | silent empty result | **clear, actionable error** |

- Output with prefix caching on now matches the non-cached baseline; deterministic across repeated runs.
- Dense (non-hybrid) models and explicitly-set `cache_interval_multiplier` are unchanged.
- C++ continuous-batching unit suite: 103/103 pass (incl. the new adaptive-multiplier test).

## Notes / design choices

- The adaptive multiplier is ratio-based (parameter-free) rather than a new magic constant, so it scales with any model's state size. Larger values trade memory for coarser prefix-cache reuse.
- The OOM guard throws from the synchronous `generate()`; in a batched call this aborts the whole batch if any single request OOMs (fail-loud). A future enhancement could report per-request OOM status instead.
- Part 2 is validated end-to-end (it requires a full pipeline + model, so there is no standalone unit test).
