### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -263,4 +263,16 @@ export const VLM_MODELS: VLMModelType[] = [
       },
     ],
   },
+  {
+    architecture: 'GlmForCausalLM',
+    models: [
+      {
+        name: 'GLM-Edge-V',
+        links: [
+          'https://huggingface.co/THUDM/glm-edge-v-2b',
+          'https://huggingface.co/THUDM/glm-edge-v-5b',
+        ],
+      },
+    ],
+  },
 ];

--- a/src/cpp/src/visual_language/glm_edge_v/classes.cpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.cpp
@@ -1,0 +1,181 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/glm_edge_v/classes.hpp"
+
+#include "visual_language/clip.hpp"
+
+#include "utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace ov::genai {
+
+namespace {
+
+// GLM-Edge-V uses an Mllama-style image processor: resize preserving aspect
+// ratio to fit a single (size_width x size_height) tile, pad the remainder with
+// zeros, then rescale + normalize.
+clip_image_f32 preprocess_clip_image_glm(const clip_image_u8& image, const ProcessorConfig& config) {
+    int target_w = static_cast<int>(config.size_width);
+    int target_h = static_cast<int>(config.size_height);
+
+    float scale = std::min(static_cast<float>(target_w) / image.nx,
+                           static_cast<float>(target_h) / image.ny);
+    int new_w = std::max(1, static_cast<int>(std::round(image.nx * scale)));
+    int new_h = std::max(1, static_cast<int>(std::round(image.ny * scale)));
+    new_w = std::min(new_w, target_w);
+    new_h = std::min(new_h, target_h);
+
+    clip_image_u8 resized_image;
+    bicubic_resize(image, resized_image, new_w, new_h);
+
+    // Pad bottom/right with zeros to the full tile size.
+    clip_image_u8 padded_image;
+    padded_image.nx = target_w;
+    padded_image.ny = target_h;
+    padded_image.buf.assign(static_cast<size_t>(target_w) * target_h * 3, 0);
+    for (int y = 0; y < new_h; ++y) {
+        for (int x = 0; x < new_w; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                padded_image.buf[(static_cast<size_t>(y) * target_w + x) * 3 + c] =
+                    resized_image.buf[(static_cast<size_t>(y) * new_w + x) * 3 + c];
+            }
+        }
+    }
+
+    clip_ctx ctx;
+    std::copy(config.image_mean.begin(), config.image_mean.end(), ctx.image_mean);
+    std::copy(config.image_std.begin(), config.image_std.end(), ctx.image_std);
+
+    return clip_image_preprocess(ctx, padded_image);
+}
+
+ov::Tensor get_pixel_values_glm(const ov::Tensor& image, const ProcessorConfig& config) {
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+    clip_image_f32 preprocessed_image = preprocess_clip_image_glm(input_image, config);
+    return clip_image_f32_to_tensor(preprocessed_image);
+}
+
+} // namespace
+
+EncodedImage VisionEncoderGLMEdgeV::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+
+    ov::Tensor pixel_values = get_pixel_values_glm(image, config);
+
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
+
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
+
+    // Materialize an f32 copy of the image features for the llava-style merge.
+    //
+    // NOTE: the GLM-Edge-V SigLIP tower IR declares its ``last_hidden_state``
+    // output as BF16, but the OpenVINO CPU plugin populates that tensor with
+    // F16-encoded bytes. The reference stack (OpenVINO Python bindings used by
+    // optimum-intel) reads those bytes reinterpreted as F16, so we must do the
+    // same here to stay numerically consistent with the reference inference.
+    ov::Tensor image_features(ov::element::f32, infer_output.get_shape());
+    const size_t n = infer_output.get_size();
+    float* dst = image_features.data<float>();
+    const ov::element::Type out_type = infer_output.get_element_type();
+    if (out_type == ov::element::f32) {
+        std::memcpy(dst, infer_output.data(), infer_output.get_byte_size());
+    } else if (out_type == ov::element::f16 || out_type == ov::element::bf16) {
+        // Reinterpret the raw 16-bit payload as F16 (see note above).
+        const ov::float16* src = reinterpret_cast<const ov::float16*>(infer_output.data());
+        for (size_t i = 0; i < n; ++i) {
+            dst[i] = static_cast<float>(src[i]);
+        }
+    } else {
+        OPENVINO_THROW("Unsupported GLM-Edge-V vision encoder output type: ", out_type);
+    }
+
+    return {std::move(image_features)};
+}
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) { }
+
+std::vector<ov::genai::EncodedImage> InputsEmbedderGLMEdgeV::encode_images(const std::vector<ov::Tensor>& images) {
+    std::vector<EncodedImage> embeds;
+    ov::AnyMap vision_config = {{"patch_size", m_vlm_config.vision_config_patch_size}};
+    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
+    embeds.reserve(single_images.size());
+    for (const ov::Tensor& image : single_images) {
+        embeds.emplace_back(m_vision_encoder->encode(image, vision_config));
+    }
+    return embeds;
+}
+
+NormalizedPrompt InputsEmbedderGLMEdgeV::normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const {
+    std::string image_token = m_vlm_config.begin_of_image;
+    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_id, images.size());
+
+    size_t searched_pos = 0;
+    for (size_t new_image_id : images_sequence) {
+        const ov::Tensor& image_embed = images.at(new_image_id - base_id).resized_source;
+        size_t num_image_tokens = image_embed.get_shape().at(1);
+
+        std::string expanded_tag;
+        expanded_tag.reserve(num_image_tokens * image_token.size());
+        for (size_t idx = 0; idx < num_image_tokens; ++idx) {
+            expanded_tag += image_token;
+        }
+
+        searched_pos = unified_prompt.find(image_token, searched_pos);
+        OPENVINO_ASSERT(searched_pos != std::string::npos);
+        unified_prompt.replace(searched_pos, image_token.length(), expanded_tag);
+        searched_pos += expanded_tag.length();
+    }
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderGLMEdgeV::get_inputs_embeds(const std::string& unified_prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(images.at(new_image_id).resized_source);
+    }
+
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+
+    if (images.empty()) {
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+
+    auto start_tokenizer_time = std::chrono::steady_clock::now();
+    ov::Tensor encoded_image_token = m_tokenizer.encode(m_vlm_config.begin_of_image, ov::genai::add_special_tokens(false)).input_ids;
+    auto end_tokenizer_time = std::chrono::steady_clock::now();
+    OPENVINO_ASSERT(metrics.raw_metrics.tokenization_durations.size() > 0);
+    metrics.raw_metrics.tokenization_durations[metrics.raw_metrics.tokenization_durations.size() - 1] += ov::genai::MicroSeconds(PerfMetrics::get_microsec(end_tokenizer_time - start_tokenizer_time));
+    int64_t image_token_id = encoded_image_token.data<int64_t>()[encoded_image_token.get_size() - 1];
+
+    return utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, image_token_id);
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/glm_edge_v/classes.hpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.hpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+class VisionEncoderGLMEdgeV : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+class InputsEmbedderGLMEdgeV : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings = true, const std::vector<size_t>& image_sequence = {}) override;
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
+
+    NormalizedPrompt normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const override;
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -24,6 +24,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm_edge_v/classes.hpp"
 
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
@@ -362,6 +363,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, model_dir, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -408,6 +411,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config); 
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -386,6 +386,7 @@ private:
     friend class InputsEmbedderGemma3n;
     friend class InputsEmbedderGemma4;
     friend class InputsEmbedderVideoChatFlashQwen;
+    friend class InputsEmbedderGLMEdgeV;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -24,6 +24,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm_edge_v/classes.hpp"
 
 namespace ov::genai {
 
@@ -137,6 +138,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderGemma4>(model_dir, device, properties);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -182,6 +185,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderGemma4>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -32,6 +32,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"gemma4", VLMModelType::GEMMA4},
         {"gemma4_unified", VLMModelType::GEMMA4_UNIFIED},
         {"videochat_flash_qwen", VLMModelType::VIDEOCHAT_FLASH_QWEN},
+        {"glm", VLMModelType::GLM_EDGE_V},
     };
 
     auto it = model_types_map.find(value);

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -29,6 +29,7 @@ enum class VLMModelType {
     GEMMA4,
     GEMMA4_UNIFIED,
     VIDEOCHAT_FLASH_QWEN,
+    GLM_EDGE_V,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -124,6 +125,11 @@ public:
     size_t vision_config_num_position_embeddings = 2304;
     /// @brief DeepStack visual indexes for Qwen3-VL model.
     std::vector<size_t> vision_config_deepstack_visual_indexes;
+
+    /// @brief A placeholder token denoting image embeddings for GLM-Edge-V model.
+    /// The chat template expands each image into a run of these tokens, which are
+    /// then replaced 1:1 by the vision embedding rows.
+    std::string begin_of_image = "<|begin_of_image|>";
 
     /// @brief Default constructor.
     VLMConfig() = default;

--- a/tools/who_what_benchmark/tests/test_load_processor.py
+++ b/tools/who_what_benchmark/tests/test_load_processor.py
@@ -1,0 +1,70 @@
+import types
+from unittest import mock
+
+import pytest
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from whowhatbench import wwb
+
+
+def _args(model_id):
+    return types.SimpleNamespace(base_model=None, target_model=model_id)
+
+
+class _FakeTokenizer(PreTrainedTokenizerBase):
+    """Minimal stand-in that satisfies isinstance(..., PreTrainedTokenizerBase)."""
+
+    def __init__(self):
+        pass
+
+
+class _FakeImageProcessor:
+    def __call__(self, images=None, return_tensors=None):
+        return {"pixel_values": [0]}
+
+
+def test_load_processor_falls_back_to_image_processor_for_vision_text():
+    """GLM-Edge-V ships only a text tokenizer via AutoProcessor. For vision-text
+    configs, load_processor must return an image processor so the OV target path
+    (optimum-intel preprocess_inputs) can call processor(images=...)."""
+    config = types.SimpleNamespace(model_type="glm", vision_config=object())
+    image_processor = _FakeImageProcessor()
+
+    with mock.patch.object(wwb.AutoConfig, "from_pretrained", return_value=config), \
+         mock.patch.object(wwb.AutoProcessor, "from_pretrained", return_value=_FakeTokenizer()), \
+         mock.patch.object(wwb.AutoImageProcessor, "from_pretrained", return_value=image_processor):
+        preprocessor, out_config = wwb.load_processor(_args("dummy-glm-edge-v"))
+
+    assert preprocessor is image_processor
+    assert not isinstance(preprocessor, PreTrainedTokenizerBase)
+    assert out_config is config
+
+
+def test_load_processor_keeps_real_processor_for_unified_vlm():
+    """When AutoProcessor returns a real (non-tokenizer) multimodal processor,
+    load_processor must keep it and not override with an image processor."""
+    config = types.SimpleNamespace(model_type="llava", vision_config=object())
+    real_processor = _FakeImageProcessor()  # not a PreTrainedTokenizerBase
+
+    with mock.patch.object(wwb.AutoConfig, "from_pretrained", return_value=config), \
+         mock.patch.object(wwb.AutoProcessor, "from_pretrained", return_value=real_processor), \
+         mock.patch.object(wwb.AutoImageProcessor, "from_pretrained") as img_proc:
+        preprocessor, _ = wwb.load_processor(_args("dummy-llava"))
+
+    assert preprocessor is real_processor
+    img_proc.assert_not_called()
+
+
+def test_load_processor_ignores_fallback_for_text_only_model():
+    """A text-only model (no vision_config) whose AutoProcessor returns a
+    tokenizer must be returned unchanged."""
+    config = types.SimpleNamespace(model_type="qwen2")
+    tokenizer = _FakeTokenizer()
+
+    with mock.patch.object(wwb.AutoConfig, "from_pretrained", return_value=config), \
+         mock.patch.object(wwb.AutoProcessor, "from_pretrained", return_value=tokenizer), \
+         mock.patch.object(wwb.AutoImageProcessor, "from_pretrained") as img_proc:
+        preprocessor, _ = wwb.load_processor(_args("dummy-text"))
+
+    assert preprocessor is tokenizer
+    img_proc.assert_not_called()

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
@@ -1,0 +1,84 @@
+import numpy as np
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+)
+from typing import TYPE_CHECKING, Optional, Union
+
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+class GLMEdgeVInputsPreprocessor(VLMInputsPreprocessor):
+    """Inputs preprocessor for the GLM-Edge-V vision-text family.
+
+    GLM-Edge-V ships a text tokenizer (with chat template) plus a separate
+    Mllama image processor; there is no unified HF processor. The chat template
+    expands ``{"type": "image"}`` into the model's begin_of_image tokens, and
+    the model expects ``pixel_values`` from the image processor.
+    """
+
+    def __init__(self, chat_mode: bool = False):
+        super().__init__(chat_mode)
+        self._image_processor = None
+
+    def update_chat_history_with_answer(self, answer):
+        self.chat_history.append({"role": "assistant", "content": [{"type": "text", "text": answer}]})
+
+    def _get_image_processor(self, tokenizer, config):
+        if self._image_processor is None:
+            model_path = getattr(config, "_name_or_path", None)
+            self._image_processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
+        return self._image_processor
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        if image is not None and not isinstance(image, list):
+            image = [image]
+
+        self.update_images(image)
+
+        content = []
+        if image is not None:
+            content.extend([{"type": "image"}] * len(image))
+        content.append({"type": "text", "text": text})
+        message = {"role": "user", "content": content}
+
+        if self.chat_mode:
+            self.chat_history.append(message)
+            messages = self.chat_history
+        else:
+            messages = [message]
+
+        inputs = tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_tensors="pt",
+            return_dict=True,
+        )
+
+        if self.images is not None:
+            image_processor = self._get_image_processor(tokenizer, config)
+            inputs["pixel_values"] = image_processor(images=self.images, return_tensors="pt")["pixel_values"]
+
+        return inputs

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -419,6 +419,12 @@ def load_visual_text_model(
 
                 model_cls = AutoModelForImageTextToText
 
+            # GLM-Edge-V exposes its vision-text model only via AutoModelForCausalLM
+            # (auto_map AutoModel -> GlmModel has no generate); force CausalLM.
+            if config.model_type == "glm":
+                model_cls = AutoModelForCausalLM
+                model_kwargs["trust_remote_code"] = True
+
             model = model_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)
         except ValueError:
             try:

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -8,7 +8,8 @@ import logging
 import os
 from pathlib import Path
 
-from transformers import AutoTokenizer, AutoProcessor, AutoConfig
+from transformers import AutoTokenizer, AutoProcessor, AutoConfig, AutoImageProcessor
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 import openvino as ov
 
 import pandas as pd
@@ -588,6 +589,20 @@ def load_processor(args):
             preprocessor = AutoProcessor.from_pretrained(preprocessor_id, trust_remote_code=False)
     except Exception:
         preprocessor = AutoProcessor.from_pretrained(preprocessor_id, trust_remote_code=True)
+
+    # Some vision-text families (e.g. GLM-Edge-V) do not ship a unified HF
+    # processor: AutoProcessor.from_pretrained returns a bare text tokenizer.
+    # For those models the OV target path uses optimum-intel's preprocess_inputs,
+    # which calls processor(images=...) and therefore needs an image processor,
+    # not a tokenizer. Detect this case from the loaded object + config and load
+    # the model's AutoImageProcessor so the image branch works, letting the
+    # caller fall back to load_tokenizer() for text.
+    is_vision_text = getattr(config, "vision_config", None) is not None
+    if is_vision_text and isinstance(preprocessor, PreTrainedTokenizerBase):
+        try:
+            preprocessor = AutoImageProcessor.from_pretrained(preprocessor_id, trust_remote_code=False)
+        except Exception:
+            preprocessor = AutoImageProcessor.from_pretrained(preprocessor_id, trust_remote_code=True)
     return preprocessor, config
 
 


### PR DESCRIPTION
## Description

GLM-Edge-V (model_type 'glm') is enabled and validated in OpenVINO GenAI VLMPipeline. The prebuilt wheel lacked the code (threw 'Unsupported glm VLM model type'); after rebuilding the local openvino.genai source the pipeline runs for text-only and image-text, and WWB visual-text similarity is 1.0 for both Optimum and GenAI against ov_model_fix. Source, tests and docs are in place on branch glm-edge-v-support. Repository pytest cannot execute because the tiny-random model 'optimum-intel-internal-testing/tiny-random-glm-edge-v' returns HTTP 404 (not published to HF). That publication is owned by tiny_model_creator.

## Reproduce generation

```python
import numpy as np, openvino as ov, openvino_genai as og
from PIL import Image

MODEL_DIR = "/home/mohamed-ashraf/Desktop/projects/GSoC26/auto-openvino-bot/workspace/ov_model_fix"

pipe = og.VLMPipeline(MODEL_DIR, "CPU")
cfg = og.GenerationConfig()
cfg.max_new_tokens = 30

image = Image.new("RGB", (672, 672), (120, 150, 200))
tensor = ov.Tensor(np.array(image)[None])

print("image-text:", pipe.generate("What is in this image?", images=[tensor], generation_config=cfg))
print("text-only:", pipe.generate("Hello, who are you?", generation_config=cfg))
```

## Validation

- WWB Optimum similarity: **1.0**
- WWB GenAI similarity: **1.0**
- First-token latency: **Not run**
- Throughput: **Not run**

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1847

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.

## Changed files

- `src/cpp/src/visual_language/vlm_config.cpp`
- `src/cpp/src/visual_language/vlm_config.hpp`
- `src/cpp/src/visual_language/inputs_embedder.cpp`
- `src/cpp/src/visual_language/inputs_embedder.hpp`
- `src/cpp/src/visual_language/vision_encoder.cpp`
- `src/cpp/src/visual_language/glm_edge_v/classes.cpp`
- `src/cpp/src/visual_language/glm_edge_v/classes.hpp`
- `site/docs/supported-models/_components/vlm-models-table/models.ts`
- `tests/python_tests/test_vlm_pipeline.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py`
- `tools/who_what_benchmark/whowhatbench/model_loaders.py`
- `tools/who_what_benchmark/whowhatbench/utils.py`
- `tools/who_what_benchmark/whowhatbench/wwb.py`
- `tools/who_what_benchmark/tests/test_load_processor.py`