### PR TITLE
[wwb] Skip visual-text due to default dataset is broken

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_vlm.py
+++ b/tools/who_what_benchmark/tests/test_cli_vlm.py
@@ -180,6 +180,7 @@ def run_test_with_lora(
     assert similarity_genai >= genai_threshold
 
 
+@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     ("model_id", "model_type"),
     [
@@ -200,6 +201,7 @@ def test_vlm_chat(model_id, model_type, tmp_path):
     run_test(model_id, model_type, None, None, tmp_path)
 
 
+@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.nanollava
 @pytest.mark.parametrize(
     ("model_id", "model_type", "optimum_threshold", "genai_threshold"),
@@ -232,6 +234,7 @@ def test_vlm_video(model_id, model_type, tmp_path):
     run_test(model_id, model_type, 0.8, 0.8, tmp_path)
 
 
+@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     (
         "model_id",


### PR DESCRIPTION
## Description
Image source from def dataset ucla-contextual/contextual_test became to not respond. The ci tests are skipping for now. If def dataset is restored during the day, the tests will be just unskipped, if not - the dataset will be moved to another one ( https://github.com/openvinotoolkit/openvino.genai/pull/4071 )

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-###](https://jira.devtools.intel.com/browse/CVS-190187)

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
