### PR TITLE
[CB] Linear Attention Prompt Lookup Decoding

### DIFF
--- a/src/cpp/src/continuous_batching/cache/block_manager.hpp
+++ b/src/cpp/src/continuous_batching/cache/block_manager.hpp
@@ -863,14 +863,7 @@ public:
     }
 
     /**
-     * @brief Raises the fixed blocks-per-sequence reservation to at least @p num_blocks.
-     *
-     * Used to grow a fixed-size cache's per-sequence footprint when the actual per-request
-     * requirement (e.g. 1 + num_assistant_tokens linear-attention rows for a speculative
-     * verifier) is only known at request admission, after construction. The value never
-     * shrinks. Sequences whose block tables predate the raise are topped up to the new count
-     * on their next append_slots; the pool itself is grown via ensure_sequence_capacity /
-     * grow_fixed_size_capacity. No-op when @p num_blocks does not exceed the current value.
+     * @brief Raises fixed blocks per sequence; never shrinks.
      * @return Whether the reservation was raised.
      */
     bool ensure_fixed_blocks_per_sequence(size_t num_blocks) {

--- a/src/cpp/src/continuous_batching/cache/block_manager.hpp
+++ b/src/cpp/src/continuous_batching/cache/block_manager.hpp
@@ -863,6 +863,27 @@ public:
     }
 
     /**
+     * @brief Raises the fixed blocks-per-sequence reservation to at least @p num_blocks.
+     *
+     * Used to grow a fixed-size cache's per-sequence footprint when the actual per-request
+     * requirement (e.g. 1 + num_assistant_tokens linear-attention rows for a speculative
+     * verifier) is only known at request admission, after construction. The value never
+     * shrinks. Sequences whose block tables predate the raise are topped up to the new count
+     * on their next append_slots; the pool itself is grown via ensure_sequence_capacity /
+     * grow_fixed_size_capacity. No-op when @p num_blocks does not exceed the current value.
+     * @return Whether the reservation was raised.
+     */
+    bool ensure_fixed_blocks_per_sequence(size_t num_blocks) {
+        OPENVINO_ASSERT(m_fixed_blocks_per_sequence > 0,
+                        "ensure_fixed_blocks_per_sequence is only valid for fixed-size-per-sequence block managers");
+        if (num_blocks <= m_fixed_blocks_per_sequence) {
+            return false;
+        }
+        m_fixed_blocks_per_sequence = num_blocks;
+        return true;
+    }
+
+    /**
      * Grows the block pool to accommodate at least the given number of additional tokens.
      * @param num_tokens Number of additional tokens to accommodate.
      */

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -683,11 +683,13 @@ public:
     //  Linear attention live/scratch block registry: single source of truth for which owned
     //  state row holds a sequence's committed ("live") recurrent state. Owned set = the
     //  sequence's LA block table (size 1 + num_assistant_tokens); live vs. scratch are index
-    //  roles within it. The registry records only explicit promotions (speculative steps); a
-    //  sequence with no recorded promotion lives on the prefill row (block_table[0]). The live
-    //  index is resolved dynamically from the current block table, so it stays correct across
-    //  block reallocation (preemption/recompute) rather than caching a physical index that can
-    //  go stale.
+    //  roles within it. The registry stores an entry only after an explicit promotion
+    //  (set_linear_attention_live_block, speculative steps); a sequence with no recorded
+    //  promotion has its live index resolved from the current prefill row (block_table[0]) on
+    //  each query. A recorded entry cannot go stale across reallocation: non-speculative
+    //  sequences (e.g. beam search) never get an entry; partial preemption skips fixed-size LA
+    //  rows (block table unchanged); and full preemption (recompute) frees the sequence, which
+    //  erases its entry via free_sequence().
     // -----------------------------------------------------------------------
 
     /// @return Physical block index of the sequence's live linear-attention state row,

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -688,7 +688,7 @@ public:
 
     /// @return Physical block index of the sequence's live linear-attention state row.
     size_t get_linear_attention_live_block(uint64_t seq_id) const {
-        return const_cast<CacheOrchestrator*>(this)->provision_linear_attention_live_block(seq_id);
+        return provision_linear_attention_live_block(seq_id);
     }
 
     /// @brief Records which owned physical block is now the sequence's live state row.
@@ -730,7 +730,7 @@ private:
 
     /// @brief Returns the sequence's live linear-attention block, provisioning it to the
     ///        prefill row (block_table[0]) on first access.
-    size_t provision_linear_attention_live_block(uint64_t seq_id) {
+    size_t provision_linear_attention_live_block(uint64_t seq_id) const {
         OPENVINO_ASSERT(has_linear_attention_cache(), "No linear attention cache registered");
         auto it = m_linear_attention_live_block.find(seq_id);
         if (it != m_linear_attention_live_block.end()) {
@@ -929,7 +929,7 @@ private:
     bool m_use_per_layer_kv_block_indices = false;
     std::map<CacheType, std::set<size_t>> m_pending_zero_blocks;
     // seq_id -> physical block index of the live linear-attention state row.
-    std::map<uint64_t, size_t> m_linear_attention_live_block;
+    mutable std::map<uint64_t, size_t> m_linear_attention_live_block;
 
     void queue_linear_attention_initial_state_zero(CacheType type,
                                                    BlockManager& block_mgr,

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -225,9 +225,26 @@ public:
                 block_mgr->free_sequence(seq_id);
             }
         }
+        m_linear_attention_live_block.erase(seq_id);
     }
 
     void fork_sequence(uint64_t parent_id, uint64_t child_id) {
+        // Forking copies KV-style block tables (shared blocks). Linear-attention rows are
+        // destructively mutated in place: once a speculative parent's live row has moved off
+        // block_table[0], the child cannot safely share it (it would lazily pick block_table[0],
+        // the wrong row). LA-aware fork (copy live row + provision the child's own workspace) is
+        // deferred; fail loud. A live row still at block_table[0] (non-speculative, or never
+        // promoted) forks exactly as before this feature.
+        if (has_linear_attention_cache()) {
+            auto live_it = m_linear_attention_live_block.find(parent_id);
+            if (live_it != m_linear_attention_live_block.end()) {
+                const BlocksPerLayer& owned = get_linear_attention_block_table(parent_id);
+                OPENVINO_ASSERT(!owned.empty() && static_cast<size_t>(owned.front()->get_index()) == live_it->second,
+                                "Forking a sequence whose linear-attention live row has moved off the prefill "
+                                "row is not supported (speculative linear-attention rows cannot be shared); "
+                                "parent sequence ", parent_id);
+            }
+        }
         for (auto& [type, block_mgr] : m_block_managers) {
             block_mgr->fork_sequence(parent_id, child_id);
         }
@@ -563,6 +580,30 @@ public:
     }
 
     /**
+     * @brief Raises the linear-attention fixed blocks-per-sequence reservation to at least
+     *        @p fixed_blocks_per_sequence rows.
+     *
+     * Eager reservation at admission: a hybrid verifier's per-request workspace requirement
+     * (1 live + num_assistant_tokens scratch rows) is only known when the request is admitted,
+     * after orchestrator construction. This raises the reservation so admission control accounts
+     * for the full footprint up front; the pool growth and per-sequence top-up then happen through
+     * the existing fixed-size capacity / append paths before the speculative step runs.
+     *
+     * Strictly gated: only applies when a linear-attention cache is registered AND it is
+     * fixed-size-per-sequence (i.e. enable_prefix_caching == false). Prefix-caching linear
+     * attention is variable-size and is left untouched, as is any KV cache. No-op when the
+     * reservation already covers @p fixed_blocks_per_sequence.
+     * @return Whether the reservation was raised.
+     */
+    bool ensure_linear_attention_fixed_blocks_per_sequence(size_t fixed_blocks_per_sequence) {
+        auto it = m_block_managers.find(CacheType::LINEAR_ATTENTION_CACHE);
+        if (it == m_block_managers.end() || !it->second->is_fixed_size_per_sequence()) {
+            return false;
+        }
+        return it->second->ensure_fixed_blocks_per_sequence(fixed_blocks_per_sequence);
+    }
+
+    /**
      * @brief Ensures each fixed-size-per-sequence cache type has enough free blocks for
      *        the sequence group. Variable-size managers are skipped.
      * @return Whether any fixed-size block pool was grown.
@@ -655,6 +696,33 @@ public:
         return m_block_managers.at(CacheType::LINEAR_ATTENTION_CACHE)->get_block_table_logical_start(seq_id);
     }
 
+    // -----------------------------------------------------------------------
+    //  Linear attention live/scratch block registry: single source of truth for which owned
+    //  state row holds a sequence's committed ("live") recurrent state. Owned set = the
+    //  sequence's LA block table (size 1 + num_assistant_tokens); live vs. scratch are index
+    //  roles within it. Live is provisioned lazily to block_table[0] (prefill row) on first query.
+    // -----------------------------------------------------------------------
+
+    /// @return Physical block index of the sequence's live linear-attention state row.
+    size_t get_linear_attention_live_block(uint64_t seq_id) const {
+        return const_cast<CacheOrchestrator*>(this)->provision_linear_attention_live_block(seq_id);
+    }
+
+    /// @brief Records which owned physical block is now the sequence's live state row.
+    void set_linear_attention_live_block(uint64_t seq_id, size_t physical_block_index) {
+        OPENVINO_ASSERT(has_linear_attention_cache(), "No linear attention cache registered");
+        // A non-owned index would poison the next paging step (scratch = owned minus live).
+        const BlocksPerLayer& owned = get_linear_attention_block_table(seq_id);
+        const bool is_owned = std::any_of(owned.begin(), owned.end(),
+            [physical_block_index](const auto& block) {
+                return static_cast<size_t>(block->get_index()) == physical_block_index;
+            });
+        OPENVINO_ASSERT(is_owned,
+                        "Linear attention live block ", physical_block_index,
+                        " is not in the owned block table for sequence ", seq_id);
+        m_linear_attention_live_block[seq_id] = physical_block_index;
+    }
+
     /// @return Number of KV attention layers only (excluding other cache types).
     size_t get_num_kv_layers() const {
         auto it = m_cache_managers.find(CacheType::KV_CACHE);
@@ -675,6 +743,21 @@ public:
 private:
     bool has_registered_types() const {
         return !m_cache_managers.empty();
+    }
+
+    /// @brief Returns the sequence's live linear-attention block, provisioning it to the
+    ///        prefill row (block_table[0]) on first access.
+    size_t provision_linear_attention_live_block(uint64_t seq_id) {
+        OPENVINO_ASSERT(has_linear_attention_cache(), "No linear attention cache registered");
+        auto it = m_linear_attention_live_block.find(seq_id);
+        if (it != m_linear_attention_live_block.end()) {
+            return it->second;
+        }
+        const BlocksPerLayer& owned = get_linear_attention_block_table(seq_id);
+        OPENVINO_ASSERT(!owned.empty(), "Linear attention block table empty for sequence ", seq_id);
+        const size_t live_block = owned.front()->get_index();
+        m_linear_attention_live_block[seq_id] = live_block;
+        return live_block;
     }
 
     /**
@@ -843,12 +926,15 @@ private:
                 0,
                 true);
         } else {
+            // One live state row per sequence. A hybrid verifier raises this to 1 + N scratch rows
+            // at admission via ensure_linear_attention_fixed_blocks_per_sequence, sized from the
+            // actual admitted request configs rather than the pipeline default.
             la_block_manager = std::make_unique<BlockManager>(
                 config.num_linear_attention_blocks,
                 false,
                 1,
                 1,
-                1);
+                /*fixed_blocks_per_sequence=*/1);
         }
 
         // Linear-attention state tensors are per physical layer/group, but share one logical block table.
@@ -859,6 +945,8 @@ private:
     std::map<CacheType, std::unique_ptr<BlockManager>> m_block_managers;
     bool m_use_per_layer_kv_block_indices = false;
     std::map<CacheType, std::set<size_t>> m_pending_zero_blocks;
+    // seq_id -> physical block index of the live linear-attention state row.
+    std::map<uint64_t, size_t> m_linear_attention_live_block;
 
     void queue_linear_attention_initial_state_zero(CacheType type,
                                                    BlockManager& block_mgr,

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -229,12 +229,7 @@ public:
     }
 
     void fork_sequence(uint64_t parent_id, uint64_t child_id) {
-        // Forking copies KV-style block tables (shared blocks). Linear-attention rows are
-        // destructively mutated in place: once a speculative parent's live row has moved off
-        // block_table[0], the child cannot safely share it (it would lazily pick block_table[0],
-        // the wrong row). LA-aware fork (copy live row + provision the child's own workspace) is
-        // deferred; fail loud. A live row still at block_table[0] (non-speculative, or never
-        // promoted) forks exactly as before this feature.
+        // LA rows are mutated in place; fork only while live row remains the prefill row.
         if (has_linear_attention_cache()) {
             auto live_it = m_linear_attention_live_block.find(parent_id);
             if (live_it != m_linear_attention_live_block.end()) {
@@ -580,19 +575,7 @@ public:
     }
 
     /**
-     * @brief Raises the linear-attention fixed blocks-per-sequence reservation to at least
-     *        @p fixed_blocks_per_sequence rows.
-     *
-     * Eager reservation at admission: a hybrid verifier's per-request workspace requirement
-     * (1 live + num_assistant_tokens scratch rows) is only known when the request is admitted,
-     * after orchestrator construction. This raises the reservation so admission control accounts
-     * for the full footprint up front; the pool growth and per-sequence top-up then happen through
-     * the existing fixed-size capacity / append paths before the speculative step runs.
-     *
-     * Strictly gated: only applies when a linear-attention cache is registered AND it is
-     * fixed-size-per-sequence (i.e. enable_prefix_caching == false). Prefix-caching linear
-     * attention is variable-size and is left untouched, as is any KV cache. No-op when the
-     * reservation already covers @p fixed_blocks_per_sequence.
+     * @brief Raises non-prefix linear-attention rows per sequence.
      * @return Whether the reservation was raised.
      */
     bool ensure_linear_attention_fixed_blocks_per_sequence(size_t fixed_blocks_per_sequence) {

--- a/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_orchestrator.hpp
@@ -683,12 +683,24 @@ public:
     //  Linear attention live/scratch block registry: single source of truth for which owned
     //  state row holds a sequence's committed ("live") recurrent state. Owned set = the
     //  sequence's LA block table (size 1 + num_assistant_tokens); live vs. scratch are index
-    //  roles within it. Live is provisioned lazily to block_table[0] (prefill row) on first query.
+    //  roles within it. The registry records only explicit promotions (speculative steps); a
+    //  sequence with no recorded promotion lives on the prefill row (block_table[0]). The live
+    //  index is resolved dynamically from the current block table, so it stays correct across
+    //  block reallocation (preemption/recompute) rather than caching a physical index that can
+    //  go stale.
     // -----------------------------------------------------------------------
 
-    /// @return Physical block index of the sequence's live linear-attention state row.
+    /// @return Physical block index of the sequence's live linear-attention state row,
+    ///         defaulting to the prefill row (block_table[0]) when no promotion was recorded.
     size_t get_linear_attention_live_block(uint64_t seq_id) const {
-        return provision_linear_attention_live_block(seq_id);
+        OPENVINO_ASSERT(has_linear_attention_cache(), "No linear attention cache registered");
+        auto it = m_linear_attention_live_block.find(seq_id);
+        if (it != m_linear_attention_live_block.end()) {
+            return it->second;
+        }
+        const BlocksPerLayer& owned = get_linear_attention_block_table(seq_id);
+        OPENVINO_ASSERT(!owned.empty(), "Linear attention block table empty for sequence ", seq_id);
+        return owned.front()->get_index();
     }
 
     /// @brief Records which owned physical block is now the sequence's live state row.
@@ -726,21 +738,6 @@ public:
 private:
     bool has_registered_types() const {
         return !m_cache_managers.empty();
-    }
-
-    /// @brief Returns the sequence's live linear-attention block, provisioning it to the
-    ///        prefill row (block_table[0]) on first access.
-    size_t provision_linear_attention_live_block(uint64_t seq_id) const {
-        OPENVINO_ASSERT(has_linear_attention_cache(), "No linear attention cache registered");
-        auto it = m_linear_attention_live_block.find(seq_id);
-        if (it != m_linear_attention_live_block.end()) {
-            return it->second;
-        }
-        const BlocksPerLayer& owned = get_linear_attention_block_table(seq_id);
-        OPENVINO_ASSERT(!owned.empty(), "Linear attention block table empty for sequence ", seq_id);
-        const size_t live_block = owned.front()->get_index();
-        m_linear_attention_live_block[seq_id] = live_block;
-        return live_block;
     }
 
     /**
@@ -929,7 +926,8 @@ private:
     bool m_use_per_layer_kv_block_indices = false;
     std::map<CacheType, std::set<size_t>> m_pending_zero_blocks;
     // seq_id -> physical block index of the live linear-attention state row.
-    mutable std::map<uint64_t, size_t> m_linear_attention_live_block;
+    // Holds only explicit promotions (speculative steps); absent => sequence lives on the prefill row.
+    std::map<uint64_t, size_t> m_linear_attention_live_block;
 
     void queue_linear_attention_initial_state_zero(CacheType type,
                                                    BlockManager& block_mgr,

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -352,11 +352,100 @@ bool ContinuousBatchingPipeline::ContinuousBatchingImpl::has_non_finished_reques
     return !m_awaiting_requests.empty() || !m_requests.empty();
 }
 
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_validate_linear_verifier_constraints() const {
+    if (!m_scheduler->has_linear_attention_cache()) {
+        return;
+    }
+
+    for (const auto& sequence_group : m_requests) {
+        if (sequence_group->get_num_tokens_to_validate() == 0) {
+            continue;
+        }
+
+        OPENVINO_ASSERT(!m_scheduler->get_config().enable_prefix_caching,
+                        "Linear-attention verifier speculative decoding requires enable_prefix_caching=false (not yet supported).");
+
+        const auto& sampling_params = sequence_group->get_sampling_parameters();
+        OPENVINO_ASSERT(sampling_params.assistant_confidence_threshold == 0.f,
+                        "Linear-attention verifier speculative decoding supports a static candidate count only; assistant_confidence_threshold>0 (dynamic candidate count) is not yet supported.");
+        OPENVINO_ASSERT(sampling_params.num_return_sequences == 1,
+                        "Linear-attention verifier speculative decoding requires num_return_sequences=1; parallel sampling / fork is not yet supported.");
+    }
+}
+
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_reserve_linear_attention_scratch() {
+    if (!m_scheduler->has_linear_attention_cache()) {
+        return;
+    }
+
+    size_t max_num_assistant_tokens = 0;
+    for (const auto& sequence_group : m_requests) {
+        const auto& params = sequence_group->get_sampling_parameters();
+        if (params.is_prompt_lookup() || params.is_assisting_generation()) {
+            max_num_assistant_tokens = std::max(max_num_assistant_tokens, params.num_assistant_tokens);
+        }
+    }
+    if (max_num_assistant_tokens == 0) {
+        return;
+    }
+
+    // Reserve 1 live row + num_assistant_tokens scratch rows
+    m_scheduler->ensure_linear_attention_fixed_blocks_per_sequence(1 + max_num_assistant_tokens);
+}
+
+int32_t ContinuousBatchingPipeline::ContinuousBatchingImpl::_select_linear_attention_live_block(
+    const Scheduler::Output::LinearAttentionPagingData& paging_data,
+    size_t processed_after) {
+    // block_indices = [live, live, scratch_1, ..., scratch_N] (size N+2).
+    // advance = how many scheduled inputs the committed state moved past after rejection.
+    OPENVINO_ASSERT(processed_after >= paging_data.num_processed_tokens_before,
+                    "Linear-attention promotion: processed tokens cannot decrease below the pre-forward count (processed_after=",
+                    processed_after, ", processed_before=", paging_data.num_processed_tokens_before, ").");
+    const size_t advance = processed_after - paging_data.num_processed_tokens_before;
+
+    OPENVINO_ASSERT(advance < paging_data.block_indices.size(),
+                    "Linear-attention promotion: advance ", advance, " out of range [0, ",
+                    paging_data.block_indices.size() - 1, "] for block_indices [live, live, scratch...].");
+
+    const int32_t new_live = paging_data.block_indices[advance];
+    OPENVINO_ASSERT(new_live >= 0,
+                    "Linear-attention promotion: selected physical block index must be non-negative, got ", new_live, ".");
+    return new_live;
+}
+
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_update_linear_attention_live_blocks(
+    const Scheduler::Output& scheduler_output) {
+    if (!m_scheduler->has_linear_attention_cache()) {
+        return;
+    }
+
+    for (size_t seq_group_id : scheduler_output.m_scheduled_sequence_groups_ids) {
+        const SequenceGroup::Ptr& sequence_group = m_requests[seq_group_id];
+        const size_t processed_after = sequence_group->get_num_processed_tokens();
+
+        for (const auto& sequence : sequence_group->get_running_sequences()) {
+            const uint64_t seq_id = sequence->get_id();
+            if (!scheduler_output.has_linear_attention_paging_data(seq_id)) {
+                continue;
+            }
+            const auto& paging_data = scheduler_output.get_linear_attention_paging_data(seq_id);
+            if (!paging_data.is_speculative) {
+                continue;
+            }
+
+            const int32_t new_live = _select_linear_attention_live_block(paging_data, processed_after);
+            m_scheduler->set_linear_attention_live_block(seq_id, static_cast<size_t>(new_live));
+        }
+    }
+}
+
 void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
     static ManualTimer step_timer("step()");
     step_timer.start();
 
     _pull_awaiting_requests();
+    _validate_linear_verifier_constraints();
+    _reserve_linear_attention_scratch();
 
     Scheduler::Output scheduler_output;
 
@@ -439,6 +528,12 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
         m_batch_size = sampler_output.num_generated_tokens;
         timer.end();
     }
+
+    // Promote the committed linear-attention state to the correct physical row for any
+    // speculative sequence. Must run after sample() (which rewound get_num_processed_tokens()
+    // to the accepted prefix) and before the fork/free loop (which would free LA rows of
+    // sequences that accepted tokens and also hit EOS this step). No-op for pure-KV models.
+    _update_linear_attention_live_blocks(scheduler_output);
 
     // process sampler_output (e.g. fork or drop sequences from BlockScheduler)
     {

--- a/src/cpp/src/continuous_batching/pipeline_impl.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.hpp
@@ -100,6 +100,26 @@ protected:
     void _prepare_rotation_data_storage(const SchedulerConfig& normalized_config, size_t embedding_size);
     void _set_adaptive_rkv_diversity_blocks(const SchedulerConfig& sched_config, const Scheduler::Output& scheduler_output);
 
+    void _validate_linear_verifier_constraints() const;
+
+    /**
+     * Eager reservation at admission: raises the linear-attention workspace to 1 live +
+     * num_assistant_tokens scratch rows before the first speculative step schedules.
+     */
+    void _reserve_linear_attention_scratch();
+
+    /**
+     * Post-sampling hook that promotes the committed linear-attention state to the correct
+     * physical row for every speculative sequence scheduled this step.
+     */
+    virtual void _update_linear_attention_live_blocks(const Scheduler::Output& scheduler_output);
+
+    /**
+     * Calculates the physical index of the live linear-attention state after verification
+     */
+    static int32_t _select_linear_attention_live_block(const Scheduler::Output::LinearAttentionPagingData& paging_data,
+                                                       size_t processed_after);
+
     virtual void drop_requests();
 
 public:

--- a/src/cpp/src/continuous_batching/pipeline_impl.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.hpp
@@ -102,21 +102,12 @@ protected:
 
     void _validate_linear_verifier_constraints() const;
 
-    /**
-     * Eager reservation at admission: raises the linear-attention workspace to 1 live +
-     * num_assistant_tokens scratch rows before the first speculative step schedules.
-     */
+    /// Reserves LA live + scratch rows for speculative verification.
     void _reserve_linear_attention_scratch();
 
-    /**
-     * Post-sampling hook that promotes the committed linear-attention state to the correct
-     * physical row for every speculative sequence scheduled this step.
-     */
+    /// Promotes committed LA state after sampling.
     virtual void _update_linear_attention_live_blocks(const Scheduler::Output& scheduler_output);
 
-    /**
-     * Calculates the physical index of the live linear-attention state after verification
-     */
     static int32_t _select_linear_attention_live_block(const Scheduler::Output::LinearAttentionPagingData& paging_data,
                                                        size_t processed_after);
 

--- a/src/cpp/src/continuous_batching/scheduler.hpp
+++ b/src/cpp/src/continuous_batching/scheduler.hpp
@@ -274,8 +274,7 @@ public:
         m_cache_orchestrator->set_linear_attention_live_block(seq_id, physical_block_index);
     }
 
-    /// @brief Raises the linear-attention fixed blocks-per-sequence reservation (eager
-    ///        reservation at admission). See CacheOrchestrator for gating and semantics.
+    /// @brief Raises non-prefix linear-attention rows per sequence.
     bool ensure_linear_attention_fixed_blocks_per_sequence(size_t fixed_blocks_per_sequence) {
         return m_cache_orchestrator->ensure_linear_attention_fixed_blocks_per_sequence(fixed_blocks_per_sequence);
     }
@@ -491,9 +490,7 @@ private:
                 // of current sequence group were evicted before
                 size_t num_available_tokens_per_seq = sequence_group->get_num_available_tokens_for_batching();
 
-                // Speculative LA validation requires the whole window (N candidates + 1 base token)
-                // in one step: a partial window desyncs the paging index map and the sampler. So
-                // schedule all N+1 atomically or defer. Scoped to the speculative LA path.
+                // Speculative LA paging requires the whole validation window in one step.
                 const bool is_speculative_linear_attention_window =
                     m_cache_orchestrator->has_linear_attention_cache() &&
                     !m_config.enable_prefix_caching &&
@@ -729,13 +726,11 @@ private:
 
         paging_data.past_length = checked_size_to_int32(num_processed_tokens, "past length", seq_id);
         if (!m_config.enable_prefix_caching) {
-            // Live-block registry is the single source of truth for the non-prefix path; do not
-            // hardcode la_blocks[0] so that interleaved speculative/non-speculative steps share one
-            // notion of "live".
+            // Non-prefix LA uses the live-block registry instead of assuming block_table[0].
             const int32_t live_block = checked_size_to_int32(get_linear_attention_live_block(seq_id), "live block index", seq_id);
             const size_t num_tokens_to_validate = sequence_group->get_num_tokens_to_validate();
             if (num_tokens_to_validate == 0) {
-                // Non-speculative step: read and write the single live state row (read aliases first write).
+                // Non-speculative step: read and write the live row.
                 paging_data.block_indices.push_back(live_block);
                 paging_data.block_indices.push_back(live_block);
                 paging_data.cache_interval = 0;
@@ -744,18 +739,12 @@ private:
                 return;
             }
 
-            // Speculative step: page as [live, live, scratch_1, ..., scratch_N] with one snapshot per
-            // consumed input. block_indices[0] reads the committed state (aliased to first write);
-            // block_indices[2..] are pure writes into reserved scratch rows. The whole validation window
-            // (N candidates + 1 base token) must have been scheduled atomically by the generate-phase
-            // scheduler; a partial window would desynchronize this index mapping from the sampler.
+            // Speculative step: [live, live, scratch_1, ..., scratch_N].
             OPENVINO_ASSERT(num_scheduled_tokens == num_tokens_to_validate + 1,
                             "Speculative linear-attention validation window was not scheduled atomically for sequence ", seq_id,
                             ": scheduled ", num_scheduled_tokens, " tokens, expected ", num_tokens_to_validate + 1,
                             " (", num_tokens_to_validate, " candidates + 1 base token)");
-            // Build [live, live, scratch_1, ..., scratch_N] directly from the owned block table: the
-            // scratch rows are simply the owned rows other than the live one, in table order. Block
-            // tables hold distinct physical blocks, so scratch rows are inherently unique.
+            // Scratch rows are owned LA rows other than the live one.
             paging_data.block_indices.reserve(num_tokens_to_validate + 2);
             paging_data.block_indices.push_back(live_block);
             paging_data.block_indices.push_back(live_block);

--- a/src/cpp/src/continuous_batching/scheduler.hpp
+++ b/src/cpp/src/continuous_batching/scheduler.hpp
@@ -74,6 +74,8 @@ public:
             std::vector<int32_t> block_indices;
             int32_t past_length = 0;
             int32_t cache_interval = 0;
+            bool is_speculative = false;
+            size_t num_processed_tokens_before = 0;
         };
 
         // IDs of scheduled groups
@@ -258,6 +260,24 @@ public:
 
     size_t get_block_size(CacheType type) const {
         return m_cache_orchestrator->get_block_size(type);
+    }
+
+    bool has_linear_attention_cache() const {
+        return m_cache_orchestrator->has_linear_attention_cache();
+    }
+
+    size_t get_linear_attention_live_block(uint64_t seq_id) const {
+        return m_cache_orchestrator->get_linear_attention_live_block(seq_id);
+    }
+
+    void set_linear_attention_live_block(uint64_t seq_id, size_t physical_block_index) {
+        m_cache_orchestrator->set_linear_attention_live_block(seq_id, physical_block_index);
+    }
+
+    /// @brief Raises the linear-attention fixed blocks-per-sequence reservation (eager
+    ///        reservation at admission). See CacheOrchestrator for gating and semantics.
+    bool ensure_linear_attention_fixed_blocks_per_sequence(size_t fixed_blocks_per_sequence) {
+        return m_cache_orchestrator->ensure_linear_attention_fixed_blocks_per_sequence(fixed_blocks_per_sequence);
     }
 
     size_t get_num_kv_logical_blocks(SequenceGroup::CPtr seq_group) const {
@@ -470,6 +490,25 @@ private:
                 // Note: current function can return more than 1 token even for generation phase in case of some tokens
                 // of current sequence group were evicted before
                 size_t num_available_tokens_per_seq = sequence_group->get_num_available_tokens_for_batching();
+
+                // Speculative LA validation requires the whole window (N candidates + 1 base token)
+                // in one step: a partial window desyncs the paging index map and the sampler. So
+                // schedule all N+1 atomically or defer. Scoped to the speculative LA path.
+                const bool is_speculative_linear_attention_window =
+                    m_cache_orchestrator->has_linear_attention_cache() &&
+                    !m_config.enable_prefix_caching &&
+                    sequence_group->get_num_tokens_to_validate() > 0;
+                if (is_speculative_linear_attention_window) {
+                    OPENVINO_ASSERT(m_config.max_num_batched_tokens >= num_available_tokens_per_seq,
+                                    "max_num_batched_tokens (", m_config.max_num_batched_tokens,
+                                    ") is too small to ever schedule the speculative linear-attention validation window of ",
+                                    num_available_tokens_per_seq, " tokens for sequence group ", sequence_group->get_request_id(),
+                                    "; increase max_num_batched_tokens to at least the validation window size");
+                    if (available_tokens_per_seq_in_megabatch < num_available_tokens_per_seq) {
+                        // Remaining megabatch budget cannot fit the full window: defer to a later step without scheduling
+                        continue;
+                    }
+                }
 
                 size_t num_scheduled_tokens_per_seq = std::min(available_tokens_per_seq_in_megabatch, num_available_tokens_per_seq);
                 sequence_group->schedule_tokens(num_scheduled_tokens_per_seq);
@@ -690,10 +729,51 @@ private:
 
         paging_data.past_length = checked_size_to_int32(num_processed_tokens, "past length", seq_id);
         if (!m_config.enable_prefix_caching) {
-            const int32_t block_index = checked_block_index_to_int32(la_blocks[0]->get_index(), seq_id);
-            paging_data.block_indices.push_back(block_index);
-            paging_data.block_indices.push_back(block_index);
-            paging_data.cache_interval = 0;
+            // Live-block registry is the single source of truth for the non-prefix path; do not
+            // hardcode la_blocks[0] so that interleaved speculative/non-speculative steps share one
+            // notion of "live".
+            const int32_t live_block = checked_size_to_int32(get_linear_attention_live_block(seq_id), "live block index", seq_id);
+            const size_t num_tokens_to_validate = sequence_group->get_num_tokens_to_validate();
+            if (num_tokens_to_validate == 0) {
+                // Non-speculative step: read and write the single live state row (read aliases first write).
+                paging_data.block_indices.push_back(live_block);
+                paging_data.block_indices.push_back(live_block);
+                paging_data.cache_interval = 0;
+                paging_data.is_speculative = false;
+                scheduler_output.set_linear_attention_paging_data(seq_id, std::move(paging_data));
+                return;
+            }
+
+            // Speculative step: page as [live, live, scratch_1, ..., scratch_N] with one snapshot per
+            // consumed input. block_indices[0] reads the committed state (aliased to first write);
+            // block_indices[2..] are pure writes into reserved scratch rows. The whole validation window
+            // (N candidates + 1 base token) must have been scheduled atomically by the generate-phase
+            // scheduler; a partial window would desynchronize this index mapping from the sampler.
+            OPENVINO_ASSERT(num_scheduled_tokens == num_tokens_to_validate + 1,
+                            "Speculative linear-attention validation window was not scheduled atomically for sequence ", seq_id,
+                            ": scheduled ", num_scheduled_tokens, " tokens, expected ", num_tokens_to_validate + 1,
+                            " (", num_tokens_to_validate, " candidates + 1 base token)");
+            // Build [live, live, scratch_1, ..., scratch_N] directly from the owned block table: the
+            // scratch rows are simply the owned rows other than the live one, in table order. Block
+            // tables hold distinct physical blocks, so scratch rows are inherently unique.
+            paging_data.block_indices.reserve(num_tokens_to_validate + 2);
+            paging_data.block_indices.push_back(live_block);
+            paging_data.block_indices.push_back(live_block);
+            for (const auto& block : la_blocks) {
+                if (paging_data.block_indices.size() == num_tokens_to_validate + 2) {
+                    break;
+                }
+                const int32_t scratch_block = checked_block_index_to_int32(block->get_index(), seq_id);
+                if (scratch_block != live_block) {
+                    paging_data.block_indices.push_back(scratch_block);
+                }
+            }
+            OPENVINO_ASSERT(paging_data.block_indices.size() == num_tokens_to_validate + 2,
+                            "Linear attention scratch rows insufficient for speculative validation of sequence ", seq_id,
+                            ": need ", num_tokens_to_validate, " scratch rows beyond the live row, owned table has ", la_blocks.size());
+            paging_data.cache_interval = 1;
+            paging_data.is_speculative = true;
+            paging_data.num_processed_tokens_before = num_processed_tokens;
             scheduler_output.set_linear_attention_paging_data(seq_id, std::move(paging_data));
             return;
         }

--- a/src/cpp/src/continuous_batching/scheduler.hpp
+++ b/src/cpp/src/continuous_batching/scheduler.hpp
@@ -496,6 +496,14 @@ private:
                     !m_config.enable_prefix_caching &&
                     sequence_group->get_num_tokens_to_validate() > 0;
                 if (is_speculative_linear_attention_window) {
+                    // LA validation must fit one base token plus all candidates.
+                    const size_t validation_window = sequence_group->get_num_tokens_to_validate() + 1;
+                    OPENVINO_ASSERT(num_available_tokens_per_seq == validation_window,
+                                    "Speculative linear-attention validation window must be scheduled atomically as ",
+                                    validation_window, " tokens (1 base + ", sequence_group->get_num_tokens_to_validate(),
+                                    " candidates) for sequence group ", sequence_group->get_request_id(), ", but ",
+                                    num_available_tokens_per_seq, " tokens are pending; recompute/eviction of a validating "
+                                    "sequence is not supported with linear-attention speculative decoding");
                     OPENVINO_ASSERT(m_config.max_num_batched_tokens >= num_available_tokens_per_seq,
                                     "max_num_batched_tokens (", m_config.max_num_batched_tokens,
                                     ") is too small to ever schedule the speculative linear-attention validation window of ",

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -26,7 +26,6 @@ using namespace ov::genai;
 constexpr size_t TEST_BLOCK_SIZE = 4;
 constexpr size_t TEST_NUM_DECODER_LAYERS = 12;
 
-/// Helper: Create a model with both KV cache and LinearAttention cache inputs.
 std::shared_ptr<ov::Model> create_hybrid_model(ov::Core core, size_t num_layers) {
     ov::NodeVector keys, values, conv_states;
     ov::ParameterVector params;
@@ -89,7 +88,7 @@ std::shared_ptr<ov::Model> create_state_table_model(ov::Core core, const std::ve
     return std::make_shared<ov::Model>(outputs, params);
 }
 
-/// Helper: Create a SequenceGroup with specified request ID and forked sequences if needed.
+/// Creates a SequenceGroup with optional forks.
 SequenceGroup::Ptr create_sequence_group(uint64_t request_id, size_t num_sequences = 1) {
     std::vector<int64_t> tokens = {0, 1, 2, 3};
     auto group = std::make_shared<SequenceGroup>(
@@ -106,13 +105,6 @@ SequenceGroup::Ptr create_sequence_group(uint64_t request_id, size_t num_sequenc
     return group;
 }
 
-/// Helper: Create a CacheOrchestrator with both KV and LinearAttention cache types.
-/// 
-/// @param num_kv_blocks Number of KV blocks to allocate.
-/// @param num_la_blocks Number of LinearAttention blocks to allocate.
-/// @param kv_block_size Block size for KV cache (in tokens).
-/// @param num_layers Number of decoder layers.
-/// @param la_fixed_blocks_per_seq Fixed blocks per sequence for LinearAttention cache.
 std::shared_ptr<CacheOrchestrator> create_hybrid_orchestrator(
         size_t num_kv_blocks,
         size_t num_la_blocks,
@@ -131,7 +123,6 @@ std::shared_ptr<CacheOrchestrator> create_hybrid_orchestrator(
     orchestrator->register_cache_type(
         CacheType::KV_CACHE, std::move(kv_manager), std::move(kv_block_manager));
 
-    // Register LinearAttention cache type with fixed-size-per-sequence mode.
     auto la_manager = std::make_unique<LinearAttentionCacheManager>(request);
     auto la_block_manager = std::make_unique<BlockManager>(
         num_la_blocks,
@@ -323,18 +314,7 @@ TEST(TestCacheOrchestratorHybrid, CreateIgnoresCacheIntervalMultiplierWithoutLin
                                               }));
 }
 
-/// @test RequiredTokens_UsesMax
-/// Verify that required_tokens_count() returns the maximum deficit across all cache types.
-///
-/// Setup: Create a hybrid orchestrator with:
-///   - KV cache: variable-size, block_size=4, 1 block total
-///   - LinearAttention cache: fixed-size-per-seq, block_size=1, 2 blocks total (max 2 sequences)
-///
-/// Scenario: Build a sequence group with 2 running sequences and compare the orchestrator
-/// result against direct per-type calculations.
-///
-/// Expected: required_tokens_count() equals
-/// max(kv_required_tokens_count, la_required_tokens_count).
+/// required_tokens_count() returns the maximum deficit across cache types.
 TEST(TestCacheOrchestratorHybrid, RequiredTokens_UsesMax) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/4,
@@ -348,12 +328,11 @@ TEST(TestCacheOrchestratorHybrid, RequiredTokens_UsesMax) {
     auto seq1 = running[0];
     auto seq2 = running[1];
 
-    // Allocate one token for each running sequence to establish non-empty block tables.
+    // Establish non-empty block tables.
     orchestrator->allocate_tokens(seq1, seq_group, 1, seq_group->get_prompt_len());
     orchestrator->allocate_tokens(seq2, seq_group, 1, seq_group->get_prompt_len());
 
-    // Increase demand for both cache types and compare orchestrator aggregation with
-    // direct per-type computations.
+    // Compare orchestrator aggregation with direct per-type computations.
     seq_group->schedule_tokens(5);
 
     const size_t kv_required_tokens = orchestrator->get_block_manager(CacheType::KV_CACHE).required_tokens_count(seq_group);
@@ -363,26 +342,11 @@ TEST(TestCacheOrchestratorHybrid, RequiredTokens_UsesMax) {
     const size_t actual = orchestrator->required_tokens_count(seq_group);
     EXPECT_EQ(actual, expected);
 
-    // Clean up.
     orchestrator->free_sequence(seq1->get_id());
     orchestrator->free_sequence(seq2->get_id());
 }
 
-/// @test NumFreeBlocks_UsesMin
-/// Verify that num_free_blocks() returns the minimum free blocks across all cache types.
-///
-/// Setup: Create a hybrid orchestrator with:
-///   - KV cache: 8 blocks total
-///   - LinearAttention cache: 4 blocks total (fixed-size-per-seq)
-///
-/// Scenario:
-///   1. Initially: KV has 8 free, LA has 4 free. min(8,4) = 4.
-///   2. Allocate 2 sequences (each uses 1 LA block, 1 KV block).
-///      KV has 7 free, LA has 2 free. min(7,2) = 2.
-///   3. Free 1 sequence.
-///      KV has 8 free, LA has 3 free. min(8,3) = 3.
-///
-/// Expected: num_free_blocks() correctly tracks the minimum across types.
+/// num_free_blocks() returns the minimum free count across cache types.
 TEST(TestCacheOrchestratorHybrid, NumFreeBlocks_UsesMin) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/8,
@@ -391,45 +355,23 @@ TEST(TestCacheOrchestratorHybrid, NumFreeBlocks_UsesMin) {
         /*num_layers=*/1,
         /*la_fixed_blocks_per_seq=*/1);
 
-    // Initially: min(8, 4) = 4 free blocks.
     EXPECT_EQ(orchestrator->num_free_blocks(), 4);
 
-    // Allocate 2 sequences.
     auto seq_group_1 = create_sequence_group(101, /*num_sequences=*/2);
     auto running_1 = seq_group_1->get_running_sequences();
     orchestrator->allocate_tokens(running_1[0], seq_group_1, 1, seq_group_1->get_prompt_len());
     orchestrator->allocate_tokens(running_1[1], seq_group_1, 1, seq_group_1->get_prompt_len());
 
-    // After allocating 2 sequences: KV has 7 or 8 free (depends on block rounding),
-    // LA has 2 free. min should be 2.
     EXPECT_EQ(orchestrator->num_free_blocks(), 2);
 
-    // Free 1 sequence.
     orchestrator->free_sequence(running_1[0]->get_id());
 
-    // After freeing 1: LA has 3 free, KV has more. min should be 3.
     EXPECT_EQ(orchestrator->num_free_blocks(), 3);
 
-    // Clean up.
     orchestrator->free_sequence(running_1[1]->get_id());
 }
 
-/// @test GrowFixedSize_OnlyAffectsFixed
-/// Verify that grow_fixed_size_capacity() only affects fixed-size-per-sequence cache types,
-/// not variable-size types like KV.
-///
-/// Setup: Create a hybrid orchestrator with:
-///   - KV cache (variable-size): 4 blocks initially
-///   - LinearAttention cache (fixed-size): 2 blocks initially
-///
-/// Scenario:
-///   1. Record initial KV and LA block counts.
-///   2. Call grow_fixed_size_capacity(3) to add capacity for 3 more sequences.
-///   3. Verify that:
-///      - KV block count remains 4 (unchanged).
-///      - LA block count increases to 2 + 3*1 = 5 (or appropriate offset).
-///
-/// Expected: Only LA cache grows; KV cache is unaffected.
+/// grow_fixed_size_capacity() affects fixed-size caches only.
 TEST(TestCacheOrchestratorHybrid, GrowFixedSize_OnlyAffectsFixed) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/4,
@@ -444,36 +386,16 @@ TEST(TestCacheOrchestratorHybrid, GrowFixedSize_OnlyAffectsFixed) {
     size_t initial_kv_blocks = kv_bm.get_total_block_count();
     size_t initial_la_blocks = la_bm.get_total_block_count();
 
-    // Grow fixed-size capacity by 3 sequences.
     orchestrator->grow_fixed_size_capacity(3);
 
     size_t final_kv_blocks = kv_bm.get_total_block_count();
     size_t final_la_blocks = la_bm.get_total_block_count();
 
-    // KV should be unchanged.
     EXPECT_EQ(final_kv_blocks, initial_kv_blocks);
-
-    // LA should grow by 3 blocks (1 per sequence).
     EXPECT_EQ(final_la_blocks, initial_la_blocks + 3);
 }
 
-/// @test EnsureSequenceTokenCapacity_SkipsFixed
-/// Verify that ensure_sequence_token_capacity() only affects variable-size cache types,
-/// not fixed-size types like LinearAttention.
-///
-/// Setup: Create a hybrid orchestrator with:
-///   - KV cache (variable-size): 4 blocks initially
-///   - LinearAttention cache (fixed-size): 2 blocks initially
-///
-/// Scenario:
-///   1. Record initial block counts for both cache types.
-///   2. Call ensure_sequence_token_capacity({{100, 1}}) to ensure the KV cache can hold one
-///      sequence with 100 tokens.
-///   3. Verify that:
-///      - KV block count increases to accommodate 100 tokens / block_size.
-///      - LA block count remains 2 (fixed-size cache is not affected by token capacity).
-///
-/// Expected: KV cache grows; LA cache remains unchanged.
+/// ensure_sequence_token_capacity() skips fixed-size caches.
 TEST(TestCacheOrchestratorHybrid, EnsureSequenceTokenCapacity_SkipsFixed) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/4,
@@ -488,32 +410,16 @@ TEST(TestCacheOrchestratorHybrid, EnsureSequenceTokenCapacity_SkipsFixed) {
     size_t initial_kv_blocks = kv_bm.get_total_block_count();
     size_t initial_la_blocks = la_bm.get_total_block_count();
 
-    // Ensure sequence-aware token capacity for one sequence with 100 tokens.
     orchestrator->ensure_sequence_token_capacity({{100, 1}});
 
     size_t final_kv_blocks = kv_bm.get_total_block_count();
     size_t final_la_blocks = la_bm.get_total_block_count();
 
-    // KV blocks should increase (at least 100 / TEST_BLOCK_SIZE = 25 blocks).
     EXPECT_GE(final_kv_blocks, (100 + TEST_BLOCK_SIZE - 1) / TEST_BLOCK_SIZE);
-
-    // LA blocks should remain unchanged (fixed-size cache ignores token capacity).
     EXPECT_EQ(final_la_blocks, initial_la_blocks);
 }
 
-/// @test TotalCacheBytes_IncludesAll
-/// Verify that get_total_cache_size_in_bytes() aggregates memory from all registered cache types.
-///
-/// Setup: Create a hybrid orchestrator with:
-///   - KV cache with block_size_in_bytes = X
-///   - LinearAttention cache with block_size_in_bytes = Y
-///
-/// Scenario:
-///   1. Query get_total_cache_size_in_bytes().
-///   2. Verify the result equals:
-///      (num_kv_blocks * kv_block_size) + (num_la_blocks * la_block_size)
-///
-/// Expected: Aggregate size correctly includes both cache types.
+/// get_total_cache_size_in_bytes() aggregates all cache types.
 TEST(TestCacheOrchestratorHybrid, TotalCacheBytes_IncludesAll) {
     const size_t num_kv_blocks = 8;
     const size_t num_la_blocks = 4;
@@ -539,8 +445,7 @@ TEST(TestCacheOrchestratorHybrid, TotalCacheBytes_IncludesAll) {
     EXPECT_EQ(actual_total, expected_total);
 }
 
-/// Helper: Provision a sequence group's KV + LA workspace through the orchestrator and
-/// return the live sequence id. The owned LA set is established by allocate_tokens.
+/// Provisions one sequence and returns its live sequence id.
 namespace {
 uint64_t provision_single_sequence(const std::shared_ptr<CacheOrchestrator>& orchestrator,
                                    uint64_t request_id) {
@@ -550,8 +455,7 @@ uint64_t provision_single_sequence(const std::shared_ptr<CacheOrchestrator>& orc
     return seq->get_id();
 }
 
-// The owned linear-attention rows that are not the current live one (scratch rows), derived from
-// the public registry accessors.
+// Owned LA rows other than the current live row.
 std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
                                                     uint64_t seq_id) {
     const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
@@ -566,9 +470,7 @@ std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheO
 }
 }  // namespace
 
-/// @test LinearAttentionWorkspace_ReservesOnePlusN
-/// Admission reserves exactly 1 + num_assistant_tokens LA rows per sequence (non-prefix).
-/// With N = 0 the footprint is a single row (unchanged from plain continuous batching).
+/// Admission reserves 1 + N non-prefix LA rows per sequence.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ReservesOnePlusN) {
     for (size_t n : {size_t{0}, size_t{1}, size_t{3}}) {
         const size_t fixed_blocks = 1 + n;
@@ -591,11 +493,7 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ReservesOnePlusN) {
     }
 }
 
-/// @test LinearAttentionWorkspace_LiveBlockDefaultsToBlockTableFront
-/// get_linear_attention_live_block(seq) initially equals block_table[0]'s physical index.
-/// @test LinearAttentionWorkspace_LiveBlockDefaultsToFrontAndRoundTrips
-/// The live block defaults to the prefill row (block_table[0]) on first query, and
-/// set_linear_attention_live_block then get_linear_attention_live_block round-trips.
+/// Live LA block defaults to block_table[0] and round-trips through setter.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_LiveBlockDefaultsToFrontAndRoundTrips) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/16,
@@ -608,10 +506,8 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_LiveBlockDefaultsToFr
     const auto& owned = orchestrator->get_linear_attention_block_table(seq_id);
     ASSERT_GE(owned.size(), 2u);
 
-    // Default: live == prefill row.
     EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), owned.front()->get_index());
 
-    // Round-trip: set then get returns the new owned live row.
     const size_t new_live = owned[1]->get_index();
     orchestrator->set_linear_attention_live_block(seq_id, new_live);
     EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), new_live);
@@ -619,10 +515,7 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_LiveBlockDefaultsToFr
     orchestrator->free_sequence(seq_id);
 }
 
-/// @test LinearAttentionWorkspace_ScratchBlocksAreOwnedSetMinusLive
-/// get_linear_attention_scratch_blocks returns exactly the N owned rows other than the
-/// current live one; after set_live to a scratch row the scratch set updates (old live
-/// becomes scratch-eligible).
+/// Scratch rows are owned LA rows excluding the live row.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ScratchBlocksAreOwnedSetMinusLive) {
     const size_t n = 3;
     const size_t fixed_blocks = 1 + n;
@@ -652,7 +545,6 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ScratchBlocksAreOwned
     reconstructed.insert(initial_live);
     EXPECT_EQ(reconstructed, owned_indices);
 
-    // Promote a scratch row to live; the old live must now be scratch-eligible.
     const size_t promoted = *scratch_set.begin();
     orchestrator->set_linear_attention_live_block(seq_id, promoted);
     auto scratch_after = linear_attention_scratch_blocks(orchestrator, seq_id);
@@ -665,9 +557,7 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ScratchBlocksAreOwned
     orchestrator->free_sequence(seq_id);
 }
 
-/// @test LinearAttentionWorkspace_OwnedSetNotReapedByCleanup
-/// The owned set is never reaped by free_empty_physical_blocks while the sequence runs,
-/// and the registry survives cleanup.
+/// Live LA registry survives cleanup while sequence runs.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_OwnedSetNotReapedByCleanup) {
     const size_t fixed_blocks = 1 + 3;
     auto orchestrator = create_hybrid_orchestrator(
@@ -694,7 +584,6 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_OwnedSetNotReapedByCl
     for (size_t i = 0; i < owned_after.size(); ++i) {
         EXPECT_EQ(owned_after[i]->get_index(), owned_before[i]->get_index());
     }
-    // Registry entry survives cleanup.
     EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), promoted);
 
     orchestrator->free_sequence(seq_id);
@@ -712,10 +601,8 @@ TEST(TestCacheOrchestratorHybrid, PartialPreemptionIsDisallowedWhenFixedSizeTarg
     auto target = create_sequence_group(201, /*num_sequences=*/1);
     auto victim_seq = victim->get_running_sequences()[0];
 
-    // Allocate victim to occupy both KV and fixed-size LA resources.
     orchestrator->allocate_tokens(victim_seq, victim, TEST_BLOCK_SIZE + 1, victim->get_prompt_len());
 
-    // Target has no LA allocation yet, so fixed-size cache needs blocks.
     EXPECT_FALSE(orchestrator->can_partially_preempt(victim, target));
 
     orchestrator->free_sequence(victim_seq->get_id());
@@ -734,24 +621,19 @@ TEST(TestCacheOrchestratorHybrid, PartialPreemptionIsDisallowedWhenFixedSizeVict
     auto victim_seq = victim->get_running_sequences()[0];
     auto target_seq = target->get_running_sequences()[0];
 
-    // Allocate both groups once to consume fixed-size LA blocks. This makes LA deficit zero for target.
+    // Target already owns LA state; only KV has token demand below.
     orchestrator->allocate_tokens(victim_seq, victim, TEST_BLOCK_SIZE * 2 + 1, victim->get_prompt_len());
     orchestrator->allocate_tokens(target_seq, target, 1, target->get_prompt_len());
 
-    // Increase target token demand so KV has a non-zero deficit.
     target->schedule_tokens(TEST_BLOCK_SIZE + 1);
 
-    // The target already owns fixed-size LA state, but the victim also owns LA state
-    // that cannot represent token-level rollback. Partial preemption must be rejected.
     EXPECT_FALSE(orchestrator->can_partially_preempt(victim, target));
 
     orchestrator->free_sequence(victim_seq->get_id());
     orchestrator->free_sequence(target_seq->get_id());
 }
 
-/// @test LinearAttentionWorkspace_SetLiveBlockRejectsNonOwnedBlock
-/// The live-block setter is the single source of truth; recording an index outside the
-/// sequence's owned block table must fail loud rather than poison the next paging step.
+/// Live LA block must belong to the sequence-owned table.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_SetLiveBlockRejectsNonOwnedBlock) {
     const size_t fixed_blocks = 1 + 3;
     auto orchestrator = create_hybrid_orchestrator(
@@ -768,23 +650,18 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_SetLiveBlockRejectsNo
     for (const auto& block : owned) {
         owned_indices.insert(block->get_index());
     }
-    // Pick an index that is definitely not owned by the sequence.
     size_t non_owned = 0;
     while (owned_indices.count(non_owned) != 0) {
         ++non_owned;
     }
     EXPECT_THROW(orchestrator->set_linear_attention_live_block(seq_id, non_owned), ov::Exception);
 
-    // An owned index is accepted.
     EXPECT_NO_THROW(orchestrator->set_linear_attention_live_block(seq_id, *owned_indices.begin()));
 
     orchestrator->free_sequence(seq_id);
 }
 
-/// @test LinearAttentionWorkspace_ForkRejectedWhenLiveRowMovedOffPrefill
-/// Forking shares block tables KV-style, which is unsafe once a speculative live row has
-/// moved off the prefill row (the child would lazily pick the wrong row). A live row still
-/// at block_table[0] forks as before.
+/// Fork is rejected after live LA row moves off prefill row.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ForkRejectedWhenLiveRowMovedOffPrefill) {
     const size_t fixed_blocks = 1 + 3;
     auto orchestrator = create_hybrid_orchestrator(
@@ -797,12 +674,12 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ForkRejectedWhenLiveR
     const uint64_t parent_id = provision_single_sequence(orchestrator, 460);
     const auto& owned = orchestrator->get_linear_attention_block_table(parent_id);
 
-    // Live still at prefill row (block_table[0]) → fork is allowed.
+    // Live at prefill row: fork allowed.
     EXPECT_EQ(orchestrator->get_linear_attention_live_block(parent_id), owned.front()->get_index());
     EXPECT_NO_THROW(orchestrator->fork_sequence(parent_id, /*child_id=*/9001));
     orchestrator->free_sequence(9001);
 
-    // Promote live off the prefill row → fork must now fail loud.
+    // Live off prefill row: fork rejected.
     orchestrator->set_linear_attention_live_block(parent_id, owned.back()->get_index());
     EXPECT_THROW(orchestrator->fork_sequence(parent_id, /*child_id=*/9002), ov::Exception);
 

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -14,7 +14,6 @@
 #include "continuous_batching/cache/linear_attention_cache_manager.hpp"
 #include "continuous_batching/cache/block_manager.hpp"
 #include "continuous_batching/scheduler.hpp"
-#include "continuous_batching/pipeline_impl.hpp"
 #include "sequence_group.hpp"
 #include "utils.hpp"
 #include "helper.hpp"

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -14,6 +14,7 @@
 #include "continuous_batching/cache/linear_attention_cache_manager.hpp"
 #include "continuous_batching/cache/block_manager.hpp"
 #include "continuous_batching/scheduler.hpp"
+#include "continuous_batching/pipeline_impl.hpp"
 #include "sequence_group.hpp"
 #include "utils.hpp"
 #include "helper.hpp"
@@ -538,6 +539,167 @@ TEST(TestCacheOrchestratorHybrid, TotalCacheBytes_IncludesAll) {
     EXPECT_EQ(actual_total, expected_total);
 }
 
+/// Helper: Provision a sequence group's KV + LA workspace through the orchestrator and
+/// return the live sequence id. The owned LA set is established by allocate_tokens.
+namespace {
+uint64_t provision_single_sequence(const std::shared_ptr<CacheOrchestrator>& orchestrator,
+                                   uint64_t request_id) {
+    auto seq_group = create_sequence_group(request_id, /*num_sequences=*/1);
+    auto seq = seq_group->get_running_sequences()[0];
+    orchestrator->allocate_tokens(seq, seq_group, 1, seq_group->get_prompt_len());
+    return seq->get_id();
+}
+
+// The owned linear-attention rows that are not the current live one (scratch rows), derived from
+// the public registry accessors.
+std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
+                                                    uint64_t seq_id) {
+    const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
+    std::vector<size_t> scratch_blocks;
+    for (const auto& block : orchestrator->get_linear_attention_block_table(seq_id)) {
+        const size_t physical_index = block->get_index();
+        if (physical_index != live_block) {
+            scratch_blocks.push_back(physical_index);
+        }
+    }
+    return scratch_blocks;
+}
+}  // namespace
+
+/// @test LinearAttentionWorkspace_ReservesOnePlusN
+/// Admission reserves exactly 1 + num_assistant_tokens LA rows per sequence (non-prefix).
+/// With N = 0 the footprint is a single row (unchanged from plain continuous batching).
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ReservesOnePlusN) {
+    for (size_t n : {size_t{0}, size_t{1}, size_t{3}}) {
+        const size_t fixed_blocks = 1 + n;
+        auto orchestrator = create_hybrid_orchestrator(
+            /*num_kv_blocks=*/16,
+            /*num_la_blocks=*/fixed_blocks,
+            TEST_BLOCK_SIZE,
+            /*num_layers=*/1,
+            /*la_fixed_blocks_per_seq=*/fixed_blocks);
+
+        const auto& la_bm = orchestrator->get_block_manager(CacheType::LINEAR_ATTENTION_CACHE);
+        EXPECT_EQ(la_bm.get_fixed_blocks_per_sequence(), fixed_blocks);
+
+        const uint64_t seq_id = provision_single_sequence(orchestrator, 400 + n);
+
+        const auto& owned = orchestrator->get_linear_attention_block_table(seq_id);
+        EXPECT_EQ(owned.size(), fixed_blocks);
+
+        orchestrator->free_sequence(seq_id);
+    }
+}
+
+/// @test LinearAttentionWorkspace_LiveBlockDefaultsToBlockTableFront
+/// get_linear_attention_live_block(seq) initially equals block_table[0]'s physical index.
+/// @test LinearAttentionWorkspace_LiveBlockDefaultsToFrontAndRoundTrips
+/// The live block defaults to the prefill row (block_table[0]) on first query, and
+/// set_linear_attention_live_block then get_linear_attention_live_block round-trips.
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_LiveBlockDefaultsToFrontAndRoundTrips) {
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/4,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/4);
+
+    const uint64_t seq_id = provision_single_sequence(orchestrator, 410);
+    const auto& owned = orchestrator->get_linear_attention_block_table(seq_id);
+    ASSERT_GE(owned.size(), 2u);
+
+    // Default: live == prefill row.
+    EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), owned.front()->get_index());
+
+    // Round-trip: set then get returns the new owned live row.
+    const size_t new_live = owned[1]->get_index();
+    orchestrator->set_linear_attention_live_block(seq_id, new_live);
+    EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), new_live);
+
+    orchestrator->free_sequence(seq_id);
+}
+
+/// @test LinearAttentionWorkspace_ScratchBlocksAreOwnedSetMinusLive
+/// get_linear_attention_scratch_blocks returns exactly the N owned rows other than the
+/// current live one; after set_live to a scratch row the scratch set updates (old live
+/// becomes scratch-eligible).
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ScratchBlocksAreOwnedSetMinusLive) {
+    const size_t n = 3;
+    const size_t fixed_blocks = 1 + n;
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/fixed_blocks,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/fixed_blocks);
+
+    const uint64_t seq_id = provision_single_sequence(orchestrator, 430);
+
+    const auto& owned = orchestrator->get_linear_attention_block_table(seq_id);
+    std::set<size_t> owned_indices;
+    for (const auto& block : owned) {
+        owned_indices.insert(block->get_index());
+    }
+    ASSERT_EQ(owned_indices.size(), fixed_blocks);
+
+    const size_t initial_live = orchestrator->get_linear_attention_live_block(seq_id);
+    auto scratch = linear_attention_scratch_blocks(orchestrator, seq_id);
+    EXPECT_EQ(scratch.size(), n);
+
+    std::set<size_t> scratch_set(scratch.begin(), scratch.end());
+    EXPECT_EQ(scratch_set.count(initial_live), 0u);
+    std::set<size_t> reconstructed = scratch_set;
+    reconstructed.insert(initial_live);
+    EXPECT_EQ(reconstructed, owned_indices);
+
+    // Promote a scratch row to live; the old live must now be scratch-eligible.
+    const size_t promoted = *scratch_set.begin();
+    orchestrator->set_linear_attention_live_block(seq_id, promoted);
+    auto scratch_after = linear_attention_scratch_blocks(orchestrator, seq_id);
+    std::set<size_t> scratch_after_set(scratch_after.begin(), scratch_after.end());
+
+    EXPECT_EQ(scratch_after.size(), n);
+    EXPECT_EQ(scratch_after_set.count(promoted), 0u);
+    EXPECT_EQ(scratch_after_set.count(initial_live), 1u);
+
+    orchestrator->free_sequence(seq_id);
+}
+
+/// @test LinearAttentionWorkspace_OwnedSetNotReapedByCleanup
+/// The owned set is never reaped by free_empty_physical_blocks while the sequence runs,
+/// and the registry survives cleanup.
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_OwnedSetNotReapedByCleanup) {
+    const size_t fixed_blocks = 1 + 3;
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/fixed_blocks,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/fixed_blocks);
+
+    auto seq_group = create_sequence_group(440, /*num_sequences=*/1);
+    auto seq = seq_group->get_running_sequences()[0];
+    orchestrator->allocate_tokens(seq, seq_group, 1, seq_group->get_prompt_len());
+    const uint64_t seq_id = seq->get_id();
+
+    const auto owned_before = orchestrator->get_linear_attention_block_table(seq_id);
+    ASSERT_EQ(owned_before.size(), fixed_blocks);
+    const size_t promoted = owned_before[2]->get_index();
+    orchestrator->set_linear_attention_live_block(seq_id, promoted);
+
+    orchestrator->free_empty_physical_blocks(seq_group);
+
+    const auto& owned_after = orchestrator->get_linear_attention_block_table(seq_id);
+    EXPECT_EQ(owned_after.size(), fixed_blocks);
+    for (size_t i = 0; i < owned_after.size(); ++i) {
+        EXPECT_EQ(owned_after[i]->get_index(), owned_before[i]->get_index());
+    }
+    // Registry entry survives cleanup.
+    EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), promoted);
+
+    orchestrator->free_sequence(seq_id);
+}
+
 TEST(TestCacheOrchestratorHybrid, PartialPreemptionIsDisallowedWhenFixedSizeTargetNeedsBlocks) {
     auto orchestrator = create_hybrid_orchestrator(
         /*num_kv_blocks=*/8,
@@ -585,4 +747,64 @@ TEST(TestCacheOrchestratorHybrid, PartialPreemptionIsDisallowedWhenFixedSizeVict
 
     orchestrator->free_sequence(victim_seq->get_id());
     orchestrator->free_sequence(target_seq->get_id());
+}
+
+/// @test LinearAttentionWorkspace_SetLiveBlockRejectsNonOwnedBlock
+/// The live-block setter is the single source of truth; recording an index outside the
+/// sequence's owned block table must fail loud rather than poison the next paging step.
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_SetLiveBlockRejectsNonOwnedBlock) {
+    const size_t fixed_blocks = 1 + 3;
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/fixed_blocks,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/fixed_blocks);
+
+    const uint64_t seq_id = provision_single_sequence(orchestrator, 450);
+
+    const auto& owned = orchestrator->get_linear_attention_block_table(seq_id);
+    std::set<size_t> owned_indices;
+    for (const auto& block : owned) {
+        owned_indices.insert(block->get_index());
+    }
+    // Pick an index that is definitely not owned by the sequence.
+    size_t non_owned = 0;
+    while (owned_indices.count(non_owned) != 0) {
+        ++non_owned;
+    }
+    EXPECT_THROW(orchestrator->set_linear_attention_live_block(seq_id, non_owned), ov::Exception);
+
+    // An owned index is accepted.
+    EXPECT_NO_THROW(orchestrator->set_linear_attention_live_block(seq_id, *owned_indices.begin()));
+
+    orchestrator->free_sequence(seq_id);
+}
+
+/// @test LinearAttentionWorkspace_ForkRejectedWhenLiveRowMovedOffPrefill
+/// Forking shares block tables KV-style, which is unsafe once a speculative live row has
+/// moved off the prefill row (the child would lazily pick the wrong row). A live row still
+/// at block_table[0] forks as before.
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ForkRejectedWhenLiveRowMovedOffPrefill) {
+    const size_t fixed_blocks = 1 + 3;
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/2 * fixed_blocks,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/fixed_blocks);
+
+    const uint64_t parent_id = provision_single_sequence(orchestrator, 460);
+    const auto& owned = orchestrator->get_linear_attention_block_table(parent_id);
+
+    // Live still at prefill row (block_table[0]) → fork is allowed.
+    EXPECT_EQ(orchestrator->get_linear_attention_live_block(parent_id), owned.front()->get_index());
+    EXPECT_NO_THROW(orchestrator->fork_sequence(parent_id, /*child_id=*/9001));
+    orchestrator->free_sequence(9001);
+
+    // Promote live off the prefill row → fork must now fail loud.
+    orchestrator->set_linear_attention_live_block(parent_id, owned.back()->get_index());
+    EXPECT_THROW(orchestrator->fork_sequence(parent_id, /*child_id=*/9002), ov::Exception);
+
+    orchestrator->free_sequence(parent_id);
 }

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -453,20 +453,6 @@ uint64_t provision_single_sequence(const std::shared_ptr<CacheOrchestrator>& orc
     orchestrator->allocate_tokens(seq, seq_group, 1, seq_group->get_prompt_len());
     return seq->get_id();
 }
-
-// Owned LA rows other than the current live row.
-std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
-                                                    uint64_t seq_id) {
-    const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
-    std::vector<size_t> scratch_blocks;
-    for (const auto& block : orchestrator->get_linear_attention_block_table(seq_id)) {
-        const size_t physical_index = block->get_index();
-        if (physical_index != live_block) {
-            scratch_blocks.push_back(physical_index);
-        }
-    }
-    return scratch_blocks;
-}
 }  // namespace
 
 /// Admission reserves 1 + N non-prefix LA rows per sequence.

--- a/tests/cpp/cache_orchestrator_hybrid.cpp
+++ b/tests/cpp/cache_orchestrator_hybrid.cpp
@@ -514,6 +514,51 @@ TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_LiveBlockDefaultsToFr
     orchestrator->free_sequence(seq_id);
 }
 
+/// Non-speculative live-row reads must track current prefill row after copy-on-write.
+TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_DefaultLiveBlockTracksReallocatedPrefillRow) {
+    auto orchestrator = create_hybrid_orchestrator(
+        /*num_kv_blocks=*/16,
+        /*num_la_blocks=*/4,
+        TEST_BLOCK_SIZE,
+        /*num_layers=*/1,
+        /*la_fixed_blocks_per_seq=*/1);
+
+    auto seq_group = create_sequence_group(420, /*num_sequences=*/1);
+    auto parent = seq_group->get_running_sequences()[0];
+    const uint64_t parent_id = parent->get_id();
+    orchestrator->allocate_tokens(parent, seq_group, 1, seq_group->get_prompt_len());
+
+    const size_t original_prefill = orchestrator->get_linear_attention_live_block(parent_id);
+    auto child = seq_group->fork_sequence(parent);
+    const uint64_t child_id = child->get_id();
+    orchestrator->fork_sequence(parent_id, child_id);
+
+    seq_group->schedule_tokens(1);
+    orchestrator->append_slots(seq_group);
+
+    const auto& parent_owned = orchestrator->get_linear_attention_block_table(parent_id);
+    EXPECT_EQ(parent_owned.size(), 1u);
+    if (parent_owned.size() == 1u) {
+        const size_t reallocated_prefill = parent_owned.front()->get_index();
+        EXPECT_NE(reallocated_prefill, original_prefill);
+        EXPECT_EQ(orchestrator->get_linear_attention_live_block(parent_id), reallocated_prefill);
+    }
+
+    bool extra_child_forked = false;
+    try {
+        orchestrator->fork_sequence(parent_id, /*child_id=*/9003);
+        extra_child_forked = true;
+    } catch (const std::exception& ex) {
+        ADD_FAILURE() << ex.what();
+    }
+
+    if (extra_child_forked) {
+        orchestrator->free_sequence(9003);
+    }
+    orchestrator->free_sequence(child_id);
+    orchestrator->free_sequence(parent_id);
+}
+
 /// Scratch rows are owned LA rows excluding the live row.
 TEST(TestCacheOrchestratorHybrid, LinearAttentionWorkspace_ScratchBlocksAreOwnedSetMinusLive) {
     const size_t n = 3;

--- a/tests/cpp/helper.cpp
+++ b/tests/cpp/helper.cpp
@@ -75,3 +75,16 @@ std::shared_ptr<ov::Model> get_dummy_hybrid_model(ov::Core core, size_t kv_num_l
     
     return std::make_shared<ov::Model>(outputs, params);
 }
+
+std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<ov::genai::CacheOrchestrator>& orchestrator,
+                                                     uint64_t seq_id) {
+    const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
+    std::vector<size_t> scratch_blocks;
+    for (const auto& block : orchestrator->get_linear_attention_block_table(seq_id)) {
+        const size_t physical_index = block->get_index();
+        if (physical_index != live_block) {
+            scratch_blocks.push_back(physical_index);
+        }
+    }
+    return scratch_blocks;
+}

--- a/tests/cpp/helper.hpp
+++ b/tests/cpp/helper.hpp
@@ -5,6 +5,13 @@
 
 #include "openvino/runtime/core.hpp"
 
+#include "continuous_batching/cache/cache_orchestrator.hpp"
+
 std::shared_ptr<ov::Model> get_dummy_model(ov::Core core, size_t num_layers);
 
 std::shared_ptr<ov::Model> get_dummy_hybrid_model(ov::Core core, size_t kv_num_layers, size_t la_num_layers);
+
+// The owned linear-attention rows that are not the current live one (scratch rows), derived from
+// the public registry accessors. Mirrors what the scheduler builds inline for speculative paging.
+std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<ov::genai::CacheOrchestrator>& orchestrator,
+                                                     uint64_t seq_id);

--- a/tests/cpp/scheduler.cpp
+++ b/tests/cpp/scheduler.cpp
@@ -95,6 +95,7 @@ std::shared_ptr<CacheOrchestrator> init_hybrid_cache_orchestrator(SchedulerConfi
 
 // The owned linear-attention rows that are not the current live one (scratch rows), derived from
 // the public registry accessors. Mirrors what the scheduler builds inline for speculative paging.
+namespace {
 std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
                                                     uint64_t seq_id) {
     const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
@@ -107,6 +108,7 @@ std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheO
     }
     return scratch_blocks;
 }
+}  // namespace
 
 std::shared_ptr<CacheOrchestrator> init_linear_attention_cache_orchestrator(SchedulerConfig scheduler_config,
                                                                             size_t la_num_layers = 1) {

--- a/tests/cpp/scheduler.cpp
+++ b/tests/cpp/scheduler.cpp
@@ -93,22 +93,6 @@ std::shared_ptr<CacheOrchestrator> init_hybrid_cache_orchestrator(SchedulerConfi
     return orchestrator;
 }
 
-// The owned linear-attention rows that are not the current live one (scratch rows), derived from
-// the public registry accessors. Mirrors what the scheduler builds inline for speculative paging.
-namespace {
-std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
-                                                    uint64_t seq_id) {
-    const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
-    std::vector<size_t> scratch_blocks;
-    for (const auto& block : orchestrator->get_linear_attention_block_table(seq_id)) {
-        const size_t physical_index = block->get_index();
-        if (physical_index != live_block) {
-            scratch_blocks.push_back(physical_index);
-        }
-    }
-    return scratch_blocks;
-}
-}  // namespace
 
 std::shared_ptr<CacheOrchestrator> init_linear_attention_cache_orchestrator(SchedulerConfig scheduler_config,
                                                                             size_t la_num_layers = 1) {

--- a/tests/cpp/scheduler.cpp
+++ b/tests/cpp/scheduler.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <numeric>
 #include <set>
 #include "openvino/runtime/core.hpp"
@@ -11,6 +12,7 @@
 #include "openvino/genai/generation_config.hpp"
 #include "sequence_group.hpp"
 #include "continuous_batching/scheduler.hpp"
+#include "continuous_batching/pipeline_impl.hpp"
 #include "continuous_batching/cache/cache_orchestrator.hpp"
 #include "continuous_batching/cache/kv_cache_manager.hpp"
 #include "continuous_batching/cache/linear_attention_cache_manager.hpp"
@@ -72,11 +74,14 @@ std::shared_ptr<CacheOrchestrator> init_hybrid_cache_orchestrator(SchedulerConfi
         const size_t num_la_blocks = scheduler_config.num_linear_attention_blocks > 0
                                          ? scheduler_config.num_linear_attention_blocks
                                          : (scheduler_config.num_kv_blocks > 0 ? scheduler_config.max_num_seqs : 0);
+        // One live row per sequence, mirroring CacheOrchestrator::register_linear_attention_cache.
+        // A hybrid verifier raises this to 1 + N at admission via
+        // ensure_linear_attention_fixed_blocks_per_sequence (see the speculative tests below).
         la_block_manager = std::make_unique<BlockManager>(num_la_blocks,
                                                           false,
                                                           1,
                                                           1,  // one logical block table for all LA layers
-                                                          1);
+                                                          /*fixed_blocks_per_sequence=*/1);
     }
 
     auto orchestrator = std::make_shared<CacheOrchestrator>();
@@ -86,6 +91,21 @@ std::shared_ptr<CacheOrchestrator> init_hybrid_cache_orchestrator(SchedulerConfi
                                       std::move(la_cache_manager),
                                       std::move(la_block_manager));
     return orchestrator;
+}
+
+// The owned linear-attention rows that are not the current live one (scratch rows), derived from
+// the public registry accessors. Mirrors what the scheduler builds inline for speculative paging.
+std::vector<size_t> linear_attention_scratch_blocks(const std::shared_ptr<CacheOrchestrator>& orchestrator,
+                                                    uint64_t seq_id) {
+    const size_t live_block = orchestrator->get_linear_attention_live_block(seq_id);
+    std::vector<size_t> scratch_blocks;
+    for (const auto& block : orchestrator->get_linear_attention_block_table(seq_id)) {
+        const size_t physical_index = block->get_index();
+        if (physical_index != live_block) {
+            scratch_blocks.push_back(physical_index);
+        }
+    }
+    return scratch_blocks;
 }
 
 std::shared_ptr<CacheOrchestrator> init_linear_attention_cache_orchestrator(SchedulerConfig scheduler_config,
@@ -364,6 +384,487 @@ TEST(TestScheduler, hybrid_non_prefix_linear_attention_returns_aliased_read_writ
     EXPECT_EQ(paging_data.cache_interval, 0);
     EXPECT_EQ(paging_data.past_length, 0);
     EXPECT_EQ(orchestrator->get_linear_attention_block_table(seq_id).size(), 1);
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_non_speculative_honors_live_block_registry) {
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = 32;
+    scheduler_config.num_kv_blocks = 8;
+    scheduler_config.num_linear_attention_blocks = 8;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 8;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id = seq_group->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group};
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+    // One scratch row so the live block can be moved off block_table[0].
+    scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + 1);
+
+    // Default (no live override): non-speculative paging is [live, live], interval 0.
+    auto out = scheduler.schedule(requests);
+    ASSERT_TRUE(out.has_linear_attention_paging_data(seq_id));
+    {
+        const auto& paging_data = out.get_linear_attention_paging_data(seq_id);
+        ASSERT_EQ(paging_data.block_indices.size(), 2);
+        EXPECT_EQ(paging_data.block_indices[0], paging_data.block_indices[1]);
+        EXPECT_EQ(paging_data.cache_interval, 0);
+        EXPECT_FALSE(paging_data.is_speculative);
+        EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[0]), orchestrator->get_linear_attention_live_block(seq_id));
+    }
+    seq_group->finish_iteration();
+
+    // Override the live block to a scratch row; the next non-speculative step must emit [X, X],
+    // proving the registry is honored rather than a hardcoded la_blocks[0].
+    const std::vector<size_t> scratch = linear_attention_scratch_blocks(orchestrator, seq_id);
+    ASSERT_FALSE(scratch.empty());
+    const size_t new_live = scratch.front();
+    EXPECT_NE(new_live, orchestrator->get_linear_attention_live_block(seq_id));
+    scheduler.set_linear_attention_live_block(seq_id, new_live);
+
+    auto running_sequence = seq_group->get_running_sequences()[0];
+    running_sequence->append_token(42, 0.9f);
+    seq_group->update_processed_tokens_num(tokens.size());
+
+    auto gen_out = scheduler.schedule(requests);
+    ASSERT_TRUE(gen_out.has_linear_attention_paging_data(seq_id));
+    {
+        const auto& paging_data = gen_out.get_linear_attention_paging_data(seq_id);
+        ASSERT_EQ(paging_data.block_indices.size(), 2);
+        EXPECT_EQ(paging_data.block_indices[0], paging_data.block_indices[1]);
+        EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[0]), new_live);
+        EXPECT_EQ(paging_data.cache_interval, 0);
+        EXPECT_FALSE(paging_data.is_speculative);
+    }
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_speculative_emits_live_live_scratch_window) {
+    constexpr size_t N = 3;
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = 32;
+    scheduler_config.num_kv_blocks = 8;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id = seq_group->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group};
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+    // Eager admission-time reservation, as the pipeline does before scheduling a speculative step.
+    scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N);
+
+    std::ignore = scheduler.schedule(requests);
+    seq_group->finish_iteration();
+
+    auto running_sequence = seq_group->get_running_sequences()[0];
+    running_sequence->append_token(42, 0.9f);
+    seq_group->update_processed_tokens_num(tokens.size());
+    seq_group->set_num_validated_tokens(N);
+
+    const size_t live = orchestrator->get_linear_attention_live_block(seq_id);
+    const std::vector<size_t> scratch = linear_attention_scratch_blocks(orchestrator, seq_id);
+    ASSERT_EQ(scratch.size(), N);
+
+    auto out = scheduler.schedule(requests);
+    ASSERT_TRUE(out.has_linear_attention_paging_data(seq_id));
+    const auto& paging_data = out.get_linear_attention_paging_data(seq_id);
+
+    ASSERT_EQ(paging_data.block_indices.size(), N + 2);
+    EXPECT_EQ(paging_data.block_indices[0], paging_data.block_indices[1]);
+    EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[0]), live);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[i + 2]), scratch[i]);
+        EXPECT_NE(paging_data.block_indices[i + 2], paging_data.block_indices[0]);
+    }
+    EXPECT_EQ(paging_data.cache_interval, 1);
+    EXPECT_TRUE(paging_data.is_speculative);
+    EXPECT_EQ(paging_data.num_processed_tokens_before, seq_group->get_num_processed_tokens());
+    EXPECT_EQ(paging_data.num_processed_tokens_before, tokens.size());
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+// Regression guard for DEFECT A: the linear-attention scratch reservation must reflect the actual
+// per-request num_assistant_tokens (known only at admission), not the construction-time value.
+// The orchestrator here is built WITHOUT N (default fixed_blocks_per_sequence == 1, mirroring an
+// orchestrator created from a generation_config.json that does not carry num_assistant_tokens). The
+// per-request requirement (1 + N) is then supplied at admission via
+// ensure_linear_attention_fixed_blocks_per_sequence (exactly what the pipeline's
+// _reserve_linear_attention_scratch does before scheduling). The reservation must grow to 1 + N and
+// the speculative window must schedule without tripping the "scratch rows insufficient" assert.
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_admission_reservation_grows_to_one_plus_n_per_request) {
+    constexpr size_t N = 2;
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = 32;
+    scheduler_config.num_kv_blocks = 8;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id = seq_group->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group};
+
+    // Orchestrator built with the default construction-time fixed_blocks_per_sequence == 1 (no scratch).
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    ASSERT_EQ(orchestrator->get_block_manager(CacheType::LINEAR_ATTENTION_CACHE).get_fixed_blocks_per_sequence(), 1u);
+
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+
+    // Eager reservation at admission, sized from the per-request num_assistant_tokens.
+    EXPECT_TRUE(scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N));
+    EXPECT_EQ(orchestrator->get_block_manager(CacheType::LINEAR_ATTENTION_CACHE).get_fixed_blocks_per_sequence(), 1u + N);
+    // Idempotent / monotonic: never shrinks, no-op when already covered.
+    EXPECT_FALSE(scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N));
+
+    std::ignore = scheduler.schedule(requests);
+    seq_group->finish_iteration();
+
+    auto running_sequence = seq_group->get_running_sequences()[0];
+    running_sequence->append_token(42, 0.9f);
+    seq_group->update_processed_tokens_num(tokens.size());
+    seq_group->set_num_validated_tokens(N);
+
+    // The reserved workspace now provides 1 live + N scratch rows for this sequence.
+    const size_t live = orchestrator->get_linear_attention_live_block(seq_id);
+    const std::vector<size_t> scratch = linear_attention_scratch_blocks(orchestrator, seq_id);
+    ASSERT_EQ(scratch.size(), N);
+
+    // Speculative schedule must succeed (previously tripped the scratch-insufficient assert).
+    auto out = scheduler.schedule(requests);
+    ASSERT_TRUE(out.has_linear_attention_paging_data(seq_id));
+    const auto& paging_data = out.get_linear_attention_paging_data(seq_id);
+    ASSERT_EQ(paging_data.block_indices.size(), N + 2);
+    EXPECT_EQ(paging_data.block_indices[0], paging_data.block_indices[1]);
+    EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[0]), live);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(static_cast<size_t>(paging_data.block_indices[i + 2]), scratch[i]);
+        EXPECT_NE(paging_data.block_indices[i + 2], paging_data.block_indices[0]);
+    }
+    EXPECT_EQ(paging_data.cache_interval, 1);
+    EXPECT_TRUE(paging_data.is_speculative);
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+// Gating guard for DEFECT A fix: ensure_linear_attention_fixed_blocks_per_sequence must be a no-op
+// for prefix-caching linear attention (variable-size, not fixed-size-per-sequence), so the fix does
+// not perturb the prefix-caching path.
+TEST(TestScheduler, hybrid_prefix_caching_linear_attention_admission_reservation_is_no_op) {
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = 32;
+    scheduler_config.num_kv_blocks = 64;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.cache_interval_multiplier = TEST_CUSTOM_CACHE_INTERVAL_MULTIPLIER;
+    scheduler_config.enable_prefix_caching = true;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+
+    EXPECT_FALSE(orchestrator->get_block_manager(CacheType::LINEAR_ATTENTION_CACHE).is_fixed_size_per_sequence());
+    EXPECT_FALSE(scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + 5));
+    EXPECT_FALSE(orchestrator->get_block_manager(CacheType::LINEAR_ATTENTION_CACHE).is_fixed_size_per_sequence());
+}
+
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_speculative_window_is_atomic_or_deferred_under_megabatch_pressure) {
+    // Two validating sequences (N candidates each => validation window N+1). The megabatch budget fits
+    // the full window of exactly one of them per step. The scheduler must schedule the full N+1 for the
+    // first and defer the second to 0 (never a partial 1..N). On the next step (budget freed) the deferred
+    // sequence schedules its full window and emits the [live, live, scratch...] paging data of size N+2.
+    constexpr size_t N = 3;
+    constexpr size_t WINDOW = N + 1;  // 4
+    SchedulerConfig scheduler_config;
+    // Budget fits one full window (4) plus a partial second (2) -- never the full second window.
+    scheduler_config.max_num_batched_tokens = WINDOW + (WINDOW - 2);  // 6
+    scheduler_config.num_kv_blocks = 32;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group_a = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    SequenceGroup::Ptr seq_group_b = std::make_shared<SequenceGroup>(
+        1,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id_a = seq_group_a->get_running_sequences()[0]->get_id();
+    const auto seq_id_b = seq_group_b->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group_a, seq_group_b};
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+    // Eager admission-time reservation, as the pipeline does before scheduling a speculative step.
+    scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N);
+
+    // The megabatch budget only fits one prompt (len 4) per step, so prompt both sequences over
+    // multiple steps before exercising the generate-phase validation-window scheduling.
+    while (seq_group_a->get_num_processed_tokens() < tokens.size() ||
+           seq_group_b->get_num_processed_tokens() < tokens.size()) {
+        std::ignore = scheduler.schedule(requests);
+        for (auto& req : requests) {
+            if (req->is_scheduled()) {
+                req->finish_iteration();
+            }
+        }
+    }
+
+    for (auto& req : requests) {
+        req->get_running_sequences()[0]->append_token(42, 0.9f);
+        req->update_processed_tokens_num(tokens.size());
+        req->set_num_validated_tokens(N);
+    }
+
+    const size_t live_b = orchestrator->get_linear_attention_live_block(seq_id_b);
+    const std::vector<size_t> scratch_b = linear_attention_scratch_blocks(orchestrator, seq_id_b);
+    ASSERT_EQ(scratch_b.size(), N);
+
+    // Step 1: first sequence gets the full window, the second is deferred (scheduled 0, not partial).
+    auto out1 = scheduler.schedule(requests);
+    ASSERT_TRUE(out1.has_linear_attention_paging_data(seq_id_a));
+    EXPECT_EQ(out1.get_linear_attention_paging_data(seq_id_a).block_indices.size(), N + 2);
+    EXPECT_TRUE(out1.get_linear_attention_paging_data(seq_id_a).is_speculative);
+    EXPECT_EQ(seq_group_a->get_num_scheduled_tokens(), WINDOW);
+
+    // The deferred sequence must not be scheduled at all this step -- never a partial 1..N window.
+    EXPECT_EQ(seq_group_b->get_num_scheduled_tokens(), 0u);
+    EXPECT_FALSE(out1.has_linear_attention_paging_data(seq_id_b));
+    EXPECT_EQ(out1.m_scheduled_sequence_groups_ids, std::vector<uint64_t>({0}));
+
+    seq_group_a->finish_iteration();
+
+    // Step 2: only the deferred sequence still requests a window; the freed budget now fits the full N+1.
+    auto out2 = scheduler.schedule(requests);
+    ASSERT_TRUE(out2.has_linear_attention_paging_data(seq_id_b));
+    const auto& paging_b = out2.get_linear_attention_paging_data(seq_id_b);
+    ASSERT_EQ(paging_b.block_indices.size(), N + 2);
+    EXPECT_EQ(seq_group_b->get_num_scheduled_tokens(), WINDOW);
+    EXPECT_EQ(paging_b.block_indices[0], paging_b.block_indices[1]);
+    EXPECT_EQ(static_cast<size_t>(paging_b.block_indices[0]), live_b);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(static_cast<size_t>(paging_b.block_indices[i + 2]), scratch_b[i]);
+        EXPECT_NE(paging_b.block_indices[i + 2], paging_b.block_indices[0]);
+    }
+    EXPECT_EQ(paging_b.cache_interval, 1);
+    EXPECT_TRUE(paging_b.is_speculative);
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_speculative_window_too_large_for_megabatch_asserts) {
+    // Misconfiguration: max_num_batched_tokens can never fit a single sequence's N+1 validation window.
+    // Deferring forever would deadlock, so the scheduler asserts instead.
+    constexpr size_t N = 5;  // window N+1 = 6 > max_num_batched_tokens
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = N;  // strictly less than N+1
+    scheduler_config.num_kv_blocks = 32;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id = seq_group->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group};
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+    // Eager admission-time reservation, as the pipeline does before scheduling a speculative step.
+    scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N);
+
+    std::ignore = scheduler.schedule(requests);
+    seq_group->finish_iteration();
+
+    seq_group->get_running_sequences()[0]->append_token(42, 0.9f);
+    seq_group->update_processed_tokens_num(tokens.size());
+    seq_group->set_num_validated_tokens(N);
+
+    EXPECT_THROW(std::ignore = scheduler.schedule(requests), ov::Exception);
+
+    for (auto& req : requests) {
+        for (auto& seq : req->get_sequences()) {
+            scheduler.free_sequence(seq->get_id());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Step 5: workspace reuse across consecutive speculative steps.
+//
+// These tests drive the scheduler through several back-to-back speculative
+// validation windows, mimicking the post-sampling promotion (Step 4's hook) by
+// calling set_linear_attention_live_block(seq_id, block_indices[advance]) with a
+// chosen advance. They assert the reuse that emerges from Steps 1+2+4: the
+// owned LA set never grows, per-step aliasing holds, a promoted scratch row
+// becomes the next step's live (with the previous live recycled as scratch), and
+// the registry only ever exposes a row that was written by the step that set it.
+// ---------------------------------------------------------------------------
+namespace {
+// Drive one speculative step for a single validating sequence and return its paging data.
+// Pre: the sequence has prompt processed and a token appended; caller has set processed/validation.
+Scheduler::Output run_one_speculative_step(Scheduler& scheduler,
+                                           std::vector<SequenceGroup::Ptr>& requests) {
+    return scheduler.schedule(requests);
+}
+}  // namespace
+
+// @test hybrid_non_prefix_linear_attention_steady_state_no_growth_mixed_advance
+// Across >=4 consecutive speculative steps with mixed advance values (full-accept,
+// partial, full-reject), the sequence's owned LA block table stays 1+N rows: no LA
+// allocation/free mid-run (invariant 1). The promoted block each step is always one
+// of that step's block_indices entries (invariant 3 / selection guard).
+TEST(TestScheduler, hybrid_non_prefix_linear_attention_steady_state_no_growth_mixed_advance) {
+    constexpr size_t N = 3;
+    SchedulerConfig scheduler_config;
+    scheduler_config.max_num_batched_tokens = 64;
+    scheduler_config.num_kv_blocks = 64;
+    scheduler_config.num_linear_attention_blocks = 16;
+    scheduler_config.enable_prefix_caching = false;
+    scheduler_config.dynamic_split_fuse = false;
+    scheduler_config.max_num_seqs = 4;
+
+    std::vector<uint64_t> tokens = {0, 1, 2, 3};
+    SequenceGroup::Ptr seq_group = std::make_shared<SequenceGroup>(
+        0,
+        ov::Tensor(ov::element::i64, {tokens.size()}, tokens.data()),
+        utils::get_greedy_config());
+    const auto seq_id = seq_group->get_running_sequences()[0]->get_id();
+    std::vector<SequenceGroup::Ptr> requests = {seq_group};
+
+    auto orchestrator = init_hybrid_cache_orchestrator(scheduler_config,
+                                                       TEST_BLOCK_SIZE,
+                                                       /*kv_num_layers=*/1,
+                                                       /*la_num_layers=*/1);
+    Scheduler scheduler = Scheduler(orchestrator, scheduler_config);
+    // Eager admission-time reservation, as the pipeline does before scheduling a speculative step.
+    scheduler.ensure_linear_attention_fixed_blocks_per_sequence(1 + N);
+
+    // Prompt phase.
+    std::ignore = scheduler.schedule(requests);
+    seq_group->finish_iteration();
+    auto sequence = seq_group->get_running_sequences()[0];
+    sequence->append_token(42, 0.9f);
+    seq_group->update_processed_tokens_num(tokens.size());
+
+    const size_t owned_size = orchestrator->get_linear_attention_block_table(seq_id).size();
+    ASSERT_EQ(owned_size, N + 1);
+
+    // Mixed advance schedule: full reject (0), full accept (N+1), partial (2), full accept, partial (1).
+    const std::vector<size_t> advances = {0, N + 1, 2, N + 1, 1};
+    size_t processed = seq_group->get_num_processed_tokens();
+
+    size_t prev_live = orchestrator->get_linear_attention_live_block(seq_id);
+    for (size_t step = 0; step < advances.size(); ++step) {
+        seq_group->set_num_validated_tokens(N);
+
+        auto out = run_one_speculative_step(scheduler, requests);
+        ASSERT_TRUE(out.has_linear_attention_paging_data(seq_id));
+        const auto& pd = out.get_linear_attention_paging_data(seq_id);
+        ASSERT_TRUE(pd.is_speculative);
+        ASSERT_EQ(pd.block_indices.size(), N + 2);
+
+        // Invariant 1: owned LA set never grows or shrinks.
+        EXPECT_EQ(orchestrator->get_linear_attention_block_table(seq_id).size(), N + 1)
+            << "owned LA set changed size at step " << step;
+
+        // Invariant 2: per-step aliasing and distinct scratch rows.
+        EXPECT_EQ(pd.block_indices[0], pd.block_indices[1]);
+        EXPECT_EQ(static_cast<size_t>(pd.block_indices[0]), prev_live);
+        std::set<int32_t> scratch_seen;
+        for (size_t i = 2; i < pd.block_indices.size(); ++i) {
+            EXPECT_NE(pd.block_indices[i], pd.block_indices[0]) << "scratch aliases live at step " << step;
+            EXPECT_TRUE(scratch_seen.insert(pd.block_indices[i]).second)
+                << "duplicate scratch row at step " << step;
+        }
+
+        // Mimic Step 4's promotion: pick block_indices[advance] (selection guard: advance <= N+1).
+        const size_t advance = advances[step];
+        ASSERT_LT(advance, pd.block_indices.size());
+        const int32_t chosen = pd.block_indices[advance];
+        // Invariant 3 / selection guard: the promoted block is always within this step's write set.
+        EXPECT_TRUE(std::find(pd.block_indices.begin(), pd.block_indices.end(), chosen) != pd.block_indices.end());
+        scheduler.set_linear_attention_live_block(seq_id, static_cast<size_t>(chosen));
+
+        // Commit the step: advance processed tokens, finish, extend content by one accepted token.
+        seq_group->finish_iteration();
+        processed += advance;  // committed prefix length advanced by `advance`
+        seq_group->update_processed_tokens_num(processed);
+        sequence->append_token(100 + static_cast<int64_t>(step), 0.9f);
+
+        prev_live = static_cast<size_t>(chosen);
+        EXPECT_EQ(orchestrator->get_linear_attention_live_block(seq_id), prev_live);
+    }
+
+    // Final no-growth check after the whole run.
+    EXPECT_EQ(orchestrator->get_linear_attention_block_table(seq_id).size(), N + 1);
 
     for (auto& req : requests) {
         for (auto& seq : req->get_sequences()) {
@@ -2425,4 +2926,100 @@ TEST(TestScheduler, prefix_caching_embeddings_test) {
             }
          }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Step 4: post-sampling live-block promotion math (ContinuousBatchingImpl::_select_linear_attention_live_block)
+// ---------------------------------------------------------------------------
+
+// Test seam: ContinuousBatchingImpl is a protected nested type of ContinuousBatchingPipeline and
+// _select_linear_attention_live_block is a protected static member. Reaching both requires deriving
+// the seam from ContinuousBatchingPipeline (mirrors CBForSDTest in speculative_decoding.cpp). The
+// thin subclass surfaces the pure promotion math (advance bounds + "no-zeroing" write-window guard)
+// so it is unit-testable without constructing a model / scheduler / orchestrator.
+namespace {
+struct LiveBlockSelectorSeam : public ContinuousBatchingPipeline {
+    class LiveBlockSelectorAccessor : public ContinuousBatchingImpl {
+    public:
+        using ContinuousBatchingImpl::_select_linear_attention_live_block;
+    };
+};
+using LiveBlockSelectorAccessor = LiveBlockSelectorSeam::LiveBlockSelectorAccessor;
+
+Scheduler::Output::LinearAttentionPagingData make_speculative_paging_data(
+    const std::vector<int32_t>& block_indices,
+    size_t num_processed_tokens_before) {
+    Scheduler::Output::LinearAttentionPagingData paging_data;
+    paging_data.block_indices = block_indices;
+    paging_data.cache_interval = 1;
+    paging_data.is_speculative = true;
+    paging_data.num_processed_tokens_before = num_processed_tokens_before;
+    return paging_data;
+}
+}  // namespace
+
+// @test live_block_promotion_advance_zero_and_one_keep_old_live_via_aliasing
+// block_indices = [live, live, s1, s2, s3]. advance 0 (counter reads 0 on full rejection) and
+// advance 1 both index the aliased read slot, so the promoted row stays the old live row.
+TEST(TestScheduler, live_block_promotion_advance_zero_and_one_keep_old_live_via_aliasing) {
+    constexpr int32_t old_live = 7;
+    const std::vector<int32_t> block_indices = {old_live, old_live, 10, 11, 12};  // N = 3
+    constexpr size_t processed_before = 100;
+
+    const auto paging_data = make_speculative_paging_data(block_indices, processed_before);
+
+    // advance == 0
+    EXPECT_EQ(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before),
+              old_live);
+    // advance == 1
+    EXPECT_EQ(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before + 1),
+              old_live);
+}
+
+// @test live_block_promotion_middle_advance_selects_scratch_row
+// advance == 2 (middle) promotes the freshly-written scratch_2 row (block_indices[2]).
+TEST(TestScheduler, live_block_promotion_middle_advance_selects_scratch_row) {
+    const std::vector<int32_t> block_indices = {7, 7, 10, 11, 12};  // N = 3
+    constexpr size_t processed_before = 100;
+    const auto paging_data = make_speculative_paging_data(block_indices, processed_before);
+
+    EXPECT_EQ(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before + 2),
+              block_indices[2]);  // 10
+    EXPECT_EQ(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before + 3),
+              block_indices[3]);  // 11
+}
+
+// @test live_block_promotion_full_acceptance_advance_n_plus_one_selects_last_scratch
+// advance == N+1 (all candidates accepted) promotes the last scratch row (block_indices.back()).
+TEST(TestScheduler, live_block_promotion_full_acceptance_advance_n_plus_one_selects_last_scratch) {
+    const std::vector<int32_t> block_indices = {7, 7, 10, 11, 12};  // N = 3, window N+1 = 4
+    constexpr size_t processed_before = 100;
+    const auto paging_data = make_speculative_paging_data(block_indices, processed_before);
+
+    // advance == N + 1 == 4 == block_indices.size() - 1 (last valid index)
+    EXPECT_EQ(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before + 4),
+              block_indices.back());  // 12
+}
+
+// @test live_block_promotion_out_of_range_advance_asserts
+// advance > N+1 indexes past the current step's write window and must fail loud (no silent
+// selection of a row outside this step's writes).
+TEST(TestScheduler, live_block_promotion_out_of_range_advance_asserts) {
+    const std::vector<int32_t> block_indices = {7, 7, 10, 11, 12};  // size 5, last valid advance 4
+    constexpr size_t processed_before = 100;
+    const auto paging_data = make_speculative_paging_data(block_indices, processed_before);
+
+    EXPECT_THROW(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before + 5),
+                 ov::Exception);
+}
+
+// @test live_block_promotion_processed_decrease_asserts
+// processed_after below the pre-forward count is impossible (would underflow advance); fail loud.
+TEST(TestScheduler, live_block_promotion_processed_decrease_asserts) {
+    const std::vector<int32_t> block_indices = {7, 7, 10, 11, 12};
+    constexpr size_t processed_before = 100;
+    const auto paging_data = make_speculative_paging_data(block_indices, processed_before);
+
+    EXPECT_THROW(LiveBlockSelectorAccessor::_select_linear_attention_live_block(paging_data, processed_before - 1),
+                 ov::Exception);
 }

--- a/tests/python_tests/data/models.py
+++ b/tests/python_tests/data/models.py
@@ -17,17 +17,9 @@ def get_models_list() -> tuple[str, ...]:
 
 CHAT_MODELS_LIST = ("Qwen/Qwen2-0.5B-Instruct",)
 
-LINEAR_ATTENTION_MODELS_LIST = ()
-if is_transformers_version(">=", "5.0"):
-    LINEAR_ATTENTION_MODELS_LIST = (
-        # "optimum-intel-internal-testing/tiny-mamba",  # beam_idx is not connected
-        # "optimum-intel-internal-testing/tiny-random-zamba2",  # no chat template
-        "optimum-intel-internal-testing/tiny-random-granitemoehybrid",
-        "optimum-intel-internal-testing/tiny-random-lfm2",
-    )
-elif is_transformers_version(">=", "4.57"):
-    # Restore after fix https://github.com/huggingface/optimum-intel/pull/1589
-    LINEAR_ATTENTION_MODELS_LIST = ("optimum-intel-internal-testing/tiny-random-qwen3-next",)
+LINEAR_ATTENTION_MODELS_LIST = ("optimum-intel-internal-testing/tiny-random-lfm2",)
+if is_transformers_version(">=", "4.57.0") and is_transformers_version("<=", "4.57.6"):
+    LINEAR_ATTENTION_MODELS_LIST += ("optimum-intel-internal-testing/tiny-random-qwen3-next",)
 
 
 GGUF_MODEL_LIST = (

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -177,13 +177,6 @@ def llm_model(request: pytest.FixtureRequest) -> OVConvertedModelSchema:
 
 @pytest.fixture(scope="module")
 def ov_pipe(llm_model: OVConvertedModelSchema) -> ov_genai.LLMPipeline:
-    if llm_model.model_id in LINEAR_ATTENTION_MODELS_LIST and (
-        is_transformers_version("<", "4.57") or is_transformers_version(">=", "5.0")
-    ):
-        # AUTO PA backend with linear attention models is not supported
-        # for transformers less than 4.57 and greater or equal to 5.0
-        # should be explicitly set to STATEFUL to avoid init error
-        return create_ov_pipeline(llm_model.models_path, pipeline_type=PipelineType.STATEFUL)
     return create_ov_pipeline(llm_model.models_path)
 
 
@@ -207,9 +200,6 @@ def test_string_inputs(
     )
 
 
-@pytest.mark.transformers_dependent(
-    reason="qwen3_next is not supported by optimum-intel 423b423 with transformers>=5.0"
-)
 @pytest.mark.parametrize("llm_model", LINEAR_ATTENTION_MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("generation_config_dict,prompt", GREEDY_INPUTS_TEST_CASES)  # exclude beam search case
 @pytest.mark.parametrize("pipeline_type", LINEAR_ATTENTION_PIPELINE_TYPES)
@@ -228,10 +218,7 @@ def test_linear_attention_string_inputs(
 
 
 ENCODED_INPUTS_MODELS_LIST = [*LINEAR_ATTENTION_MODELS_LIST]
-if is_transformers_version(">=", "5.0"):
-    # LINEAR_ATTENTION_MODELS_LIST depends on the tranformers version, but MODELS_LIST is the same
-    # to eliminate duplication of tests, MODELS_LIST will be added for transformers>=5.0 only
-    ENCODED_INPUTS_MODELS_LIST += MODELS_LIST
+ENCODED_INPUTS_MODELS_LIST += MODELS_LIST
 
 
 @pytest.mark.transformers_dependent(

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -28,6 +28,7 @@ from utils.tokenizers import (
 from utils.ov_genai_pipelines import (
     ALL_PIPELINE_TYPES,
     LINEAR_ATTENTION_PIPELINE_TYPES,
+    LINEAR_ATTENTION_SPECULATIVE_PIPELINE_TYPES,
     create_ov_pipeline,
     generate_and_compare,
     MAIN_PIPELINE_TYPES,
@@ -373,6 +374,43 @@ def test_linear_model_deterministic(
     result1 = ov_pipe.generate(prompt, generation_config=config)
     result2 = ov_pipe.generate(prompt, generation_config=config)
     assert result1 == result2
+
+
+LINEAR_ATTENTION_SPECULATIVE_PROMPTS = [
+    "Repeat this text exactly: the quick brown fox jumps. "
+    "the quick brown fox jumps. the quick brown fox jumps. the quick brown fox jumps.",
+    "one two three four one two three four one two three four one two three four one two three four",
+]
+
+
+@pytest.mark.parametrize("llm_model", LINEAR_ATTENTION_MODELS_LIST, indirect=True)
+@pytest.mark.parametrize("pipeline_type", LINEAR_ATTENTION_SPECULATIVE_PIPELINE_TYPES)
+@pytest.mark.parametrize("prompt", LINEAR_ATTENTION_SPECULATIVE_PROMPTS)
+def test_linear_attention_prompt_lookup_matches_non_speculative(
+    llm_model: OVConvertedModelSchema,
+    pipeline_type: PipelineType,
+    prompt: str,
+) -> None:
+    prompts = [prompt]
+    config = ov_genai.GenerationConfig(max_new_tokens=64, apply_chat_template=False, do_sample=False)
+
+    speculative_config = ov_genai.GenerationConfig(
+        max_new_tokens=64, apply_chat_template=False, do_sample=False, num_assistant_tokens=5, max_ngram_size=3
+    )
+    speculative_pipe = create_ov_pipeline(llm_model.models_path, pipeline_type=pipeline_type)
+    speculative_result = speculative_pipe.generate(prompts, generation_config=speculative_config)
+    del speculative_pipe
+
+    non_speculative_pipe = create_ov_pipeline(llm_model.models_path, pipeline_type=PipelineType.PAGED_ATTENTION)
+    non_speculative_result = non_speculative_pipe.generate(prompts, generation_config=config)
+    del non_speculative_pipe
+
+    assert speculative_result.texts == non_speculative_result.texts, (
+        f"Prompt-lookup (speculative) output differs from non-speculative output.\n"
+        f"Prompt: {prompt}\n"
+        f"Speculative texts:     {speculative_result.texts}\n"
+        f"Non-speculative texts: {non_speculative_result.texts}"
+    )
 
 
 @pytest.mark.transformers_dependent(

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -444,6 +444,16 @@ def ov_pipe_model(request: pytest.FixtureRequest) -> VlmModelInfo:
 
     models_path = _get_ov_model(ov_model)
 
+    pipeline_properties: dict = {"ATTENTION_BACKEND": ov_backend, "prompt_lookup": ov_prompt_lookup}
+    if "qwen3.5" in ov_model and ov_backend == "PA" and ov_prompt_lookup:
+        # qwen3.5 is a hybrid (linear-attention) model. Prompt lookup on the PA backend engages the
+        # linear-attention verifier, which does not yet support prefix caching. VLMPipeline enables
+        # prefix caching by default (latency-oriented scheduler config), so pass an explicit config
+        # with it disabled instead of relying on the default.
+        scheduler_config = SchedulerConfig()
+        scheduler_config.enable_prefix_caching = False
+        pipeline_properties["scheduler_config"] = scheduler_config
+
     vision_preprocess_env_set = False
     key = "VISION_PREPROCESS"
     if preprocess_method == "CPP":
@@ -453,7 +463,7 @@ def ov_pipe_model(request: pytest.FixtureRequest) -> VlmModelInfo:
             vision_preprocess_env_set = True
 
     try:
-        pipeline = VLMPipeline(models_path, "CPU", ATTENTION_BACKEND=ov_backend, prompt_lookup=ov_prompt_lookup)
+        pipeline = VLMPipeline(models_path, "CPU", **pipeline_properties)
     finally:
         if vision_preprocess_env_set:
             os.environ.pop(key, None)

--- a/tests/python_tests/utils/ov_genai_pipelines.py
+++ b/tests/python_tests/utils/ov_genai_pipelines.py
@@ -65,14 +65,12 @@ MAIN_PIPELINE_TYPES = (
     PipelineType.PROMPT_LOOKUP_DECODING,
 )
 
+LINEAR_ATTENTION_PIPELINE_TYPES = (
+    PipelineType.STATEFUL,
+    PipelineType.PAGED_ATTENTION,
+)
 
-if is_transformers_version("<", "4.57") or is_transformers_version(">=", "5.0"):
-    LINEAR_ATTENTION_PIPELINE_TYPES = (PipelineType.STATEFUL,)
-else:  # transformers==4.57.*
-    LINEAR_ATTENTION_PIPELINE_TYPES = (
-        PipelineType.STATEFUL,
-        PipelineType.PAGED_ATTENTION,
-    )
+LINEAR_ATTENTION_SPECULATIVE_PIPELINE_TYPES = (PipelineType.PROMPT_LOOKUP_DECODING,)
 
 ALL_PIPELINE_TYPES = (
     *MAIN_PIPELINE_TYPES,

--- a/tests/python_tests/utils/ov_genai_pipelines.py
+++ b/tests/python_tests/utils/ov_genai_pipelines.py
@@ -17,8 +17,6 @@ from openvino_genai import (
     StreamerBase, 
     DecodedResults,
 )
-from optimum.intel.utils.import_utils import is_transformers_version
-
 from utils.constants import get_default_llm_properties
 from utils.comparation import compare_generation_results, compare_generation_results_vs_ref
 from utils.hugging_face import OVConvertedModelSchema, download_and_convert_model, run_hugging_face


### PR DESCRIPTION
Enable LA draft token verification via Prompt Lookup decoding enablement.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

```python
import time
from pathlib import Path

import openvino_genai


MODEL_PATH = Path("/path/to/lfm2-350M")
DEVICE = "CPU"
MAX_NEW_TOKENS = 200

PASSAGE = (
    "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. "
    "How vexingly quick daft zebras jump! Sphinx of black quartz, judge my vow. "
    "The five boxing wizards jump quickly. Bright vixens jump; dozy fowl quack. "
    "Jackdaws love my big sphinx of quartz. Two driven jocks help fax my big quiz. "
    "Crazy Fredrick bought many very exquisite opal jewels."
)
USER_MSG = (
    "Repeat the following text verbatim, then write it again with each sentence on a new line, "
    "then list every sentence as a numbered bullet. Do not add any commentary.\n\n"
    f"TEXT:\n{PASSAGE}"
)


def build_config():
    config = openvino_genai.GenerationConfig()
    config.max_new_tokens = MAX_NEW_TOKENS
    config.do_sample = False  # greedy: deterministic oracle
    return config


def run_baseline(chat_history):
    """Non-speculative reference: plain continuous batching, no prompt lookup."""
    # SchedulerConfig() defaults enable_prefix_caching = false (plan scope).
    scheduler_config = openvino_genai.SchedulerConfig()
    assert scheduler_config.enable_prefix_caching is False

    pipe = openvino_genai.LLMPipeline(
        MODEL_PATH, DEVICE, scheduler_config=scheduler_config,
    )
    config = build_config()

    start = time.perf_counter()
    res = pipe.generate(chat_history, config)
    elapsed = time.perf_counter() - start
    del pipe
    return res.texts[0], elapsed


def run_prompt_lookup(chat_history, num_assistant_tokens, max_ngram_size=3):
    """Hybrid LA verifier speculative path: prompt-lookup, prefix caching off."""
    scheduler_config = openvino_genai.SchedulerConfig()
    assert scheduler_config.enable_prefix_caching is False

    pipe = openvino_genai.LLMPipeline(
        MODEL_PATH, DEVICE, prompt_lookup=True, scheduler_config=scheduler_config,
    )
    config = build_config()
    config.num_assistant_tokens = num_assistant_tokens
    config.max_ngram_size = max_ngram_size

    start = time.perf_counter()
    res = pipe.generate(chat_history, config)
    elapsed = time.perf_counter() - start
    del pipe
    return res.texts[0], elapsed


def main():
    messages = [{"role": "user", "content": USER_MSG}]
    chat_history = openvino_genai.ChatHistory(messages)

    print("=== Baseline (non-speculative continuous batching) ===")
    text_base, t_base = run_baseline(chat_history)
    print(text_base)
    print(f"\nBaseline time: {t_base:.2f}s\n")

    # Sweep candidate counts to exercise all-accepted / partial / full-rejection
    # advance values in the live/scratch rollback.
    for n in (3, 5, 6):
        print(f"=== Prompt-lookup (num_assistant_tokens={n}) ===")
        text_pl, t_pl = run_prompt_lookup(chat_history, num_assistant_tokens=n)
        same = text_pl == text_base
        print(text_pl)
        print(f"\nPrompt-lookup time: {t_pl:.2f}s")
        print(f"Output matches baseline (ORACLE): {same}")
        if t_pl > 0:
            print(f"Speedup vs baseline: {t_base / t_pl:.2f}x")
        if not same:
            print("[!] OUTPUT MISMATCH — LA live/scratch rollback is incorrect")
        print()


if __name__ == "__main__":
    main()
```

Output:
```bash
=== Baseline (non-speculative continuous batching) ===
Here are the text repetitions with each sentence on a new line:

1. Quick brown fox jumps over the lazy dog.
2. Pack my box with five dozen liquor jugs.
3. How vexingly quick daft zebras jump!
4. Sphinx of black quartz, judge my vow.
5. The five boxing wizards jump quickly.
6. Bright vixens jump; dozy fowl quack.
7. Jackdaws love my big sphinx of quartz.
8. Two driven jocks help fax my big quiz.
9. Crazy Fredrick bought many very exquisite opal jewels.

**Sentence List:**

1. Pack my box with five dozen liquor jugs.
2. How vexingly quick daft zebras jump!
3. Sphinx of black quartz, judge my vow.
4. The five boxing wizards jump quickly.
5. Bright vixens jump; dozy fowl qu

Baseline time: 3.22s

=== Prompt-lookup (num_assistant_tokens=3) ===
Here are the text repetitions with each sentence on a new line:

1. Quick brown fox jumps over the lazy dog.
2. Pack my box with five dozen liquor jugs.
3. How vexingly quick daft zebras jump!
4. Sphinx of black quartz, judge my vow.
5. The five boxing wizards jump quickly.
6. Bright vixens jump; dozy fowl quack.
7. Jackdaws love my big sphinx of quartz.
8. Two driven jocks help fax my big quiz.
9. Crazy Fredrick bought many very exquisite opal jewels.

**Sentence List:**

1. Pack my box with five dozen liquor jugs.
2. How vexingly quick daft zebras jump!
3. Sphinx of black quartz, judge my vow.
4. The five boxing wizards jump quickly.
5. Bright vixens jump; dozy fowl qu

Prompt-lookup time: 1.66s
Output matches baseline (ORACLE): True
Speedup vs baseline: 1.95x

=== Prompt-lookup (num_assistant_tokens=5) ===
Here are the text repetitions with each sentence on a new line:

1. Quick brown fox jumps over the lazy dog.
2. Pack my box with five dozen liquor jugs.
3. How vexingly quick daft zebras jump!
4. Sphinx of black quartz, judge my vow.
5. The five boxing wizards jump quickly.
6. Bright vixens jump; dozy fowl quack.
7. Jackdaws love my big sphinx of quartz.
8. Two driven jocks help fax my big quiz.
9. Crazy Fredrick bought many very exquisite opal jewels.

**Sentence List:**

1. Pack my box with five dozen liquor jugs.
2. How vexingly quick daft zebras jump!
3. Sphinx of black quartz, judge my vow.
4. The five boxing wizards jump quickly.
5. Bright vixens jump; dozy fowl qu

Prompt-lookup time: 1.65s
Output matches baseline (ORACLE): True
Speedup vs baseline: 1.95x

=== Prompt-lookup (num_assistant_tokens=6) ===
Here are the text repetitions with each sentence on a new line:

1. Quick brown fox jumps over the lazy dog.
2. Pack my box with five dozen liquor jugs.
3. How vexingly quick daft zebras jump!
4. Sphinx of black quartz, judge my vow.
5. The five boxing wizards jump quickly.
6. Bright vixens jump; dozy fowl quack.
7. Jackdaws love my big sphinx of quartz.
8. Two driven jocks help fax my big quiz.
9. Crazy Fredrick bought many very exquisite opal jewels.

**Sentence List:**

1. Pack my box with five dozen liquor jugs.
2. How vexingly quick daft zebras jump!
3. Sphinx of black quartz, judge my vow.
4. The five boxing wizards jump quickly.
5. Bright vixens jump; dozy fowl qu

Prompt-lookup time: 1.77s
Output matches baseline (ORACLE): True
Speedup vs baseline: 1.82x
```

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
