### PR TITLE
Fix xgrammar structured-output crash at EOS under speculative decoding

### DIFF
--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
@@ -178,7 +178,7 @@ XGrammarLogitsTransformer::XGrammarLogitsTransformer(
 void XGrammarLogitsTransformer::accept_tokens(const TokenIds& input_ids) {
     for (const auto& token : input_ids) {
         if (m_grammar_matcher.IsTerminated()) {
-            break;   // stop feeding draft tokens past the accepted stop token (grammar_matcher.cc:493)
+            break;  // stop accepting tokens once the matcher has terminated (e.g., after accepting the stop token)
         }
         m_grammar_matcher.AcceptToken(token);
     }

--- a/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
+++ b/src/cpp/src/sampling/structured_output/xgrammar_backend.cpp
@@ -177,15 +177,18 @@ XGrammarLogitsTransformer::XGrammarLogitsTransformer(
 
 void XGrammarLogitsTransformer::accept_tokens(const TokenIds& input_ids) {
     for (const auto& token : input_ids) {
+        if (m_grammar_matcher.IsTerminated()) {
+            break;   // stop feeding draft tokens past the accepted stop token (grammar_matcher.cc:493)
+        }
         m_grammar_matcher.AcceptToken(token);
     }
 }
 
 void XGrammarLogitsTransformer::apply(Logits& logits) {
-    m_grammar_matcher.FillNextTokenBitmask(m_token_bitmask.get());
     if (m_grammar_matcher.IsTerminated()) {
         return;
     }
+    m_grammar_matcher.FillNextTokenBitmask(m_token_bitmask.get());
 
     if (logits.is_vector_initialized()) {
         // logprobs > 0 path: m_data holds pristine raw logits — must not be written.


### PR DESCRIPTION
## Root cause

`XGrammarLogitsTransformer::apply()` in `src/cpp/src/sampling/structured_output/xgrammar_backend.cpp` calls `FillNextTokenBitmask()` **before** checking `m_grammar_matcher.IsTerminated()` — but `FillNextTokenBitmask` is exactly the call that asserts `!IsStopTokenAccepted()`.

Under non-speculative decoding the matcher terminates on the final token and `apply()` is never invoked again, so the mis-ordering never bites. Under speculative decoding, the draft model proposes tokens *past* the accepted stop token, so `apply()` runs one more time on an already-terminated matcher and the `CHECK` in `grammar_matcher.cc:627` fires:

```
Check failed: (!IsStopTokenAccepted()) is false: GrammarMatcher has terminated after accepting the stop token, but is trying to find the next token mask
```

This matches a fixed bug in sglang ([sgl-project/sglang#14464](https://github.com/sgl-project/sglang/pull/14464)) with the identical error under the same speculative-decoding + grammar combination, fixed by adding an `is_terminated` guard.

## The fix

Two small edits in `xgrammar_backend.cpp`:

1. **`apply()`** — check `IsTerminated()` first; only fill the bitmask if not terminated. Semantically identical on the non-terminated path (the rest of `apply()` is unchanged); removes the crash on the terminated path.
2. **`accept_tokens()`** — break out of the token-acceptance loop once the matcher is terminated, instead of continuing to call `AcceptToken()` on draft tokens past the stop. This silences a companion non-fatal warning at `grammar_matcher.cc:493` ("trying to accept new token") from the same root cause.

## Verification

Rebuilt from source at the exact commit the previously-crashing release wheel (`2026.2.1.0-3123-7dea0459b2a`) was built from (`7dea045`, `releases/2026/2`), so this is a same-commit before/after comparison, not a cross-version diff.

- **Baseline (unpatched, same commit), GPU:** re-ran the reproducer against the stock release wheel — 1 crash / 95 generations, same failing case and same assertion as previously observed.
- **Patched, CPU:** the official Python wheel's `.pyd` is ABI-locked to the release build (a `.dll`-only swap fails to load; a full from-source Python-bindings rebuild against this checkout couldn't reach a linked GPU plugin locally). Built a standalone C++ reproducer (mirrors the Python one, driving `LLMPipeline` + `draft_model` + a triggered `StructuralTagsConfig`) against the patched library and the local build's CPU plugin instead — the guard-reorder bug is in the sampler's state machine and is device-independent, so CPU is a valid substitute where a from-source GPU plugin wasn't available. Result: **0 crashes / 95 generations**, same sample size as the baseline.
- **Control, patched, CPU, spec-decode OFF:** 0 crashes / 19 generations — confirms the fix doesn't change behavior when speculative decoding isn't in play.

Hardware: Intel Core Ultra 7 258V (Lunar Lake), Arc 140V (Xe2) GPU, driver 32.0.101.8826. Full methodology and numbers: `PERFORMANCE_LOG.md` + `docs/performance/` in the reporter's downstream repo (referenced for completeness; not part of this PR).

## DCO + AI assistance disclosure

Signed off per DCO (`git commit -s`).

AI assistance used: yes — root-cause analysis and the patch were drafted with AI assistance, working from this project's own source. The fix was verified by rebuilding from source and running a reproducer (crash → 0 across 95 generations, same sample size as the confirmed-crashing baseline) on the author's own hardware.

Fixes #4081
