### PR TITLE
[wwb] Move dataset for VLM instruction cases to lmms-lab/VQAv2

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_cdpruner.py
+++ b/tools/who_what_benchmark/tests/test_cli_cdpruner.py
@@ -74,7 +74,6 @@ def run_test(model_id, model_type, tmp_path, pruning_ratio, relevance_weight):
     assert pruner_info in output
 
 
-@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     ("model_id", "model_type", "pruning_ratio", "relevance_weight"),
     [

--- a/tools/who_what_benchmark/tests/test_cli_vlm.py
+++ b/tools/who_what_benchmark/tests/test_cli_vlm.py
@@ -180,7 +180,6 @@ def run_test_with_lora(
     assert similarity_genai >= genai_threshold
 
 
-@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     ("model_id", "model_type"),
     [
@@ -201,7 +200,6 @@ def test_vlm_chat(model_id, model_type, tmp_path):
     run_test(model_id, model_type, None, None, tmp_path)
 
 
-@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.nanollava
 @pytest.mark.parametrize(
     ("model_id", "model_type", "optimum_threshold", "genai_threshold"),
@@ -234,7 +232,6 @@ def test_vlm_video(model_id, model_type, tmp_path):
     run_test(model_id, model_type, 0.8, 0.8, tmp_path)
 
 
-@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     (
         "model_id",

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -211,14 +211,14 @@ def apply_peft_adapters(model, adapters, alphas, merged_adapter_name="merged_lor
 # preapre default dataset for visualtext(VLM) evalutor
 def preprocess_fn(example):
     return {
-        "prompts": example["instruction"],
-        "images": load_image(example["image_url"]),
+        "prompts": example["question"],
+        "images": load_image(example["image"]),
         "videos": None,
     }
 
 
 def prepare_default_data_image(num_samples=None):
-    DATASET_NAME = "ucla-contextual/contextual_test"
+    DATASET_NAME = "lmms-lab/VQAv2"
     NUM_SAMPLES = 24 if num_samples is None else num_samples
     set_seed(42)
     default_dataset = datasets.load_dataset(DATASET_NAME, split="test", streaming=True).shuffle(42).take(NUM_SAMPLES)


### PR DESCRIPTION
## Description
Image source from def dataset ucla-contextual/contextual_test became to not respond. Dataset was replaced to lmms-lab/VQAv2

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-###](https://jira.devtools.intel.com/browse/CVS-190187)


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
