### PR TITLE
[wwb] Skip test_pruner_basic due to default dataset for visual-text is broken

### DIFF
--- a/tools/who_what_benchmark/tests/test_cli_cdpruner.py
+++ b/tools/who_what_benchmark/tests/test_cli_cdpruner.py
@@ -74,6 +74,7 @@ def run_test(model_id, model_type, tmp_path, pruning_ratio, relevance_weight):
     assert pruner_info in output
 
 
+@pytest.mark.xfail(strict=True, reason="CVS-190187: The default dataset is broken.")
 @pytest.mark.parametrize(
     ("model_id", "model_type", "pruning_ratio", "relevance_weight"),
     [


### PR DESCRIPTION
https://github.com/openvinotoolkit/openvino.genai/pull/4072 + skip test_pruner_basic  
Image source from def dataset ucla-contextual/contextual_test became to not respond. The ci tests are skipping for now. If def dataset is restored during the day, the tests will be just unskipped, if not - the dataset will be moved to another one ( https://github.com/openvinotoolkit/openvino.genai/pull/4071 )

CVS-190187

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
