### PR TITLE
Reject empty vocab in structured output constructor

### DIFF
--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
@@ -13,6 +13,10 @@ namespace genai {
 
 XGrammarStructuredOutput::XGrammarStructuredOutput(const ov::genai::Tokenizer::TokenizerImpl& tokenizer_impl, std::optional<int> vocab_size) {
     auto vocab_vector = tokenizer_impl.m_vocab;
+    OPENVINO_ASSERT(!vocab_vector.empty(),
+        "Structured output requires the tokenizer to expose its full vocabulary, but the current tokenizer "
+        "has no vocabulary entries. This typically occurs when the tokenizer is a SentencePiece wrapper "
+        "without a decomposed VocabDecoder node.");
     if (!vocab_size.has_value()) {
         vocab_size = vocab_vector.size();
     }


### PR DESCRIPTION
Tokenizer must expose the vocab to xgrammar, so it can build the state machine. 
Some models have tokenizers that are just wrappers around sentencepiece library (not a decomposed OV tokenizer) - for example https://huggingface.co/OpenVINO/Phi-3-mini-FastDraft-50M-int8-ov/blob/main/openvino_tokenizer.xml#L61 - and doesn't have a vocab constant to expose.

Reject SO for such models early instead of late failure during request processing.