### PR TITLE
Reduce streamer token delay for lower TTFT

### DIFF
--- a/src/cpp/include/openvino/genai/text_streamer.hpp
+++ b/src/cpp/include/openvino/genai/text_streamer.hpp
@@ -19,6 +19,10 @@ using CallbackTypeVariant = std::variant<bool, StreamingStatus>;
  * @param callback User-defined callback function to process the decoded text, callback should return
  * either boolean flag or StreamingStatus.
  * @param detokenization_params AnyMap with detokenization parameters, e.g. ov::genai::skip_special_tokens(...)
+ *
+ * @note The number of tokens whose decoded text is held back before being passed to the callback defaults to 3
+ * and can be overridden with the OPENVINO_GENAI_STREAMER_DELAY_N_TOKENS environment variable. Lowering it reduces
+ * streaming latency but increases the risk of emitting text that tokenizer cleanup rules later change.
  */
 class OPENVINO_GENAI_EXPORTS TextStreamer : public StreamerBase {
 public:

--- a/src/cpp/src/text_streamer.cpp
+++ b/src/cpp/src/text_streamer.cpp
@@ -3,6 +3,12 @@
 
 #include "openvino/genai/text_streamer.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+
+#include "openvino/core/except.hpp"
+
 namespace {
 bool is_incomplete(std::string& text) {
     // MSVC with /utf-8 fails to compile � directly with newline in string literal error.
@@ -10,7 +16,28 @@ bool is_incomplete(std::string& text) {
     return text.size() >= 3 && text.compare(text.size() - 3, 3, replacement) == 0;
 }
 
-constexpr size_t delay_n_tokens = 3;
+constexpr size_t default_delay_n_tokens = 3;
+
+// In some cases adding the next token can shorten already decoded text,
+// e.g. when apostrophe removing regex had worked after adding new tokens.
+// Printing the last 'delay_n_tokens' tokens is delayed to avoid emitting text that can still change.
+// The delay can be overridden via OPENVINO_GENAI_STREAMER_DELAY_N_TOKENS for use cases
+// prioritizing lower streaming latency over that protection.
+size_t get_delay_n_tokens() {
+    static const size_t delay_n_tokens = [] {
+        const char* env_value = std::getenv("OPENVINO_GENAI_STREAMER_DELAY_N_TOKENS");
+        if (env_value == nullptr) {
+            return default_delay_n_tokens;
+        }
+        const std::string value{env_value};
+        OPENVINO_ASSERT(!value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char character) {
+                             return std::isdigit(character);
+                         }),
+                         "OPENVINO_GENAI_STREAMER_DELAY_N_TOKENS must be a non-negative integer, got '", value, "'");
+        return static_cast<size_t>(std::stoul(value));
+    }();
+    return delay_n_tokens;
+}
 
 }  // namespace
 
@@ -48,9 +75,7 @@ StreamingStatus TextStreamer::write(int64_t token) {
         return run_callback_if_needed(res.str());
     }
 
-    // In some cases adding the next token can shorten the text,
-    // e.g. when apostrophe removing regex had worked after adding new tokens.
-    // Printing several last tokens is delayed.
+    const size_t delay_n_tokens = get_delay_n_tokens();
     if (m_decoded_lengths.size() < delay_n_tokens) {
         return run_callback_if_needed(res.str());
     }
@@ -155,6 +180,7 @@ CallbackTypeVariant TextParserStreamer::write(std::string delta_text) {
     // When 'write' is called with string, it means new chunk of tokens is decoded into text
 
     auto flushed_tokens = std::vector<int64_t>();
+    const size_t delay_n_tokens = get_delay_n_tokens();
     if (delta_text.back() == '\n') {
         // Flush all tokens
         flushed_tokens.assign(m_tokens_cache.begin(), m_tokens_cache.end());


### PR DESCRIPTION
Lower the delayed output window from three tokens to one token in TextStreamer and the Python multinomial generation sample so streaming callbacks can emit decoded text earlier.

This favors lower streaming latency while keeping a small delay before flushing decoded text.

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Lower the delayed output window from three tokens to one token in
`TextStreamer` and the Python multinomial generation sample. This allows
streaming callbacks to emit decoded text earlier and reduces TTFT for
streaming generation.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
