### PR TITLE
[llm_bench] Resolving complicated use cases moved from tool to --task

### DIFF
--- a/tools/llm_bench/llm_bench_utils/get_use_case.py
+++ b/tools/llm_bench/llm_bench_utils/get_use_case.py
@@ -50,19 +50,6 @@ def safe_json_load(file_path: Path) -> Optional[dict]:
     return None
 
 
-def resolve_complex_model_types(config):
-    model_type = config.get("model_type").lower().replace('_', '-')
-    if model_type == "gemma3":
-        return USE_CASES["visual_text_gen"][0], model_type
-    if model_type == "gemma3-text":
-        return USE_CASES["text_gen"][0], model_type
-    if model_type in ["phi4mm", "phi4-multimodal"]:
-        return USE_CASES["visual_text_gen"][0], model_type
-    if model_type == "llama4":
-        return USE_CASES["visual_text_gen"][0], model_type
-    return None, None
-
-
 def get_model_name(model_path: Path, task: Optional[str] = None) -> Tuple[Optional[object], Optional[str], Optional[str]]:
     """
     Attempts to extract the model name and its use case/type from the given path.
@@ -165,10 +152,6 @@ def get_use_case(model_path: Path, task: Optional[str] = None):
     # Strategy 2 & 3: Determine a 'model_id' from config or GGUF metadata
     model_id = None
     if (config := safe_json_load(model_path / "config.json")):
-        # First, attempt resolution with more complex logic
-        case, model_type = resolve_complex_model_types(config)
-        if case and model_type:
-            return log_and_return(case, model_type, cur_model_name)
         # Fallback to simple 'model_type' key
         if model_type_val := config.get("model_type"):
             model_id = str(model_type_val).lower().replace('_', '-')


### PR DESCRIPTION
## Description
Currently, a model_type can no longer be uniquely associated with a case. For example gemma3_text can be treated as text_gen or text_emb. The user can choos the use_case themselves by --task. Therefore, this code should be removed.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-###](https://jira.devtools.intel.com/browse/CVS-190153)

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
