### PR TITLE
[VLM] QWEN-3-Omni support

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -8,6 +8,7 @@ if(ENABLE_SAMPLES)
     add_subdirectory(cpp/speech_generation)
     add_subdirectory(cpp/visual_language_chat)
     add_subdirectory(cpp/automatic_speech_recognition)
+    add_subdirectory(cpp/omni)
     add_subdirectory(cpp/rag)
     add_subdirectory(c/text_generation)
     add_subdirectory(c/whisper_speech_recognition)
@@ -31,6 +32,7 @@ install(DIRECTORY
             cpp/speech_generation
             cpp/visual_language_chat
             cpp/automatic_speech_recognition
+            cpp/omni
             cpp/rag
         DESTINATION samples/cpp COMPONENT cpp_samples_genai)
 

--- a/samples/cpp/automatic_speech_recognition/audio_utils.cpp
+++ b/samples/cpp/automatic_speech_recognition/audio_utils.cpp
@@ -4,6 +4,7 @@
 #include "audio_utils.hpp"
 
 #include <iostream>
+#include <memory>
 #include <vector>
 
 #include "openvino/genai/whisper_pipeline.hpp"
@@ -113,6 +114,30 @@ ov::genai::RawSpeechInput read_wav(const std::string& filename) {
     }
 
     return pcmf32;
+}
+
+ov::Tensor read_wav_as_tensor(const std::string& filename) {
+    ov::genai::RawSpeechInput pcm = read_wav(filename);
+    const size_t sample_count = pcm.size();
+
+    // Move the decoded samples into an allocator so the tensor owns them directly, avoiding a
+    // copy of the PCM buffer. Mirrors SharedImageAllocator in visual_language_chat/load_image.cpp.
+    // The buffer is held via shared_ptr so copying the allocator is cheap and ownership is unambiguous.
+    struct SharedPcmAllocator {
+        std::shared_ptr<std::vector<float>> pcm;
+        void* allocate(size_t bytes, size_t) const {
+            OPENVINO_ASSERT(bytes == pcm->size() * sizeof(float),
+                            "Unexpected number of bytes was requested to allocate.");
+            return pcm->data();
+        }
+        void deallocate(void*, size_t, size_t) const noexcept {}
+        bool is_equal(const SharedPcmAllocator& other) const noexcept {
+            return pcm == other.pcm;
+        }
+    };
+    return ov::Tensor(ov::element::f32,
+                      ov::Shape{sample_count},
+                      SharedPcmAllocator{std::make_shared<std::vector<float>>(std::move(pcm))});
 }
 }  // namespace audio
 }  // namespace utils

--- a/samples/cpp/automatic_speech_recognition/audio_utils.hpp
+++ b/samples/cpp/automatic_speech_recognition/audio_utils.hpp
@@ -4,9 +4,15 @@
 #pragma once
 
 #include "openvino/genai/whisper_pipeline.hpp"
+#include "openvino/runtime/tensor.hpp"
 
 namespace utils {
 namespace audio {
 ov::genai::RawSpeechInput read_wav(const std::string& filename);
+
+/// @brief Read a WAV file into a 1-D f32 ov::Tensor without copying the decoded samples.
+/// The PCM buffer produced by read_wav() is moved into the tensor's allocator, so the tensor
+/// owns the samples directly.
+ov::Tensor read_wav_as_tensor(const std::string& filename);
 }  // namespace audio
 }  // namespace utils

--- a/samples/cpp/omni/CMakeLists.txt
+++ b/samples/cpp/omni/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if (MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
+find_package(OpenVINOGenAI REQUIRED
+    PATHS
+        "${CMAKE_BINARY_DIR}"  # Reuse the package from the build.
+        ${OpenVINO_DIR}  # GenAI may be installed alongside OpenVINO.
+    NO_CMAKE_FIND_ROOT_PATH
+)
+
+file(DOWNLOAD
+    https://raw.githubusercontent.com/nothings/stb/f75e8d1cad7d90d72ef7a4661f1b994ef78b4e31/stb_image.h
+    ${CMAKE_BINARY_DIR}/stb_image.h
+    EXPECTED_HASH MD5=27932e6fb3a2f26aee2fc33f2cb4e696)
+
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
+include(FetchContent)
+
+if(NOT TARGET dr_libs)
+    FetchContent_Declare(dr_libs
+        URL https://github.com/mackron/dr_libs/archive/da35f9d6c7374a95353fd1df1d394d44ab66cf01.tar.gz
+        URL_HASH SHA256=2704d347f480ca1bc92233fb01747e4550cc8031735b6ea62ca9990ebb8851ae)
+    FetchContent_MakeAvailable(dr_libs)
+endif()
+
+add_executable(omni_chat omni_chat.cpp ../automatic_speech_recognition/audio_utils.cpp ../visual_language_chat/load_image.cpp)
+target_include_directories(omni_chat PRIVATE "${CMAKE_BINARY_DIR}" "../visual_language_chat" "../automatic_speech_recognition" "$<BUILD_INTERFACE:${dr_libs_SOURCE_DIR}>")
+target_link_libraries(omni_chat PRIVATE openvino::genai)
+
+set_target_properties(omni_chat PROPERTIES
+    # Ensure out of box LC_RPATH on macOS with SIP
+    INSTALL_RPATH_USE_LINK_PATH ON)
+
+install(TARGETS omni_chat
+        RUNTIME DESTINATION samples_bin/
+        COMPONENT samples_bin
+        EXCLUDE_FROM_ALL)

--- a/samples/cpp/omni/README.md
+++ b/samples/cpp/omni/README.md
@@ -1,0 +1,99 @@
+# Qwen3-Omni Chat Sample
+
+> **Preview:** The Qwen3-Omni API (`OmniPipeline` and related types) is a preview feature and is subject to change in future releases.
+
+Interactive multimodal chat with Qwen3-Omni models supporting text, image, and speech input/output.
+
+## Description
+
+Demonstrates `ov::genai::OmniPipeline` for end-to-end multimodal conversations. Qwen3-Omni models accept text, images, and audio inputs, generating text and optionally synthesized speech responses.
+
+**Key features:**
+- Multi-turn conversations with image context
+- Optional speech synthesis (talker mode)
+- Separate generation configs for text decoding and speech output
+- Interactive CLI interface
+
+## Prerequisites
+
+Prepare image files (JPG, PNG) and audio files (16kHz mono WAV) for testing.
+
+## Usage
+
+```bash
+omni_chat <MODEL_DIR> <IMAGE_FILE_OR_DIR> <AUDIO_FILE>
+```
+
+**Parameters:**
+- `<MODEL_DIR>` — Path to exported Qwen3-Omni OpenVINO model directory
+- `<IMAGE_FILE_OR_DIR>` — Path to input image(s) for visual context
+- `<AUDIO_FILE>` — Path to input audio file (16kHz mono WAV)
+
+**Example:**
+
+```bash
+./build/samples/cpp/omni/omni_chat /models/qwen3-omni-ov ./coco.jpg ./audio.wav
+```
+
+**Interactive usage:**
+1. Images are loaded once at startup and available to all turns
+2. Type questions and press Enter
+3. Model responds with streaming text; speech output indicated when enabled
+4. Continue the conversation across multiple turns
+5. Press Ctrl+D to exit
+
+## Model Support
+
+Compatible with Qwen3-Omni models exported to OpenVINO format.
+
+Export using [Optimum Intel](https://github.com/huggingface/optimum-intel) CLI or Python API.
+
+## Configuration
+
+### Text Generation
+
+`GenerationConfig` controls text decoding (the "thinker" phase):
+
+```cpp
+ov::genai::GenerationConfig text_config;
+text_config.max_new_tokens = 256;
+```
+
+### Speech Synthesis
+
+`OmniTalkerSpeechConfig` controls talker and speech output:
+
+```cpp
+ov::genai::OmniTalkerSpeechConfig talker_speech_config(models_path);
+talker_speech_config.return_audio = true;  // Enable speech synthesis
+talker_speech_config.speaker = "Cherry";   // Select voice (optional)
+```
+
+**Available voices** vary by checkpoint. MoE models typically expose: `"Ethan"`, `"Chelsie"`, `"Aiden"`, `"Cherry"`. Check `talker_config.speaker_id` in the model's `config.json` for the full list. Leaving `speaker` empty selects the default voice.
+
+**Speech output:** 24kHz mono PCM samples returned in `OmniDecodedResults.speech_result.waveforms`.
+
+## GPU Inference
+
+**Important:** Qwen3-Omni speech synthesis requires FP32 precision on GPU. FP16 causes numerical drift → codec token corruption → distorted audio. The pipeline enforces `INFERENCE_PRECISION_HINT=f32` automatically for GPU devices. Change the device argument in `OmniPipeline` constructor:
+
+```cpp
+ov::genai::OmniPipeline pipe(models_path, "GPU");
+```
+
+**MoE models** (30B-A3B) may exceed available GPU memory. Use CPU for MoE inference.
+
+## Speaker API Features
+
+The main sample demonstrates speaker enumeration and voice blending at startup:
+
+1. **List speakers** — shows all named voices in the model
+2. **Voice blending** — when 2+ speakers are available, creates a 50/50 blend and uses it for generation
+
+**Custom blending:** Retrieve speaker embeddings via `pipe.get_talker()->get_speaker_embedding(name)`, mix with custom ratios (e.g., 0.75A + 0.25B), and pass via `OmniTalkerSpeechConfig::speaker`.
+
+## See Also
+
+- [Python Qwen3-Omni chat sample](../../python/omni/)
+- [OmniPipeline C++ API reference](../../../src/cpp/include/openvino/genai/omni/pipeline.hpp)
+- [Qwen3-Omni model documentation](https://github.com/QwenLM/Qwen3-Omni)

--- a/samples/cpp/omni/omni_chat.cpp
+++ b/samples/cpp/omni/omni_chat.cpp
@@ -1,0 +1,143 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "audio_utils.hpp"
+#include "load_image.hpp"
+#include "openvino/genai/generation_config.hpp"
+#include "openvino/genai/omni/pipeline.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+
+ov::genai::StreamingStatus print_subword(std::string&& subword) {
+    std::cout << subword << std::flush;
+    return ov::genai::StreamingStatus::RUNNING;
+}
+
+int main(int argc, char* argv[]) try {
+    if (argc != 4) {
+        throw std::runtime_error(std::string{"Usage: "} + argv[0] + " <MODEL_DIR> <IMAGE_FILE_OR_DIR> <AUDIO_FILE>");
+    }
+
+    const std::filesystem::path models_path = argv[1];
+
+    // Two configs: text_config drives the thinker text decode, talker_speech_config drives
+    // the talker + speech output. Speech output is hardcoded on here to show the multimodal
+    // path. Set talker_speech_config.return_audio = false to get text-only responses.
+    ov::genai::GenerationConfig text_config;
+    text_config.max_new_tokens = 256;
+
+    ov::genai::OmniTalkerSpeechConfig talker_speech_config(models_path);
+    talker_speech_config.return_audio = true;
+    // Leaving talker_speech_config.speaker empty selects the model's default voice. Available
+    // voices vary by checkpoint.
+
+    std::vector<ov::Tensor> rgbs = utils::load_images(argv[2]);
+
+    ov::Tensor audio_tensor = utils::audio::read_wav_as_tensor(argv[3]);
+    std::vector<ov::Tensor> audios = {std::move(audio_tensor)};
+
+    // Compose OmniPipeline from separate VLM and Talker components.
+    // This allows independent device selection (e.g., VLM on GPU, Talker on CPU),
+    // sharing a VLM base across pipelines, or injecting custom TalkerBase implementations.
+    // For simpler use cases: ov::genai::OmniPipeline pipe(models_path, "CPU");
+
+    auto vlm = std::make_shared<ov::genai::VLMPipeline>(models_path, "CPU");
+    auto talker = std::make_shared<ov::genai::Talker>(models_path, "CPU");
+    ov::genai::OmniPipeline pipe(vlm, talker);
+
+    std::cout << "OmniPipeline composed successfully.\n";
+
+    // Speaker API demo: list available speakers and demonstrate voice blending.
+    std::vector<std::string> speakers = talker->list_speakers();
+    std::cout << "\n=== Available Speakers ===\n";
+    if (speakers.empty()) {
+        std::cout << "No named speakers (model has single default voice)\n";
+    } else {
+        std::cout << "Found " << speakers.size() << " speakers:\n";
+        for (const auto& name : speakers) {
+            std::cout << "  - " << name << "\n";
+        }
+        std::cout << "\n";
+
+        if (speakers.size() >= 2) {
+            std::cout << "=== Voice Blending Demo ===\n";
+            std::cout << "Blending " << speakers[0] << " + " << speakers[1] << " (50/50 mix)\n";
+            ov::Tensor emb1 = talker->get_speaker_embedding(speakers[0]);
+            ov::Tensor emb2 = talker->get_speaker_embedding(speakers[1]);
+            ov::Tensor blended(emb1.get_element_type(), emb1.get_shape());
+            const float* data1 = emb1.data<float>();
+            const float* data2 = emb2.data<float>();
+            float* blended_data = blended.data<float>();
+            for (size_t i = 0; i < emb1.get_size(); ++i) {
+                blended_data[i] = 0.5f * data1[i] + 0.5f * data2[i];
+            }
+            talker_speech_config.speaker = blended;
+            std::cout << "Using blended voice for generation.\n\n";
+        }
+    }
+
+    ov::genai::ChatHistory history;
+    std::vector<ov::Tensor> videos;  // Empty: sample uses images and audio only
+    std::vector<ov::genai::VideoMetadata> videos_metadata;
+
+    std::string prompt;
+    std::cout << "question:\n";
+    std::getline(std::cin, prompt);
+
+    history.push_back({{"role", "user"}, {"content", std::move(prompt)}});
+    ov::genai::OmniDecodedResults decoded_results = pipe.generate(history,
+                                                                   rgbs,
+                                                                   videos,
+                                                                   videos_metadata,
+                                                                   audios,
+                                                                   text_config,
+                                                                   talker_speech_config,
+                                                                   print_subword);
+    history.push_back({{"role", "assistant"}, {"content", std::move(decoded_results.texts[0])}});
+
+    if (!decoded_results.speech_result.waveforms.empty()) {
+        std::cout << "\n[Speech output: " << decoded_results.speech_result.waveforms[0].get_size() << " samples at 24kHz]"
+                  << std::endl;
+    }
+
+    std::cout << "\n----------\n"
+                 "question:\n";
+    while (std::getline(std::cin, prompt)) {
+        history.push_back({{"role", "user"}, {"content", std::move(prompt)}});
+        // New images and audio can be passed at each turn; here we rely on the info from turn 1.
+        std::vector<ov::Tensor> images, turn_audios;
+        decoded_results = pipe.generate(history,
+                                        images,
+                                        videos,
+                                        videos_metadata,
+                                        turn_audios,
+                                        text_config,
+                                        talker_speech_config,
+                                        print_subword);
+        history.push_back({{"role", "assistant"}, {"content", std::move(decoded_results.texts[0])}});
+
+        if (!decoded_results.speech_result.waveforms.empty()) {
+            std::cout << "\n[Speech output: " << decoded_results.speech_result.waveforms[0].get_size() << " samples at 24kHz]"
+                      << std::endl;
+        }
+        std::cout << "\n----------\n"
+                     "question:\n";
+    }
+    return 0;
+} catch (const std::exception& error) {
+    try {
+        std::cerr << error.what() << '\n';
+    } catch (const std::ios_base::failure&) {
+    }
+    return EXIT_FAILURE;
+} catch (...) {
+    try {
+        std::cerr << "Non-exception object thrown\n";
+    } catch (const std::ios_base::failure&) {
+    }
+    return EXIT_FAILURE;
+}

--- a/samples/python/omni/README.md
+++ b/samples/python/omni/README.md
@@ -1,0 +1,71 @@
+# Qwen3-Omni Chat Sample (Python)
+
+> **Preview:** The Qwen3-Omni API (`OmniPipeline` and related types) is a preview feature and is subject to change in future releases.
+
+This example demonstrates interactive multimodal chat with Qwen3-Omni models: text, image, and audio input producing text and optionally synthesized speech output. The sample features `openvino_genai.OmniPipeline` and configures it for the chat scenario using the `ChatHistory` API.
+
+The following are sample files:
+ - [`qwen3_omni_chat.py`](./qwen3_omni_chat.py) demonstrates multimodal chat with optional speech synthesis.
+
+## Download and convert the model and tokenizers
+
+The `--upgrade-strategy eager` option is needed to ensure `optimum-intel` is upgraded to the latest version.
+
+Install [../../export-requirements.txt](../../export-requirements.txt) to convert a model.
+
+```sh
+pip install --upgrade-strategy eager -r ../../export-requirements.txt
+```
+
+Then export a Qwen3-Omni model to OpenVINO format using the Optimum Intel CLI or Python API.
+
+Install [deployment-requirements.txt](../../deployment-requirements.txt) via `pip install -r ../../deployment-requirements.txt` to run the sample.
+
+## Run the sample
+
+```sh
+python qwen3_omni_chat.py <MODEL_DIR> <IMAGE_FILE_OR_DIR> [--audio AUDIO_WAV]
+```
+
+**Parameters:**
+- `<MODEL_DIR>` — Path to the exported Qwen3-Omni OpenVINO model directory.
+- `<IMAGE_FILE_OR_DIR>` — Path to an input image or a directory of images for visual context.
+- `--audio AUDIO_WAV` — Optional path to an input audio file (16kHz mono WAV).
+
+**Example:**
+
+```sh
+python qwen3_omni_chat.py ./qwen3-omni-ov ./coco.jpg --audio ./audio.wav
+```
+
+Images are loaded once at startup and available to all turns. Type questions and press Enter; the model responds with streaming text and, when speech output is enabled, 24kHz mono PCM samples in `OmniDecodedResults.speech_result.waveforms`. Press Ctrl+D to exit.
+
+## Speech synthesis
+
+Text decoding (the "thinker" phase) and speech output (the "talker" phase) are configured separately:
+
+```python
+text_config = openvino_genai.GenerationConfig()
+text_config.max_new_tokens = 256
+
+talker_speech_config = openvino_genai.OmniTalkerSpeechConfig(model_dir)
+talker_speech_config.return_audio = True  # Enable speech synthesis
+talker_speech_config.speaker = "Cherry"   # Select voice (optional)
+```
+
+Available voices vary by checkpoint. MoE models typically expose `"Ethan"`, `"Chelsie"`, `"Aiden"`, `"Cherry"`. Check `talker_config.speaker_id` in the model's `config.json` for the full list. Leaving `speaker` empty selects the default voice. Set `talker_speech_config.return_audio = False` for text-only responses.
+
+## GPU inference
+
+Qwen3-Omni speech synthesis requires FP32 precision on GPU — FP16 causes numerical drift that corrupts codec tokens and distorts audio. The pipeline enforces `INFERENCE_PRECISION_HINT=f32` automatically for GPU devices. Change the device by passing it to the `OmniPipeline` constructor:
+
+```python
+pipe = openvino_genai.OmniPipeline(model_dir, "GPU")
+```
+
+MoE models (30B-A3B) may exceed available GPU memory; use CPU for MoE inference.
+
+## See Also
+
+- [C++ Qwen3-Omni chat sample](../../cpp/omni/)
+- [Qwen3-Omni model documentation](https://github.com/QwenLM/Qwen3-Omni)

--- a/samples/python/omni/qwen3_omni_chat.py
+++ b/samples/python/omni/qwen3_omni_chat.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Qwen3-Omni multimodal chat sample.
+
+Preview: the Qwen3-Omni API (OmniPipeline and related types) is a preview feature
+and is subject to change in future releases.
+
+Demonstrates text + image + audio -> text + speech output using the ChatHistory API.
+
+Usage:
+    python qwen3_omni_chat.py <MODEL_DIR> <IMAGE_FILE_OR_DIR> [--audio AUDIO_WAV]
+"""
+
+import argparse
+from pathlib import Path
+
+import librosa
+import numpy as np
+import openvino_genai
+import soundfile as sf
+from openvino import Tensor
+from PIL import Image
+
+
+def streamer(subword: str) -> openvino_genai.StreamingStatus:
+    """Stream text tokens to stdout."""
+    print(subword, end="", flush=True)
+    return openvino_genai.StreamingStatus.RUNNING
+
+
+def read_image(path: str) -> Tensor:
+    pic = Image.open(path).convert("RGB")
+    image_data = np.array(pic)
+    return Tensor(image_data)
+
+
+def read_images(path: str) -> list[Tensor]:
+    entry = Path(path)
+    if entry.is_dir():
+        return [read_image(str(file)) for file in sorted(entry.iterdir())]
+    return [read_image(path)]
+
+
+def load_audio(audio_path: str, target_sr: int = 16000) -> Tensor:
+    """Load audio from WAV file and convert to float32 mono tensor at target_sr."""
+    audio_data, sample_rate = sf.read(audio_path, dtype="float32")
+
+    if audio_data.ndim > 1:
+        audio_data = audio_data.mean(axis=1)
+
+    if sample_rate != target_sr:
+        audio_data = librosa.resample(audio_data, orig_sr=sample_rate, target_sr=target_sr)
+
+    return Tensor(audio_data.astype(np.float32))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Qwen3-Omni multimodal chat")
+    parser.add_argument("model_dir", help="Path to the OpenVINO model directory")
+    parser.add_argument("image_dir", help="Image file or directory with images")
+    parser.add_argument("--audio", help="Path to input audio WAV file (optional)")
+    args = parser.parse_args()
+
+    rgbs = read_images(args.image_dir)
+
+    pipe = openvino_genai.OmniPipeline(args.model_dir, "CPU")
+
+    # Two configs: text_config drives the thinker text decode; talker_speech_config drives the
+    # talker + speech output. Speech output is hardcoded on here to show the multimodal path.
+    # Set talker_speech_config.return_audio = False to get text-only responses.
+    text_config = openvino_genai.GenerationConfig()
+    text_config.max_new_tokens = 256
+
+    talker_speech_config = openvino_genai.OmniTalkerSpeechConfig(args.model_dir)
+    talker_speech_config.return_audio = True
+    # Leaving speaker empty selects the model's default voice. Available voices vary by checkpoint
+    # (e.g. MoE exposes "Ethan", "Chelsie", "Aiden", "Cherry"); the full list is in
+    # talker_config.speaker_id of the model's config.json.
+
+    videos = []
+    audios = [load_audio(args.audio)] if args.audio else []
+
+    history = openvino_genai.ChatHistory()
+    prompt = input("question:\n")
+    history.append({"role": "user", "content": prompt})
+    decoded_results = pipe.generate(
+        history,
+        images=rgbs,
+        videos=videos,
+        audios=audios,
+        text_config=text_config,
+        talker_speech_config=talker_speech_config,
+        streamer=streamer,
+    )
+    history.append({"role": "assistant", "content": decoded_results.texts[0]})
+
+    if decoded_results.speech_result.waveforms:
+        print(f"\n[Speech output: {decoded_results.speech_result.waveforms[0].get_size()} samples at 24kHz]")
+
+    while True:
+        try:
+            prompt = input("\n----------\nquestion:\n")
+        except EOFError:
+            break
+
+        history.append({"role": "user", "content": prompt})
+        # New images can be passed at each turn; here we rely on the info from turn 1.
+        images = []
+        decoded_results = pipe.generate(
+            history,
+            images=images,
+            videos=videos,
+            audios=audios,
+            text_config=text_config,
+            talker_speech_config=talker_speech_config,
+            streamer=streamer,
+        )
+        history.append({"role": "assistant", "content": decoded_results.texts[0]})
+
+        if decoded_results.speech_result.waveforms:
+            print(f"\n[Speech output: {decoded_results.speech_result.waveforms[0].get_size()} samples at 24kHz]")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/continuous_batching_pipeline.hpp
@@ -384,4 +384,11 @@ OPENVINO_GENAI_EXPORTS std::pair<std::string, ov::Any> videos_metadata_batches(
     const std::vector<std::vector<VideoMetadata>>& videos_metadata_batches
 );
 
+/// @brief Factory for audios_batches AnyMap entry.
+/// Audios must be encoded before text tokenization for Qwen3-Omni's interleaved layout.
+/// @note This is a preview API and is subject to change.
+OPENVINO_GENAI_EXPORTS std::pair<std::string, ov::Any> audios_batches(
+    const std::vector<std::vector<ov::Tensor>>& audios_batches
+);
+
 }

--- a/src/cpp/include/openvino/genai/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/generation_config.hpp
@@ -634,6 +634,10 @@ operator|(const StructuredOutputConfig::StructuralTag& lhs,
  * @param structured_output_config if set, the output will be a string constrained by the specified json_schema, regex, or EBNF grammar.
  *
  * @param apply_chat_template whether or not to apply chat_template for non-chat scenarios
+ *
+ * @param return_omni_outputs if set to true, the pipeline accumulates per-token intermediate hidden
+ *        states and full token ids in the result so a Qwen3-Omni talker can consume them. Only the
+ *        continuous-batching backend supports this; OmniPipeline sets it internally on the audio path.
  */
 class OPENVINO_GENAI_EXPORTS GenerationConfig {
 public:
@@ -658,7 +662,7 @@ public:
 
     // penalties (not used in beam search)
     float repetition_penalty = 1.0f;
-    float presence_penalty = 0.0;
+    float presence_penalty = 0.0f;
     float frequency_penalty = 0.0f;
 
     // Beam search specific
@@ -699,6 +703,10 @@ public:
     // set to true if chat template should be applied for non-chat scenarios, set to false otherwise
     bool apply_chat_template = true;
 
+    // Accumulate intermediate hidden states and full token ids in the result for Qwen3-Omni speech
+    // generation. Only supported by the continuous-batching backend; set internally by OmniPipeline.
+    // Preview API: subject to change.
+    bool return_omni_outputs = false;
 
     /** @brief sets eos_token_id to tokenizer_eos_token_id if eos_token_id is less than 0.
      * Otherwise verifies eos_token_id == tokenizer_eos_token_id.
@@ -778,6 +786,9 @@ static constexpr ov::Property<std::string> grammar{"grammar"};
 static constexpr ov::Property<std::string> backend{"backend"};
 
 static constexpr ov::Property<bool> apply_chat_template{"apply_chat_template"};
+
+// Preview API: subject to change.
+static constexpr ov::Property<bool> return_omni_outputs{"return_omni_outputs"};
 
 }  // namespace genai
 }  // namespace ov

--- a/src/cpp/include/openvino/genai/generation_handle.hpp
+++ b/src/cpp/include/openvino/genai/generation_handle.hpp
@@ -50,6 +50,14 @@ struct EncodedGenerationResult {
     // To get metrics, it should be cast to corresponding class for extended perf metrics from pipeline
     // Cast to SDPerModelsPerfMetrics for SpeculativeDecoding
     std::shared_ptr<ExtendedPerfMetrics> extended_perf_metrics;
+
+    // Accumulated intermediate hidden states per sequence.
+    // Outer vector: per return sequence. Inner vector: one tensor per generation step.
+    std::vector<std::vector<ov::Tensor>> m_intermediate_hidden_states;
+
+    // Full prompt + generated token IDs (needed for talker input construction).
+    // Outer vector: per return sequence, aligned with m_intermediate_hidden_states.
+    std::vector<std::vector<int64_t>> m_full_token_ids;
 };
 
 struct GenerationResult {
@@ -82,6 +90,8 @@ struct GenerationOutput {
     std::vector<float> generated_log_probs;
     float score = 0;
     GenerationFinishReason finish_reason = GenerationFinishReason::NONE;
+    // Per-token hidden states collected for Qwen3-Omni speech generation. Preview API: subject to change.
+    std::vector<ov::Tensor> intermediate_hidden_states;
 };
 
 using GenerationOutputs = std::unordered_map<uint64_t, GenerationOutput>;

--- a/src/cpp/include/openvino/genai/omni/decoded_results.hpp
+++ b/src/cpp/include/openvino/genai/omni/decoded_results.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "openvino/genai/omni/talker.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
+
+namespace ov::genai {
+
+/**
+ * @brief Omni-specific decoded results including speech outputs.
+ *
+ * Extends VLMDecodedResults with a TalkerResults that holds speech waveforms and perf metrics.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+class OPENVINO_GENAI_EXPORTS OmniDecodedResults : public VLMDecodedResults {
+public:
+    /// Talker-side result: speech waveforms + perf metrics.
+    /// `speech_result.waveforms` is empty when speech generation was not requested.
+    TalkerResults speech_result;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/omni/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/omni/pipeline.hpp
@@ -1,0 +1,207 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/core/any.hpp"
+#include "openvino/genai/chat_history.hpp"
+#include "openvino/genai/generation_config.hpp"
+#include "openvino/genai/llm_pipeline.hpp"
+#include "openvino/genai/omni/decoded_results.hpp"
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+#include "openvino/genai/omni/talker.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "openvino/genai/streamer_base.hpp"
+#include "openvino/genai/visibility.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
+#include "openvino/genai/visual_language/video_metadata.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace ov::genai {
+
+/**
+ * @brief Public Qwen3-Omni pipeline supporting text + speech outputs.
+ *
+ * OmniPipeline composes a VLM pipeline (text generation with hidden-state collection)
+ * with a Qwen3-Omni speech pipeline (Talker + CodePredictor + Code2Wav). Each call to
+ * `generate` takes two configs:
+ *
+ *   - `GenerationConfig text_config`     — drives the thinker text decode
+ *     (max_new_tokens, do_sample, temperature, top_p, top_k, repetition_penalty,
+ *      num_beams, eos_token_id, ...).
+ *   - `OmniTalkerSpeechConfig talker_speech_config` — drives the talker + speech output
+ *     (return_audio, speaker (name or embedding tensor), audio_chunk_frames, max_new_tokens,
+ *      rng_seed, talker_x / cp_x sampling overrides). Speech is gated per-call by
+ *      `talker_speech_config.return_audio`.
+ *
+ * Cross-config validation (e.g. return_audio incompatible with beam search) runs inside
+ * generate() before any work begins.
+ *
+ * Constructors:
+ *   - Path-based: loads VLM and speech models from a single models_path.
+ *   - Pure-DI: takes pre-built VLM and talker components for independent device choices
+ *              or a custom TalkerBase subclass.
+ *
+ * Both ctors enforce that the loaded model is Qwen3-Omni capable (model_type == QWEN3_OMNI
+ * and enable_audio_output) — non-Omni models throw at construction time.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+class OPENVINO_GENAI_EXPORTS OmniPipeline {
+public:
+    /// @brief Sugar ctor: loads the VLM and the default Qwen3-Omni talker from a single
+    /// `models_path`, both compiled to `device` with the same `properties`. Equivalent to
+    /// constructing a `VLMPipeline(models_path, device, properties)` plus a
+    /// `Talker(models_path, device, properties)` and passing them to the DI ctor.
+    OmniPipeline(const std::filesystem::path& models_path,
+                 const std::string& device,
+                 const ov::AnyMap& properties = {});
+
+    /// @brief Pure-DI ctor: takes pre-built VLM and talker components. Use when you want
+    /// independent device/property choices for the two stages (e.g. VLM on GPU, talker on
+    /// CPU), or to inject a custom `TalkerBase` subclass. The VLM must be Qwen3-Omni-capable
+    /// (audio output enabled) and use the continuous-batching backend; the ctor asserts on both.
+    /// @param vlm Backing VLM pipeline. Shared ownership allows independent lifetime management.
+    /// @param talker Backing speech generator. The default impl is `Talker`.
+    OmniPipeline(const std::shared_ptr<VLMPipelineBase>& vlm, const std::shared_ptr<TalkerBase>& talker);
+
+    ~OmniPipeline();
+
+    /// @brief Generate text + (optionally) speech from a flat prompt.
+    /// @param prompt The user prompt.
+    /// @param images Image tensors to be prepended to the prompt.
+    /// @param videos Video tensors to be prepended to the prompt.
+    /// @param audios Audio tensors to be prepended to the prompt.
+    /// @param text_generation_config Thinker text-decode config.
+    /// @param talker_speech_config Talker + speech-output config.
+    /// @param streamer Optional streamer for text tokens.
+    /// @param speech_streamer Optional streamer for audio chunks.
+    /// @return OmniDecodedResults with `speech_result.waveforms` populated when
+    ///         `talker_speech_config.return_audio` is true.
+    OmniDecodedResults generate(const std::string& prompt,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const std::vector<ov::Tensor>& audios,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Images-only flat-prompt overload (no videos / no audios).
+    OmniDecodedResults generate(const std::string& prompt,
+                                const std::vector<ov::Tensor>& images,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Images + videos flat-prompt overload (no audios).
+    OmniDecodedResults generate(const std::string& prompt,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Single-image flat-prompt overload.
+    OmniDecodedResults generate(const std::string& prompt,
+                                const ov::Tensor& image,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Property-bag overload for flat-prompt generation. Recognized keys:
+    ///        `images`, `videos`, `videos_metadata`, `audios`, `text_config`,
+    ///        `talker_speech_config`, `streamer`, `speech_streamer`, plus any field of
+    ///        `GenerationConfig` or `OmniTalkerSpeechConfig`.
+    /// @note Leftover keys are forwarded to BOTH configs' `update_generation_config`. Shared
+    ///       field names (e.g. `max_new_tokens`, `rng_seed`) end up on both — this is the
+    ///       intended broadcast behavior. Pass typed configs explicitly to set different values.
+    OmniDecodedResults generate(const std::string& prompt, const ov::AnyMap& config_map);
+
+    /// @brief Variadic-properties flat-prompt overload.
+    /// Example:
+    ///   `pipe.generate("text", ov::genai::images(rgbs), ov::genai::audios(audios),
+    ///                   ov::genai::text_config(g), ov::genai::talker_speech_config(t));`
+    template <typename... Properties>
+    util::EnableIfAllStringAny<OmniDecodedResults, Properties...> generate(const std::string& prompt,
+                                                                           Properties&&... properties) {
+        return generate(prompt, AnyMap{std::forward<Properties>(properties)...});
+    }
+
+    /// @brief Generate text + (optionally) speech from a chat history.
+    OmniDecodedResults generate(const ChatHistory& history,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const std::vector<ov::Tensor>& audios,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Images-only chat-history overload (no videos / no audios).
+    OmniDecodedResults generate(const ChatHistory& history,
+                                const std::vector<ov::Tensor>& images,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Images + videos chat-history overload (no audios).
+    OmniDecodedResults generate(const ChatHistory& history,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Single-image chat-history overload.
+    OmniDecodedResults generate(const ChatHistory& history,
+                                const ov::Tensor& image,
+                                const GenerationConfig& text_generation_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer = std::monostate{},
+                                const OmniSpeechStreamerVariant& speech_streamer = std::monostate{});
+
+    /// @brief Property-bag overload for chat-history generation. Recognized keys mirror the prompt overload.
+    OmniDecodedResults generate(const ChatHistory& history, const ov::AnyMap& config_map);
+
+    /// @brief Variadic-properties chat-history overload.
+    template <typename... Properties>
+    util::EnableIfAllStringAny<OmniDecodedResults, Properties...> generate(const ChatHistory& history,
+                                                                           Properties&&... properties) {
+        return generate(history, AnyMap{std::forward<Properties>(properties)...});
+    }
+
+    /// @brief Return the underlying VLM. Useful for inspecting model metadata or reusing the
+    /// same thinker across pipelines.
+    std::shared_ptr<VLMPipelineBase> get_vlm() const;
+
+    /// @brief Return the underlying TalkerBase. Speaker enumeration and embedding retrieval
+    /// live here: `get_talker()->list_speakers()`, `get_talker()->get_speaker_embedding(name)`.
+    std::shared_ptr<TalkerBase> get_talker() const;
+
+private:
+    class OmniPipelineImpl;
+    std::unique_ptr<OmniPipelineImpl> m_pimpl;
+};
+
+/// @brief Property bag keys for OmniPipeline::generate(prompt|history, AnyMap).
+/// `images`, `videos`, `audios` are reused from `openvino/genai/visual_language/pipeline.hpp`.
+static constexpr ov::Property<GenerationConfig> text_config{"text_config"};
+static constexpr ov::Property<OmniTalkerSpeechConfig> talker_speech_config{"talker_speech_config"};
+static constexpr ov::Property<OmniSpeechStreamerVariant> speech_streamer{"speech_streamer"};
+
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/omni/speech_streamer_base.hpp
+++ b/src/cpp/include/openvino/genai/omni/speech_streamer_base.hpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <variant>
+
+#include "openvino/genai/streamer_base.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace ov::genai {
+
+/**
+ * @brief Base class for audio streamers. Inherit and implement write() and end()
+ * to receive audio chunks during speech generation.
+ *
+ * Thread safety: write() and end() are called sequentially on the thread that
+ * runs generate(). No concurrent calls are made.
+ *
+ * Lifecycle (for OmniSpeechStreamerBase implementations):
+ *   1. write() is called zero or more times with audio chunks.
+ *   2. end() is always called exactly once after the last write(), even if
+ *      generation was stopped or cancelled early, or if an error occurred.
+ *
+ * Note: Plain function callbacks (std::function<StreamingStatus(const ov::Tensor&)>)
+ * accepted via OmniSpeechStreamerVariant have no end() hook — lifecycle applies only to
+ * OmniSpeechStreamerBase subclasses.
+ *
+ * Return values from write():
+ *   - RUNNING  -- continue generating and streaming audio chunks.
+ *   - STOP     -- stop generation gracefully. end() is still called.
+ *                  Already-generated audio is kept in the output.
+ *   - CANCEL   -- cancel generation. end() is still called.
+ *                  Generated audio may be discarded depending on the pipeline.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+class OPENVINO_GENAI_EXPORTS OmniSpeechStreamerBase {
+public:
+    /// @brief Called with each audio chunk during speech generation.
+    /// @param audio_chunk Waveform tensor [1, 1, N_samples] float32 PCM at 24kHz.
+    ///        The tensor is valid only for the duration of this call; copy if needed.
+    /// @return StreamingStatus to continue (RUNNING), stop (STOP), or cancel (CANCEL).
+    virtual StreamingStatus write(const ov::Tensor& audio_chunk) = 0;
+
+    /// @brief Called exactly once when speech generation ends.
+    ///        Always called, even on early stop/cancel or error.
+    virtual void end() = 0;
+
+    virtual ~OmniSpeechStreamerBase();
+};
+
+/// @brief Variant type for audio streaming callbacks.
+/// - Lambda: std::function<StreamingStatus(const ov::Tensor&)> — called with each audio chunk
+/// - OmniSpeechStreamerBase subclass via shared_ptr
+/// - monostate: no streaming (batch mode, default)
+using OmniSpeechStreamerVariant = std::variant<
+    std::function<StreamingStatus(const ov::Tensor&)>,
+    std::shared_ptr<OmniSpeechStreamerBase>,
+    std::monostate>;
+
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/omni/talker.hpp
+++ b/src/cpp/include/openvino/genai/omni/talker.hpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/core/any.hpp"
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+#include "openvino/genai/omni/talker_perf_metrics.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "openvino/genai/visibility.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
+
+namespace ov::genai {
+
+/**
+ * @brief Output of TalkerBase::generate. Holds the talker-side waveform plus its perf metrics.
+ * OmniPipelineImpl combines this with VLMDecodedResults from the VLM stage to produce the
+ * public OmniDecodedResults.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+struct OPENVINO_GENAI_EXPORTS TalkerResults {
+    /// Speech output waveforms. Empty when `talker_speech_config.return_audio == false`.
+    std::vector<ov::Tensor> waveforms;
+
+    /// Speech-side perf metrics: wall-clock time and sample count.
+    /// Populated even when `waveforms` is empty so callers can see how long the no-op path took.
+    TalkerPerfMetrics perf_metrics;
+};
+
+/**
+ * @brief Public abstract interface for OmniPipeline's speech-output backend.
+ *
+ * The talker consumes the hidden states accumulated during VLM generation and produces
+ * a waveform plus optional streamed audio chunks. Inject a custom subclass into
+ * `OmniPipeline(shared_ptr<VLMPipeline::VLMBackend>, shared_ptr<TalkerBase>)` to swap the
+ * default Qwen3-Omni speech stack for an alternative implementation (e.g. a different
+ * codec, a different talker model, or a mock for testing).
+ *
+ * The default implementation `Talker` (declared in this header) wraps the
+ * existing Qwen3-Omni Talker + CodePredictor + Code2Wav stack.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+class OPENVINO_GENAI_EXPORTS TalkerBase {
+public:
+    virtual ~TalkerBase() = default;
+
+    /// @brief Run speech generation against a VLM result.
+    /// @param vlm_result VLM-side text result; must carry hidden states from a generate()
+    ///                   call that ran with `talker_speech_config.return_audio == true`. The
+    ///                   talker reads `intermediate_hidden_states` and `full_token_ids` from the
+    ///                   result. Passed by const-ref — the talker does
+    ///                   not own the VLM result; OmniPipelineImpl assembles the final
+    ///                   `OmniDecodedResults` from both the VLM and talker outputs.
+    /// @param talker_speech_config Generation knobs for the talker (`return_audio`, `speaker`
+    ///                             (name or embedding), `audio_chunk_frames`, `max_new_tokens`,
+    ///                             `rng_seed`, validated before calling).
+    /// @param speech_streamer Optional callback or `OmniSpeechStreamerBase` for streaming
+    ///                        audio chunks. `monostate` = batch mode (single waveform).
+    /// @return TalkerResults with `waveforms` populated when `return_audio` is true and
+    ///         `perf_metrics` populated regardless.
+    virtual TalkerResults generate(const VLMDecodedResults& vlm_result,
+                                  const OmniTalkerSpeechConfig& talker_speech_config,
+                                  const OmniSpeechStreamerVariant& speech_streamer = std::monostate{}) = 0;
+
+    /// @brief List names of speakers exposed by this talker.
+    /// Returns an empty vector when the backend does not enumerate named speakers.
+    virtual std::vector<std::string> list_speakers() const = 0;
+
+    /// @brief Return precomputed speaker embedding for the named speaker.
+    /// Tensor shape and dtype are backend-defined (Qwen3-Omni: `[1, 1, talker_hidden_size]`, f32).
+    /// Use to blend voices: combine two named embeddings and pass the result via
+    /// `OmniTalkerSpeechConfig::speaker` (the Tensor alternative of the variant).
+    /// @throws when the backend has no named speakers, or `name` doesn't match.
+    virtual ov::Tensor get_speaker_embedding(const std::string& name) const = 0;
+};
+
+/**
+ * @brief Default OmniPipeline talker for Qwen3-Omni Talker + CodePredictor + Code2Wav.
+ *
+ * Loads the speech stack from a model directory (the same directory as the VLM weights
+ * for path-based OmniPipeline construction; an arbitrary directory containing the
+ * speech submodels for the DI ctor).
+ *
+ * Public-API thin wrapper around the internal `Qwen3OmniSpeechPipeline`. Construct
+ * directly when you want to inject your own VLM (e.g. placed on a different device) but keep
+ * the default speech backend:
+ *
+ *     auto vlm = std::make_shared<ov::genai::VLMPipeline>(model_dir, "GPU", props);
+ *     auto talker = std::make_shared<ov::genai::Talker>(model_dir, "CPU", props);
+ *     ov::genai::OmniPipeline pipe(vlm, talker);
+ *
+ * @note This is a preview API and is subject to change.
+ */
+class OPENVINO_GENAI_EXPORTS Talker : public TalkerBase {
+public:
+    /// @brief Load Qwen3-Omni speech submodels from a directory containing
+    /// `openvino_talker_model.xml`, `openvino_code_predictor_model.xml`,
+    /// `openvino_code2wav_model.xml`, plus the talker text-embedding and projection
+    /// submodels. The directory must contain `config.json` (used for talker config).
+    Talker(const std::filesystem::path& model_dir,
+                    const std::string& device,
+                    const ov::AnyMap& properties = {});
+
+    ~Talker() override;
+
+    TalkerResults generate(const VLMDecodedResults& vlm_result,
+                          const OmniTalkerSpeechConfig& talker_speech_config,
+                          const OmniSpeechStreamerVariant& speech_streamer = std::monostate{}) override;
+
+    std::vector<std::string> list_speakers() const override;
+    ov::Tensor get_speaker_embedding(const std::string& name) const override;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/omni/talker_perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/omni/talker_perf_metrics.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+#include "openvino/genai/visibility.hpp"
+
+namespace ov::genai {
+
+/**
+ * @brief Performance metrics for Talker speech generation.
+ *
+ * Captures wall-clock time and output size for a single generate() call.
+ * Unlike SpeechGenerationPerfMetrics, this type omits LLM-oriented fields
+ * (TTFT, TPOT, tokenization durations) that are not applicable to speech codec workflows.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+struct OPENVINO_GENAI_EXPORTS TalkerPerfMetrics {
+    /// Number of audio samples generated (waveform length in samples, not bytes).
+    size_t num_generated_samples = 0;
+
+    /// Total speech generation time in milliseconds (autoregressive token prediction + vocoding).
+    /// Vocoding = converting neural codec tokens to PCM waveform, not WAV file I/O.
+    float generation_time_ms = 0;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/omni/talker_speech_config.hpp
+++ b/src/cpp/include/openvino/genai/omni/talker_speech_config.hpp
@@ -1,0 +1,100 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <limits>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "openvino/genai/visibility.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace ov {
+namespace genai {
+
+/**
+ * @brief Speech-side generation config for the Qwen3-Omni talker (and future omni
+ * models with a similar two-stage thinker + talker architecture).
+ *
+ * Standalone POD struct — does NOT inherit from GenerationConfig. The thinker text
+ * decode is steered by a separate `GenerationConfig text_config` argument to
+ * OmniPipeline::generate; this struct only carries fields the talker actually
+ * consumes.
+ *
+ * @note This is a preview API and is subject to change.
+ */
+struct OPENVINO_GENAI_EXPORTS OmniTalkerSpeechConfig {
+    OmniTalkerSpeechConfig() = default;
+
+    /**
+     * @brief Read defaults from `<models_dir>/config.json`.
+     *
+     * Currently picks up `talker_config.speaker_id` (single-string case) into
+     * `speaker`. Multi-speaker models leave `speaker` empty so the talker resolves
+     * a default at generate time. Sampling defaults (`talker_temperature`,
+     * `talker_top_k`, etc.) live in the speech pipeline's m_config (loaded from
+     * `generation_config.json`) and the std::optional override fields stay unset
+     * here so the pipeline keeps using those checkpoint defaults.
+     */
+    explicit OmniTalkerSpeechConfig(const std::filesystem::path& models_dir);
+
+    /// @brief Enable speech output. Defaults to true; set false to short-circuit
+    /// the talker and produce text only.
+    bool return_audio = true;
+
+    /// @brief Speaker identity: either a name (std::string) looked up in
+    /// `talker_config.speaker_id`, or an explicit embedding tensor
+    /// (`[1, 1, talker_hidden_size]`, f32). Default is empty string which
+    /// selects the model's default speaker.
+    /// Use `pipe.get_talker()->get_speaker_embedding(name)` to fetch precomputed
+    /// tensors and blend them yourself (e.g. weighted sum) to mix voices.
+    std::variant<std::string, ov::Tensor> speaker;
+
+    /// @brief Number of codec frames accumulated before streaming each audio chunk.
+    /// Must be >= 1. Each frame is 80ms of audio at 24 kHz (1920 samples).
+    std::size_t audio_chunk_frames = 1;
+
+    /// @brief Cap on talker AR steps. Independent of `text_config.max_new_tokens`
+    /// (which caps the thinker text decode).
+    std::size_t max_new_tokens = std::numeric_limits<std::size_t>::max();
+
+    /// @brief RNG seed for talker + CodePredictor sampling.
+    std::size_t rng_seed = 0;
+
+    // Qwen3-Omni speech generation has two AR stages:
+    // 1. **Talker** — generates semantic tokens (speech content).
+    // 2. **CodePredictor (cp)** — converts semantic tokens to codec tokens (audio waveform).
+    // Fields below control sampling for each stage independently.
+    // Checkpoint defaults loaded from generation_config.json when present.
+
+    /// @brief Talker sampling temperature override (must be > 0 when set).
+    /// Checkpoint default from `generation_config.json -> talker_temperature` if present.
+    std::optional<float> talker_temperature;
+
+    /// @brief Talker top-k override (must be >= 1 when set).
+    /// Checkpoint default from `generation_config.json -> talker_top_k` if present.
+    std::optional<std::size_t> talker_top_k;
+
+    /// @brief Talker repetition penalty override (must be > 0 when set; 1.0 = no penalty).
+    /// Checkpoint default from `generation_config.json -> talker_repetition_penalty` if present.
+    std::optional<float> talker_repetition_penalty;
+
+    /// @brief CodePredictor sampling temperature override (must be > 0 when set).
+    /// Checkpoint default from `generation_config.json -> cp_temperature` if present.
+    std::optional<float> cp_temperature;
+
+    /// @brief CodePredictor top-k override (must be >= 1 when set).
+    /// Checkpoint default from `generation_config.json -> cp_top_k` if present.
+    std::optional<std::size_t> cp_top_k;
+
+    /// @brief CodePredictor repetition penalty override (must be > 0 when set; 1.0 = no penalty).
+    /// Checkpoint default from `generation_config.json -> cp_repetition_penalty` if present.
+    std::optional<float> cp_repetition_penalty;
+};
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
@@ -18,11 +18,217 @@ namespace ov::genai {
 class OPENVINO_GENAI_EXPORTS VLMDecodedResults : public DecodedResults{
 public:
     VLMPerfMetrics perf_metrics;
+
+    // Hidden-state fields for speech generation (exposed to Python to enable custom Talker impls).
+    // Populated by the CB pipeline when `return_omni_outputs` is set on the GenerationConfig.
+    // Consumed by Talker / TalkerBase impls to drive Qwen3-Omni speech generation.
+    // Both fields are empty (default-constructed) on the text-only path.
+    // Preview API: subject to change.
+    //
+    // Outer index of intermediate_hidden_states is per return sequence;
+    // inner is one tensor per generation step.
+    std::vector<std::vector<ov::Tensor>> intermediate_hidden_states;
+    // Full prompt + generated token ids (talker input construction).
+    // Outer index is per return sequence, aligned with intermediate_hidden_states;
+    // inner is prompt tokens followed by that sequence's generated tokens.
+    std::vector<std::vector<int64_t>> full_token_ids;
+};
+
+/**
+ * @brief Public abstract interface for VLM-style pipelines.
+ *
+ * Promoted to a public top-level type so callers can hold a `std::shared_ptr<VLMPipelineBase>`
+ * without depending on `VLMPipeline`'s internal pimpl. Carries the user-visible surface —
+ * `generate()` overloads, tokenizer/config accessors, chat-template setter — plus the Qwen3-Omni
+ * capability queries OmniPipeline needs to compose a `shared_ptr<VLMPipelineBase>`. Backend-only
+ * machinery lives on internal sub-classes declared in `src/`-private headers, not here.
+ */
+class OPENVINO_GENAI_EXPORTS VLMPipelineBase {
+public:
+    virtual ~VLMPipelineBase() = default;
+
+    /// @brief Generate a response given a prompt and any number of
+    /// uint8 RGB images with [NHWC] or [HWC] layout.
+    /// @param prompt A prompt to respond to.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param images Images to be prepended to a prompt.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    /// chat_template will be applied to the prompt, run pipe.set_chat_template(custom_chat_template) to update it.
+    /// To disable it for non-chat mode, please, use custom_chat_template eq "" or set generation_config.apply_chat_template to false.
+    virtual VLMDecodedResults generate(const std::string& prompt,
+                                       const std::vector<ov::Tensor>& images,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief Generate a response given a prompt and uint8 RGB image with [NHWC] or [HWC] layout.
+    /// @param prompt A prompt to respond to.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param images Image to be prepended to a prompt.
+    /// @param videos Multiple videos, each providing multiple frames, to be prepended to a prompt.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    /// chat_template will be applied to the prompt, run pipe.set_chat_template(custom_chat_template) to update it.
+    /// To disable it for non-chat mode, please, use custom_chat_template eq "" or set generation_config.apply_chat_template to false.
+    virtual VLMDecodedResults generate(const std::string& prompt,
+                                       const std::vector<ov::Tensor>& images,
+                                       const std::vector<ov::Tensor>& videos,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief Generate a response given a prompt and a single uint8 RGB image with [NHWC] or [HWC] layout.
+    /// @param prompt A prompt to respond to.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param image Image to be prepended to a prompt.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    virtual VLMDecodedResults generate(const std::string& prompt,
+                                       const ov::Tensor& image,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) {
+        return generate(prompt, std::vector<ov::Tensor>{image}, generation_config, streamer);
+    }
+
+    /// @brief Generate a response given a prompt and config.
+    /// @param prompt A prompt to respond to.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param config_map A config may contain GenerationConfig, values
+    /// for its members, StreamerVariant, a single image or multiple
+    /// images/videos, and audios.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    /// chat_template will be applied to the prompt, run pipe.set_chat_template(custom_chat_template) to update it.
+    /// To disable it for non-chat mode, please, use custom_chat_template eq "" or set generation_config.apply_chat_template to false.
+    virtual VLMDecodedResults generate(const std::string& prompt, const ov::AnyMap& config_map) = 0;
+
+    /// @brief Generate a response given a chat history and any number of
+    /// uint8 RGB images with [NHWC] or [HWC] layout.
+    /// @param history Chat history with messages.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param images Images to be associated with the last chat history user message.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    virtual VLMDecodedResults generate(const ChatHistory& history,
+                                       const std::vector<ov::Tensor>& images,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief Generate a response given a chat history and any number of
+    /// uint8 RGB images/videos with [NHWC] layout.
+    /// @param history Chat history with messages.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param images Images to be associated with the last chat history user message.
+    /// @param videos Videos (each providing multiple frames) to be associated with the last chat history user message.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    virtual VLMDecodedResults generate(const ChatHistory& history,
+                                       const std::vector<ov::Tensor>& images,
+                                       const std::vector<ov::Tensor>& videos,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief Generate a response given a chat history and a single uint8 RGB image with [NHWC] or [HWC] layout.
+    /// @param history Chat history with messages.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param image Image to be associated with the last chat history user message.
+    /// @param generation_config A config to follow for text generation.
+    /// @param streamer A streamer to acquire intermediate result.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    virtual VLMDecodedResults generate(const ChatHistory& history,
+                                       const ov::Tensor& image,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) {
+        return generate(history, std::vector<ov::Tensor>{image}, generation_config, streamer);
+    }
+
+    /// @brief Generate a response given a chat history and config.
+    /// @param history Chat history with messages.
+    /// For using image and video tags in prompt, see:
+    /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
+    /// @param config_map A config may contain GenerationConfig, values
+    /// for its members, StreamerVariant, a single image or multiple
+    /// images/videos, and audios.
+    /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
+    virtual VLMDecodedResults generate(const ChatHistory& history, const ov::AnyMap& config_map) = 0;
+
+    /// @brief Get a Tokenizer used to tokenize input and detokenize
+    /// output.
+    virtual Tokenizer get_tokenizer() const = 0;
+
+    /// @brief Set a custom chat template. Can be used to deactivate
+    /// chat_template application for chat mode if called with
+    /// "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    /// or workaround unsupported chat_template entries in a default
+    /// model chat_template.
+    /// @param new_template A new template to override with.
+    virtual void set_chat_template(const std::string& new_template) = 0;
+
+    /// @brief Extract GenerationConfig used to get default values.
+    /// @return Default values used.
+    virtual GenerationConfig get_generation_config() const = 0;
+
+    /// @brief Override default values for GenerationConfig
+    /// @param new_config A config to override default values with.
+    virtual void set_generation_config(const GenerationConfig& new_config) = 0;
+
+    // --- Qwen3-Omni support hooks --------------------------------------------------------------
+    // Promoted onto the public base so OmniPipeline can compose a `shared_ptr<VLMPipelineBase>`
+    // and still reach the Qwen3-Omni-specific plumbing without
+    // depending on any internal sub-class. Meaningful only for Qwen3-Omni-capable pipelines;
+    // conventional VLM implementations report `false` for the capability queries below.
+
+    /// @brief videos_metadata-aware generate. Forwards to the backing implementation; used by
+    /// OmniPipeline to drive Qwen3-VL-style timestamp prompts. `audios` carries raw audio inputs
+    /// (Qwen3-Omni); conventional VLM implementations ignore it.
+    virtual VLMDecodedResults generate(const std::string& prompt,
+                                       const std::vector<ov::Tensor>& images,
+                                       const std::vector<ov::Tensor>& videos,
+                                       const std::vector<ov::Tensor>& audios,
+                                       const std::vector<VideoMetadata>& videos_metadata,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief videos_metadata-aware ChatHistory generate.
+    virtual VLMDecodedResults generate(const ChatHistory& history,
+                                       const std::vector<ov::Tensor>& images,
+                                       const std::vector<ov::Tensor>& videos,
+                                       const std::vector<ov::Tensor>& audios,
+                                       const std::vector<VideoMetadata>& videos_metadata,
+                                       const GenerationConfig& generation_config,
+                                       const StreamerVariant& streamer) = 0;
+
+    /// @brief Backend capability: true when the active execution path emits the per-step hidden
+    /// states the talker consumes. Depends on how the model was loaded — only the continuous-batching
+    /// backend collects them today; the SDPA fallback returns false. Independent of the model itself:
+    /// the same Omni model reports true on the CB path and false on SDPA. OmniPipeline asserts on this
+    /// so speech requests against the SDPA fallback fail early with a clear message.
+    /// @see is_audio_output_enabled(), which instead reflects a fixed property of the loaded model.
+    /// @note This is a preview API and is subject to change.
+    virtual bool supports_hidden_states_collection() const = 0;
+
+    /// @brief Model capability: true when the loaded model has a speech head (config.json
+    /// enable_audio_output=true, i.e. Qwen3-Omni). Depends on which model was loaded, not on the
+    /// backend — both backends report the same value for a given model. OmniPipeline's ctor rejects
+    /// non-Omni-capable models on this signal.
+    /// @see supports_hidden_states_collection(), which instead reflects the active backend.
+    /// @note This is a preview API and is subject to change.
+    virtual bool is_audio_output_enabled() const = 0;
 };
 
 /// @brief A Visual language modeling pipeline class used to generate a
 /// response or run a chat given a prompt and an image.
-class OPENVINO_GENAI_EXPORTS VLMPipeline {
+class OPENVINO_GENAI_EXPORTS VLMPipeline : public VLMPipelineBase {
 public:
     /// @brief Construct a pipeline from a folder containing tokenizer
     /// and model IRs.
@@ -103,7 +309,7 @@ public:
         const std::vector<ov::Tensor>& images,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
     /// @brief Generate a response given a prompt and uint8 RGB image with [NHWC] or [HWC] layout.
     /// @param prompt A prompt to respond to.
@@ -122,9 +328,9 @@ public:
         const std::vector<ov::Tensor>& videos,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
-    /// @brief Generate a response given a prompt and uint8 RGB image with [NHWC] or [HWC] layout.
+    /// @brief Generate a response given a prompt and a single uint8 RGB image with [NHWC] or [HWC] layout.
     /// @param prompt A prompt to respond to.
     /// For using image and video tags in prompt, see:
     /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
@@ -132,29 +338,27 @@ public:
     /// @param generation_config A config to follow for text generation.
     /// @param streamer A streamer to acquire intermediate result.
     /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
-    /// chat_template will be applied to the prompt, run pipe.set_chat_template(custom_chat_template) to update it.
-    /// To disable it for non-chat mode, please, use custom_chat_template eq "" or set generation_config.apply_chat_template to false.
     VLMDecodedResults generate(
         const std::string& prompt,
         const ov::Tensor& image,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
     /// @brief Generate a response given a prompt and config.
     /// @param prompt A prompt to respond to.
     /// For using image and video tags in prompt, see:
     /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
     /// @param config_map A config may contain GenerationConfig, values
-    /// for its members, StreamerVariant a single image or multiple
-    /// images.
+    /// for its members, StreamerVariant, a single image or multiple
+    /// images/videos, and audios.
     /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
     /// chat_template will be applied to the prompt, run pipe.set_chat_template(custom_chat_template) to update it.
     /// To disable it for non-chat mode, please, use custom_chat_template eq "" or set generation_config.apply_chat_template to false.
     VLMDecodedResults generate(
         const std::string& prompt,
         const ov::AnyMap& config_map
-    );
+    ) override;
 
     /// @brief Generate a response given a prompt and arbitrary number
     /// of ov::Property instances.
@@ -192,7 +396,7 @@ public:
         const std::vector<ov::Tensor>& images,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
     /// @brief Generate a response given a chat history and any number of
     /// uint8 RGB images/videos with [NHWC] layout.
@@ -210,9 +414,33 @@ public:
         const std::vector<ov::Tensor>& videos,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
-    /// @brief Generate a response given a chat history and uint8 RGB image with [NHWC] or [HWC] layout.
+    /// @brief videos_metadata-aware generate. Forwards to the backing implementation; used by
+    /// OmniPipeline to drive Qwen3-VL-style timestamp prompts. `audios` carries raw audio inputs
+    /// (Qwen3-Omni); conventional VLM implementations ignore it.
+    VLMDecodedResults generate(
+        const std::string& prompt,
+        const std::vector<ov::Tensor>& images,
+        const std::vector<ov::Tensor>& videos,
+        const std::vector<ov::Tensor>& audios,
+        const std::vector<VideoMetadata>& videos_metadata,
+        const GenerationConfig& generation_config,
+        const StreamerVariant& streamer
+    ) override;
+
+    /// @brief videos_metadata-aware ChatHistory generate.
+    VLMDecodedResults generate(
+        const ChatHistory& history,
+        const std::vector<ov::Tensor>& images,
+        const std::vector<ov::Tensor>& videos,
+        const std::vector<ov::Tensor>& audios,
+        const std::vector<VideoMetadata>& videos_metadata,
+        const GenerationConfig& generation_config,
+        const StreamerVariant& streamer
+    ) override;
+
+    /// @brief Generate a response given a chat history and a single uint8 RGB image with [NHWC] or [HWC] layout.
     /// @param history Chat history with messages.
     /// For using image and video tags in prompt, see:
     /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
@@ -225,7 +453,7 @@ public:
         const ov::Tensor& image,
         const GenerationConfig& generation_config,
         const StreamerVariant& streamer
-    );
+    ) override;
 
     /// @brief Generate a response given a chat history and arbitrary number
     /// of ov::Property instances.
@@ -233,13 +461,13 @@ public:
     /// For using image and video tags in prompt, see:
     /// https://openvinotoolkit.github.io/openvino.genai/docs/use-cases/image-processing/#use-image-or-video-tags-in-prompt
     /// @param config_map A config may contain GenerationConfig, values
-    /// for its members, StreamerVariant a single image or multiple
-    /// images/videos.
+    /// for its members, StreamerVariant, a single image or multiple
+    /// images/videos, and audios.
     /// @return VLMDecodedResults structure containing generated texts, scores and perf metrics.
     VLMDecodedResults generate(
         const ChatHistory& history,
         const ov::AnyMap& config_map
-    );
+    ) override;
 
     /// @brief Generate a response given a chat history and config.
     /// @param history Chat history with messages.
@@ -284,25 +512,30 @@ public:
     /// or workaround unsupported chat_template entries in a default
     /// model chat_template.
     /// @param new_template A new template to override with.
-    void set_chat_template(const std::string& new_template);
+    void set_chat_template(const std::string& new_template) override;
 
     /// @brief Get a Tokenizer used to tokenize input and detokenize
     /// output.
-    ov::genai::Tokenizer get_tokenizer() const;
+    ov::genai::Tokenizer get_tokenizer() const override;
 
     /// @brief Extract GenerationConfig used to get default values.
     /// @return Default values used.
-    GenerationConfig get_generation_config() const;
+    GenerationConfig get_generation_config() const override;
 
     /// @brief Override default values for GenerationConfig
     /// @param new_config A config to override default values with.
-    void set_generation_config(const GenerationConfig& new_config);
+    void set_generation_config(const GenerationConfig& new_config) override;
+
+    // Qwen3-Omni support hooks forwarded to the backing implementation. See VLMPipelineBase.
+    bool supports_hidden_states_collection() const override;
+    bool is_audio_output_enabled() const override;
 
 private:
-    class VLMPipelineBase;
+    class VLMBackend;  // internal Omni-aware base; defined in src/cpp/src/visual_language/pipeline_base.hpp.
     class VLMPipelineImpl;
     class VLMContinuousBatchingAdapter;
-    std::unique_ptr<VLMPipelineBase> m_pimpl;
+
+    std::shared_ptr<VLMBackend> m_pimpl;
 };
 
 /*
@@ -315,4 +548,5 @@ static constexpr ov::Property<ov::Tensor> image{"image"};
 static constexpr ov::Property<std::vector<ov::Tensor>> images{"images"};
 static constexpr ov::Property<std::vector<ov::Tensor>> videos{"videos"};
 static constexpr ov::Property<std::vector<VideoMetadata>> videos_metadata{"videos_metadata"};
+static constexpr ov::Property<std::vector<ov::Tensor>> audios{"audios"};
 }

--- a/src/cpp/src/continuous_batching/cache/cache_state_dumper.hpp
+++ b/src/cpp/src/continuous_batching/cache/cache_state_dumper.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <filesystem>
+#include <fstream>
 #include <vector>
 
 #include "continuous_batching/cache/block_manager.hpp"

--- a/src/cpp/src/continuous_batching/generate_properties.cpp
+++ b/src/cpp/src/continuous_batching/generate_properties.cpp
@@ -24,6 +24,12 @@ std::pair<std::string, ov::Any> videos_metadata_batches(
     return {utils::VIDEOS_METADATA_BATCHES_ARG_NAME, wrap_vectors_to_any(videos_metadata_batches)};
 }
 
+std::pair<std::string, ov::Any> audios_batches(
+    const std::vector<std::vector<ov::Tensor>>& audios_batches
+) {
+    return {utils::AUDIOS_BATCHES_ARG_NAME, wrap_vectors_to_any(audios_batches)};
+}
+
 CBGenerateProperties extract_cb_generate_properties(const ov::AnyMap& properties_map) {
     CBGenerateProperties properties;
 
@@ -51,6 +57,11 @@ CBGenerateProperties extract_cb_generate_properties(const ov::AnyMap& properties
         properties.videos_metadata_batches = unwrap_vectors_from_any<VideoMetadata>(
             videos_metadata_batches_iter->second.as<ov::AnyVector>()
         );
+    }
+
+    auto audios_batches_iter = properties_map.find(utils::AUDIOS_BATCHES_ARG_NAME);
+    if (audios_batches_iter != properties_map.end()) {
+        properties.audios_batches = unwrap_vectors_from_any<ov::Tensor>(audios_batches_iter->second.as<ov::AnyVector>());
     }
 
     return properties;

--- a/src/cpp/src/continuous_batching/generate_properties.hpp
+++ b/src/cpp/src/continuous_batching/generate_properties.hpp
@@ -19,6 +19,7 @@ struct CBGenerateProperties {
     std::optional<std::vector<std::vector<ov::Tensor>>> images_batches;
     std::optional<std::vector<std::vector<ov::Tensor>>> videos_batches;
     std::optional<std::vector<std::vector<VideoMetadata>>> videos_metadata_batches;
+    std::optional<std::vector<std::vector<ov::Tensor>>> audios_batches;
     std::optional<std::vector<GenerationConfig>> generation_config_batches;
     StreamerVariant streamer = std::monostate();
 

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -10,6 +10,7 @@
 #include <openvino/runtime/infer_request.hpp>
 
 #include "visual_language/embedding_model.hpp"
+#include "visual_language/inputs_embedder.hpp"
 #include "sequence_group.hpp"
 #include "continuous_batching/scheduler.hpp"
 #include "continuous_batching/timer.hpp"
@@ -388,8 +389,20 @@ public:
                     name.compare(name.size() - marker.size(), marker.size(), marker) == 0) {
                     std::string prefix = name.substr(0, name.size() - marker.size());
                     m_linear_attention_paging_groups.push_back({prefix, {}, {}, {}, {}});
+                } else if (name == "qq_bias_begins") {
+                    m_has_qq_bias_input = true;
                 }
                 break;  // use first name per input
+            }
+        }
+
+        // Detect model output names for hidden state handling (Qwen3-Omni)
+        for (const auto& output : compiled_model.outputs()) {
+            const auto& name = output.get_any_name();
+            if (name == "hidden_states") {
+                m_has_hidden_states_output = true;
+            } else if (name == "intermediate_hidden_states") {
+                m_has_intermediate_hidden_states_output = true;
             }
         }
     }
@@ -850,12 +863,15 @@ public:
         if (hidden_state_input && hidden_state_input.get_size() > 0) {
             m_request.set_tensor("hidden_states", hidden_state_input);
         }
-        if (_is_hs_export_only()) {
+        if (_is_hs_export_only() && m_has_qq_bias_input) {
             _set_query_to_query_tensors(sequence_groups, scheduler_output);
         }
         if (position_ids.get_shape().size() == 3 && position_ids.get_shape()[1] == 1) {
-            // M-RoPE: squeeze pseudo-batch dim [dim, 1, total_token_num] -> [dim, total_token_num]
+            // M-RoPE: squeeze pseudo-batch dim [N, 1, total_token_num] -> [N, total_token_num]
+            // Validate that N is within expected range (3 for Qwen2/2.5/3-VL, 4 for Qwen3-Omni)
             const auto& position_ids_shape = position_ids.get_shape();
+            OPENVINO_ASSERT(position_ids_shape[0] >= 3 && position_ids_shape[0] <= 4,
+                            "M-RoPE position_ids first dimension must be 3 or 4, got ", position_ids_shape[0]);
             position_ids.set_shape({position_ids_shape[0], position_ids_shape[2]});
         }
         // typical LLM parameters
@@ -924,7 +940,18 @@ public:
         _reset_cache_rotation_coefficients();
 
         if (_is_hs_export()) {
-            m_hidden_states = m_request.get_tensor("last_hidden_state");
+            // Use "hidden_states" output only when the model also exports "intermediate_hidden_states"
+            // (Qwen3-Omni pattern). Otherwise prefer "last_hidden_state" to preserve existing behavior
+            // for speculative decoding and other models.
+            m_hidden_states = (m_has_hidden_states_output && m_has_intermediate_hidden_states_output)
+                ? m_request.get_tensor("hidden_states")
+                : m_request.get_tensor("last_hidden_state");
+
+            // Capture intermediate hidden states if available (Qwen3-Omni talker support)
+            if (m_has_intermediate_hidden_states_output) {
+                m_intermediate_hidden_states = m_request.get_tensor("intermediate_hidden_states");
+            }
+
             for (size_t i = 0; i < num_sequence_groups; ++i) {
                 size_t seq_group_id = scheduler_output.m_scheduled_sequence_groups_ids[i];
                 SequenceGroup::Ptr sequence_group = sequence_groups[seq_group_id];
@@ -933,6 +960,25 @@ public:
                     Sequence::Ptr sequence = running_sequences[seq_idx];
                     sequence->update_hidden_state(
                         _get_hidden_state(sequence_group->get_request_id(), sequence->get_grouped_id()));
+                    if (m_has_intermediate_hidden_states_output) {
+                        auto ihs = _get_intermediate_hidden_state(sequence_group->get_request_id(), sequence->get_grouped_id());
+                        if (ihs.get_size() == 0) {
+                            continue;
+                        }
+                        auto ihs_shape = ihs.get_shape();
+                        size_t num_tokens = ihs_shape.at(0);
+                        if (num_tokens > 1) {
+                            // Prefill: slice the batch tensor into per-token tensors so that
+                            // the accumulated vector is indexed by absolute token position.
+                            for (size_t t = 0; t < num_tokens; ++t) {
+                                const auto [start_coord, end_coord] = ov::genai::utils::make_roi(ihs_shape, 0, t, t + 1);
+                                ov::Tensor token_hs(ihs, start_coord, end_coord);
+                                sequence->update_intermediate_hidden_state(token_hs);
+                            }
+                        } else {
+                            sequence->update_intermediate_hidden_state(ihs);
+                        }
+                    }
                 }
             }
         }
@@ -1003,6 +1049,15 @@ public:
 
 private:
     ov::Tensor m_hidden_states;
+    ov::Tensor m_intermediate_hidden_states;
+    // Whether model has "hidden_states" vs "last_hidden_state" output name
+    bool m_has_hidden_states_output = false;
+    // Whether model has intermediate_hidden_states output (e.g., Qwen3-Omni)
+    bool m_has_intermediate_hidden_states_output = false;
+    // Whether model has the Eagle3 "qq_bias_begins" input (tree-decoding query-to-query bias).
+    // Guards _set_query_to_query_tensors so the HS_EXPORT flag, which Qwen3-Omni also reuses to
+    // collect thinker hidden states, does not trigger an Eagle3-only tensor bind on Omni models.
+    bool m_has_qq_bias_input = false;
 
     // Hidden state flags and helpers
     bool _is_hs_export()   const { return m_hidden_state_flags & HS_EXPORT; }
@@ -1107,21 +1162,12 @@ private:
             }
         }
     }
-    /**
-     * @brief Retrieves a slice of the hidden state tensor corresponding to a specific request and sequence group.
-     *
-     * This method looks up the hidden state mapping for the given request and sequence group IDs.
-     * If the mapping exists and the hidden states tensor is available, it returns a sub-tensor (region of interest)
-     * representing the hidden state for the specified sequence. If the mapping does not exist or the hidden states
-     * tensor is empty, an empty tensor is returned.
-     *
-     * @param request_id        The unique identifier for the request.
-     * @param seq_grouped_id    The identifier for the sequence group within the request.
-     * @return ov::Tensor       The tensor slice representing the hidden state for the specified sequence,
-     *                          or an empty tensor if not found.
-     */
-    ov::Tensor _get_hidden_state(uint64_t request_id, uint64_t seq_grouped_id) const {
-        if (m_hidden_states.get_size() == 0) {
+    /// @brief Extract a per-sequence slice from a hidden states tensor using the sequence mapping.
+    /// Returns an empty tensor if the tensor is empty or the sequence is not found.
+    ov::Tensor _get_hidden_state_slice(const ov::Tensor& states_tensor,
+                                       uint64_t request_id,
+                                       uint64_t seq_grouped_id) const {
+        if (states_tensor.get_size() == 0) {
             return ov::Tensor();
         }
 
@@ -1131,15 +1177,22 @@ private:
             return ov::Tensor();
         }
 
-        size_t start_idx = it->second.start_token_idx;
-        size_t length = it->second.length;
+        const size_t start_idx = it->second.start_token_idx;
+        const size_t length = it->second.length;
 
-        auto shape = m_hidden_states.get_shape();
-        OPENVINO_ASSERT(shape.size() >= 2,
-                        "Hidden states tensor rank is less than 2.");
+        const auto shape = states_tensor.get_shape();
+        OPENVINO_ASSERT(shape.size() >= 2, "Hidden states tensor rank is less than 2.");
 
-        auto [start_coord, end_coord] = ov::genai::utils::make_roi(shape, 0, start_idx, start_idx + length);
-        return ov::Tensor(m_hidden_states, start_coord, end_coord);
+        const auto [start_coord, end_coord] = ov::genai::utils::make_roi(shape, 0, start_idx, start_idx + length);
+        return ov::Tensor(states_tensor, start_coord, end_coord);
+    }
+
+    ov::Tensor _get_hidden_state(uint64_t request_id, uint64_t seq_grouped_id) const {
+        return _get_hidden_state_slice(m_hidden_states, request_id, seq_grouped_id);
+    }
+
+    ov::Tensor _get_intermediate_hidden_state(uint64_t request_id, uint64_t seq_grouped_id) const {
+        return _get_hidden_state_slice(m_intermediate_hidden_states, request_id, seq_grouped_id);
     }
 
     /**

--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -19,7 +19,7 @@
 #include "utils.hpp"
 #include "model_desc.hpp"
 #include "visual_language/inputs_embedder.hpp"
-#include "visual_language/vision_properties.hpp"
+#include "visual_language/multimodal_inputs.hpp"
 #include "json_utils.hpp"
 #include "lora/helper.hpp"
 
@@ -457,19 +457,19 @@ GenerationHandle ContinuousBatchingPipeline::add_request(
     ov::genai::OptionalGenerationConfig generation_config = utils::get_config_from_map(properties_map);
     OPENVINO_ASSERT(generation_config.has_value(),
         "\"generation_config\" property is required in add_request with properties map");
-    
-    const auto vision_properties = extract_vision_properties(properties_map);
 
-    if (!vision_properties.has_value()) {
+    const auto multimodal_inputs = extract_multimodal_inputs(properties_map);
+
+    if (!multimodal_inputs.has_value()) {
         return m_impl->add_request(request_id, prompt, generation_config.value());
     }
 
     return m_impl->add_request(
         request_id,
         prompt,
-        vision_properties.images.value_or(std::vector<ov::Tensor>{}),
-        vision_properties.videos.value_or(std::vector<ov::Tensor>{}),
-        vision_properties.videos_metadata.value_or(std::vector<VideoMetadata>{}),
+        multimodal_inputs.images.value_or(std::vector<ov::Tensor>{}),
+        multimodal_inputs.videos.value_or(std::vector<ov::Tensor>{}),
+        multimodal_inputs.videos_metadata.value_or(std::vector<VideoMetadata>{}),
         generation_config.value()
     );
 }
@@ -552,6 +552,7 @@ std::vector<VLMDecodedResults> ContinuousBatchingPipeline::generate(
         CBGenerateProperties::resolve_property(properties.images_batches, batch_size),
         CBGenerateProperties::resolve_property(properties.videos_batches, batch_size),
         CBGenerateProperties::resolve_property(properties.videos_metadata_batches, batch_size),
+        CBGenerateProperties::resolve_property(properties.audios_batches, batch_size),
         properties.generation_config_batches.value(),
         properties.streamer
     );
@@ -595,6 +596,7 @@ std::vector<VLMDecodedResults> ContinuousBatchingPipeline::generate(
         CBGenerateProperties::resolve_property(properties.images_batches, batch_size),
         CBGenerateProperties::resolve_property(properties.videos_batches, batch_size),
         CBGenerateProperties::resolve_property(properties.videos_metadata_batches, batch_size),
+        CBGenerateProperties::resolve_property(properties.audios_batches, batch_size),
         properties.generation_config_batches.value(),
         properties.streamer
     );

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "continuous_batching/pipeline_base.hpp"
+
 #include "visual_language/chat_history_state.hpp"
 #include "visual_language/vlm_chat_context.hpp"
 
 namespace {
 
 std::unordered_map<std::string, ov::Tensor> deep_copy_tensors_map(
-    const std::unordered_map<std::string, ov::Tensor>& src
-) {
+    const std::unordered_map<std::string, ov::Tensor>& src) {
     std::unordered_map<std::string, ov::Tensor> dst;
     dst.reserve(src.size());
     for (const auto& [name, tensor] : src) {
@@ -20,12 +20,9 @@ std::unordered_map<std::string, ov::Tensor> deep_copy_tensors_map(
     return dst;
 }
 
-} // namespace
+}  // namespace
 
 namespace ov::genai {
-
-template<class... Ts> struct overloaded : Ts... {using Ts::operator()...;};
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 GenerationConfig ContinuousBatchingPipeline::IContinuousBatchingPipeline::get_config() const {
     return m_generation_config;
@@ -65,13 +62,12 @@ void ContinuousBatchingPipeline::IContinuousBatchingPipeline::finish_chat() {
     m_video_id = 0;
 };
 
-std::vector<GenerationResult>
-ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
+std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     const std::vector<std::string>& prompts,
     std::vector<ov::genai::GenerationConfig> sampling_params,
     const StreamerVariant& streamer) {
     if (m_model_input_type == ModelInputType::EMBEDDINGS) {
-        // TODO: remove this code and within model runner add check: if sequence group type is tokens, 
+        // TODO: remove this code and within model runner add check: if sequence group type is tokens,
         // but embedding model is available => compute embeddings first, then pass to LLM
         std::vector<std::vector<ov::Tensor>> images(prompts.size());
         auto results_vlm = generate(prompts, images, sampling_params, streamer);
@@ -162,7 +158,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
-        perf_metrics.raw_metrics.generate_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
+        perf_metrics.raw_metrics.generate_durations.emplace_back(
+            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
         // Reevaluate taking into account tokenization/detokenization times.
         perf_metrics.m_evaluated = false;
         perf_metrics.evaluate_statistics(start_time);
@@ -178,24 +175,24 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         });
     }
 
-    // if streaming was cancelled, prompt/answer of current step shouldn't be presented in history, so let's remove prompt from history
+    // if streaming was cancelled, prompt/answer of current step shouldn't be presented in history, so let's remove
+    // prompt from history
     if (m_is_chat_conversation && encoded[0].m_status == ov::genai::GenerationStatus::CANCEL)
         m_history.pop_back();
 
     return decoded;
 }
 
-std::vector<GenerationResult>
-ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
+std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     const std::vector<ChatHistory>& histories,
     const std::vector<ov::genai::GenerationConfig>& sampling_params,
-    const StreamerVariant& streamer
-) {
+    const StreamerVariant& streamer) {
     OPENVINO_ASSERT(histories.size() == sampling_params.size(), "Number of histories must match sampling params");
-    OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(), "Chat template must not be empty when using ChatHistory in generate method.");
+    OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(),
+                    "Chat template must not be empty when using ChatHistory in generate method.");
 
     if (m_model_input_type == ModelInputType::EMBEDDINGS) {
-        // TODO: remove this code and within model runner add check: if sequence group type is tokens, 
+        // TODO: remove this code and within model runner add check: if sequence group type is tokens,
         // but embedding model is available => compute embeddings first, then pass to LLM
         std::vector<std::vector<ov::Tensor>> images(histories.size());
         auto results_vlm = generate(histories, images, sampling_params, streamer);
@@ -210,7 +207,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         }
         return results;
     }
-    
+
     auto start_time = std::chrono::steady_clock::now();
 
     std::vector<ov::Tensor> input_ids;
@@ -227,9 +224,9 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     for (size_t i = 0; i < histories.size(); i++) {
         OPENVINO_ASSERT(sampling_params[i].apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
         OPENVINO_ASSERT(!histories[i].empty(), "Chat history must not be empty when using ChatHistory in generate method.");
-        
+
         constexpr bool add_generation_prompt = true;
-        
+
         const auto template_start = std::chrono::steady_clock::now();
         std::string templated_history = m_tokenizer.apply_chat_template(histories[i], add_generation_prompt);
 
@@ -238,12 +235,11 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             m_tokenizer.encode(templated_history, add_special_tokens(false)).input_ids
         );
         const auto encode_end = std::chrono::steady_clock::now();
-        
+
         tokenization_durations.emplace_back(PerfMetrics::get_microsec(encode_end - encode_start));
-        // Store chat template duration for metrics tracking
         template_durations.emplace_back(PerfMetrics::get_microsec(encode_start - template_start));
     }
-    
+
     timer.end();
 
     std::vector<EncodedGenerationResult> encoded_results = generate(input_ids, sampling_params, streamer);
@@ -269,7 +265,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
-        perf_metrics.raw_metrics.generate_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
+        perf_metrics.raw_metrics.generate_durations.emplace_back(
+            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
         // Reevaluate taking into accound tokenization/detokenization times.
         perf_metrics.m_evaluated = false;
         perf_metrics.evaluate_statistics(start_time);
@@ -288,13 +285,11 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     return decoded_results;
 }
 
-std::vector<VLMDecodedResults>
-ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
-             const std::vector<std::string>& prompts,
-             const std::vector<std::vector<ov::Tensor>>& images_vector,
-             const std::vector<GenerationConfig>& sampling_params,
-             const StreamerVariant& streamer) {
-    // empty videos batch size should match prompt batch size
+std::vector<VLMDecodedResults> ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
+    const std::vector<std::string>& prompts,
+    const std::vector<std::vector<ov::Tensor>>& images_vector,
+    const std::vector<GenerationConfig>& sampling_params,
+    const StreamerVariant& streamer) {
     const std::vector<std::vector<ov::Tensor>> empty_videos_vector(prompts.size());
     return generate(prompts, images_vector, empty_videos_vector, sampling_params, streamer);
 }
@@ -307,7 +302,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     const std::vector<GenerationConfig>& sampling_params,
     const StreamerVariant& streamer
 ) {
-    // empty videos metadata batch size should match prompt batch size
     const std::vector<std::vector<VideoMetadata>> empty_videos_metadata_vector(prompts.size());
     return generate(prompts, images_vector, videos_vector, empty_videos_metadata_vector, sampling_params, streamer);
 }
@@ -335,7 +329,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     std::vector<std::pair<ov::Tensor, std::optional<int64_t>>> position_ids_list;
     std::vector<ov::Tensor> original_prompt_ids_list;
     std::vector<std::unordered_map<std::string, ov::Tensor>> lm_extra_inputs_list;
-    
+
     std::vector<VLMPerfMetrics> vlm_perf_metrics(prompts.size());
     std::vector<EncodedImage> encoded_images = {};
     std::vector<EncodedVideo> encoded_videos = {};
@@ -345,6 +339,24 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     // Set visual token pruning configuration
     m_inputs_embedder->set_vision_token_pruning_config(generation_config.pruning_ratio,
                                                        generation_config.relevance_weight);
+
+    // Shared helpers for prompt-ID extraction used in both chat-conversation and multi-prompt branches.
+    // Cache-state size is captured pre-embedding so the new prompt-ids slice can be sent
+    // downstream for speech when needed.
+    auto prepare_prompt_ids = [&](const std::string& prompt, const GenerationConfig& params) -> size_t {
+        if (params.is_prompt_lookup()) {
+            original_prompt_ids_list.push_back(m_inputs_embedder->encode_prompt(prompt));
+        }
+        return m_inputs_embedder->get_cache_state().get_state().size();
+    };
+
+    auto extract_audio_prompt_ids = [&](const GenerationConfig& /*params*/, size_t cache_size_before) {
+        const auto& cache_ids = m_inputs_embedder->get_cache_state().get_state();
+        const size_t new_tokens = cache_ids.size() - cache_size_before;
+        ov::Tensor prompt_ids_tensor(ov::element::i64, {1, new_tokens});
+        std::copy(cache_ids.begin() + cache_size_before, cache_ids.end(), prompt_ids_tensor.data<int64_t>());
+        original_prompt_ids_list.push_back(prompt_ids_tensor);
+    };
 
     if (m_is_chat_conversation) {
         OPENVINO_ASSERT(1 == prompts.size(), "Can't chat with multiple prompts");
@@ -357,7 +369,14 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         encoded_videos = m_inputs_embedder->encode_videos(videos_vector[0], videos_metadata_vector[0]);
         m_history_videos.insert(m_history_videos.end(), encoded_videos.begin(), encoded_videos.end());
 
-        auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
+        // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
+        if (!m_pending_audios_batches.empty() && !m_pending_audios_batches[0].empty()) {
+            std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+            m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
+        }
+
+        auto [unified_prompt, image_sequence, video_sequence] =
+            m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
 
         m_history.push_back({{"role", "user"}, {"content", unified_prompt}});
         m_history_image_ids.insert(m_history_image_ids.end(), image_sequence.begin(), image_sequence.end());
@@ -372,20 +391,18 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         m_inputs_embedder->set_apply_chat_template_status(false);
 
-        if (sampling_params[0].is_prompt_lookup()) {
-            auto prompt_ids = m_inputs_embedder->encode_prompt(prompt);
-            original_prompt_ids_list.push_back(prompt_ids);
-        }
+        size_t cache_size_before = prepare_prompt_ids(prompt, sampling_params[0]);
 
         if (m_inputs_embedder->has_token_type_ids()) {
-            auto [embeds, tt_ids] = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(templated_history,
-                                                                                             m_history_images,
-                                                                                             m_history_videos,
-                                                                                             vlm_perf_metrics[0],
-                                                                                             recalculate_merged_embeddings,
-                                                                                             m_history_image_ids,
-                                                                                             m_history_video_ids,
-                                                                                             m_history_vision_count);
+            auto [embeds, tt_ids] =
+                m_inputs_embedder->get_inputs_embeds_with_token_type_ids(templated_history,
+                                                                         m_history_images,
+                                                                         m_history_videos,
+                                                                         vlm_perf_metrics[0],
+                                                                         recalculate_merged_embeddings,
+                                                                         m_history_image_ids,
+                                                                         m_history_video_ids,
+                                                                         m_history_vision_count);
             input_embeds_list.push_back(std::move(embeds));
             token_type_ids_list.push_back(std::move(tt_ids));
         } else {
@@ -399,18 +416,21 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                                                 m_history_vision_count));
         }
 
+        extract_audio_prompt_ids(sampling_params[0], cache_size_before);
+
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[0].get_shape()[1], 0));
 
         lm_extra_inputs_list.push_back(m_inputs_embedder->get_lm_extra_inputs());
 
         auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+        vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
+            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
 
     } else {
         for (size_t i = 0; i < prompts.size(); i++) {
             const auto& prompt = prompts[i];
             auto start_get_inputs_embeds = std::chrono::steady_clock::now();
-            
+
             auto images_to_encode = images_vector.size() > 0 ? images_vector[i] : std::vector<ov::Tensor>{};
             const auto encoded_images = m_inputs_embedder->encode_images(images_to_encode);
 
@@ -418,35 +438,50 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             auto videos_metadata = videos_metadata_vector.size() > 0 ? videos_metadata_vector[i] : std::vector<ov::genai::VideoMetadata>{};
             const auto encoded_videos = m_inputs_embedder->encode_videos(videos_to_encode, videos_metadata);
 
-            auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
+            // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
+            // encode_audios overwrites the embedder's audio cache, so this must run per-prompt.
+            if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
+                std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+                m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
+            }
+
+            auto [unified_prompt, image_sequence, video_sequence] =
+                m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
 
             m_inputs_embedder->set_apply_chat_template_status(sampling_params[i].apply_chat_template);
 
-            if (sampling_params[i].is_prompt_lookup()) {
-                auto prompt_ids = m_inputs_embedder->encode_prompt(prompt);
-                original_prompt_ids_list.push_back(prompt_ids);
-            }
+            size_t cache_size_before = prepare_prompt_ids(prompt, sampling_params[i]);
 
             if (m_inputs_embedder->has_token_type_ids()) {
-                auto [embeds, tt_ids] = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(unified_prompt,
-                                                                                                 encoded_images,
-                                                                                                 encoded_videos,
-                                                                                                 vlm_perf_metrics[i],
-                                                                                                 recalculate_merged_embeddings,
-                                                                                                 image_sequence,
-                                                                                                 video_sequence);
+                auto [embeds, tt_ids] =
+                    m_inputs_embedder->get_inputs_embeds_with_token_type_ids(unified_prompt,
+                                                                             encoded_images,
+                                                                             encoded_videos,
+                                                                             vlm_perf_metrics[i],
+                                                                             recalculate_merged_embeddings,
+                                                                             image_sequence,
+                                                                             video_sequence);
                 input_embeds_list.push_back(std::move(embeds));
                 token_type_ids_list.push_back(std::move(tt_ids));
             } else {
-                input_embeds_list.emplace_back(m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, encoded_videos, vlm_perf_metrics[i], recalculate_merged_embeddings, image_sequence, video_sequence));
+                input_embeds_list.emplace_back(m_inputs_embedder->get_inputs_embeds(unified_prompt,
+                                                                                    encoded_images,
+                                                                                    encoded_videos,
+                                                                                    vlm_perf_metrics[i],
+                                                                                    recalculate_merged_embeddings,
+                                                                                    image_sequence,
+                                                                                    video_sequence));
             }
+
+            extract_audio_prompt_ids(sampling_params[i], cache_size_before);
 
             position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[i].get_shape()[1], 0));
 
             lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
-        
+
             auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-            vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+            vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
+                PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
         }
     }
     std::vector<VLMDecodedResults> results;
@@ -468,7 +503,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         gen_result.perf_metrics.raw_metrics.tokenization_durations = vlm_perf_metrics[i].raw_metrics.tokenization_durations;
         gen_result.perf_metrics.raw_metrics.chat_template_durations = vlm_perf_metrics[i].raw_metrics.chat_template_durations;
         gen_result.perf_metrics.raw_metrics.detokenization_durations = vlm_perf_metrics[i].raw_metrics.detokenization_durations;
-        
+
+
         auto decode_start_time = std::chrono::steady_clock::now();
         for (size_t idx = 0; idx < result.m_generation_ids.size(); ++idx) {
             gen_result.texts.push_back(m_tokenizer.decode(result.m_generation_ids.at(idx)));
@@ -476,10 +512,18 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         }
         gen_result.finish_reasons = result.m_finish_reasons;
         auto decode_end_time = std::chrono::steady_clock::now();
-        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(PerfMetrics::get_microsec(decode_end_time - decode_start_time));
-        
+        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(
+            PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+
         gen_result.perf_metrics.m_evaluated = false;
         gen_result.perf_metrics.evaluate_statistics(generate_start_time);
+
+        // Propagate hidden states for speech generation (Qwen3-Omni). Both fields stay empty
+        // on the text-only path (CB only fills m_intermediate_hidden_states when return_omni_outputs is set).
+        if (!result.m_intermediate_hidden_states.empty()) {
+            gen_result.intermediate_hidden_states = std::move(result.m_intermediate_hidden_states);
+            gen_result.full_token_ids = std::move(result.m_full_token_ids);
+        }
 
         results.emplace_back(gen_result);
     }
@@ -489,8 +533,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             m_image_id += encoded_images.size();
             m_video_id += encoded_videos.size();
             m_history.push_back({{"role", "assistant"}, {"content", results[0].texts[0]}});
-        }
-        else {
+        } else {
             m_history.pop_back();
             for (size_t idx = 0; idx < encoded_images.size(); idx++) {
                 m_history_image_ids.pop_back();
@@ -513,7 +556,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     const std::vector<GenerationConfig>& sampling_params,
     const StreamerVariant& streamer
 ) {
-    // empty videos batch size should match histories batch size
     const std::vector<std::vector<ov::Tensor>> empty_videos_vector(histories.size());
     return generate(histories, images_vector, empty_videos_vector, sampling_params, streamer);
 }
@@ -526,9 +568,49 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     const std::vector<GenerationConfig>& sampling_params,
     const StreamerVariant& streamer
 ) {
-    // empty videos metadata batch size should match histories batch size
     const std::vector<std::vector<VideoMetadata>> empty_videos_metadata_vector(histories.size());
     return generate(histories, images_vector, videos_vector, empty_videos_metadata_vector, sampling_params, streamer);
+}
+
+std::vector<VLMDecodedResults>
+ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
+    const std::vector<std::string>& prompts,
+    const std::vector<std::vector<ov::Tensor>>& images_vector,
+    const std::vector<std::vector<ov::Tensor>>& videos_vector,
+    const std::vector<std::vector<VideoMetadata>>& videos_metadata_vector,
+    const std::vector<std::vector<ov::Tensor>>& audios_vector,
+    const std::vector<GenerationConfig>& sampling_params,
+    const StreamerVariant& streamer
+) {
+    // Stash audios per-request and clear on scope exit so the inner per-prompt loop can
+    // encode the i-th batch immediately before tokenizing prompts[i]. Pre-encoding all
+    // batches up front would overwrite the embedder's audio cache and leave every prompt
+    // seeing the last batch's embeddings.
+    struct PendingAudiosGuard {
+        std::vector<std::vector<ov::Tensor>>& slot;
+        ~PendingAudiosGuard() { slot.clear(); }
+    } guard{m_pending_audios_batches};
+    m_pending_audios_batches = audios_vector;
+    return generate(prompts, images_vector, videos_vector, videos_metadata_vector, sampling_params, streamer);
+}
+
+std::vector<VLMDecodedResults>
+ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
+    const std::vector<ChatHistory>& histories,
+    const std::vector<std::vector<ov::Tensor>>& images_vector,
+    const std::vector<std::vector<ov::Tensor>>& videos_vector,
+    const std::vector<std::vector<VideoMetadata>>& videos_metadata_vector,
+    const std::vector<std::vector<ov::Tensor>>& audios_vector,
+    const std::vector<GenerationConfig>& sampling_params,
+    const StreamerVariant& streamer
+) {
+    // Same per-prompt deferral as the prompts overload — see comment there.
+    struct PendingAudiosGuard {
+        std::vector<std::vector<ov::Tensor>>& slot;
+        ~PendingAudiosGuard() { slot.clear(); }
+    } guard{m_pending_audios_batches};
+    m_pending_audios_batches = audios_vector;
+    return generate(histories, images_vector, videos_vector, videos_metadata_vector, sampling_params, streamer);
 }
 
 std::vector<VLMDecodedResults>
@@ -557,7 +639,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     // FIXME original_prompt_ids_list is not populated for VLM prompt lookup with ChatHistory API
     std::vector<ov::Tensor> original_prompt_ids_list;
     std::vector<std::unordered_map<std::string, ov::Tensor>> lm_extra_inputs_list;
-    
+
     std::vector<VLMPerfMetrics> vlm_perf_metrics(histories.size());
     bool recalculate_merged_embeddings = images_vector.size() > 0 || videos_vector.size() > 0;
 
@@ -565,8 +647,10 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     chat_contexts.reserve(histories.size());
 
     for (size_t i = 0; i < histories.size(); i++) {
-        OPENVINO_ASSERT(sampling_params[i].apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
-        OPENVINO_ASSERT(!histories[i].empty(), "Chat history must not be empty when using ChatHistory in generate method.");
+        OPENVINO_ASSERT(sampling_params[i].apply_chat_template,
+                        "Chat template must be applied when using ChatHistory in generate method.");
+        OPENVINO_ASSERT(!histories[i].empty(),
+                        "Chat history must not be empty when using ChatHistory in generate method.");
 
         const auto& generation_config = sampling_params[i];
         // Set visual token pruning configuration
@@ -574,12 +658,19 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                            generation_config.relevance_weight);
 
         auto start_get_inputs_embeds = std::chrono::steady_clock::now();
-        
+
+        // Encode this history's audios under m_embeddings_mutex right before tokenization.
+        // encode_audios overwrites the embedder's audio cache, so this must run per-history.
+        if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
+            std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+            m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
+        }
+
         VLMChatContext chat_context(histories[i], m_vision_registry, *m_inputs_embedder);
         chat_contexts.push_back(std::move(chat_context));
-    
+
         auto processed_chat_data = chat_contexts[i].process(images_vector[i], videos_vector[i], videos_metadata_vector[i]);
-    
+
         const auto template_start = std::chrono::steady_clock::now();
         std::string templated_history = m_tokenizer.apply_chat_template(
             processed_chat_data.normalized_history,
@@ -588,18 +679,20 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         vlm_perf_metrics[i].raw_metrics.chat_template_durations.emplace_back(
             PerfMetrics::get_microsec(std::chrono::steady_clock::now() - template_start)
         );
-    
+
+
         m_inputs_embedder->set_apply_chat_template_status(false);
-    
+
         if (m_inputs_embedder->has_token_type_ids()) {
-            auto [embeds, tt_ids] = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(templated_history,
-                                                                                            processed_chat_data.encoded_images,
-                                                                                            processed_chat_data.encoded_videos,
-                                                                                            vlm_perf_metrics[i],
-                                                                                            recalculate_merged_embeddings,
-                                                                                            processed_chat_data.image_sequence,
-                                                                                            processed_chat_data.video_sequence,
-                                                                                            processed_chat_data.vision_counts);
+            auto [embeds, tt_ids] =
+                m_inputs_embedder->get_inputs_embeds_with_token_type_ids(templated_history,
+                                                                         processed_chat_data.encoded_images,
+                                                                         processed_chat_data.encoded_videos,
+                                                                         vlm_perf_metrics[i],
+                                                                         recalculate_merged_embeddings,
+                                                                         processed_chat_data.image_sequence,
+                                                                         processed_chat_data.video_sequence,
+                                                                         processed_chat_data.vision_counts);
             input_embeds_list.push_back(std::move(embeds));
             token_type_ids_list.push_back(std::move(tt_ids));
         } else {
@@ -616,9 +709,10 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[i].get_shape()[1], 0));
 
         lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
-    
+
         auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+        vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
+            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
     }
 
     std::vector<EncodedGenerationResult> encoded_results = generate(input_embeds_list,
@@ -637,12 +731,13 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         VLMDecodedResults gen_result;
         gen_result.perf_metrics = result.perf_metrics;
         gen_result.extended_perf_metrics = result.extended_perf_metrics;
-    
+
         gen_result.perf_metrics.vlm_raw_metrics = vlm_perf_metrics[i].vlm_raw_metrics;
         gen_result.perf_metrics.raw_metrics.tokenization_durations = vlm_perf_metrics[i].raw_metrics.tokenization_durations;
         gen_result.perf_metrics.raw_metrics.chat_template_durations = vlm_perf_metrics[i].raw_metrics.chat_template_durations;
         gen_result.perf_metrics.raw_metrics.detokenization_durations = vlm_perf_metrics[i].raw_metrics.detokenization_durations;
-        
+
+
         auto decode_start_time = std::chrono::steady_clock::now();
         for (size_t idx = 0; idx < result.m_generation_ids.size(); ++idx) {
             gen_result.texts.push_back(m_tokenizer.decode(result.m_generation_ids.at(idx)));
@@ -650,15 +745,16 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         }
         gen_result.finish_reasons = result.m_finish_reasons;
         auto decode_end_time = std::chrono::steady_clock::now();
-        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(PerfMetrics::get_microsec(decode_end_time - decode_start_time));
-        
+        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(
+            PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+
         gen_result.perf_metrics.m_evaluated = false;
         gen_result.perf_metrics.evaluate_statistics(generate_start_time);
-    
+
         results.emplace_back(gen_result);
-    
+
         m_inputs_embedder->update_chat_history(results[i].texts[0], encoded_results[i].m_status);
-    
+
         if (encoded_results[i].m_status == ov::genai::GenerationStatus::CANCEL) {
             chat_contexts[i].rollback();
         }
@@ -667,11 +763,11 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     return results;
 }
 
-GenerationHandle 
-ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(uint64_t request_id,
-                                        const std::string& prompt,
-                                        const std::vector<ov::Tensor>& rgbs,
-                                        GenerationConfig sampling_params) {
+GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
+    uint64_t request_id,
+    const std::string& prompt,
+    const std::vector<ov::Tensor>& rgbs,
+    GenerationConfig sampling_params) {
     OPENVINO_ASSERT(m_model_input_type == ModelInputType::EMBEDDINGS, "Model doesn't support embeddings.");
     ov::genai::VLMPerfMetrics metrics;
     ov::Tensor inputs;
@@ -683,18 +779,23 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(uint64_t re
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
         const auto encoded_images = m_inputs_embedder->encode_images(rgbs);
 
-        const auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, 0, encoded_images);
+        const auto [unified_prompt, image_sequence, video_sequence] =
+            m_inputs_embedder->normalize_prompt(prompt, 0, encoded_images);
         if (m_inputs_embedder->has_token_type_ids()) {
-            std::tie(inputs, token_type_ids) = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(unified_prompt, encoded_images, metrics, true, image_sequence);
+            std::tie(inputs, token_type_ids) = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(unified_prompt,
+                                                                                                        encoded_images,
+                                                                                                        metrics,
+                                                                                                        true,
+                                                                                                        image_sequence);
         } else {
-            inputs = m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, metrics, true, image_sequence);
+            inputs =
+                m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, metrics, true, image_sequence);
         }
         return add_request(request_id, inputs, sampling_params, token_type_ids, prompt_ids, m_inputs_embedder->get_lm_extra_inputs());
     }
 }
 
-GenerationHandle
-ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
+GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
     uint64_t request_id,
     const std::string& prompt,
     const std::vector<ov::Tensor>& images,
@@ -734,8 +835,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
 
 void ContinuousBatchingPipeline::IContinuousBatchingPipeline::stream_tokens(
     const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr,
-    const GenerationHandle& handle
-) {
+    const GenerationHandle& handle) {
     if (!streamer_ptr->has_callback() || !handle->can_read()) {
         return;
     }
@@ -771,4 +871,4 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::~IContinuousBatchingPip
     utils::release_core_plugin(m_device);
 }
 
-}
+}  // namespace ov::genai

--- a/src/cpp/src/continuous_batching/pipeline_base.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.hpp
@@ -68,6 +68,13 @@ protected:
     std::shared_ptr<InputsEmbedder> m_inputs_embedder;
     std::mutex m_embeddings_mutex;
 
+    // Per-request audio batches passed by the audios-aware generate() overloads.
+    // Populated under m_embeddings_mutex by the audio overload and consumed inside the
+    // per-prompt loop right before tokenization, so each prompt sees its own audio
+    // embeddings (m_inputs_embedder->encode_audios overwrites internal cache state).
+    // Empty when the no-audio overloads are used.
+    std::vector<std::vector<ov::Tensor>> m_pending_audios_batches;
+
     std::shared_ptr<VisionRegistry> m_vision_registry;
 
     void stream_tokens(const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr, const GenerationHandle& handle);
@@ -126,6 +133,18 @@ public:
                                  GenerationConfig sampling_params);
 
     /**
+     * Overload accepting audios. Audios are encoded under m_embeddings_mutex before text tokenization so
+     * <|AUDIO|> placeholders resolve to fresh embeddings (Qwen3-Omni).
+     */
+    GenerationHandle add_request(uint64_t request_id,
+                                 const std::string& prompt,
+                                 const std::vector<ov::Tensor>& images,
+                                 const std::vector<ov::Tensor>& videos,
+                                 const std::vector<VideoMetadata>& videos_metadata,
+                                 const std::vector<ov::Tensor>& audios,
+                                 GenerationConfig sampling_params);
+
+    /**
      * Checks whether server (pipeline) has non-finished requests and step() should be called within a loop
      */
     virtual bool has_non_finished_requests() = 0;
@@ -180,7 +199,17 @@ public:
         const StreamerVariant& streamer
     );
 
-    
+    virtual std::vector<VLMDecodedResults> generate(
+        const std::vector<std::string>& prompts,
+        const std::vector<std::vector<ov::Tensor>>& images,
+        const std::vector<std::vector<ov::Tensor>>& videos,
+        const std::vector<std::vector<VideoMetadata>>& videos_metadata,
+        const std::vector<std::vector<ov::Tensor>>& audios,
+        const std::vector<GenerationConfig>& sampling_params,
+        const StreamerVariant& streamer
+    );
+
+
     /**
      * Performs monolitic generation based on ChatHistory objects
      */
@@ -210,6 +239,16 @@ public:
         const std::vector<std::vector<ov::Tensor>>& images,
         const std::vector<std::vector<ov::Tensor>>& videos,
         const std::vector<std::vector<VideoMetadata>>& videos_metadata,
+        const std::vector<GenerationConfig>& sampling_params,
+        const StreamerVariant& streamer
+    );
+
+    virtual std::vector<VLMDecodedResults> generate(
+        const std::vector<ChatHistory>& histories,
+        const std::vector<std::vector<ov::Tensor>>& images,
+        const std::vector<std::vector<ov::Tensor>>& videos,
+        const std::vector<std::vector<VideoMetadata>>& videos_metadata,
+        const std::vector<std::vector<ov::Tensor>>& audios,
         const std::vector<GenerationConfig>& sampling_params,
         const StreamerVariant& streamer
     );

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -1,47 +1,49 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <atomic>
-#include <thread>
 #include <optional>
+#include <thread>
+
 #include "openvino/genai/cache_eviction.hpp"
 
 #ifdef __APPLE__
-#include <sys/types.h>
-#include <sys/sysctl.h>
+#    include <sys/sysctl.h>
+#    include <sys/types.h>
 #elif !defined(_WIN32)
-#include <sys/sysinfo.h>
+#    include <sys/sysinfo.h>
 #endif
 
+#include "continuous_batching/cache/cache_orchestrator.hpp"
+#include "continuous_batching/cache/cache_state_dumper.hpp"
+#include "continuous_batching/paged_attention_transformations.hpp"
+#include "continuous_batching/pipeline_impl.hpp"
+#include "lora/helper.hpp"
 #include "openvino/genai/text_streamer.hpp"
 #include "openvino/pass/sdpa_to_paged_attention.hpp"
-#include "continuous_batching/pipeline_impl.hpp"
 #include "utils.hpp"
-#include "continuous_batching/paged_attention_transformations.hpp"
-#include "lora/helper.hpp"
-#include "continuous_batching/cache/cache_state_dumper.hpp"
-#include "continuous_batching/cache/cache_orchestrator.hpp"
 
 namespace {
 
 // Returns available RAM memory on system if possible, otherwise returns std::numeric_limits<std::streamsize>::max()
 size_t get_available_cpu_memory() {
-#ifdef __APPLE__ 
+#ifdef __APPLE__
     int64_t memsize;
     size_t len = sizeof(memsize);
     if (sysctlbyname("hw.memsize", &memsize, &len, NULL, 0) == 0) {
         return memsize;
     }
-#endif 
+#endif
 
 #if !defined(_WIN32)
     std::string token;
     std::ifstream file("/proc/meminfo");
-    if(file.is_open()) {
-        while(file >> token) {
-            if(token == "MemTotal:") {
+    if (file.is_open()) {
+        while (file >> token) {
+            if (token == "MemTotal:") {
                 size_t mem;
-                if(file >> mem) {
+                if (file >> mem) {
                     constexpr auto max_bytes = std::numeric_limits<size_t>::max() / 1024;
                     if (mem > max_bytes) {
                         return std::numeric_limits<size_t>::max();
@@ -58,11 +60,15 @@ size_t get_available_cpu_memory() {
     return std::numeric_limits<size_t>::max();
 }
 
-} // namespace
+}  // namespace
 
 namespace ov::genai {
-template<class... Ts> struct overloaded : Ts... {using Ts::operator()...;};
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
 
 void prepare_model_for_paged_attention(const std::shared_ptr<ov::Model>& model,
                                        const SchedulerConfig& scheduler_config) {
@@ -109,7 +115,14 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::ContinuousBatchingImpl(
     const std::string& device,
     const ov::AnyMap& properties,
     const ov::genai::GenerationConfig& generation_config,
-    bool is_validation_mode_enabled) : ContinuousBatchingImpl(model, tokenizer, scheduler_config, device, properties, generation_config, is_validation_mode_enabled){
+    bool is_validation_mode_enabled)
+    : ContinuousBatchingImpl(model,
+                             tokenizer,
+                             scheduler_config,
+                             device,
+                             properties,
+                             generation_config,
+                             is_validation_mode_enabled) {
     m_inputs_embedder = inputs_embedder;
     
     // Note: set_inputs_embedder also sets the embedding model internally.
@@ -138,11 +151,10 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_pull_awaiting_requests
     m_pipeline_metrics.requests = m_requests.size();
 }
 
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
-    std::shared_ptr<ov::Model> model,
-    const SchedulerConfig& scheduler_config,
-    const std::string& device,
-    const ov::AnyMap& properties) {
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(std::shared_ptr<ov::Model> model,
+                                                                             const SchedulerConfig& scheduler_config,
+                                                                             const std::string& device,
+                                                                             const ov::AnyMap& properties) {
     m_device = device;
     SchedulerConfig normalized_config = scheduler_config;
     normalized_config.validate();
@@ -155,14 +167,16 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
     auto filtered_properties = extract_adapters_from_properties(language_model_properties, &m_generation_config.adapters);
     if (m_generation_config.adapters) {
         m_generation_config.adapters->set_tensor_name_prefix("base_model.model.");
-        m_adapter_controller = AdapterController(model, *m_generation_config.adapters, device);   // TODO: Make the prefix name configurable
+        m_adapter_controller =
+            AdapterController(model, *m_generation_config.adapters, device);  // TODO: Make the prefix name configurable
     }
     // Extract sampler_num_threads property if exists and remove it from properties
     size_t sampler_num_threads = std::thread::hardware_concurrency();
     auto sampler_num_threads_it = filtered_properties->find("sampler_num_threads");
     if (sampler_num_threads_it != filtered_properties->end()) {
         sampler_num_threads = sampler_num_threads_it->second.as<size_t>();
-        filtered_properties.fork().erase("sampler_num_threads");   // do not use iterator sampler_num_threads_it because a forked container may not be the same container
+        filtered_properties.fork().erase("sampler_num_threads");  // do not use iterator sampler_num_threads_it because
+                                                                  // a forked container may not be the same container
     }
 
     ov::CompiledModel compiled_model = utils::singleton_core().compile_model(model, device, *filtered_properties);
@@ -196,7 +210,8 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
     }
 
     // Scheduler and Model Runner instantiation
-    bool is_use_xattention = scheduler_config.use_sparse_attention && scheduler_config.sparse_attention_config.mode == SparseAttentionMode::XATTENTION;
+    bool is_use_xattention = scheduler_config.use_sparse_attention &&
+                             scheduler_config.sparse_attention_config.mode == SparseAttentionMode::XATTENTION;
     bool is_use_cache_eviction = scheduler_config.use_cache_eviction;
     bool is_use_per_layer_kv_block_indices = cache_orchestrator->needs_per_layer_kv_block_indices();
     const size_t kv_block_size = cache_orchestrator->get_block_size(CacheType::KV_CACHE);
@@ -238,10 +253,12 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::initialize_pipeline(
         m_generation_config.set_eos_token_id(m_tokenizer.get_eos_token_id());
 };
 
-
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_prepare_rotation_data_storage(const SchedulerConfig& normalized_config, size_t embedding_size) {
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_prepare_rotation_data_storage(
+    const SchedulerConfig& normalized_config,
+    size_t embedding_size) {
     m_rotation_deltas_stores.reserve(m_num_decoder_layers);
-    ov::Shape rotation_deltas_store_shape{normalized_config.num_kv_blocks, 1}; // last dim can be later changed to BLOCK_SIZE for per-token granularity
+    ov::Shape rotation_deltas_store_shape{normalized_config.num_kv_blocks,
+                                          1};  // last dim can be later changed to BLOCK_SIZE for per-token granularity
     for (size_t i = 0; i < m_num_decoder_layers; i++) {
         ov::Tensor store(ov::element::i32, rotation_deltas_store_shape);
         std::memset(store.data(), 0, store.get_byte_size());
@@ -260,26 +277,25 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_prepare_rotation_data_
     const auto& cos_lut = m_cache_rotation_calculator->get_cos_lut();
     const auto& sin_lut = m_cache_rotation_calculator->get_sin_lut();
 
-
     for (size_t pos_idx = 0; pos_idx < max_sequence_cache_occupation_length_in_blocks; pos_idx++) {
         for (size_t embedding_pair_idx = 0; embedding_pair_idx < cos_lut[0].size(); embedding_pair_idx++) {
-            rotation_trig_lut_data[pos_idx * embedding_size + embedding_pair_idx] = cos_lut[pos_idx][embedding_pair_idx];
-            rotation_trig_lut_data[pos_idx * embedding_size + embedding_size / 2 + embedding_pair_idx] = sin_lut[pos_idx][embedding_pair_idx];
+            rotation_trig_lut_data[pos_idx * embedding_size + embedding_pair_idx] =
+                cos_lut[pos_idx][embedding_pair_idx];
+            rotation_trig_lut_data[pos_idx * embedding_size + embedding_size / 2 + embedding_pair_idx] =
+                sin_lut[pos_idx][embedding_pair_idx];
         }
     }
 
     m_model_runner->set_cache_rotation_trig_lut(std::move(rotation_trig_lut));
 }
 
-GenerationHandle
-ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
+GenerationHandle ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
     uint64_t request_id,
     const ov::Tensor& input_ids,
     const ov::genai::GenerationConfig& sampling_params,
     std::optional<ov::Tensor> token_type_ids,
     std::optional<ov::Tensor> prompt_ids,
-    std::optional<std::unordered_map<std::string, ov::Tensor>> lm_extra_inputs
-) {
+    std::optional<std::unordered_map<std::string, ov::Tensor>> lm_extra_inputs) {
     auto sampling_params_copy = sampling_params;
     // If stop_token_ids were not provided, take value from default m_generation_config
     if (sampling_params_copy.stop_token_ids.empty())
@@ -294,17 +310,18 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
     } else {
         prompt_len = input_ids.get_size();
     }
-    OPENVINO_ASSERT(sampling_params_copy.max_length > prompt_len, "'max_length' must be greater than the number of prompt tokens");
+    OPENVINO_ASSERT(sampling_params_copy.max_length > prompt_len,
+                    "'max_length' must be greater than the number of prompt tokens");
 
     std::shared_ptr<SequenceGroup> sequence_group;
     if (m_model_input_type == ModelInputType::EMBEDDINGS) {
         const auto [position_ids, rope_delta] = m_inputs_embedder->get_position_ids(input_ids.get_shape()[1], 0);
-        sequence_group = std::make_shared<SequenceGroup>(request_id, 
-                                                         input_ids, 
-                                                         sampling_params_copy, 
+        sequence_group = std::make_shared<SequenceGroup>(request_id,
+                                                         input_ids,
+                                                         sampling_params_copy,
                                                          token_type_ids,
                                                          lm_extra_inputs,
-                                                         position_ids, 
+                                                         position_ids,
                                                          rope_delta,
                                                          prompt_ids);
     }
@@ -313,6 +330,12 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
                                                          input_ids,
                                                          sampling_params_copy,
                                                          token_type_ids);
+    }
+
+    // Enable hidden state accumulation for speech output (Qwen3-Omni).
+    // Always collect when model outputs hidden states.
+    for (auto& seq : sequence_group->get_running_sequences()) {
+        seq->set_accumulate_hidden_states(true);
     }
 
     if (m_scheduler->get_config().enable_prefix_caching) {
@@ -327,25 +350,24 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
     return std::make_shared<GenerationHandleImpl>(sequence_group->get_generation_stream(), sampling_params_copy);
 }
 
-GenerationHandle
-ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(uint64_t request_id,
-                                                                const std::string& prompt,
-                                                                const ov::genai::GenerationConfig& sampling_params) {
-    ov::Tensor inputs;
-    ov::genai::VLMPerfMetrics metrics;
+GenerationHandle ContinuousBatchingPipeline::ContinuousBatchingImpl::add_request(
+    uint64_t request_id,
+    const std::string& prompt,
+    const ov::genai::GenerationConfig& sampling_params) {
     if (m_model_input_type == ModelInputType::TOKENS) {
         static ManualTimer timer("tokenize");
         timer.start();
-        inputs = m_tokenizer.encode(prompt).input_ids;
+        ov::Tensor inputs = m_tokenizer.encode(prompt).input_ids;
         timer.end();
         return add_request(request_id, inputs, sampling_params);
     } else if (m_model_input_type == ModelInputType::EMBEDDINGS) {
-        return ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(request_id, prompt, {}, sampling_params);
+        return ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(request_id,
+                                                                                    prompt,
+                                                                                    {},
+                                                                                    sampling_params);
     } else {
         OPENVINO_THROW("Unknown model input type.");
     }
-
-    return add_request(request_id, inputs, sampling_params);
 }
 
 bool ContinuousBatchingPipeline::ContinuousBatchingImpl::has_non_finished_requests() {
@@ -370,19 +392,19 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
         m_pipeline_metrics.cache_size_in_bytes = scheduler_output.m_cache_size_in_bytes;
         m_pipeline_metrics.scheduled_requests = scheduler_output.m_scheduled_sequence_groups_ids.size();
         m_pipeline_metrics.cache_usage = scheduler_output.m_cache_usage;
-        m_pipeline_metrics.max_cache_usage = std::max(m_pipeline_metrics.max_cache_usage, scheduler_output.m_cache_usage);
+        m_pipeline_metrics.max_cache_usage =
+            std::max(m_pipeline_metrics.max_cache_usage, scheduler_output.m_cache_usage);
         _register_step_cache_usage(scheduler_output.m_cache_usage);
         m_pipeline_metrics.avg_cache_usage = _get_current_running_average_cache_usage();
 
         const auto& sched_config = m_scheduler->get_config();
         if (sched_config.use_cache_eviction) {
-           if (sched_config.cache_eviction_config.apply_rotation) {
+            if (sched_config.cache_eviction_config.apply_rotation) {
                 _compute_cache_rotation_data(m_requests, scheduler_output);
                 m_model_runner->set_cache_rotation_data(std::move(m_current_step_rotated_block_indices_per_sequence),
                                                         std::move(m_current_step_rotation_deltas));
-           }
+            }
         }
-
     }
 
     // if no tokens were scheduled, we are out of memory => free all requests and return
@@ -501,20 +523,21 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::set_adapters(const std:
     }
 }
 
-std::vector<EncodedGenerationResult>
-ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<ov::Tensor>& input_ids,
-                                                             const std::vector<GenerationConfig>& sampling_params,
-                                                             const StreamerVariant& streamer,
-                                                             const std::optional<std::vector<ov::Tensor>>& token_type_ids,
-                                                             const std::optional<std::vector<std::pair<ov::Tensor, std::optional<int64_t>>>>& position_ids_list,
-                                                             const std::optional<std::vector<ov::Tensor>>& prompt_ids,
-                                                             const std::optional<std::vector<std::unordered_map<std::string, ov::Tensor>>>& lm_extra_inputs_list) {
-
+std::vector<EncodedGenerationResult> ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(
+    const std::vector<ov::Tensor>& input_ids,
+    const std::vector<GenerationConfig>& sampling_params,
+    const StreamerVariant& streamer,
+    const std::optional<std::vector<ov::Tensor>>& token_type_ids,
+    const std::optional<std::vector<std::pair<ov::Tensor, std::optional<int64_t>>>>& position_ids_list,
+    const std::optional<std::vector<ov::Tensor>>& prompt_ids,
+    const std::optional<std::vector<std::unordered_map<std::string, ov::Tensor>>>& lm_extra_inputs_list) {
     _reset_cache_usage_statistics();
     ManualTimer generate_timer("generate()");
     generate_timer.start();
 
-    OPENVINO_ASSERT(!has_non_finished_requests(), "Generate cannot be called while ContinuousBatchingPipeline is already in running state. Use ContinuousBatchingPipeline::add_request");
+    OPENVINO_ASSERT(!has_non_finished_requests(),
+                    "Generate cannot be called while ContinuousBatchingPipeline is already in running state. Use "
+                    "ContinuousBatchingPipeline::add_request");
     OPENVINO_ASSERT(input_ids.size() == sampling_params.size());
 
     if (position_ids_list.has_value()) {
@@ -524,7 +547,7 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
         OPENVINO_ASSERT((*lm_extra_inputs_list).size() == input_ids.size());
     }
 
-    auto start_time =  std::chrono::steady_clock::now();
+    auto start_time = std::chrono::steady_clock::now();
     PerfMetrics perf_metrics;
     auto& raw_perf_counters = perf_metrics.raw_metrics;
     raw_perf_counters.m_inference_durations = {{ MicroSeconds(0.0f) }};
@@ -532,14 +555,42 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
     // checks that all requests has the same LoRA adapters property value
     for (size_t i = 1; i < sampling_params.size(); ++i) {
         OPENVINO_ASSERT(sampling_params[i - 1].adapters == sampling_params[i].adapters,
-            "LoRA adapters value must be the same for all requests");
+                        "LoRA adapters value must be the same for all requests");
     }
     set_adapters(sampling_params[0].adapters);
 
+    // RAII guard so the flag is restored on every exit path (including exceptions).
+    struct HiddenStateExportGuard {
+        std::shared_ptr<ModelRunner>& m_runner;
+        explicit HiddenStateExportGuard(std::shared_ptr<ModelRunner>& runner) : m_runner(runner) {
+            if (m_runner)
+                m_runner->enable_hidden_state_export(true);
+        }
+        ~HiddenStateExportGuard() {
+            if (m_runner)
+                m_runner->enable_hidden_state_export(false);
+        }
+        HiddenStateExportGuard(const HiddenStateExportGuard&) = delete;
+        HiddenStateExportGuard& operator=(const HiddenStateExportGuard&) = delete;
+    };
+
+    // Enable hidden state export only when a request opts in via GenerationConfig::return_omni_outputs
+    // (set by OmniPipeline on the audio path).
+    const bool collect_hidden_states = std::any_of(sampling_params.begin(), sampling_params.end(),
+                                                   [](const GenerationConfig& params) {
+                                                       return params.return_omni_outputs;
+                                                   });
+    std::optional<HiddenStateExportGuard> hidden_state_guard;
+    if (collect_hidden_states) {
+        hidden_state_guard.emplace(m_model_runner);
+    }
+
     const auto streamer_ptr = std::make_shared<ThreadedStreamerWrapper>(streamer, m_tokenizer);
 
-    OPENVINO_ASSERT(!streamer_ptr->has_callback() || input_ids.size() == 1 && sampling_params[0].num_return_sequences == 1 &&
-        (sampling_params[0].is_greedy_decoding() || sampling_params[0].is_multinomial()),
+    OPENVINO_ASSERT(
+        !streamer_ptr->has_callback() ||
+            input_ids.size() == 1 && sampling_params[0].num_return_sequences == 1 &&
+                (sampling_params[0].is_greedy_decoding() || sampling_params[0].is_multinomial()),
         "Currently streaming is possible only with batch size=1 and only for greedy or multinomial decoding");
 
     std::vector<GenerationHandle> generations;
@@ -554,21 +605,20 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
         }
         const bool has_valid_token_type_ids = token_type_ids.has_value() && request_id < token_type_ids->size();
         const bool has_valid_prompt_ids = prompt_ids.has_value() && request_id < prompt_ids->size();
-        const bool has_valid_lm_extra_inputs = lm_extra_inputs_list.has_value() && request_id < lm_extra_inputs_list->size();
+        const bool has_valid_lm_extra_inputs =
+            lm_extra_inputs_list.has_value() && request_id < lm_extra_inputs_list->size();
 
-        generations.push_back(
-            add_request(
-                request_id,
-                input_ids[request_id],
-                sampling_params[request_id],
-                has_valid_token_type_ids ? std::make_optional((*token_type_ids)[request_id]) : std::nullopt,
-                has_valid_prompt_ids ? std::make_optional((*prompt_ids)[request_id]) : std::nullopt,
-                has_valid_lm_extra_inputs ? std::make_optional((*lm_extra_inputs_list)[request_id]) : std::nullopt
-            )
-        );
+        generations.push_back(add_request(
+            request_id,
+            input_ids[request_id],
+            sampling_params[request_id],
+            has_valid_token_type_ids ? std::make_optional((*token_type_ids)[request_id]) : std::nullopt,
+            has_valid_prompt_ids ? std::make_optional((*prompt_ids)[request_id]) : std::nullopt,
+            has_valid_lm_extra_inputs ? std::make_optional((*lm_extra_inputs_list)[request_id]) : std::nullopt));
     }
 
-    auto all_requests = get_awaiting_requests(); // we need to store all requests to get results from them once generation has finished
+    auto all_requests =
+        get_awaiting_requests();  // we need to store all requests to get results from them once generation has finished
 
     GenerationHandle& generation = generations.at(0);
 
@@ -578,7 +628,7 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
         try {
             const auto infer_start = std::chrono::steady_clock::now();
             step();
-            
+
             // During prefill step (or steps if max_batch_size < prompt_len) we don't generate new tokens,
             // but still inference took place, so we need to add this time to the total inference duration.
             raw_perf_counters.m_inference_durations[0] += MicroSeconds(m_pipeline_metrics.inference_duration);
@@ -591,7 +641,7 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
                 raw_perf_counters.m_sampling_durations.emplace_back(m_pipeline_metrics.sampling_duration);
             }
         } catch (...) {
-            drop_requests(); // remove all requests from pipeline state in case of exception
+            drop_requests();  // remove all requests from pipeline state in case of exception
             streamer_ptr->end();
             std::rethrow_exception(std::current_exception());
         }
@@ -600,14 +650,15 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
 
     auto times = m_sampler->get_structured_output_times();
     perf_metrics.grammar_compiler_init_times = times.first;
-    for (const auto& t: times.second) {
+    for (const auto& t : times.second) {
         raw_perf_counters.m_grammar_compile_times.emplace_back(t);
     }
 
     // waiting for completion of streaming
     streamer_ptr->end();
 
-    OPENVINO_ASSERT(m_requests.empty(), "Internal error: current request is supposed to be dropped within step() function as completed");
+    OPENVINO_ASSERT(m_requests.empty(),
+                    "Internal error: current request is supposed to be dropped within step() function as completed");
 
     std::vector<EncodedGenerationResult> results;
     results.reserve(all_requests.size());
@@ -625,10 +676,16 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
         result.m_finish_reasons.resize(num_outputs, GenerationFinishReason::NONE);
         result.m_status = request->get_generation_stream()->get_status();
 
+        // Always collect intermediate hidden states when model outputs them.
+        result.m_intermediate_hidden_states.resize(num_outputs);
+        result.m_full_token_ids.resize(num_outputs);
+        const auto& prompt_ids = request->get_prompt_ids();
+
         for (size_t i = 0; i < num_outputs; ++i) {
-            const auto & sequence = sequences[i];
-            const float score = sampling_params.is_beam_search() ? sequence->get_beam_search_score(sampling_params) : sequence->get_cumulative_log_prob();
-            const auto & generated_ids = sequence->get_generated_ids();
+            const auto& sequence = sequences[i];
+            const float score = sampling_params.is_beam_search() ? sequence->get_beam_search_score(sampling_params)
+                                                                 : sequence->get_cumulative_log_prob();
+            const auto& generated_ids = sequence->get_generated_ids();
 
             if (sampling_params.echo)
                 result.m_generation_ids[i] = request->get_prompt_ids();
@@ -638,13 +695,23 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
             if (result.m_finish_reasons[i] == GenerationFinishReason::NONE && request->handle_stopped()) {
                 result.m_finish_reasons[i] = request->get_generation_stream()->get_finish_reason();
             }
+
+            // Extract accumulated intermediate hidden states for speech generation.
+            result.m_intermediate_hidden_states[i] = sequence->get_all_intermediate_hidden_states();
+
+            // Full token ids for this sequence: prompt followed by its generated ids.
+            auto& seq_full_ids = result.m_full_token_ids[i];
+            seq_full_ids.reserve(prompt_ids.size() + generated_ids.size());
+            seq_full_ids.insert(seq_full_ids.end(), prompt_ids.begin(), prompt_ids.end());
+            seq_full_ids.insert(seq_full_ids.end(), generated_ids.begin(), generated_ids.end());
         }
 
         result.m_status = generations[request_id]->get_status();
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
-        perf_metrics.raw_metrics.generate_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
+        perf_metrics.raw_metrics.generate_durations.emplace_back(
+            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
         perf_metrics.num_input_tokens = request->get_prompt_len();
         perf_metrics.evaluate_statistics(start_time);
 
@@ -655,7 +722,7 @@ ContinuousBatchingPipeline::ContinuousBatchingImpl::generate(const std::vector<o
     OPENVINO_ASSERT(results.size() == input_ids.size());
 
     generate_timer.end();
-    
+
     const auto& scheduler_config = m_scheduler->get_config();
     // Clear cache in case of dynamic cache allocation and no prefix caching
     if (!scheduler_config.enable_prefix_caching && scheduler_config.cache_size == 0 && scheduler_config.num_kv_blocks == 0) {
@@ -668,8 +735,8 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_free_non_running_reque
     std::vector<SequenceGroup::Ptr>::iterator requests_iterator = m_requests.begin();
     while (requests_iterator != m_requests.end()) {
         const auto& request = *requests_iterator;
-        if(request->has_finished() || request->handle_stopped() || request->handle_cancelled()) {
-            for (const auto& sequence: request->get_sequences()) {
+        if (request->has_finished() || request->handle_stopped() || request->handle_cancelled()) {
+            for (const auto& sequence : request->get_sequences()) {
                 if (m_scheduler->has_block_table(sequence->get_id())) {
                     m_scheduler->free_sequence(sequence->get_id());
                 }
@@ -699,7 +766,8 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_register_step_cache_us
 }
 
 float ContinuousBatchingPipeline::ContinuousBatchingImpl::_get_current_running_average_cache_usage() const {
-    return std::accumulate(m_previous_step_cache_usages.begin(), m_previous_step_cache_usages.end(), 0.0) / m_previous_step_cache_usages.size();
+    return std::accumulate(m_previous_step_cache_usages.begin(), m_previous_step_cache_usages.end(), 0.0) /
+           m_previous_step_cache_usages.size();
 }
 
 void ContinuousBatchingPipeline::ContinuousBatchingImpl::_reset_cache_usage_statistics() {
@@ -711,7 +779,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_reset_cache_usage_stat
 
 void ContinuousBatchingPipeline::ContinuousBatchingImpl::drop_requests() {
     for (const std::shared_ptr<ov::genai::SequenceGroup> request : m_requests) {
-        for (const auto& sequence: request->get_sequences()) {
+        for (const auto& sequence : request->get_sequences()) {
             if (m_scheduler->has_block_table(sequence->get_id())) {
                 m_scheduler->free_sequence(sequence->get_id());
             }
@@ -721,8 +789,9 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::drop_requests() {
     m_requests.clear();
 }
 
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation_data(const std::vector<SequenceGroup::Ptr>& sequence_groups,
-        const Scheduler::Output& scheduler_output) {
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation_data(
+    const std::vector<SequenceGroup::Ptr>& sequence_groups,
+    const Scheduler::Output& scheduler_output) {
     size_t num_sequence_groups = scheduler_output.m_scheduled_sequence_groups_ids.size();
     std::map<size_t, size_t> live_seq_ids_to_num_occupied_blocks;
     for (size_t i = 0; i < num_sequence_groups; ++i) {
@@ -735,8 +804,11 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation
             Sequence::CPtr sequence = running_sequences[i];
             size_t num_blocks = m_scheduler->get_num_kv_logical_blocks(sequence_group);
             size_t seq_id = sequence->get_id();
-            OPENVINO_ASSERT(live_seq_ids_to_num_occupied_blocks.find(seq_id) == live_seq_ids_to_num_occupied_blocks.end(),
-                    "duplicate seq_id ", seq_id, " among sequence groups");
+            OPENVINO_ASSERT(
+                live_seq_ids_to_num_occupied_blocks.find(seq_id) == live_seq_ids_to_num_occupied_blocks.end(),
+                "duplicate seq_id ",
+                seq_id,
+                " among sequence groups");
             live_seq_ids_to_num_occupied_blocks[seq_id] = num_blocks;
         }
     }
@@ -747,7 +819,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation
     m_current_step_rotation_deltas.clear();
 
     std::vector<size_t> num_blocks_to_rotate_for_each_layer(m_num_decoder_layers, 0);
-
 
     for (const auto& seq_id_and_evicted_blocks : m_previous_evicted_block_logical_indices_per_sequence) {
         size_t seq_id = seq_id_and_evicted_blocks.first;
@@ -766,7 +837,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation
             size_t num_blocks_before_eviction = m_previous_num_blocks_before_eviction_per_sequence[seq_id];
             auto rotation_multipliers =
                 m_cache_rotation_calculator->get_rotation_data(logical_blocks_to_evict[layer_idx],
-                                                                       num_blocks_before_eviction);
+                                                               num_blocks_before_eviction);
             for (size_t i = 0; i < rotation_multipliers.size(); i++) {
                 const auto& block_rotation_data = rotation_multipliers[i];
 
@@ -786,15 +857,15 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_compute_cache_rotation
     }
     // Select the previously filled rotation coefficients from the store tensor
     for (size_t i = 0; i < m_num_decoder_layers; i++) {
-        m_current_step_rotation_deltas.emplace_back(
-            m_rotation_deltas_stores[i],
-            ov::Coordinate{0, 0},
-            ov::Coordinate{num_blocks_to_rotate_for_each_layer[i], 1});
+        m_current_step_rotation_deltas.emplace_back(m_rotation_deltas_stores[i],
+                                                    ov::Coordinate{0, 0},
+                                                    ov::Coordinate{num_blocks_to_rotate_for_each_layer[i], 1});
     }
 }
 
-
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_maybe_evict_cache_blocks(const SchedulerConfig& sched_config, const Scheduler::Output& scheduler_output) {
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_maybe_evict_cache_blocks(
+    const SchedulerConfig& sched_config,
+    const Scheduler::Output& scheduler_output) {
     std::unordered_map<SequenceGroup::Ptr, size_t> seq_group_to_num_blocks_evicted_map;
     const auto& sequence_attention_scores = m_model_runner->get_last_attention_scores();
 
@@ -822,14 +893,17 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_maybe_evict_cache_bloc
             cache_eviction_algo.register_new_token_scores(attention_scores_for_all_decoder_layers, skip_set, scheduler_output.get_score_aggregation_window(seq_id));
         }
 
-        auto seq_group_ptr_it = std::find_if(m_requests.begin(), m_requests.end(), [seq_id](const SequenceGroup::Ptr& val) { return val->has_sequence_with_id(seq_id); });
+        auto seq_group_ptr_it =
+            std::find_if(m_requests.begin(), m_requests.end(), [seq_id](const SequenceGroup::Ptr& val) {
+                return val->has_sequence_with_id(seq_id);
+            });
         OPENVINO_ASSERT(seq_group_ptr_it != m_requests.end(), "could not find sequence group with sequence ", seq_id);
         auto seq_group_ptr = *seq_group_ptr_it;
 
-         if (!seq_group_ptr->can_generate_tokens()) {
-             // do not evict during prefill
-             continue;
-         }
+        if (!seq_group_ptr->can_generate_tokens()) {
+            // do not evict during prefill
+            continue;
+        }
 
         if (sched_config.cache_eviction_config.aggregation_mode == AggregationMode::ADAPTIVE_RKV) {
             const auto& block_diversities = m_model_runner->get_last_block_diversities();
@@ -849,33 +923,38 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_maybe_evict_cache_bloc
         size_t num_blocks_evicted = logical_blocks_to_evict[0].size();
 
         if (seq_group_to_num_blocks_evicted_map.find(seq_group_ptr) != seq_group_to_num_blocks_evicted_map.end()) {
-            OPENVINO_ASSERT(seq_group_to_num_blocks_evicted_map[seq_group_ptr] == num_blocks_evicted, "internal error - each sequence in the same group must have the same number of blocks evicted");
+            OPENVINO_ASSERT(
+                seq_group_to_num_blocks_evicted_map[seq_group_ptr] == num_blocks_evicted,
+                "internal error - each sequence in the same group must have the same number of blocks evicted");
         } else {
             seq_group_to_num_blocks_evicted_map[seq_group_ptr] = num_blocks_evicted;
         }
-
     }
 
     for (const auto& seq_group_ptr_and_num_blocks_evicted : seq_group_to_num_blocks_evicted_map) {
-        // Assuming that the evicted blocks are always full (since they by design are only selected from intermediate-age blocks)
+        // Assuming that the evicted blocks are always full (since they by design are only selected from
+        // intermediate-age blocks)
         auto seq_group_ptr = seq_group_ptr_and_num_blocks_evicted.first;
         auto num_blocks_evicted = seq_group_ptr_and_num_blocks_evicted.second;
         seq_group_ptr->register_token_eviction(num_blocks_evicted * m_scheduler->get_block_size(CacheType::KV_CACHE));
     }
 }
 
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_set_adaptive_rkv_diversity_blocks(const SchedulerConfig& sched_config, const Scheduler::Output& scheduler_output) {
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_set_adaptive_rkv_diversity_blocks(
+    const SchedulerConfig& sched_config,
+    const Scheduler::Output& scheduler_output) {
     // TODO(vshampor): implement
 }
 
-
-
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(std::vector<SequenceGroup::Ptr>& sequence_groups, ov::Tensor& logits) {
-    const float * logits_data = logits.data<float>();
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(
+    std::vector<SequenceGroup::Ptr>& sequence_groups,
+    ov::Tensor& logits) {
+    const float* logits_data = logits.data<float>();
     ov::Shape logits_shape = logits.get_shape();
     OPENVINO_ASSERT(logits_shape.size() == 3);
     size_t vocab_size = logits_shape[2];
-    for (size_t sequence_group_id = 0, currently_processed_tokens = 0; sequence_group_id < sequence_groups.size(); ++sequence_group_id) {
+    for (size_t sequence_group_id = 0, currently_processed_tokens = 0; sequence_group_id < sequence_groups.size();
+         ++sequence_group_id) {
         SequenceGroup::Ptr sequence_group = sequence_groups[sequence_group_id];
         // requests not scheduled, in decoding phase or not echoing are not processed
         if (!sequence_group->is_scheduled() || sequence_group->get_context_len() > sequence_group->get_prompt_len() ||
@@ -886,13 +965,13 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(
         OPENVINO_ASSERT(num_running_sequences == 1);
         size_t output_seq_len = sequence_group->get_output_seq_len();
 
-        const float * sequence_group_logits_data = logits_data + vocab_size * currently_processed_tokens;
+        const float* sequence_group_logits_data = logits_data + vocab_size * currently_processed_tokens;
 
         size_t num_prompt_tokens_processed = sequence_group->get_num_processed_tokens();
         OPENVINO_ASSERT(num_prompt_tokens_processed + output_seq_len <= sequence_group->get_prompt_len());
 
-        // if we processed the whole prompt we don't include last logprob as it will be processed by the sampler (it's already completion)
-        // otherwise we include it as it will be used in the next part of the prompt
+        // if we processed the whole prompt we don't include last logprob as it will be processed by the sampler (it's
+        // already completion) otherwise we include it as it will be used in the next part of the prompt
         int exclude_last_logprob = 1;
         if (num_prompt_tokens_processed + output_seq_len < sequence_group->get_prompt_len())
             exclude_last_logprob = 0;
@@ -904,7 +983,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(
         for (int token_logits_offset = 0, token_id_offset = num_prompt_tokens_processed + 1;
              token_logits_offset < output_seq_len - exclude_last_logprob;
              token_logits_offset++, token_id_offset++) {
-
             const float* token_logits = (sequence_group_logits_data + token_logits_offset * vocab_size);
             int64_t token_id = sequence_group->get_prompt_ids()[token_id_offset];
             float token_logit = token_logits[token_id];
@@ -920,16 +998,18 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(
             }
 
             // apply log softmax to token logit
-            float log_sum = std::log(std::accumulate(
-                token_logits, token_logits + vocab_size, 0.0f, [max_value](float accumulated, float to_add) {
-                    return accumulated + std::exp(to_add - max_value);
-            }));
+            float log_sum = std::log(std::accumulate(token_logits,
+                                                     token_logits + vocab_size,
+                                                     0.0f,
+                                                     [max_value](float accumulated, float to_add) {
+                                                         return accumulated + std::exp(to_add - max_value);
+                                                     }));
 
             sequence_group->append_prompt_log_prob(token_logit - max_value - log_sum);
         }
         currently_processed_tokens += output_seq_len * num_running_sequences;
         // For max_new_tokens == 0, we don't reach sampling so need to notify handle separately
-        if(sequence_group->get_max_new_tokens() == 0) {
+        if (sequence_group->get_max_new_tokens() == 0) {
             sequence_group->notify_handle_echo_only();
         }
     }
@@ -939,4 +1019,4 @@ std::vector<SequenceGroup::Ptr> ContinuousBatchingPipeline::ContinuousBatchingIm
     std::lock_guard<std::mutex> lock{m_awaiting_requests_mutex};
     return m_awaiting_requests;
 }
-} // namespace ov::genai
+}  // namespace ov::genai

--- a/src/cpp/src/generation_config.cpp
+++ b/src/cpp/src/generation_config.cpp
@@ -129,6 +129,7 @@ void GenerationConfig::update_generation_config(const ov::AnyMap& properties) {
     read_anymap_param(properties, "num_return_sequences", num_return_sequences);
     read_anymap_param(properties, "adapters", adapters);
     read_anymap_param(properties, "apply_chat_template", apply_chat_template);
+    read_anymap_param(properties, "return_omni_outputs", return_omni_outputs);
 
     // penalties
     read_anymap_param(properties, "frequency_penalty", frequency_penalty);

--- a/src/cpp/src/generation_handle.cpp
+++ b/src/cpp/src/generation_handle.cpp
@@ -55,6 +55,12 @@ void add_partial_result(std::unordered_map<uint64_t, GenerationOutput>& partial_
             }
             partial_result_iter->second.score = iteration_result.second.score;
             partial_result_iter->second.finish_reason = iteration_result.second.finish_reason;
+            // Hidden states are emitted only on the terminal push, so the last iteration that
+            // carries them wins; earlier partial iterations leave the field empty.
+            if (!iteration_result.second.intermediate_hidden_states.empty()) {
+                partial_result_iter->second.intermediate_hidden_states =
+                    std::move(iteration_result.second.intermediate_hidden_states);
+            }
         }
     }
 }

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
-#include <cmath>
-#include <iostream>
 #include <numeric>
-#include <random>
 #include <vector>
 
 #include "utils.hpp"

--- a/src/cpp/src/omni/pipeline.cpp
+++ b/src/cpp/src/omni/pipeline.cpp
@@ -1,0 +1,267 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/genai/omni/pipeline.hpp"
+
+#include <optional>
+
+#include "omni/pipeline_impl.hpp"
+#include "omni/talker_speech_config_utils.hpp"
+
+namespace ov::genai {
+
+OmniPipeline::OmniPipeline(const std::filesystem::path& models_path,
+                           const std::string& device,
+                           const ov::AnyMap& properties)
+    : OmniPipeline(std::make_shared<VLMPipeline>(models_path, device, properties),
+                   std::make_shared<Talker>(models_path, device, properties)) {}
+
+OmniPipeline::OmniPipeline(const std::shared_ptr<VLMPipelineBase>& vlm,
+                           const std::shared_ptr<TalkerBase>& talker)
+    : m_pimpl(std::make_unique<OmniPipelineImpl>(vlm, talker)) {}
+
+OmniPipeline::~OmniPipeline() = default;
+
+OmniDecodedResults OmniPipeline::generate(const std::string& prompt,
+                                           const std::vector<ov::Tensor>& images,
+                                           const std::vector<ov::Tensor>& videos,
+                                           const std::vector<VideoMetadata>& videos_metadata,
+                                           const std::vector<ov::Tensor>& audios,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(prompt,
+                             images,
+                             videos,
+                             videos_metadata,
+                             audios,
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const std::string& prompt,
+                                           const std::vector<ov::Tensor>& images,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(prompt,
+                             images,
+                             /*videos=*/{},
+                             /*videos_metadata=*/{},
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const std::string& prompt,
+                                           const std::vector<ov::Tensor>& images,
+                                           const std::vector<ov::Tensor>& videos,
+                                           const std::vector<VideoMetadata>& videos_metadata,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(prompt,
+                             images,
+                             videos,
+                             videos_metadata,
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const std::string& prompt,
+                                           const ov::Tensor& image,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(prompt,
+                             std::vector<ov::Tensor>{image},
+                             /*videos=*/{},
+                             /*videos_metadata=*/{},
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const ChatHistory& history,
+                                           const std::vector<ov::Tensor>& images,
+                                           const std::vector<ov::Tensor>& videos,
+                                           const std::vector<VideoMetadata>& videos_metadata,
+                                           const std::vector<ov::Tensor>& audios,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(history,
+                             images,
+                             videos,
+                             videos_metadata,
+                             audios,
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const ChatHistory& history,
+                                           const std::vector<ov::Tensor>& images,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(history,
+                             images,
+                             /*videos=*/{},
+                             /*videos_metadata=*/{},
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const ChatHistory& history,
+                                           const std::vector<ov::Tensor>& images,
+                                           const std::vector<ov::Tensor>& videos,
+                                           const std::vector<VideoMetadata>& videos_metadata,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(history,
+                             images,
+                             videos,
+                             videos_metadata,
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const ChatHistory& history,
+                                           const ov::Tensor& image,
+                                           const GenerationConfig& text_config,
+                                           const OmniTalkerSpeechConfig& talker_speech_config,
+                                           const StreamerVariant& streamer,
+                                           const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_pimpl->generate(history,
+                             std::vector<ov::Tensor>{image},
+                             /*videos=*/{},
+                             /*videos_metadata=*/{},
+                             /*audios=*/{},
+                             text_config,
+                             talker_speech_config,
+                             streamer,
+                             speech_streamer);
+}
+
+namespace {
+
+// Pull recognized OmniPipeline keys out of `config_map`. Anything left over is forwarded to
+// BOTH update_omni_talker_speech_config AND (a copy of) the resolved
+// GenerationConfig, so users can pass GenerationConfig fields (max_new_tokens, do_sample,
+// ...) and OmniTalkerSpeechConfig fields (return_audio, speaker, audio_chunk_frames, ...)
+// inline alongside the IO properties. Shared field names (`max_new_tokens`, `rng_seed`)
+// land on both configs intentionally — that's the broadcast contract for the AnyMap form.
+struct ExtractedOmniProps {
+    std::vector<ov::Tensor> images;
+    std::vector<ov::Tensor> videos;
+    std::vector<VideoMetadata> videos_metadata;
+    std::vector<ov::Tensor> audios;
+    std::optional<GenerationConfig> explicit_text_config;
+    std::optional<OmniTalkerSpeechConfig> explicit_talker_speech_config;
+    StreamerVariant streamer = std::monostate{};
+    OmniSpeechStreamerVariant speech_streamer = std::monostate{};
+    ov::AnyMap leftover;
+};
+
+ExtractedOmniProps extract_omni_props(const ov::AnyMap& config_map) {
+    ExtractedOmniProps out;
+    for (const auto& [property_key, value] : config_map) {
+        if (property_key == ov::genai::images.name()) {
+            out.images = value.as<std::vector<ov::Tensor>>();
+        } else if (property_key == ov::genai::videos.name()) {
+            out.videos = value.as<std::vector<ov::Tensor>>();
+        } else if (property_key == ov::genai::videos_metadata.name()) {
+            out.videos_metadata = value.as<std::vector<VideoMetadata>>();
+        } else if (property_key == ov::genai::audios.name()) {
+            out.audios = value.as<std::vector<ov::Tensor>>();
+        } else if (property_key == ov::genai::text_config.name()) {
+            out.explicit_text_config = value.as<GenerationConfig>();
+        } else if (property_key == ov::genai::talker_speech_config.name()) {
+            out.explicit_talker_speech_config = value.as<OmniTalkerSpeechConfig>();
+        } else if (property_key == "streamer") {
+            out.streamer = value.as<StreamerVariant>();
+        } else if (property_key == ov::genai::speech_streamer.name()) {
+            out.speech_streamer = value.as<OmniSpeechStreamerVariant>();
+        } else {
+            out.leftover.emplace(property_key, value);
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+OmniDecodedResults OmniPipeline::generate(const std::string& prompt, const ov::AnyMap& config_map) {
+    auto omni_props = extract_omni_props(config_map);
+    GenerationConfig text_config = omni_props.explicit_text_config.value_or(m_pimpl->get_text_generation_config());
+    OmniTalkerSpeechConfig talker_speech_config =
+        omni_props.explicit_talker_speech_config.value_or(m_pimpl->get_talker_speech_config());
+    if (!omni_props.leftover.empty()) {
+        text_config.update_generation_config(omni_props.leftover);
+        update_omni_talker_speech_config(talker_speech_config, omni_props.leftover);
+    }
+    return m_pimpl->generate(prompt,
+                             omni_props.images,
+                             omni_props.videos,
+                             omni_props.videos_metadata,
+                             omni_props.audios,
+                             text_config,
+                             talker_speech_config,
+                             omni_props.streamer,
+                             omni_props.speech_streamer);
+}
+
+OmniDecodedResults OmniPipeline::generate(const ChatHistory& history, const ov::AnyMap& config_map) {
+    auto omni_props = extract_omni_props(config_map);
+    GenerationConfig text_config = omni_props.explicit_text_config.value_or(m_pimpl->get_text_generation_config());
+    OmniTalkerSpeechConfig talker_speech_config =
+        omni_props.explicit_talker_speech_config.value_or(m_pimpl->get_talker_speech_config());
+    if (!omni_props.leftover.empty()) {
+        text_config.update_generation_config(omni_props.leftover);
+        update_omni_talker_speech_config(talker_speech_config, omni_props.leftover);
+    }
+    return m_pimpl->generate(history,
+                             omni_props.images,
+                             omni_props.videos,
+                             omni_props.videos_metadata,
+                             omni_props.audios,
+                             text_config,
+                             talker_speech_config,
+                             omni_props.streamer,
+                             omni_props.speech_streamer);
+}
+
+std::shared_ptr<VLMPipelineBase> OmniPipeline::get_vlm() const {
+    return m_pimpl->get_vlm();
+}
+
+std::shared_ptr<TalkerBase> OmniPipeline::get_talker() const {
+    return m_pimpl->get_talker();
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/omni/pipeline_impl.cpp
+++ b/src/cpp/src/omni/pipeline_impl.cpp
@@ -1,0 +1,132 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "omni/pipeline_impl.hpp"
+
+#include <utility>
+
+#include "openvino/core/except.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+/// @brief Cross-config validation: when speech output is requested the thinker text decode
+/// must use a sampling mode the talker can consume — single hidden-state stream, no beam
+/// candidates, no speculative draft tokens.
+void enforce_text_config_compatible_with_audio(const GenerationConfig& text_config,
+                                               const OmniTalkerSpeechConfig& talker_speech_config) {
+    if (!talker_speech_config.return_audio) {
+        return;
+    }
+    OPENVINO_ASSERT(!text_config.is_beam_search(),
+                    "OmniPipeline: return_audio is not compatible with beam search (num_beams > 1)");
+    OPENVINO_ASSERT(!text_config.is_prompt_lookup() && !text_config.is_assisting_generation(),
+                    "OmniPipeline: return_audio is not compatible with prompt lookup or assistant/speculative decoding");
+    OPENVINO_ASSERT(text_config.num_return_sequences == 1,
+                    "OmniPipeline: return_audio requires num_return_sequences == 1 (got ",
+                    text_config.num_return_sequences,
+                    "); the talker consumes a single hidden-state stream");
+}
+
+}  // namespace
+
+OmniPipeline::OmniPipelineImpl::OmniPipelineImpl(const std::shared_ptr<VLMPipelineBase>& vlm,
+                                                  const std::shared_ptr<TalkerBase>& talker) :
+    m_vlm{vlm}, m_talker{talker} {
+    OPENVINO_ASSERT(m_vlm, "OmniPipeline: VLM pointer is null");
+    OPENVINO_ASSERT(m_talker, "OmniPipeline: talker pointer is null");
+    assert_omni_capable();
+}
+
+void OmniPipeline::OmniPipelineImpl::assert_omni_capable() const {
+    OPENVINO_ASSERT(
+        m_vlm->is_audio_output_enabled(),
+        "OmniPipeline requires a Qwen3-Omni model with audio output enabled (config.json: enable_audio_output=true)");
+    OPENVINO_ASSERT(
+        m_vlm->supports_hidden_states_collection(),
+        "OmniPipeline speech output requires the continuous-batching backend, but the loaded VLM uses the SDPA "
+        "fallback path. Load the model with attention_backend=PA on a CPU or GPU device (NPU is not supported "
+        "for Qwen3-Omni speech output).");
+}
+
+OmniDecodedResults OmniPipeline::OmniPipelineImpl::generate(const std::string& prompt,
+                                                             const std::vector<ov::Tensor>& images,
+                                                             const std::vector<ov::Tensor>& videos,
+                                                             const std::vector<VideoMetadata>& videos_metadata,
+                                                             const std::vector<ov::Tensor>& audios,
+                                                             const GenerationConfig& text_config,
+                                                             const OmniTalkerSpeechConfig& talker_speech_config,
+                                                             const StreamerVariant& streamer,
+                                                             const OmniSpeechStreamerVariant& speech_streamer) {
+    validate_omni_talker_speech_config(talker_speech_config);
+    enforce_text_config_compatible_with_audio(text_config, talker_speech_config);
+
+    OPENVINO_ASSERT(videos_metadata.empty() || videos_metadata.size() == videos.size(),
+                    "OmniPipeline: videos_metadata size (", videos_metadata.size(),
+                    ") must match videos size (", videos.size(), ") or be empty");
+
+    if (talker_speech_config.return_audio) {
+        GenerationConfig text_cfg = text_config;
+        text_cfg.return_omni_outputs = true;
+        VLMDecodedResults vlm_result =
+            m_vlm->generate(prompt, images, videos, audios, videos_metadata, text_cfg, streamer);
+        TalkerResults talker_result = m_talker->generate(vlm_result, talker_speech_config, speech_streamer);
+        OmniDecodedResults omni_result;
+        static_cast<VLMDecodedResults&>(omni_result) = std::move(vlm_result);
+        omni_result.speech_result = std::move(talker_result);
+        return omni_result;
+    }
+
+    // Text-only path: convert VLMDecodedResults to OmniDecodedResults with empty speech_result.
+    VLMDecodedResults vlm_result =
+        m_vlm->generate(prompt, images, videos, audios, videos_metadata, text_config, streamer);
+    OmniDecodedResults omni_result;
+    static_cast<VLMDecodedResults&>(omni_result) = std::move(vlm_result);
+    return omni_result;
+}
+
+OmniDecodedResults OmniPipeline::OmniPipelineImpl::generate(const ChatHistory& history,
+                                                             const std::vector<ov::Tensor>& images,
+                                                             const std::vector<ov::Tensor>& videos,
+                                                             const std::vector<VideoMetadata>& videos_metadata,
+                                                             const std::vector<ov::Tensor>& audios,
+                                                             const GenerationConfig& text_config,
+                                                             const OmniTalkerSpeechConfig& talker_speech_config,
+                                                             const StreamerVariant& streamer,
+                                                             const OmniSpeechStreamerVariant& speech_streamer) {
+    validate_omni_talker_speech_config(talker_speech_config);
+    enforce_text_config_compatible_with_audio(text_config, talker_speech_config);
+
+    OPENVINO_ASSERT(videos_metadata.empty() || videos_metadata.size() == videos.size(),
+                    "OmniPipeline: videos_metadata size (", videos_metadata.size(),
+                    ") must match videos size (", videos.size(), ") or be empty");
+
+    if (talker_speech_config.return_audio) {
+        // Speech output requires the prompts overload's per-prompt loop, which captures the
+        // prompt-id slice into VLMDecodedResults::prompt_ids. The histories overload doesn't
+        // yet wire that capture (CB pipeline_base.cpp leaves original_prompt_ids_list empty
+        // for the ChatHistory path — see the FIXME there). Apply the chat template here and
+        // route through the prompts path so speech generation has its prompt_ids.
+        const std::string templated_prompt = m_vlm->get_tokenizer().apply_chat_template(history, true);
+        GenerationConfig text_cfg = text_config;
+        text_cfg.apply_chat_template = false;
+        text_cfg.return_omni_outputs = true;
+        VLMDecodedResults vlm_result =
+            m_vlm->generate(templated_prompt, images, videos, audios, videos_metadata, text_cfg, streamer);
+        TalkerResults talker_result = m_talker->generate(vlm_result, talker_speech_config, speech_streamer);
+        OmniDecodedResults omni_result;
+        static_cast<VLMDecodedResults&>(omni_result) = std::move(vlm_result);
+        omni_result.speech_result = std::move(talker_result);
+        return omni_result;
+    }
+
+    // Text-only path: convert VLMDecodedResults to OmniDecodedResults with empty speech_result.
+    VLMDecodedResults vlm_result =
+        m_vlm->generate(history, images, videos, audios, videos_metadata, text_config, streamer);
+    OmniDecodedResults omni_result;
+    static_cast<VLMDecodedResults&>(omni_result) = std::move(vlm_result);
+    return omni_result;
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/omni/pipeline_impl.hpp
+++ b/src/cpp/src/omni/pipeline_impl.hpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openvino/core/any.hpp"
+#include "openvino/genai/chat_history.hpp"
+#include "openvino/genai/omni/pipeline.hpp"
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+#include "openvino/genai/omni/talker.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "openvino/genai/streamer_base.hpp"
+#include "omni/talker_speech_config_utils.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
+#include "openvino/genai/visual_language/video_metadata.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace ov::genai {
+
+/// @brief Implementation backing OmniPipeline. Holds a VLMPipelineBase (text-side) and a
+/// TalkerBase (speech-side). Speech is gated per-call via OmniTalkerSpeechConfig::return_audio.
+class OmniPipeline::OmniPipelineImpl {
+public:
+    OmniPipelineImpl(const std::shared_ptr<VLMPipelineBase>& vlm,
+                     const std::shared_ptr<TalkerBase>& talker);
+
+    OmniDecodedResults generate(const std::string& prompt,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const std::vector<ov::Tensor>& audios,
+                                const GenerationConfig& text_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer,
+                                const OmniSpeechStreamerVariant& speech_streamer);
+
+    OmniDecodedResults generate(const ChatHistory& history,
+                                const std::vector<ov::Tensor>& images,
+                                const std::vector<ov::Tensor>& videos,
+                                const std::vector<VideoMetadata>& videos_metadata,
+                                const std::vector<ov::Tensor>& audios,
+                                const GenerationConfig& text_config,
+                                const OmniTalkerSpeechConfig& talker_speech_config,
+                                const StreamerVariant& streamer,
+                                const OmniSpeechStreamerVariant& speech_streamer);
+
+    /// @brief Return the VLM's loaded GenerationConfig (parsed from generation_config.json).
+    /// Used as the default text_config when callers don't pass one explicitly.
+    GenerationConfig get_text_generation_config() const {
+        return m_vlm->get_generation_config();
+    }
+
+    OmniTalkerSpeechConfig get_talker_speech_config() const {
+        return m_default_talker_speech_config;
+    }
+
+    std::shared_ptr<VLMPipelineBase> get_vlm() const {
+        return m_vlm;
+    }
+
+    std::shared_ptr<TalkerBase> get_talker() const {
+        return m_talker;
+    }
+
+private:
+    /// @brief Reject non-Omni-capable models early, before any inference work.
+    void assert_omni_capable() const;
+
+    std::shared_ptr<VLMPipelineBase> m_vlm;
+    std::shared_ptr<TalkerBase> m_talker;
+    OmniTalkerSpeechConfig m_default_talker_speech_config;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/omni/speech_streamer_base.cpp
+++ b/src/cpp/src/omni/speech_streamer_base.cpp
@@ -1,0 +1,12 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+
+namespace ov {
+namespace genai {
+
+OmniSpeechStreamerBase::~OmniSpeechStreamerBase() = default;
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/omni/talker.cpp
+++ b/src/cpp/src/omni/talker.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/genai/omni/talker.hpp"
+
+#include "openvino/core/except.hpp"
+#include "utils.hpp"
+#include "visual_language/qwen3_omni/speech_pipeline.hpp"
+#include "visual_language/vlm_config.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+/// @brief Flatten per-step hidden states into per-token hidden states.
+/// Each step tensor has shape [num_tokens, 1, hidden_size]. Multi-token tensors
+/// (from prefill) are split into individual [1, 1, hidden_size] slices.
+std::vector<ov::Tensor> split_hidden_states(const std::vector<ov::Tensor>& per_step_hidden_states) {
+    std::vector<ov::Tensor> per_token;
+    size_t total_tokens = 0;
+    for (const auto& step_hs : per_step_hidden_states) {
+        total_tokens += step_hs.get_shape()[0];
+    }
+    per_token.reserve(total_tokens);
+    for (const auto& step_hs : per_step_hidden_states) {
+        const auto shape = step_hs.get_shape();
+        const size_t num_tokens = shape[0];
+        for (size_t t = 0; t < num_tokens; t++) {
+            const auto [begin, end] = ov::genai::utils::make_roi(shape, 0, t, t + 1);
+            ov::Tensor token_hs(step_hs, begin, end);
+            per_token.push_back(std::move(token_hs));
+        }
+    }
+    return per_token;
+}
+
+}  // namespace
+
+class Talker::Impl {
+public:
+    Impl(const std::filesystem::path& model_dir, const std::string& device, const ov::AnyMap& properties) {
+        VLMConfig vlm_config(model_dir / "config.json");
+        m_speech = std::make_unique<Qwen3OmniSpeechPipeline>(model_dir, vlm_config, device, properties);
+
+        OPENVINO_ASSERT(m_speech->is_available(),
+                        "Talker: speech generation submodels are missing from ", model_dir.string(),
+                        ". If your model has no speech generation capability, use VLMPipeline directly instead of OmniPipeline.");
+    }
+
+    TalkerResults generate(const VLMDecodedResults& vlm_result,
+                          const OmniTalkerSpeechConfig& talker_speech_config,
+                          const OmniSpeechStreamerVariant& speech_streamer) {
+        OPENVINO_ASSERT(!vlm_result.intermediate_hidden_states.empty(),
+                        "Talker: intermediate hidden states missing on VLMDecodedResults; the VLM must run "
+                        "with talker_speech_config.return_audio=true so it accumulates thinker hidden states.");
+        OPENVINO_ASSERT(!vlm_result.full_token_ids.empty(),
+                        "Talker: full_token_ids missing on VLMDecodedResults; the VLM must run "
+                        "with talker_speech_config.return_audio=true.");
+        OPENVINO_ASSERT(vlm_result.intermediate_hidden_states.size() == 1 && vlm_result.full_token_ids.size() == 1,
+                        "Talker: expected a single return sequence, got ",
+                        vlm_result.full_token_ids.size(),
+                        "; speech generation consumes one hidden-state stream.");
+
+        auto all_intermediate_hidden_states = split_hidden_states(vlm_result.intermediate_hidden_states[0]);
+
+        // talker_speech_config carries audio_chunk_frames, speaker / speaker_embedding,
+        // max_new_tokens, rng_seed, plus the talker_* / cp_* sampling overrides. The pipeline
+        // resolves each std::optional<...> against the JSON-loaded checkpoint defaults at the
+        // top of generate_speech(); unset overrides keep the checkpoint values.
+        return m_speech->generate_speech(vlm_result.full_token_ids[0],
+                                         all_intermediate_hidden_states,
+                                         speech_streamer,
+                                         talker_speech_config);
+    }
+
+    std::vector<std::string> list_speakers() const {
+        return m_speech->list_speakers();
+    }
+
+    ov::Tensor get_speaker_embedding(const std::string& name) const {
+        return m_speech->get_speaker_embedding(name);
+    }
+
+private:
+    std::unique_ptr<Qwen3OmniSpeechPipeline> m_speech;
+};
+
+Talker::Talker(const std::filesystem::path& model_dir,
+                                 const std::string& device,
+                                 const ov::AnyMap& properties)
+    : m_impl(std::make_unique<Impl>(model_dir, device, properties)) {}
+
+Talker::~Talker() = default;
+
+TalkerResults Talker::generate(const VLMDecodedResults& vlm_result,
+                                        const OmniTalkerSpeechConfig& talker_speech_config,
+                                        const OmniSpeechStreamerVariant& speech_streamer) {
+    return m_impl->generate(vlm_result, talker_speech_config, speech_streamer);
+}
+
+std::vector<std::string> Talker::list_speakers() const {
+    return m_impl->list_speakers();
+}
+
+ov::Tensor Talker::get_speaker_embedding(const std::string& name) const {
+    return m_impl->get_speaker_embedding(name);
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/omni/talker_speech_config.cpp
+++ b/src/cpp/src/omni/talker_speech_config.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "openvino/genai/omni/talker_speech_config.hpp"
+
+#include <fstream>
+#include <variant>
+
+#include <nlohmann/json.hpp>
+
+#include "omni/talker_speech_config_utils.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace genai {
+
+OmniTalkerSpeechConfig::OmniTalkerSpeechConfig(const std::filesystem::path& models_dir) {
+    const auto config_path = models_dir / "config.json";
+    if (!std::filesystem::exists(config_path)) {
+        return;
+    }
+
+    std::ifstream stream(config_path);
+    if (!stream.is_open()) {
+        return;
+    }
+
+    const nlohmann::json parsed = nlohmann::json::parse(stream);
+    if (!parsed.contains("talker_config")) {
+        return;
+    }
+
+    const auto& talker = parsed.at("talker_config");
+    if (talker.contains("speaker_id") && talker.at("speaker_id").is_string()) {
+        speaker = talker.at("speaker_id").get<std::string>();
+    }
+}
+
+void update_omni_talker_speech_config(OmniTalkerSpeechConfig& config, const ov::AnyMap& properties) {
+    using ov::genai::utils::read_anymap_param;
+
+    read_anymap_param(properties, "return_audio", config.return_audio);
+    if (properties.count("speaker_embedding")) {
+        ov::Tensor tensor;
+        read_anymap_param(properties, "speaker_embedding", tensor);
+        config.speaker = tensor;
+    }
+    if (properties.count("speaker")) {
+        const auto& val = properties.at("speaker");
+        if (val.is<std::string>()) {
+            config.speaker = val.as<std::string>();
+        } else if (val.is<ov::Tensor>()) {
+            config.speaker = val.as<ov::Tensor>();
+        }
+    }
+
+    read_anymap_param(properties, "audio_chunk_frames", config.audio_chunk_frames);
+    read_anymap_param(properties, "max_new_tokens", config.max_new_tokens);
+    read_anymap_param(properties, "rng_seed", config.rng_seed);
+
+    read_anymap_param(properties, "talker_temperature", config.talker_temperature);
+    read_anymap_param(properties, "talker_top_k", config.talker_top_k);
+    read_anymap_param(properties, "talker_repetition_penalty", config.talker_repetition_penalty);
+    read_anymap_param(properties, "cp_temperature", config.cp_temperature);
+    read_anymap_param(properties, "cp_top_k", config.cp_top_k);
+    read_anymap_param(properties, "cp_repetition_penalty", config.cp_repetition_penalty);
+}
+
+void validate_omni_talker_speech_config(const OmniTalkerSpeechConfig& config) {
+    if (!config.return_audio) {
+        return;
+    }
+
+    if (std::holds_alternative<ov::Tensor>(config.speaker)) {
+        const auto& tensor = std::get<ov::Tensor>(config.speaker);
+        OPENVINO_ASSERT(static_cast<bool>(tensor),
+                        "OmniTalkerSpeechConfig: speaker Tensor variant is set but the tensor is empty");
+        OPENVINO_ASSERT(tensor.get_element_type() == ov::element::f32,
+                        "OmniTalkerSpeechConfig: speaker embedding must be f32, got ",
+                        tensor.get_element_type());
+        const auto& shape = tensor.get_shape();
+        OPENVINO_ASSERT(shape.size() == 3 && shape[0] == 1 && shape[1] == 1,
+                        "OmniTalkerSpeechConfig: speaker embedding must have shape "
+                        "[1, 1, talker_hidden_size], got ",
+                        shape);
+    }
+    if (config.talker_temperature) {
+        OPENVINO_ASSERT(*config.talker_temperature > 0.0f,
+                        "OmniTalkerSpeechConfig: talker_temperature must be > 0, got ",
+                        *config.talker_temperature);
+    }
+    if (config.talker_top_k) {
+        OPENVINO_ASSERT(*config.talker_top_k >= 1,
+                        "OmniTalkerSpeechConfig: talker_top_k must be >= 1, got ",
+                        *config.talker_top_k);
+    }
+    if (config.talker_repetition_penalty) {
+        OPENVINO_ASSERT(*config.talker_repetition_penalty > 0.0f,
+                        "OmniTalkerSpeechConfig: talker_repetition_penalty must be > 0, got ",
+                        *config.talker_repetition_penalty);
+    }
+    if (config.cp_temperature) {
+        OPENVINO_ASSERT(*config.cp_temperature > 0.0f,
+                        "OmniTalkerSpeechConfig: cp_temperature must be > 0, got ",
+                        *config.cp_temperature);
+    }
+    if (config.cp_top_k) {
+        OPENVINO_ASSERT(*config.cp_top_k >= 1,
+                        "OmniTalkerSpeechConfig: cp_top_k must be >= 1, got ",
+                        *config.cp_top_k);
+    }
+    if (config.cp_repetition_penalty) {
+        OPENVINO_ASSERT(*config.cp_repetition_penalty > 0.0f,
+                        "OmniTalkerSpeechConfig: cp_repetition_penalty must be > 0, got ",
+                        *config.cp_repetition_penalty);
+    }
+    OPENVINO_ASSERT(config.audio_chunk_frames >= 1,
+                    "OmniTalkerSpeechConfig: audio_chunk_frames must be >= 1, got ",
+                    config.audio_chunk_frames);
+    constexpr std::size_t kAudioChunkFramesUpperBound = 4096;
+    OPENVINO_ASSERT(config.audio_chunk_frames <= kAudioChunkFramesUpperBound,
+                    "OmniTalkerSpeechConfig: audio_chunk_frames is unreasonably large: ",
+                    config.audio_chunk_frames,
+                    ". Max allowed: ",
+                    kAudioChunkFramesUpperBound);
+}
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/omni/talker_speech_config_utils.hpp
+++ b/src/cpp/src/omni/talker_speech_config_utils.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "openvino/core/any.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+
+namespace ov {
+namespace genai {
+
+/// @brief Populate fields of `config` from an AnyMap (kwargs-style properties).
+/// Recognized keys: return_audio, speaker, speaker_embedding (legacy alias),
+/// audio_chunk_frames, max_new_tokens, rng_seed, talker_temperature, talker_top_k,
+/// talker_repetition_penalty, cp_temperature, cp_top_k, cp_repetition_penalty.
+void update_omni_talker_speech_config(OmniTalkerSpeechConfig& config, const ov::AnyMap& properties);
+
+/// @brief Validate talker-only invariants on `config`.
+/// Cross-config rules (e.g. return_audio vs beam search on text_config) are NOT
+/// checked here — the caller (OmniPipelineImpl) handles those separately.
+/// @throws ov::Exception if config is invalid.
+void validate_omni_talker_speech_config(const OmniTalkerSpeechConfig& config);
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -14,6 +14,7 @@
 #include "openvino/genai/generation_handle.hpp"
 #include "openvino/genai/generation_config.hpp"
 #include "generation_stream.hpp"
+#include "logger.hpp"
 
 namespace ov::genai {
 enum class SequenceStatus {
@@ -53,6 +54,12 @@ class Sequence {
     uint64_t m_grouped_id;
     uint64_t m_id = _get_next_global_sequence_id();
     ov::Tensor m_hidden_state = ov::Tensor();
+    // When enabled, one intermediate hidden state is accumulated per generated token
+    // (prefill batches are sliced into per-token tensors before accumulation)
+    static constexpr size_t kMaxAccumulatedHiddenStates = 512;
+    bool m_accumulate_hidden_states = false;
+    bool m_hidden_state_cap_warned = false;
+    std::vector<ov::Tensor> m_all_intermediate_hidden_states;
     SequenceStatus m_status = SequenceStatus::RUNNING;
     GenerationFinishReason m_finish_reason = GenerationFinishReason::NONE;
     float m_cumulative_log_prob = 0.0f;
@@ -81,6 +88,9 @@ class Sequence {
         m_generated_log_probs(seq.m_generated_log_probs),
         m_grouped_id(id),
         m_hidden_state(seq.m_hidden_state),
+        m_accumulate_hidden_states(seq.m_accumulate_hidden_states),
+        m_hidden_state_cap_warned(seq.m_hidden_state_cap_warned),
+        m_all_intermediate_hidden_states(seq.m_all_intermediate_hidden_states),
         m_status(seq.m_status),
         m_cumulative_log_prob(seq.m_cumulative_log_prob),
         m_sequence_group(seq.m_sequence_group),
@@ -147,7 +157,6 @@ public:
         m_finish_reason = finish_reason;
     }
 
-    // appends new tokens to a generated part
     void append_token(int64_t token_id, float log_prob) {
         m_cumulative_log_prob += log_prob;
         m_generated_log_probs.push_back(log_prob);
@@ -168,6 +177,34 @@ public:
 
     const TreeMetaData& get_tree_metadata() const {
         return m_tree_metadata;
+    }
+
+    void update_intermediate_hidden_state(const ov::Tensor& tensor) {
+        if (m_accumulate_hidden_states && tensor.get_size() > 0) {
+            if (m_all_intermediate_hidden_states.size() >= kMaxAccumulatedHiddenStates) {
+                if (!m_hidden_state_cap_warned) {
+                    GENAI_WARN("Hidden state accumulation cap reached (%zu tokens); stopping accumulation",
+                               kMaxAccumulatedHiddenStates);
+                    m_hidden_state_cap_warned = true;
+                }
+                return;
+            }
+            ov::Tensor copy(tensor.get_element_type(), tensor.get_shape());
+            tensor.copy_to(copy);
+            m_all_intermediate_hidden_states.push_back(std::move(copy));
+        }
+    }
+
+    void set_accumulate_hidden_states(bool enable) {
+        m_accumulate_hidden_states = enable;
+        m_hidden_state_cap_warned = false;
+        if (enable) {
+            m_all_intermediate_hidden_states.reserve(256);
+        }
+    }
+
+    const std::vector<ov::Tensor>& get_all_intermediate_hidden_states() const {
+        return m_all_intermediate_hidden_states;
     }
 
     // removes n last tokens and updates cumulative log prob
@@ -694,7 +731,6 @@ public:
         m_num_processed_tokens -= num_preempt_tokens;
     }
 
-    // returns context length taking into account scheduled tokens
     size_t get_context_len() const {
         return get_num_processed_tokens() + get_num_scheduled_tokens();
     }
@@ -741,7 +777,6 @@ public:
         return std::max<size_t>(num_available_tokens - m_num_processed_tokens, 1u) + m_num_validation_tokens;
     }
 
-    // mark current schedule phase as finished and updates internal counters
     void finish_iteration() {
         m_num_processed_tokens += m_num_scheduled_tokens;
         // if some processed tokens were evicted, max content len is greater than number of processed tokens
@@ -870,6 +905,25 @@ public:
         m_generation_stream->push({});
     }
 
+    void push_finished_hidden_states() {
+        GenerationOutputs outputs;
+        for (auto& sequence : m_sequences) {
+            if (!sequence->has_finished()) {
+                continue;
+            }
+            const auto& hidden_states = sequence->get_all_intermediate_hidden_states();
+            if (hidden_states.empty()) {
+                continue;
+            }
+            GenerationOutput output;
+            output.score = m_sampling_params.is_beam_search() ? sequence->get_beam_search_score(m_sampling_params) : sequence->get_cumulative_log_prob();
+            output.finish_reason = sequence->get_finish_reason();
+            output.intermediate_hidden_states = hidden_states;
+            outputs.emplace(sequence->get_grouped_id(), output);
+        }
+        m_generation_stream->push(std::move(outputs));
+    }
+
     void push_outputs() {
         GenerationOutputs outputs;
         for (auto& sequence: m_sequences) {
@@ -882,6 +936,7 @@ public:
             }
             output.score = m_sampling_params.is_beam_search() ? sequence->get_beam_search_score(m_sampling_params) : sequence->get_cumulative_log_prob();
             output.finish_reason = sequence->get_finish_reason();
+            output.intermediate_hidden_states = sequence->get_all_intermediate_hidden_states();
             outputs.emplace(sequence->get_grouped_id(), output);
         }
         m_generation_stream->push(std::move(outputs));
@@ -897,6 +952,10 @@ public:
                 output.generated_ids.insert(output.generated_ids.begin(), m_prompt_ids.begin(), m_prompt_ids.end());
                 output.generated_log_probs.insert(output.generated_log_probs.begin(), m_prompt_log_probs.begin(), m_prompt_log_probs.end());
             }
+            // Hidden states are complete only once the sequence finishes; ride them out on the
+            // terminal streaming push so the add_request() handle receives them too.
+            if (sequence->has_finished())
+                output.intermediate_hidden_states = sequence->get_all_intermediate_hidden_states();
             outputs.emplace(sequence->get_grouped_id(), output);
         }
         m_has_echoed = true;
@@ -925,7 +984,9 @@ public:
                 // push empty output in case we won't stream generation res
                 if (generated_len <= (m_num_streamed_tokens + m_stream_window_size)) {
                     if (has_finished()) {
-                        push_empty_outputs();
+                        // All tokens already streamed; still deliver accumulated hidden states
+                        // (falls back to an empty terminator push when there are none).
+                        push_finished_hidden_states();
                     }
                     return;
                 }

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -204,6 +204,20 @@ ov::genai::StreamerVariant get_streamer_from_map(const ov::AnyMap& config_map) {
     return streamer;
 }
 
+ov::genai::OmniSpeechStreamerVariant get_audio_streamer_from_map(const ov::AnyMap& config_map) {
+    ov::genai::OmniSpeechStreamerVariant streamer = std::monostate();
+
+    if (config_map.count(AUDIO_STREAMER_ARG_NAME)) {
+        auto any_val = config_map.at(AUDIO_STREAMER_ARG_NAME);
+        if (any_val.is<std::shared_ptr<ov::genai::OmniSpeechStreamerBase>>()) {
+            streamer = any_val.as<std::shared_ptr<ov::genai::OmniSpeechStreamerBase>>();
+        } else if (any_val.is<std::function<StreamingStatus(const ov::Tensor&)>>()) {
+            streamer = any_val.as<std::function<StreamingStatus(const ov::Tensor&)>>();
+        }
+    }
+    return streamer;
+}
+
 std::shared_ptr<StreamerBase> create_streamer(StreamerVariant streamer, Tokenizer tokenizer) {
     return std::visit(overloaded{
         [](std::monostate) -> std::shared_ptr<StreamerBase> {

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <cstdint>
 
+#include "openvino/genai/omni/speech_streamer_base.hpp"
 #include "openvino/genai/extensions.hpp"
 #include "openvino/genai/llm_pipeline.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
@@ -96,12 +97,14 @@ void read_anymap_param(const ov::AnyMap& config_map, const std::string& name, T&
 }
 
 const std::string STREAMER_ARG_NAME = "streamer";
+const std::string AUDIO_STREAMER_ARG_NAME = "audio_streamer";
 const std::string CONFIG_ARG_NAME = "generation_config";
 const std::string DRAFT_MODEL_ARG_NAME = "draft_model";
 const std::string EXTENSIONS_ARG_NAME = "extensions";
 const std::string IMAGES_BATCHES_ARG_NAME = "images_batches";
 const std::string VIDEOS_BATCHES_ARG_NAME = "videos_batches";
 const std::string VIDEOS_METADATA_BATCHES_ARG_NAME = "videos_metadata_batches";
+const std::string AUDIOS_BATCHES_ARG_NAME = "audios_batches";
 
 template<typename Config = ov::genai::GenerationConfig>
 Config from_config_json_if_exists(const std::filesystem::path& models_path, const char config_name[] = "generation_config.json") {
@@ -110,6 +113,7 @@ Config from_config_json_if_exists(const std::filesystem::path& models_path, cons
 }
 
 ov::genai::StreamerVariant get_streamer_from_map(const ov::AnyMap& config_map);
+ov::genai::OmniSpeechStreamerVariant get_audio_streamer_from_map(const ov::AnyMap& config_map);
 
 ov::genai::OptionalGenerationConfig get_config_from_map(const ov::AnyMap& config_map);
 

--- a/src/cpp/src/visual_language/continuous_batching_adapter.hpp
+++ b/src/cpp/src/visual_language/continuous_batching_adapter.hpp
@@ -3,199 +3,210 @@
 
 #pragma once
 
-#include "visual_language/pipeline_base.hpp"
-#include "visual_language/chat_history_state.hpp"
 #include "openvino/genai/continuous_batching_pipeline.hpp"
+#include "utils.hpp"
+#include "visual_language/chat_history_state.hpp"
+#include "visual_language/pipeline_base.hpp"
+#include "visual_language/vlm_config.hpp"
 
 using namespace ov::genai;
 
-class ov::genai::VLMPipeline::VLMContinuousBatchingAdapter : public ov::genai::VLMPipeline::VLMPipelineBase {
+class ov::genai::VLMPipeline::VLMContinuousBatchingAdapter : public ov::genai::VLMPipeline::VLMBackend {
 public:
     ContinuousBatchingPipeline m_impl;
 
-    VLMContinuousBatchingAdapter(
-        const std::filesystem::path& models_dir,
-        const SchedulerConfig& scheduler_config,
-        const std::string& device,
-        const ov::AnyMap& properties
-    ): m_impl{
-        models_dir, 
-        scheduler_config, 
-        device, 
-        properties} {
+    VLMContinuousBatchingAdapter(const std::filesystem::path& models_dir,
+                                 const SchedulerConfig& scheduler_config,
+                                 const std::string& device,
+                                 const ov::AnyMap& properties)
+        : m_impl{models_dir, scheduler_config, device, properties} {
         set_attention_backend(PA_BACKEND);
+        load_vlm_config(models_dir);
     }
 
-    VLMContinuousBatchingAdapter(
-        const std::shared_ptr<ov::Model>& language_model,
-        const std::filesystem::path& models_dir,
-        const SchedulerConfig& scheduler_config,
-        const std::string& device,
-        const ov::AnyMap& properties
-    ): m_impl{
-        language_model,
-        models_dir,
-        scheduler_config,
-        device,
-        properties} {
+    VLMContinuousBatchingAdapter(const std::shared_ptr<ov::Model>& language_model,
+                                 const std::filesystem::path& models_dir,
+                                 const SchedulerConfig& scheduler_config,
+                                 const std::string& device,
+                                 const ov::AnyMap& properties)
+        : m_impl{language_model, models_dir, scheduler_config, device, properties} {
         set_attention_backend(PA_BACKEND);
+        load_vlm_config(models_dir);
     }
 
-    VLMContinuousBatchingAdapter(
-        const ModelsMap& models_map,
-        const Tokenizer& tokenizer,
-        const std::filesystem::path& config_dir_path,
-        const SchedulerConfig& scheduler_config,
-        const std::string& device,
-        const ov::AnyMap& properties,
-        const ov::genai::GenerationConfig& generation_config
-    ): m_impl{
-        models_map,
-        tokenizer,
-        scheduler_config,
-        device,
-        config_dir_path,
-        properties,
-        generation_config} {
+    VLMContinuousBatchingAdapter(const ModelsMap& models_map,
+                                 const Tokenizer& tokenizer,
+                                 const std::filesystem::path& config_dir_path,
+                                 const SchedulerConfig& scheduler_config,
+                                 const std::string& device,
+                                 const ov::AnyMap& properties,
+                                 const ov::genai::GenerationConfig& generation_config)
+        : m_impl{models_map, tokenizer, scheduler_config, device, config_dir_path, properties, generation_config} {
         set_attention_backend(PA_BACKEND);
+        load_vlm_config(config_dir_path);
     }
 
-    VLMContinuousBatchingAdapter(
-        const std::shared_ptr<ov::Model>& language_model,
-        const ModelsMap& models_map,
-        const Tokenizer& tokenizer,
-        const std::filesystem::path& config_dir_path,
-        const SchedulerConfig& scheduler_config,
-        const std::string& device,
-        const ov::AnyMap& properties,
-        const ov::genai::GenerationConfig& generation_config
-    ): m_impl{
-        language_model,
-        models_map,
-        tokenizer,
-        scheduler_config,
-        device,
-        config_dir_path,
-        properties,
-        generation_config} {
+    VLMContinuousBatchingAdapter(const std::shared_ptr<ov::Model>& language_model,
+                                 const ModelsMap& models_map,
+                                 const Tokenizer& tokenizer,
+                                 const std::filesystem::path& config_dir_path,
+                                 const SchedulerConfig& scheduler_config,
+                                 const std::string& device,
+                                 const ov::AnyMap& properties,
+                                 const ov::genai::GenerationConfig& generation_config)
+        : m_impl{language_model,
+                 models_map,
+                 tokenizer,
+                 scheduler_config,
+                 device,
+                 config_dir_path,
+                 properties,
+                 generation_config} {
         set_attention_backend(PA_BACKEND);
+        load_vlm_config(config_dir_path);
     }
 
-    VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
-        return generate(prompt, images, {}, std::move(generation_config), streamer);
+    VLMDecodedResults generate(const std::string& prompt,
+                               const std::vector<ov::Tensor>& images,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
+        return generate(prompt, images, {}, generation_config, streamer);
     }
 
-    VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
-        return generate(prompt, images, videos, {}, std::move(generation_config), streamer);
+    VLMDecodedResults generate(const std::string& prompt,
+                               const std::vector<ov::Tensor>& images,
+                               const std::vector<ov::Tensor>& videos,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
+        return generate(prompt, images, videos, {}, {}, generation_config, streamer);
     }
 
-    VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
+    VLMDecodedResults generate(const std::string& prompt,
+                               const std::vector<ov::Tensor>& images,
+                               const std::vector<ov::Tensor>& videos,
+                               const std::vector<ov::Tensor>& audios,
+                               const std::vector<VideoMetadata>& videos_metadata,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
         auto start_time = std::chrono::steady_clock::now();
-        std::vector<ov::genai::GenerationConfig> generation_configs = {std::move(generation_config)};
-        const auto decoded_results = m_impl.generate(
-            {prompt},
-            ov::genai::images_batches({images}),
-            ov::genai::videos_batches({videos}),
-            ov::genai::videos_metadata_batches({videos_metadata}),
-            ov::genai::generation_config_batches(generation_configs),
-            ov::genai::streamer(streamer)
-        )[0];
+        std::vector<ov::genai::GenerationConfig> generation_configs = {generation_config};
+        const auto decoded_results = m_impl.generate({prompt},
+                                                     ov::genai::images_batches({images}),
+                                                     ov::genai::videos_batches({videos}),
+                                                     ov::genai::videos_metadata_batches({videos_metadata}),
+                                                     ov::genai::audios_batches({audios}),
+                                                     ov::genai::generation_config_batches(generation_configs),
+                                                     ov::genai::streamer(streamer))[0];
         auto stop_time = std::chrono::steady_clock::now();
         return finalize_decoded_results(decoded_results, start_time, stop_time);
     }
 
-    VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
-        return generate(history, images, {}, std::move(generation_config), streamer);
+    VLMDecodedResults generate(const ChatHistory& history,
+                               const std::vector<ov::Tensor>& images,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
+        return generate(history, images, {}, generation_config, streamer);
     }
 
-    VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
-        return generate(history, images, videos, {}, std::move(generation_config), streamer);
+    VLMDecodedResults generate(const ChatHistory& history,
+                               const std::vector<ov::Tensor>& images,
+                               const std::vector<ov::Tensor>& videos,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
+        return generate(history, images, videos, {}, {}, generation_config, streamer);
     }
 
-    VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) override {
+    VLMDecodedResults generate(const ChatHistory& history,
+                               const std::vector<ov::Tensor>& images,
+                               const std::vector<ov::Tensor>& videos,
+                               const std::vector<ov::Tensor>& audios,
+                               const std::vector<VideoMetadata>& videos_metadata,
+                               const GenerationConfig& generation_config,
+                               const StreamerVariant& streamer) override {
         auto start_time = std::chrono::steady_clock::now();
-        // Ensure chat history internal state is initialized for original history
         ChatHistoryInternalState::get_or_create(history);
-        std::vector<ov::genai::GenerationConfig> generation_configs = {std::move(generation_config)};
-        const auto decoded_results = m_impl.generate(
-            {history},
-            ov::genai::images_batches({images}),
-            ov::genai::videos_batches({videos}),
-            ov::genai::videos_metadata_batches({videos_metadata}),
-            ov::genai::generation_config_batches(generation_configs),
-            ov::genai::streamer(streamer)
-        )[0];
+        std::vector<ov::genai::GenerationConfig> generation_configs = {generation_config};
+        const auto decoded_results = m_impl.generate({history},
+                                                     ov::genai::images_batches({images}),
+                                                     ov::genai::videos_batches({videos}),
+                                                     ov::genai::videos_metadata_batches({videos_metadata}),
+                                                     ov::genai::audios_batches({audios}),
+                                                     ov::genai::generation_config_batches(generation_configs),
+                                                     ov::genai::streamer(streamer))[0];
         auto stop_time = std::chrono::steady_clock::now();
         return finalize_decoded_results(decoded_results, start_time, stop_time);
     }
 
-    virtual void start_chat(const std::string& system_message) override { m_impl.start_chat(system_message); };
+    void start_chat(const std::string& system_message) override {
+        m_impl.start_chat(system_message);
+    }
 
-    virtual void finish_chat() override { m_impl.finish_chat(); };
+    void finish_chat() override {
+        m_impl.finish_chat();
+    }
 
-    virtual Tokenizer get_tokenizer() const override { return m_impl.get_tokenizer(); };
+    Tokenizer get_tokenizer() const override {
+        return m_impl.get_tokenizer();
+    }
 
-    virtual void set_chat_template(const std::string& new_template) override { OPENVINO_THROW("Chat mode is not supported."); };
+    void set_chat_template(const std::string& new_template) override {
+        OPENVINO_THROW("Chat mode is not supported.");
+    }
 
-    virtual GenerationConfig get_generation_config() const override { return m_impl.get_config(); };
+    GenerationConfig get_generation_config() const override {
+        return m_impl.get_config();
+    }
 
-    virtual void set_generation_config(const GenerationConfig& new_config)  override { m_impl.set_config(new_config); };
+    void set_generation_config(const GenerationConfig& new_config) override {
+        m_impl.set_config(new_config);
+    }
+
+    bool supports_hidden_states_collection() const override {
+        return true;
+    }
+
+    bool is_audio_output_enabled() const override {
+        return m_vlm_config.enable_audio_output;
+    }
 
 private:
-    VLMDecodedResults finalize_decoded_results(
-        const VLMDecodedResults& decoded_results,
-        std::chrono::steady_clock::time_point start_time,
-        std::chrono::steady_clock::time_point stop_time
-    ) {
-        VLMDecodedResults final_decoded_results;
-        final_decoded_results.perf_metrics = decoded_results.perf_metrics;
-        final_decoded_results.perf_metrics.load_time = get_load_time();
-        final_decoded_results.perf_metrics.raw_metrics.generate_durations.clear();
-        final_decoded_results.perf_metrics.raw_metrics.generate_durations.emplace_back(
-            PerfMetrics::get_microsec(stop_time - start_time)
-        );
-        final_decoded_results.perf_metrics.m_evaluated = false;
-        final_decoded_results.perf_metrics.evaluate_statistics(start_time);
-        final_decoded_results.texts = decoded_results.texts;
-        final_decoded_results.scores = decoded_results.scores;
-        final_decoded_results.finish_reasons = decoded_results.finish_reasons;
-        final_decoded_results.extended_perf_metrics = decoded_results.extended_perf_metrics;
-        return final_decoded_results;
+    /// VLM config loaded once at construction so model-type/audio-output queries are cheap.
+    /// Empty/default when no config.json is present (e.g., test scaffolding paths).
+    VLMConfig m_vlm_config;
+
+    void load_vlm_config(const std::filesystem::path& models_dir) {
+        if (!std::filesystem::exists(models_dir / "config.json")) {
+            return;
+        }
+        m_vlm_config = utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json");
+    }
+
+    /// @brief Build VLMDecodedResults from CB generate output, attaching pipeline-level perf metrics.
+    /// Speech generation is intentionally NOT performed here; the speech pipeline lives in
+    /// `OmniPipelineImpl`.
+    VLMDecodedResults finalize_decoded_results(const VLMDecodedResults& result,
+                                               std::chrono::steady_clock::time_point start_time,
+                                               std::chrono::steady_clock::time_point stop_time) {
+        VLMDecodedResults decoded;
+        decoded.perf_metrics = result.perf_metrics;
+        decoded.perf_metrics.load_time = get_load_time();
+        decoded.perf_metrics.raw_metrics.generate_durations.clear();
+        decoded.perf_metrics.raw_metrics.generate_durations.emplace_back(
+            PerfMetrics::get_microsec(stop_time - start_time));
+        decoded.perf_metrics.m_evaluated = false;
+        decoded.perf_metrics.evaluate_statistics(start_time);
+        decoded.extended_perf_metrics = result.extended_perf_metrics;
+
+        for (size_t idx = 0; idx < result.texts.size(); ++idx) {
+            decoded.texts.push_back(result.texts.at(idx));
+            decoded.scores.push_back(result.scores.at(idx));
+        }
+        decoded.finish_reasons = result.finish_reasons;
+        // Forward hidden-states fields so OmniPipelineImpl / TalkerBase can drive speech
+        // generation. Inner ov::Tensor copies are ref-counted handles, so the outer-vector
+        // copies are O(n) in step count, not in tensor bytes.
+        decoded.intermediate_hidden_states = result.intermediate_hidden_states;
+        decoded.full_token_ids = result.full_token_ids;
+        return decoded;
     }
 };

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -12,6 +12,7 @@
 #include "visual_language/qwen2_5_vl/classes.hpp"
 #include "visual_language/qwen3_vl/classes.hpp"
 #include "visual_language/qwen3_5/classes.hpp"
+#include "visual_language/qwen3_omni/classes.hpp"
 #include "visual_language/phi3_vision/classes.hpp"
 #include "visual_language/phi4mm/classes.hpp"
 #include "visual_language/minicpm/classes.hpp"
@@ -40,8 +41,6 @@ void throw_if_video_not_implemented(const std::vector<VideoType>& videos) {
 }  // anonymous namespace
 
 namespace ov::genai {
-
-// Base InputsEmbedder class
 
 std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::IInputsEmbedder::get_position_ids(const size_t inputs_embeds_size, const size_t history_size) {
     ov::Tensor position_ids = ov::Tensor{ov::element::i64, { 1, inputs_embeds_size }};
@@ -206,6 +205,22 @@ ov::Tensor InputsEmbedder::IInputsEmbedder::sample_video_if_needed(
         return video;
     }
 
+    // Skip the allocate + per-frame memcpy when the indices select every frame in order (identity
+    // sampling). fill_video_metadata populates the full [0..N-1] range when do_sample_frames is
+    // false (needed for timestamps), which would otherwise trigger a full no-op copy of the video.
+    if (video_metadata.frames_indices.size() == video_frames_num) {
+        bool is_identity = true;
+        for (size_t i = 0; i < video_frames_num; ++i) {
+            if (video_metadata.frames_indices[i] != i) {
+                is_identity = false;
+                break;
+            }
+        }
+        if (is_identity) {
+            return video;
+        }
+    }
+
     ov::Tensor sampled(video.get_element_type(),
         {video_metadata.frames_indices.size(), video_shape[1], video_shape[2], video_shape[3]});
         
@@ -321,8 +336,6 @@ const std::unordered_map<std::string, ov::Tensor>& InputsEmbedder::IInputsEmbedd
     return empty_map;
 }
 
-/// Public InputsEmbedder class
-
 InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
                                const std::string& device,
                                const ov::AnyMap device_config) {
@@ -352,6 +365,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderQwen3VL>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN3_5 || vlm_config.model_type == VLMModelType::QWEN3_5_MOE) {
         m_impl = std::make_shared<InputsEmbedderQwen3_5>(vlm_config, model_dir, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::QWEN3_OMNI) {
+        m_impl = std::make_shared<InputsEmbedderQwen3Omni>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3) {
         m_impl = std::make_shared<InputsEmbedderGemma3>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3N) {
@@ -398,6 +413,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderQwen3VL>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN3_5 || vlm_config.model_type == VLMModelType::QWEN3_5_MOE) {
         m_impl = std::make_shared<InputsEmbedderQwen3_5>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::QWEN3_OMNI) {
+        m_impl = std::make_shared<InputsEmbedderQwen3Omni>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3) {
         m_impl = std::make_shared<InputsEmbedderGemma3>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3N) {
@@ -487,6 +504,10 @@ std::vector<ov::genai::EncodedVideo> InputsEmbedder::encode_videos(
     return m_impl->encode_videos(videos, videos_metadata);
 }
 
+void InputsEmbedder::encode_audios(const std::vector<ov::Tensor>& audios) {
+    m_impl->encode_audios(audios);
+}
+
 std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::get_position_ids(const size_t inputs_embeds_size, const size_t history_size) {
     return m_impl->get_position_ids(inputs_embeds_size, history_size);
 }
@@ -512,7 +533,7 @@ EmbeddingsModel::Ptr InputsEmbedder::get_embedding_model() const {
 }
 
 ov::genai::utils::CacheState& InputsEmbedder::get_cache_state() {
-    return  m_impl->get_cache_state();
+    return m_impl->get_cache_state();
 }
 
 Tokenizer InputsEmbedder::get_tokenizer() const {
@@ -520,23 +541,23 @@ Tokenizer InputsEmbedder::get_tokenizer() const {
 }
 
 void InputsEmbedder::start_chat(const std::string& system_message) {
-    return m_impl->start_chat(system_message);
+    m_impl->start_chat(system_message);
 }
 
 void InputsEmbedder::update_chat_history(const std::string& decoded_results, const ov::genai::GenerationStatus generation_finish_status) {
-    return m_impl->update_chat_history(decoded_results, generation_finish_status);
+    m_impl->update_chat_history(decoded_results, generation_finish_status);
 }
 
 void InputsEmbedder::set_apply_chat_template_status(bool apply_chat_template) {
-    return m_impl->set_apply_chat_template_status(apply_chat_template);
+    m_impl->set_apply_chat_template_status(apply_chat_template);
 }
 
 void InputsEmbedder::finish_chat() {
-    return m_impl->finish_chat();
+    m_impl->finish_chat();
 }
 
 void InputsEmbedder::set_vision_token_pruning_config(size_t pruning_ratio, float relevance_weight) {
-    return m_impl->set_vision_token_pruning_config(pruning_ratio, relevance_weight);
+    m_impl->set_vision_token_pruning_config(pruning_ratio, relevance_weight);
 }
 
 std::string InputsEmbedder::get_last_pruned_prompt(const std::string& original_prompt) const {
@@ -558,7 +579,7 @@ NormalizedPrompt InputsEmbedder::normalize_prompt(const std::string& prompt,
     const std::vector<EncodedImage>& images,
     const std::vector<EncodedVideo>& videos
 ) const {
-     return m_impl->normalize_prompt(prompt, base_image_id, base_video_id, images, videos);
+    return m_impl->normalize_prompt(prompt, base_image_id, base_video_id, images, videos);
 }
 
 void verify_ids(const std::vector<size_t>& vision_indices, size_t base_idx, size_t n_visions) {

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -83,6 +83,8 @@ public:
         const std::vector<VideoMetadata>& videos_metadata = {}
     );
 
+    void encode_audios(const std::vector<ov::Tensor>& audios);
+
     // compute position ids for language model input
     std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
 
@@ -212,6 +214,8 @@ private:
             const std::vector<ov::Tensor>& videos,
             const std::vector<VideoMetadata>& videos_metadata = {}
         );
+
+        virtual void encode_audios(const std::vector<ov::Tensor>& audios) {}
 
         virtual std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
         
@@ -382,6 +386,7 @@ private:
     friend class InputsEmbedderQwen2_5_VL;
     friend class InputsEmbedderQwen3VL;
     friend class InputsEmbedderQwen3_5;
+    friend class InputsEmbedderQwen3Omni;
     friend class InputsEmbedderGemma3;
     friend class InputsEmbedderGemma3n;
     friend class InputsEmbedderGemma4;

--- a/src/cpp/src/visual_language/multimodal_inputs.hpp
+++ b/src/cpp/src/visual_language/multimodal_inputs.hpp
@@ -13,31 +13,31 @@
 
 namespace ov::genai {
 
-struct VisionProperties {
+struct MultimodalInputs {
     std::optional<std::vector<ov::Tensor>> images;
     std::optional<std::vector<ov::Tensor>> videos;
     std::optional<std::vector<VideoMetadata>> videos_metadata;
+    std::optional<std::vector<ov::Tensor>> audios;
 
     bool has_value() const {
-        return images.has_value() || videos.has_value() || videos_metadata.has_value();
+        return images.has_value() || videos.has_value() || videos_metadata.has_value() || audios.has_value();
     }
 };
 
-inline VisionProperties extract_vision_properties(const ov::AnyMap& properties_map) {
-    VisionProperties vision_properties;
-    
+inline MultimodalInputs extract_multimodal_inputs(const ov::AnyMap& properties_map) {
+    MultimodalInputs multimodal_inputs;
+
     const auto image_it = properties_map.find(ov::genai::image.name());
     if (image_it != properties_map.end()) {
-        vision_properties.images = {image_it->second.as<ov::Tensor>()};
+        multimodal_inputs.images = {image_it->second.as<ov::Tensor>()};
     }
 
     const auto images_it = properties_map.find(ov::genai::images.name());
     if (images_it != properties_map.end()) {
         if (images_it->second.is<std::vector<ov::Tensor>>()) {
-            const auto images = images_it->second.as<std::vector<ov::Tensor>>();
-            vision_properties.images = images_it->second.as<std::vector<ov::Tensor>>();
+            multimodal_inputs.images = images_it->second.as<std::vector<ov::Tensor>>();
         } else if (images_it->second.is<ov::Tensor>()) {
-            vision_properties.images = {images_it->second.as<ov::Tensor>()};
+            multimodal_inputs.images = {images_it->second.as<ov::Tensor>()};
         } else if (!images_it->second.empty()) {
             OPENVINO_THROW("Unknown images type.");
         }
@@ -46,9 +46,9 @@ inline VisionProperties extract_vision_properties(const ov::AnyMap& properties_m
     const auto videos_it = properties_map.find(ov::genai::videos.name());
     if (videos_it != properties_map.end()) {
         if (videos_it->second.is<std::vector<ov::Tensor>>()) {
-            vision_properties.videos = videos_it->second.as<std::vector<ov::Tensor>>();
+            multimodal_inputs.videos = videos_it->second.as<std::vector<ov::Tensor>>();
         } else if (videos_it->second.is<ov::Tensor>()) {
-            vision_properties.videos = {videos_it->second.as<ov::Tensor>()};
+            multimodal_inputs.videos = {videos_it->second.as<ov::Tensor>()};
         } else if (!videos_it->second.empty()) {
             OPENVINO_THROW("Unknown videos type.");
         }
@@ -57,15 +57,26 @@ inline VisionProperties extract_vision_properties(const ov::AnyMap& properties_m
     const auto videos_metadata_it = properties_map.find(ov::genai::videos_metadata.name());
     if (videos_metadata_it != properties_map.end()) {
         if (videos_metadata_it->second.is<std::vector<VideoMetadata>>()) {
-            vision_properties.videos_metadata = videos_metadata_it->second.as<std::vector<VideoMetadata>>();
+            multimodal_inputs.videos_metadata = videos_metadata_it->second.as<std::vector<VideoMetadata>>();
         } else if (videos_metadata_it->second.is<VideoMetadata>()) {
-            vision_properties.videos_metadata = {videos_metadata_it->second.as<VideoMetadata>()};
+            multimodal_inputs.videos_metadata = {videos_metadata_it->second.as<VideoMetadata>()};
         } else if (!videos_metadata_it->second.empty()) {
             OPENVINO_THROW("Unknown videos metadata type.");
         }
     }
 
-    return vision_properties;
+    const auto audios_it = properties_map.find(ov::genai::audios.name());
+    if (audios_it != properties_map.end()) {
+        if (audios_it->second.is<std::vector<ov::Tensor>>()) {
+            multimodal_inputs.audios = audios_it->second.as<std::vector<ov::Tensor>>();
+        } else if (audios_it->second.is<ov::Tensor>()) {
+            multimodal_inputs.audios = {audios_it->second.as<ov::Tensor>()};
+        } else if (!audios_it->second.empty()) {
+            OPENVINO_THROW("Unknown audios type.");
+        }
+    }
+
+    return multimodal_inputs;
 }
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -54,9 +54,11 @@ void npu_auto_default_properties(ov::AnyMap& device_properties) {
 
 }
 
-class VLMPipeline::VLMPipelineImpl : public VLMPipelineBase{
+class VLMPipeline::VLMPipelineImpl : public VLMBackend{
     // A config to follow for text generation.
     GenerationConfig m_generation_config;
+    // VLM model config (model_type, enable_audio_output, etc.); loaded from config.json.
+    VLMConfig m_vlm_config;
     // A tokenizer encoding a prompt.
     Tokenizer m_tokenizer;
     // A model to compute token embeddings.
@@ -245,6 +247,9 @@ public:
             utils::from_config_json_if_exists<GenerationConfig>(
                 models_dir, "generation_config.json"
             )
+        },
+        m_vlm_config{
+            utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json")
         } {
         auto language_model_path = models_dir / "openvino_language_model.xml";
         auto properties_copy = properties;
@@ -263,7 +268,10 @@ public:
         const ov::AnyMap& properties,
         const GenerationConfig& generation_config
     ) :
-        m_generation_config{generation_config} {
+        m_generation_config{generation_config},
+        m_vlm_config{
+            utils::from_config_json_if_exists<VLMConfig>(config_dir_path, "config.json")
+        } {
         auto properties_copy = properties;
         utils::extract_extensions_to_core(properties_copy);
         const auto& language_pair = utils::get_model_weights_pair(models_map, "language");
@@ -281,6 +289,9 @@ public:
             utils::from_config_json_if_exists<GenerationConfig>(
                 models_dir, "generation_config.json"
             )
+        },
+        m_vlm_config{
+            utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json")
         } {
         initialize_from_model_and_dir(language_model, models_dir, device, properties);
     }
@@ -294,37 +305,44 @@ public:
         const ov::AnyMap& properties,
         const GenerationConfig& generation_config
     ) :
-        m_generation_config{generation_config} {
+        m_generation_config{generation_config},
+        m_vlm_config{
+            utils::from_config_json_if_exists<VLMConfig>(config_dir_path, "config.json")
+        } {
         initialize_from_model_and_map(language_model, models_map, tokenizer, config_dir_path, device, properties);
     }
 
     VLMDecodedResults generate(
         const std::string& prompt,
         const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config,
         const StreamerVariant& streamer
     ) override {
-        return generate(prompt, images, {}, std::move(generation_config), streamer);
+        return generate(prompt, images, {}, generation_config, streamer);
     }
 
     VLMDecodedResults generate(
         const std::string& prompt,
         const std::vector<ov::Tensor>& images,
         const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config,
         const StreamerVariant& streamer
     ) override {
-        return generate(prompt, images, videos, {}, std::move(generation_config), streamer);
+        return generate(prompt, images, videos, {}, {}, generation_config, streamer);
     }
 
     VLMDecodedResults generate(
         const std::string& prompt,
         const std::vector<ov::Tensor>& images,
         const std::vector<ov::Tensor>& videos,
+        const std::vector<ov::Tensor>& audios,
         const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config_in,
         const StreamerVariant& streamer
     ) override {
+        // Local mutable copy: setup_generation_config(...) and downstream callees mutate fields
+        // (rng_seed, eos_token_id, ...). The public-base signature is const-ref by contract.
+        GenerationConfig generation_config = generation_config_in;
         auto generate_start_time = std::chrono::steady_clock::now();
         VLMPerfMetrics perf_metrics;
         auto& raw_counters = perf_metrics.raw_metrics;
@@ -346,6 +364,7 @@ public:
                                                            generation_config.relevance_weight);
 
         const auto embeddings_start_time = std::chrono::steady_clock::now();
+        m_inputs_embedder->encode_audios(audios);
         auto encoded_images = m_inputs_embedder->encode_images(images);
         auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
         auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
@@ -486,30 +505,32 @@ public:
     VLMDecodedResults generate(
         const ChatHistory& history,
         const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config,
         const StreamerVariant& streamer
     ) override {
-        return generate(history, images, {}, std::move(generation_config), streamer);
+        return generate(history, images, {}, generation_config, streamer);
     }
 
     VLMDecodedResults generate(
         const ChatHistory& history,
         const std::vector<ov::Tensor>& images,
         const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config,
         const StreamerVariant& streamer
     ) override {
-        return generate(history, images, videos, {}, std::move(generation_config), streamer);
+        return generate(history, images, videos, {}, {}, generation_config, streamer);
     }
 
     VLMDecodedResults generate(
         const ChatHistory& history,
         const std::vector<ov::Tensor>& images,
         const std::vector<ov::Tensor>& videos,
+        const std::vector<ov::Tensor>& audios,
         const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
+        const GenerationConfig& generation_config_in,
         const StreamerVariant& streamer
     ) override {
+        GenerationConfig generation_config = generation_config_in;
         auto generate_start_time = std::chrono::steady_clock::now();
         VLMPerfMetrics perf_metrics;
         auto& raw_counters = perf_metrics.raw_metrics;
@@ -681,6 +702,14 @@ public:
             m_generation_config.set_eos_token_id(default_eos_token_id);
 
         m_generation_config.validate();
+    }
+
+    bool supports_hidden_states_collection() const override {
+        return false;
+    }
+
+    bool is_audio_output_enabled() const override {
+        return m_vlm_config.enable_audio_output;
     }
 
 private:
@@ -869,7 +898,7 @@ VLMPipeline::VLMPipeline(
     if (device == "NPU") {
         auto it = properties.find("scheduler_config");
         OPENVINO_ASSERT(it == properties.end(), "scheduler_config should be removed for VLMPipeline initialization");
-        m_pimpl = std::make_unique<VLMPipelineImpl>(models_dir, device, properties);
+        m_pimpl = std::make_shared<VLMPipelineImpl>(models_dir, device, properties);
     } else {
         utils::extract_extensions_to_core(properties);
         auto language_model_path = models_dir / "openvino_language_model.xml";
@@ -879,8 +908,7 @@ VLMPipeline::VLMPipeline(
         // If CB is invoked explicitly, create CB adapter as is and re-throw in case if internal issues
         if (utils::explicitly_requires_paged_attention(user_properties)) {
             auto [plugin_properties, scheduler_config] = utils::extract_scheduler_config(properties, utils::get_latency_oriented_scheduler_config());
-            m_pimpl = std::make_unique<VLMContinuousBatchingAdapter>(
-                language_model, models_dir, scheduler_config, device, plugin_properties);
+            m_pimpl = std::make_shared<VLMContinuousBatchingAdapter>(language_model, models_dir, scheduler_config, device, plugin_properties);
         } else if (attention_backend == PA_BACKEND && !requires_sdpa(models_dir)) {
             // try to call CB adapter one more time, but with safe guard to silent exception
             try {
@@ -888,8 +916,7 @@ VLMPipeline::VLMPipeline(
                 // we need use CB only for x86 and arm64, as for other architectures like risc-v we can create Paged Attention based model
                 // but cannot perform its inference later
     #if defined(OPENVINO_ARCH_X86_64) || defined(OPENVINO_ARCH_ARM64)
-                m_pimpl = std::make_unique<VLMContinuousBatchingAdapter>(
-                    language_model, models_dir, scheduler_config, device, plugin_properties);
+                m_pimpl = std::make_shared<VLMContinuousBatchingAdapter>(language_model, models_dir, scheduler_config, device, plugin_properties);
 #endif
             } catch (const ov::Exception& exception) {
                 log_paged_attention_fallback(exception);
@@ -898,7 +925,7 @@ VLMPipeline::VLMPipeline(
         }
 
         if (m_pimpl == nullptr) {
-            m_pimpl = std::make_unique<VLMPipelineImpl>(language_model, models_dir, device, properties);
+            m_pimpl = std::make_shared<VLMPipelineImpl>(language_model, models_dir, device, properties);
         }
     }
 
@@ -922,7 +949,7 @@ VLMPipeline::VLMPipeline(
     if (device == "NPU") {
         auto it = properties.find("scheduler_config");
         OPENVINO_ASSERT(it == properties.end(), "scheduler_config should be removed for VLMPipeline initialization");
-        m_pimpl = std::make_unique<VLMPipelineImpl>(models_map, tokenizer, config_dir_path, device, properties, generation_config);
+        m_pimpl = std::make_shared<VLMPipelineImpl>(models_map, tokenizer, config_dir_path, device, properties, generation_config);
     } else {
         utils::extract_extensions_to_core(properties);
         const auto& [model_str, weights] = utils::get_model_weights_pair(models_map, "language");
@@ -931,7 +958,7 @@ VLMPipeline::VLMPipeline(
         // If CB is invoked explicitly, create CB adapter as is and re-throw in case if internal issues
         if (utils::explicitly_requires_paged_attention(user_properties)) {
             auto [plugin_properties, scheduler_config] = utils::extract_scheduler_config(properties, utils::get_latency_oriented_scheduler_config());
-            m_pimpl = std::make_unique<VLMContinuousBatchingAdapter>(language_model, models_map, tokenizer, config_dir_path, scheduler_config, device, plugin_properties, generation_config);
+            m_pimpl = std::make_shared<VLMContinuousBatchingAdapter>(language_model, models_map, tokenizer, config_dir_path, scheduler_config, device, plugin_properties, generation_config);
         } else if (attention_backend == PA_BACKEND && !requires_sdpa(config_dir_path)) {
             // try to call CB adapter one more time, but with safe guard to silent exception
             try {
@@ -939,7 +966,7 @@ VLMPipeline::VLMPipeline(
                 // we need use CB only for x86 and arm64, as for other architectures like risc-v we can create Paged Attention based model
                 // but cannot perform its inference later
     #if defined(OPENVINO_ARCH_X86_64) || defined(OPENVINO_ARCH_ARM64)
-                m_pimpl = std::make_unique<VLMContinuousBatchingAdapter>(language_model, models_map, tokenizer, config_dir_path, scheduler_config, device, plugin_properties, generation_config);
+                m_pimpl = std::make_shared<VLMContinuousBatchingAdapter>(language_model, models_map, tokenizer, config_dir_path, scheduler_config, device, plugin_properties, generation_config);
     #endif
             } catch (const ov::Exception& exception) {
                 log_paged_attention_fallback(exception);
@@ -948,7 +975,7 @@ VLMPipeline::VLMPipeline(
         }
 
         if (m_pimpl == nullptr) {
-            m_pimpl = std::make_unique<VLMPipelineImpl>(language_model, models_map, tokenizer, config_dir_path, device, properties, generation_config);
+            m_pimpl = std::make_shared<VLMPipelineImpl>(language_model, models_map, tokenizer, config_dir_path, device, properties, generation_config);
         }
 
     }
@@ -984,7 +1011,19 @@ VLMDecodedResults VLMPipeline::generate(
     const GenerationConfig& generation_config,
     const StreamerVariant& streamer
 ) {
-    return m_pimpl->generate(prompt, {image}, generation_config, streamer);
+    return m_pimpl->generate(prompt, std::vector<ov::Tensor>{image}, generation_config, streamer);
+}
+
+VLMDecodedResults VLMPipeline::generate(
+    const std::string& prompt,
+    const std::vector<ov::Tensor>& images,
+    const std::vector<ov::Tensor>& videos,
+    const std::vector<ov::Tensor>& audios,
+    const std::vector<VideoMetadata>& videos_metadata,
+    const GenerationConfig& generation_config,
+    const StreamerVariant& streamer
+) {
+    return m_pimpl->generate(prompt, images, videos, audios, videos_metadata, generation_config, streamer);
 }
 
 VLMDecodedResults VLMPipeline::generate(
@@ -1019,7 +1058,19 @@ VLMDecodedResults VLMPipeline::generate(
     const GenerationConfig& generation_config,
     const StreamerVariant& streamer
 ) {
-    return m_pimpl->generate(history, {image}, generation_config, streamer);
+    return m_pimpl->generate(history, std::vector<ov::Tensor>{image}, generation_config, streamer);
+}
+
+VLMDecodedResults VLMPipeline::generate(
+    const ChatHistory& history,
+    const std::vector<ov::Tensor>& images,
+    const std::vector<ov::Tensor>& videos,
+    const std::vector<ov::Tensor>& audios,
+    const std::vector<VideoMetadata>& videos_metadata,
+    const GenerationConfig& generation_config,
+    const StreamerVariant& streamer
+) {
+    return m_pimpl->generate(history, images, videos, audios, videos_metadata, generation_config, streamer);
 }
 
 VLMDecodedResults VLMPipeline::generate(
@@ -1052,4 +1103,12 @@ GenerationConfig VLMPipeline::get_generation_config() const {
 
 void VLMPipeline::set_generation_config(const GenerationConfig& new_config) {
     m_pimpl->set_generation_config(new_config);
+}
+
+bool VLMPipeline::supports_hidden_states_collection() const {
+    return m_pimpl->supports_hidden_states_collection();
+}
+
+bool VLMPipeline::is_audio_output_enabled() const {
+    return m_pimpl->is_audio_output_enabled();
 }

--- a/src/cpp/src/visual_language/pipeline_base.cpp
+++ b/src/cpp/src/visual_language/pipeline_base.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/pipeline_base.hpp"
+
+#include "utils.hpp"
+#include "visual_language/multimodal_inputs.hpp"
+
+namespace ov {
+namespace genai {
+
+VLMPipeline::VLMBackend::VLMBackend() : m_attention_backend(SDPA_BACKEND) {}
+
+VLMPipeline::VLMBackend::~VLMBackend() = default;
+
+GenerationConfig VLMPipeline::VLMBackend::resolve_generation_config(const ov::AnyMap& config_map) {
+    ov::genai::OptionalGenerationConfig optional_config = utils::get_config_from_map(config_map);
+    GenerationConfig config = optional_config.value_or(get_generation_config());
+    config.update_generation_config(config_map);
+    return config;
+}
+
+VLMDecodedResults VLMPipeline::VLMBackend::generate(const std::string& prompt, const ov::AnyMap& config_map) {
+    const auto multimodal_inputs = extract_multimodal_inputs(config_map);
+    m_pending_speech_streamer = utils::get_audio_streamer_from_map(config_map);
+    GenerationConfig config = resolve_generation_config(config_map);
+    AudioStreamerGuard guard{m_pending_speech_streamer};
+    return generate(prompt,
+                    multimodal_inputs.images.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.videos.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.audios.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.videos_metadata.value_or(std::vector<VideoMetadata>{}),
+                    config,
+                    utils::get_streamer_from_map(config_map));
+}
+
+VLMDecodedResults VLMPipeline::VLMBackend::generate(const ChatHistory& history, const ov::AnyMap& config_map) {
+    const auto multimodal_inputs = extract_multimodal_inputs(config_map);
+    m_pending_speech_streamer = utils::get_audio_streamer_from_map(config_map);
+    GenerationConfig config = resolve_generation_config(config_map);
+    AudioStreamerGuard guard{m_pending_speech_streamer};
+    return generate(history,
+                    multimodal_inputs.images.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.videos.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.audios.value_or(std::vector<ov::Tensor>{}),
+                    multimodal_inputs.videos_metadata.value_or(std::vector<VideoMetadata>{}),
+                    config,
+                    utils::get_streamer_from_map(config_map));
+}
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/visual_language/pipeline_base.hpp
+++ b/src/cpp/src/visual_language/pipeline_base.hpp
@@ -3,120 +3,57 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
+#include "openvino/genai/omni/speech_streamer_base.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
-#include "visual_language/vision_properties.hpp"
-#include "utils.hpp"
+#include "openvino/runtime/tensor.hpp"
 
-using namespace ov::genai;
+namespace ov {
+namespace genai {
 
-namespace ov::genai {
-class ov::genai::VLMPipeline::VLMPipelineBase {
-    // Load pipeline time
-    float m_load_time_ms = 0;
-    std::string m_attention_backend = SDPA_BACKEND;
+/**
+ * @brief Internal Omni-aware base for `VLMPipeline` implementations.
+ */
+class VLMPipeline::VLMBackend : public ov::genai::VLMPipelineBase {
+    float m_load_time_ms = 0.0f;
+    std::string m_attention_backend;
 
-    GenerationConfig resolve_generation_config(const ov::AnyMap& config_map) {
-        ov::genai::OptionalGenerationConfig optional_config = utils::get_config_from_map(config_map);
-        GenerationConfig config = optional_config.value_or(get_generation_config());
-        config.update_generation_config(config_map);
-        return config;
-    }
+protected:
+    VLMBackend();
+
+    // Audio streamer extracted from AnyMap, forwarded to speech pipeline
+    OmniSpeechStreamerVariant m_pending_speech_streamer = std::monostate{};
+
+    // RAII guard to reset the audio streamer on scope exit (exception-safe)
+    struct AudioStreamerGuard {
+        OmniSpeechStreamerVariant& streamer_ref;
+        ~AudioStreamerGuard() {
+            streamer_ref = std::monostate{};
+        }
+    };
+
+    GenerationConfig resolve_generation_config(const ov::AnyMap& config_map);
 
 public:
+    ~VLMBackend() override;
 
-    virtual ~VLMPipelineBase() = default;
+    // Bring in the generate() overloads declared on the public abstract base so callers
+    // that hold `VLMPipeline::VLMBackend*` can reach all of them (otherwise the
+    // AnyMap overrides below would hide the inherited ones via name lookup rules).
+    // The videos_metadata-aware overloads and the Omni hooks are declared on VLMPipelineBase.
+    using ov::genai::VLMPipelineBase::generate;
 
-    virtual VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
+    /// @brief Public-base AnyMap entry — extracts audios/streamer/vision props then delegates.
+    VLMDecodedResults generate(const std::string& prompt, const ov::AnyMap& config_map) override;
+    VLMDecodedResults generate(const ChatHistory& history, const ov::AnyMap& config_map) override;
 
-    virtual VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
-
-    virtual VLMDecodedResults generate(
-        const std::string& prompt,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
-
-    VLMDecodedResults generate(
-        const std::string& prompt,
-        const ov::AnyMap& config_map
-    ) {
-        const auto vision_properties = extract_vision_properties(config_map);
-        GenerationConfig config = resolve_generation_config(config_map);
-        return generate(
-            prompt,
-            vision_properties.images.value_or(std::vector<ov::Tensor>{}),
-            vision_properties.videos.value_or(std::vector<ov::Tensor>{}),
-            vision_properties.videos_metadata.value_or(std::vector<VideoMetadata>{}),
-            config,
-            utils::get_streamer_from_map(config_map)
-        );
-    }
-
-    virtual VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
-
-    virtual VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
-
-    virtual VLMDecodedResults generate(
-        const ChatHistory& history,
-        const std::vector<ov::Tensor>& images,
-        const std::vector<ov::Tensor>& videos,
-        const std::vector<VideoMetadata>& videos_metadata,
-        GenerationConfig generation_config,
-        const StreamerVariant& streamer
-    ) = 0;
-
-    VLMDecodedResults generate(
-        const ChatHistory& history,
-        const ov::AnyMap& config_map
-    ) {
-        const auto vision_properties = extract_vision_properties(config_map);
-        GenerationConfig config = resolve_generation_config(config_map);
-        return generate(
-            history,
-            vision_properties.images.value_or(std::vector<ov::Tensor>{}),
-            vision_properties.videos.value_or(std::vector<ov::Tensor>{}),
-            vision_properties.videos_metadata.value_or(std::vector<VideoMetadata>{}),
-            config,
-            utils::get_streamer_from_map(config_map)
-        );
-    }
-
+    /// @brief Activate chat mode (legacy stateful path; deprecated on `VLMPipeline` itself
+    /// but kept on the internal base because OmniPipeline / pipeline_base.cpp still calls
+    /// these to thread through impls).
     virtual void start_chat(const std::string& system_message) = 0;
-
     virtual void finish_chat() = 0;
-
-    virtual Tokenizer get_tokenizer() const = 0;
-
-    virtual void set_chat_template(const std::string& new_template) = 0;
-
-    virtual GenerationConfig get_generation_config() const = 0;
-
-    virtual void set_generation_config(const GenerationConfig& new_config) = 0;
 
     void set_attention_backend(const std::string& attention_backend) {
         m_attention_backend = attention_backend;
@@ -126,8 +63,10 @@ public:
         m_load_time_ms = load_time_ms;
     }
 
-    float get_load_time() {
+    float get_load_time() const {
         return m_load_time_ms;
     }
 };
-}  // namespace ov::genai
+
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -682,6 +682,12 @@ VisionEncoderQwen2VL::VisionEncoderQwen2VL(const ModelsMap& models_map,
     }
 }
 
+VisionEncoderQwen2VL::VisionEncoderQwen2VL(const std::filesystem::path& config_dir, ConfigOnlyTag)
+    : VisionEncoder(config_dir, ConfigOnlyTag{}) {}
+
+VisionEncoderQwen2VL::VisionEncoderQwen2VL(const ModelsMap& models_map, const std::filesystem::path& config_dir, ConfigOnlyTag)
+    : VisionEncoder(models_map, config_dir, ConfigOnlyTag{}) {}
+
 // keep both implementations for comparison and testing, here is the cpp version
 void VisionEncoderQwen2VL::encode_with_imagepreprocess_cpp(const std::vector<ov::Tensor>& images,
                                                            const ProcessorConfig& config,
@@ -935,22 +941,25 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     const std::string& device,
     const ov::AnyMap device_config) :
     IInputsEmbedder(vlm_config, model_dir, device, device_config) {
-    auto model = utils::singleton_core().read_model(model_dir / "openvino_vision_embeddings_merger_model.xml");
-    utils::request_vl_sdpa_transformations(model);
+    auto merger_path = model_dir / "openvino_vision_embeddings_merger_model.xml";
+    if (std::filesystem::exists(merger_path)) {
+        auto model = utils::singleton_core().read_model(merger_path);
+        utils::request_vl_sdpa_transformations(model);
 
-    auto compiled_model = utils::singleton_core().compile_model(
-        model, device, utils::get_model_properties(device_config, "vision_embeddings_merger", device));
+        auto compiled_model = utils::singleton_core().compile_model(
+            model, device, utils::get_model_properties(device_config, "vision_embeddings_merger", device));
 
-    m_with_cu_seqlens_input = utils::check_vl_sdpa_transformations(compiled_model);
-    ov::genai::utils::print_compiled_model_properties(compiled_model,
-        m_with_cu_seqlens_input ? "VLM vision embeddings merger model with VLSDPA optimization ENABLED" :
-        "VLM vision embeddings merger model with VLSDPA optimization DISABLED");
+        m_with_cu_seqlens_input = utils::check_vl_sdpa_transformations(compiled_model);
+        ov::genai::utils::print_compiled_model_properties(compiled_model,
+            m_with_cu_seqlens_input ? "VLM vision embeddings merger model with VLSDPA optimization ENABLED" :
+            "VLM vision embeddings merger model with VLSDPA optimization DISABLED");
 
-    m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
-        compiled_model.get_property(ov::optimal_number_of_infer_requests),
-        [&compiled_model]() -> ov::InferRequest {
-            return compiled_model.create_infer_request();
-        });
+        m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled_model.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled_model]() -> ov::InferRequest {
+                return compiled_model.create_infer_request();
+            });
+    }
 
     encode_vision_placeholder_tokens();
 
@@ -965,24 +974,26 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     const std::string& device,
     const ov::AnyMap device_config) :
     IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {
-    auto model = utils::singleton_core().read_model(
-        utils::get_model_weights_pair(models_map, "vision_embeddings_merger").first,
-        utils::get_model_weights_pair(models_map, "vision_embeddings_merger").second);
-    utils::request_vl_sdpa_transformations(model);
+    if (models_map.count("vision_embeddings_merger")) {
+        auto model = utils::singleton_core().read_model(
+            utils::get_model_weights_pair(models_map, "vision_embeddings_merger").first,
+            utils::get_model_weights_pair(models_map, "vision_embeddings_merger").second);
+        utils::request_vl_sdpa_transformations(model);
 
-    auto compiled_model = utils::singleton_core().compile_model(
-        model, device, utils::get_model_properties(device_config, "vision_embeddings_merger", device));
+        auto compiled_model = utils::singleton_core().compile_model(
+            model, device, utils::get_model_properties(device_config, "vision_embeddings_merger", device));
 
-    m_with_cu_seqlens_input = utils::check_vl_sdpa_transformations(compiled_model);
-    ov::genai::utils::print_compiled_model_properties(compiled_model,
-        m_with_cu_seqlens_input ? "VLM vision embeddings merger model with VLSDPA optimization ENABLED" :
-        "VLM vision embeddings merger model with VLSDPA optimization DISABLED");
+        m_with_cu_seqlens_input = utils::check_vl_sdpa_transformations(compiled_model);
+        ov::genai::utils::print_compiled_model_properties(compiled_model,
+            m_with_cu_seqlens_input ? "VLM vision embeddings merger model with VLSDPA optimization ENABLED" :
+            "VLM vision embeddings merger model with VLSDPA optimization DISABLED");
 
-    m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
-        compiled_model.get_property(ov::optimal_number_of_infer_requests),
-        [&compiled_model]() -> ov::InferRequest {
-            return compiled_model.create_infer_request();
-        });
+        m_ireq_queue_vision_embeddings_merger = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled_model.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled_model]() -> ov::InferRequest {
+                return compiled_model.create_infer_request();
+            });
+    }
 
     encode_vision_placeholder_tokens();
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.hpp
@@ -23,6 +23,10 @@ public:
     EncodedVideo encode_frames(const std::vector<ov::Tensor>& frames) override;
 
 protected:
+    // Config-only constructor for subclasses where vision encoder is merged with merger
+    VisionEncoderQwen2VL(const std::filesystem::path& config_dir, ConfigOnlyTag);
+    VisionEncoderQwen2VL(const ModelsMap& models_map, const std::filesystem::path& config_dir, ConfigOnlyTag);
+
     /**
      * @brief Encodes video frames by grouping them into chunks of config.temporal_patch_size adjacent frames
      * and saves results into the encoded_video struct.
@@ -178,6 +182,15 @@ protected:
 };
 
 namespace qwen2_vl_utils {
+
+ImageSize smart_resize(size_t height, size_t width, size_t factor, size_t min_pixels, size_t max_pixels);
+
+ov::Tensor reshape_image_patches(
+    const ov::Tensor& patches,
+    size_t grid_t, size_t grid_h, size_t grid_w,
+    size_t channel, size_t temporal_patch_size, size_t patch_size, size_t merge_size);
+
+ov::Tensor transpose_image_patches(const ov::Tensor& reshaped_patches);
 
 std::pair<std::vector<ov::Tensor>, std::vector<std::array<size_t, 3>>> reorder_image_embeds_and_grid_thw(
     const std::vector<EncodedImage>& encoded_images,

--- a/src/cpp/src/visual_language/qwen3_omni/audio_encoder.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/audio_encoder.cpp
@@ -1,0 +1,213 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/qwen3_omni/audio_encoder.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include "openvino/openvino.hpp"
+#include "utils.hpp"
+
+namespace ov::genai {
+
+namespace {
+// Qwen3-Omni declares "feature_extractor_type": "WhisperFeatureExtractor" in its
+// HF preprocessor_config.json. These match the HF WhisperFeatureExtractor defaults.
+constexpr size_t WHISPER_SAMPLING_RATE = 16000;
+constexpr size_t WHISPER_N_FFT = 400;
+constexpr size_t WHISPER_HOP_LENGTH = 160;
+}  // namespace
+
+AudioEncoderQwen3Omni::AudioEncoderQwen3Omni(const std::filesystem::path& model_dir,
+                                             const VLMConfig& config,
+                                             const std::string& device,
+                                             const ov::AnyMap& properties)
+    : m_config(config),
+      m_feature_extractor(config.audio_config_num_mel_bins,
+                          WHISPER_SAMPLING_RATE,
+                          WHISPER_N_FFT,
+                          WHISPER_HOP_LENGTH) {
+    // Resolve canonical paths to prevent path traversal via attacker-controlled model_dir.
+    const auto canonical_model_dir = std::filesystem::weakly_canonical(model_dir);
+    auto model_path = model_dir / "openvino_audio_encoder_model.xml";
+    auto canonical_model_path = std::filesystem::weakly_canonical(model_path);
+    OPENVINO_ASSERT(canonical_model_path.string().rfind(canonical_model_dir.string(), 0) == 0,
+                    "Refusing to load audio encoder file outside model_dir: ",
+                    canonical_model_path.string());
+    // Audio encoder is optional - model works as text+vision VLM without it
+    if (!std::filesystem::exists(model_path)) {
+        return;
+    }
+
+    OPENVINO_ASSERT(m_config.audio_config_n_window_infer > 0,
+                    "audio_config.n_window_infer must be > 0");
+    OPENVINO_ASSERT(m_config.audio_config_n_window > 0,
+                    "audio_config.n_window must be > 0");
+
+    auto model = utils::singleton_core().read_model(model_path);
+    auto compiled = utils::singleton_core().compile_model(model, device, properties);
+    m_ireq_queue = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled] {
+            return compiled.create_infer_request();
+        });
+}
+
+void AudioEncoderQwen3Omni::validate_audio_shape(const ov::Shape& shape, ov::element::Type element_type) {
+    OPENVINO_ASSERT(element_type == ov::element::f32,
+                    "Audio input must be float32 PCM, got ",
+                    element_type);
+    OPENVINO_ASSERT(shape.size() == 1,
+                    "Audio input must be a 1-D tensor of PCM samples, got rank ",
+                    shape.size());
+    const size_t audio_len = ov::shape_size(shape);
+    OPENVINO_ASSERT(audio_len > WHISPER_N_FFT / 2,
+                    "Audio input too short: got ",
+                    audio_len,
+                    " samples, need at least ",
+                    WHISPER_N_FFT / 2 + 1,
+                    ".");
+    OPENVINO_ASSERT(audio_len <= MAX_AUDIO_SAMPLES,
+                    "Audio input too large: got ",
+                    audio_len,
+                    " samples, max is ",
+                    MAX_AUDIO_SAMPLES,
+                    " (~500 min @ 16 kHz)");
+}
+
+void AudioEncoderQwen3Omni::validate_audio_input(const ov::Tensor& audio_raw) {
+    validate_audio_shape(audio_raw.get_shape(), audio_raw.get_element_type());
+}
+
+std::tuple<ov::Tensor, ov::Tensor, ov::Tensor, ov::Tensor> AudioEncoderQwen3Omni::preprocess_audio(
+    const ov::Tensor& audio_raw) {
+    // Reject malformed or oversized audio before any allocation.
+    validate_audio_input(audio_raw);
+
+    const auto* audio_data = audio_raw.data<float>();
+    const auto audio_len = audio_raw.get_size();
+    std::vector<float> raw_speech(audio_data, audio_data + audio_len);
+
+    auto features = m_feature_extractor.extract(raw_speech);
+    const auto& mel_data = features.data;
+    const size_t n_frames = features.n_frames;
+    OPENVINO_ASSERT(n_frames > 0, "Audio input too short to produce mel spectrogram frames");
+
+    const auto num_mel_bins = m_config.audio_config_num_mel_bins;
+    const auto n_window_infer = m_config.audio_config_n_window_infer;
+    const auto n_window = m_config.audio_config_n_window;
+
+    // Chunk the mel spectrogram into windows of (n_window_infer * 2) frames
+    // Each window overlaps: window i covers frames [i * n_window_infer, i * n_window_infer + 2 * n_window_infer)
+    const size_t chunk_size = n_window_infer * 2;
+    const size_t num_chunks = (n_frames + n_window_infer - 1) / n_window_infer;
+
+    ov::Tensor padded_feature(ov::element::f32, {num_chunks, num_mel_bins, chunk_size});
+    auto* pf_data = padded_feature.data<float>();
+    std::fill(pf_data, pf_data + padded_feature.get_size(), 0.0f);
+
+    std::vector<size_t> chunk_frame_lens(num_chunks);
+    for (size_t c = 0; c < num_chunks; c++) {
+        const size_t start = c * n_window_infer;
+        const size_t end = std::min(start + chunk_size, n_frames);
+        chunk_frame_lens[c] = end - start;
+
+        // Copy mel data for this chunk: mel_data is [num_mel_bins, n_frames] row-major
+        for (size_t mel = 0; mel < num_mel_bins; mel++) {
+            for (size_t f = 0; f < chunk_frame_lens[c]; f++) {
+                pf_data[c * num_mel_bins * chunk_size + mel * chunk_size + f] = mel_data[mel * n_frames + start + f];
+            }
+        }
+    }
+
+    const auto max_aftercnn_len = get_feat_extract_output_length(chunk_size);
+    ov::Tensor aftercnn_lens(ov::element::i64, {num_chunks});
+    auto* acl_data = aftercnn_lens.data<int64_t>();
+
+    ov::Tensor padded_mask_after_cnn(ov::element::boolean, {num_chunks, max_aftercnn_len});
+    auto* mask_data = padded_mask_after_cnn.data<bool>();
+    std::fill(mask_data, mask_data + padded_mask_after_cnn.get_size(), false);
+
+    for (size_t c = 0; c < num_chunks; c++) {
+        const auto cnn_len = get_feat_extract_output_length(chunk_frame_lens[c]);
+        acl_data[c] = static_cast<int64_t>(cnn_len);
+        for (size_t i = 0; i < cnn_len; i++) {
+            mask_data[c * max_aftercnn_len + i] = true;
+        }
+    }
+
+    // Compute cu_seqlens for chunked attention (must be done outside the model
+    // because it uses data-dependent loops that can't be traced)
+    const size_t window_aftercnn = max_aftercnn_len * (n_window_infer / (n_window * 2));
+    std::vector<int32_t> cu_chunk_lens = {0};
+    OPENVINO_ASSERT(window_aftercnn > 0,
+                    "Audio encoder: window_aftercnn is zero — check config values n_window_infer and n_window");
+    for (size_t c = 0; c < num_chunks; c++) {
+        const auto cnn_len = static_cast<size_t>(acl_data[c]);
+        const size_t full_windows = cnn_len / window_aftercnn;
+        for (size_t w = 0; w < full_windows; w++) {
+            cu_chunk_lens.push_back(static_cast<int32_t>(window_aftercnn));
+        }
+        const size_t remainder = cnn_len % window_aftercnn;
+        if (remainder != 0) {
+            cu_chunk_lens.push_back(static_cast<int32_t>(remainder));
+        }
+    }
+
+    ov::Tensor cu_seqlens(ov::element::i32, {cu_chunk_lens.size()});
+    auto* cu_data = cu_seqlens.data<int32_t>();
+    cu_data[0] = cu_chunk_lens[0];
+    for (size_t i = 1; i < cu_chunk_lens.size(); i++) {
+        cu_data[i] = cu_data[i - 1] + cu_chunk_lens[i];
+    }
+
+    return {padded_feature, padded_mask_after_cnn, aftercnn_lens, cu_seqlens};
+}
+
+ov::Tensor AudioEncoderQwen3Omni::encode(const ov::Tensor& audio_raw) {
+    OPENVINO_ASSERT(m_ireq_queue, "Audio encoder not initialized (model not found)");
+
+    auto [padded_feature, padded_mask, aftercnn_lens, cu_seqlens] = preprocess_audio(audio_raw);
+
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(m_ireq_queue.get());
+    auto& ireq = infer_request_guard.get();
+    ireq.set_tensor("padded_feature", padded_feature);
+    ireq.set_tensor("padded_mask_after_cnn", padded_mask);
+    ireq.set_tensor("aftercnn_lens", aftercnn_lens);
+    ireq.set_tensor("cu_seqlens", cu_seqlens);
+    ireq.infer();
+
+    const auto audio_features = ireq.get_tensor("audio_features");
+
+    // Output is padded 3D [N_chunks, aftercnn_time, dim] -- extract valid tokens using mask
+    const auto feat_shape = audio_features.get_shape();
+    const auto num_chunks = feat_shape[0];
+    const auto max_aftercnn_len = feat_shape[1];
+    const auto dim = feat_shape[2];
+
+    const auto* mask_data = padded_mask.data<const bool>();
+    const auto* feat_data = audio_features.data<const float>();
+
+    size_t total_valid = 0;
+    for (size_t i = 0; i < num_chunks * max_aftercnn_len; i++) {
+        if (mask_data[i])
+            total_valid++;
+    }
+
+    ov::Tensor result(ov::element::f32, {total_valid, dim});
+    auto* dst = result.data<float>();
+    for (size_t c = 0; c < num_chunks; c++) {
+        for (size_t t = 0; t < max_aftercnn_len; t++) {
+            if (mask_data[c * max_aftercnn_len + t]) {
+                std::memcpy(dst, feat_data + (c * max_aftercnn_len + t) * dim, dim * sizeof(float));
+                dst += dim;
+            }
+        }
+    }
+
+    return result;
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/audio_encoder.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/audio_encoder.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "whisper/feature_extractor.hpp"
+#include "circular_buffer_queue.hpp"
+#include "openvino/runtime/infer_request.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "visual_language/vlm_config.hpp"
+
+namespace ov::genai {
+
+/// @brief Audio encoder for Qwen3-Omni. Converts raw PCM audio into
+/// audio feature embeddings at the thinker's hidden dimension.
+class AudioEncoderQwen3Omni {
+public:
+    /// @brief Maximum accepted audio length in samples (~500 minutes at 16 kHz).
+    /// Inputs above this are rejected at the boundary so that downstream allocations
+    /// (mel spectrogram buffers, padded chunks) have a known upper bound and cannot
+    /// overflow on attacker-controlled tensor shapes.
+    static constexpr size_t MAX_AUDIO_SAMPLES = 480'000'000;
+
+    AudioEncoderQwen3Omni(const std::filesystem::path& model_dir,
+                          const VLMConfig& config,
+                          const std::string& device,
+                          const ov::AnyMap& properties);
+
+    /// @brief Reject an audio shape/element-type combination that would overflow
+    /// downstream allocations. Static so it can be called before tensor allocation
+    /// (used by tests to exercise the size cap without OOMing).
+    static void validate_audio_shape(const ov::Shape& shape, ov::element::Type element_type);
+
+    /// @brief Validate that @p audio_raw is a 1-D float32 tensor in
+    /// [WHISPER_N_FFT/2 + 1, MAX_AUDIO_SAMPLES] samples. Throws ov::Exception otherwise.
+    /// Called at the start of preprocess_audio() — exposed publicly so callers
+    /// (and tests) can validate inputs before incurring inference cost.
+    static void validate_audio_input(const ov::Tensor& audio_raw);
+
+    /// @brief Check whether the audio encoder model was found and loaded.
+    /// The audio encoder is optional — the model works as text+vision VLM without it.
+    /// Callers should check this before calling encode().
+    bool is_available() const {
+        return m_ireq_queue != nullptr;
+    }
+
+    /// @brief Encode raw PCM audio into audio feature embeddings.
+    /// @param audio_raw 1-D float32 tensor of PCM samples at 16kHz.
+    /// @return Audio features tensor [total_tokens, output_dim].
+    ov::Tensor encode(const ov::Tensor& audio_raw);
+
+private:
+    VLMConfig m_config;
+    WhisperFeatureExtractor m_feature_extractor;
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue;
+
+    /// @brief Preprocess audio: mel spectrogram -> chunk into windows -> pad.
+    /// @return Tuple of (padded_feature, padded_mask_after_cnn, aftercnn_lens, cu_seqlens).
+    std::tuple<ov::Tensor, ov::Tensor, ov::Tensor, ov::Tensor> preprocess_audio(const ov::Tensor& audio_raw);
+
+    /// @brief Compute CNN output length after 8x total downsampling (three stride-2 Conv2d stages).
+    static constexpr size_t get_feat_extract_output_length(size_t input_length) {
+        // Three Conv2d layers with kernel=3, stride=2, padding=1: out = ceil(in / 2)
+        size_t len = input_length;
+        len = (len + 1) / 2;
+        len = (len + 1) / 2;
+        len = (len + 1) / 2;
+        return len;
+    }
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.cpp
@@ -1,0 +1,678 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/qwen3_omni/classes.hpp"
+
+#include <cmath>
+#include <cstring>
+
+#include "utils.hpp"
+#include "visual_language/clip.hpp"
+
+namespace ov::genai {
+
+// --- VisionEncoderQwen3Omni ---
+
+VisionEncoderQwen3Omni::VisionEncoderQwen3Omni(const std::filesystem::path& model_dir,
+                                               const std::string& device,
+                                               const ov::AnyMap properties)
+    : VisionEncoderQwen3VL(model_dir, ConfigOnlyTag{}) {
+    // Unused: Qwen3Omni vision encoder only preprocesses, no inference (merged model handles vision inference)
+}
+
+VisionEncoderQwen3Omni::VisionEncoderQwen3Omni(const ModelsMap& models_map,
+                                               const std::filesystem::path& config_dir_path,
+                                               const std::string& device,
+                                               const ov::AnyMap properties)
+    : VisionEncoderQwen3VL(models_map, config_dir_path, ConfigOnlyTag{}) {
+    // Unused: Qwen3Omni vision encoder only preprocesses, no inference (merged model handles vision inference)
+}
+
+void VisionEncoderQwen3Omni::preprocess_to_patches(const std::vector<ov::Tensor>& images,
+                                                   const ProcessorConfig& config,
+                                                   ov::Tensor& out_tensor,
+                                                   ImageSize& out_rsz_size,
+                                                   size_t frame_num,
+                                                   size_t frame_id) {
+    OPENVINO_ASSERT(config.temporal_patch_size == 2u, "temporal_patch_size != 2.");
+    if (images.size() > 1) {
+        OPENVINO_ASSERT(config.temporal_patch_size == images.size(), "temporal_patch_size != images.size()");
+    }
+
+    const auto& orig_shape = images[0].get_shape();
+    const auto target_image_size = qwen2_vl_utils::smart_resize(orig_shape.at(1),
+                                                                orig_shape.at(2),
+                                                                config.patch_size * config.merge_size,
+                                                                config.min_pixels,
+                                                                config.max_pixels);
+
+    ov::Tensor tiled_patches(ov::element::f32,
+                             {config.temporal_patch_size, 3, target_image_size.height, target_image_size.width});
+
+    for (size_t i = 0; i < config.temporal_patch_size; i++) {
+        const auto& image = images.size() > i ? images[i] : images[0];
+        auto input_image = tensor_to_clip_image_u8(image);
+        clip_image_u8 resized_image;
+        bicubic_resize(input_image, resized_image, target_image_size.width, target_image_size.height);
+        clip_ctx ctx;
+        std::copy(config.image_mean.begin(), config.image_mean.end(), ctx.image_mean);
+        std::copy(config.image_std.begin(), config.image_std.end(), ctx.image_std);
+        auto normalized_image = clip_image_preprocess(ctx, resized_image);
+        auto patch = clip_image_f32_to_tensor(normalized_image);
+        std::memcpy(tiled_patches.data<float>() + i * patch.get_byte_size() / sizeof(float),
+                    patch.data<float>(),
+                    patch.get_byte_size());
+    }
+
+    const auto channel = tiled_patches.get_shape().at(1);
+    const auto grid_t = tiled_patches.get_shape().at(0) / config.temporal_patch_size;
+    const auto grid_h = target_image_size.height / config.patch_size;
+    const auto grid_w = target_image_size.width / config.patch_size;
+
+    auto reshaped = qwen2_vl_utils::reshape_image_patches(tiled_patches,
+                                                          grid_t,
+                                                          grid_h,
+                                                          grid_w,
+                                                          channel,
+                                                          config.temporal_patch_size,
+                                                          config.patch_size,
+                                                          config.merge_size);
+    auto transposed = qwen2_vl_utils::transpose_image_patches(reshaped);
+
+    ov::Shape flat_shape{grid_t * grid_h * grid_w,
+                         channel * config.temporal_patch_size * config.patch_size * config.patch_size};
+    ov::Tensor flattened(transposed.get_element_type(), flat_shape);
+    std::memcpy(flattened.data(), transposed.data(), transposed.get_byte_size());
+
+    // Accumulate into output tensor (same pattern as VisionEncoderQwen2VL)
+    if (frame_id == 0u) {
+        auto out_shape = flat_shape;
+        out_shape[0] = flat_shape[0] * frame_num;
+        out_tensor = ov::Tensor(flattened.get_element_type(), out_shape);
+    }
+    std::memcpy(reinterpret_cast<uint8_t*>(out_tensor.data()) + frame_id * flattened.get_byte_size(),
+                flattened.data(),
+                flattened.get_byte_size());
+    out_rsz_size = ImageSize{grid_h, grid_w};
+}
+
+EncodedImage VisionEncoderQwen3Omni::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    (void)config_map;  // Required by interface but not used in this implementation
+    EncodedImage encoded_img;
+    preprocess_to_patches({image},
+                          m_processor_config,
+                          encoded_img.resized_source,
+                          encoded_img.resized_source_size,
+                          1,
+                          0);
+    return encoded_img;
+}
+
+EncodedVideo VisionEncoderQwen3Omni::encode_frames(const std::vector<ov::Tensor>& frames) {
+    EncodedVideo encoded_video;
+    const auto& config = m_video_processor_config;
+
+    fill_video_metadata(encoded_video, frames.size(), config);
+
+    std::vector<ov::Tensor> sampled_frames;
+    if (!config.do_sample_frames) {
+        sampled_frames = frames;
+    } else {
+        sampled_frames.reserve(encoded_video.metadata.frames_indices.size());
+        for (size_t idx : encoded_video.metadata.frames_indices) {
+            OPENVINO_ASSERT(idx < frames.size(), "Frame index ", idx, " out of range for ", frames.size(), " frames.");
+            sampled_frames.push_back(frames.at(idx));
+        }
+    }
+
+    const auto frames_size = sampled_frames.size();
+    encoded_video.frame_num = (frames_size + config.temporal_patch_size - 1) / config.temporal_patch_size;
+
+    size_t frame_id = 0;
+    size_t i = 0;
+    for (; i + config.temporal_patch_size <= frames_size; i += config.temporal_patch_size) {
+        preprocess_to_patches(std::vector<ov::Tensor>(sampled_frames.begin() + i,
+                                                      sampled_frames.begin() + i + config.temporal_patch_size),
+                              config,
+                              encoded_video.video_features,
+                              encoded_video.resized_source_size,
+                              encoded_video.frame_num,
+                              frame_id);
+        frame_id++;
+    }
+    for (; i < frames_size; i++) {
+        preprocess_to_patches({sampled_frames[i]},
+                              config,
+                              encoded_video.video_features,
+                              encoded_video.resized_source_size,
+                              encoded_video.frame_num,
+                              frame_id);
+        frame_id++;
+    }
+    return encoded_video;
+}
+
+// --- InputsEmbedderQwen3Omni ---
+
+InputsEmbedderQwen3Omni::InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
+                                                 const std::filesystem::path& model_dir,
+                                                 const std::string& device,
+                                                 const ov::AnyMap device_config)
+    : InputsEmbedderQwen3VL(vlm_config, model_dir, device, device_config),
+      m_audio_token_id(vlm_config.audio_token_id) {
+    // Audio encoder is optional — check is_available() / has_audio_encoder() before encoding
+    m_audio_encoder = std::make_unique<AudioEncoderQwen3Omni>(model_dir, vlm_config, device, device_config);
+
+    // Merged vision model is optional — check has_merged_vision_model() before calling
+    // run_video_image_embeddings_merger(). Without it the model works as text+audio only.
+    auto vision_model_path = model_dir / "openvino_vision_embeddings_model.xml";
+    if (std::filesystem::exists(vision_model_path)) {
+        auto model = utils::singleton_core().read_model(vision_model_path);
+        auto compiled = utils::singleton_core().compile_model(model, device, device_config);
+        m_ireq_queue_merged_vision = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled]() -> ov::InferRequest {
+                return compiled.create_infer_request();
+            });
+        // Cache rotary dim to avoid queue lock in get_rotary_pos_emb
+        auto rotary_pshape = compiled.input("rotary_pos_emb").get_partial_shape();
+        m_rotary_dim = static_cast<size_t>(rotary_pshape[rotary_pshape.rank().get_length() - 1].get_length());
+    }
+}
+
+InputsEmbedderQwen3Omni::InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
+                                                 const ModelsMap& models_map,
+                                                 const Tokenizer& tokenizer,
+                                                 const std::filesystem::path& config_dir_path,
+                                                 const std::string& device,
+                                                 const ov::AnyMap device_config)
+    : InputsEmbedderQwen3VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config),
+      m_audio_token_id(vlm_config.audio_token_id) {
+    // Audio encoder is optional — check is_available() / has_audio_encoder() before encoding
+    m_audio_encoder = std::make_unique<AudioEncoderQwen3Omni>(config_dir_path, vlm_config, device, device_config);
+
+    // Merged vision model is optional — check has_merged_vision_model() before calling
+    // run_video_image_embeddings_merger(). Without it the model works as text+audio only.
+    if (models_map.count("vision_embeddings")) {
+        const auto& [model_str, weights] = utils::get_model_weights_pair(models_map, "vision_embeddings");
+        auto model = utils::singleton_core().read_model(model_str, weights);
+        auto compiled = utils::singleton_core().compile_model(model, device, device_config);
+        m_ireq_queue_merged_vision = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+            compiled.get_property(ov::optimal_number_of_infer_requests),
+            [&compiled]() -> ov::InferRequest {
+                return compiled.create_infer_request();
+            });
+        // Cache rotary dim to avoid queue lock in get_rotary_pos_emb
+        auto rotary_pshape = compiled.input("rotary_pos_emb").get_partial_shape();
+        m_rotary_dim = static_cast<size_t>(rotary_pshape[rotary_pshape.rank().get_length() - 1].get_length());
+    }
+}
+
+void InputsEmbedderQwen3Omni::encode_audios(const std::vector<ov::Tensor>& audios) {
+    if (audios.empty() || !has_audio_encoder()) {
+        m_audio_embeddings = ov::Tensor();
+        return;
+    }
+
+    std::vector<ov::Tensor> all_features;
+    size_t total_tokens = 0;
+    size_t hidden_size = 0;
+
+    for (const auto& audio : audios) {
+        // Empty audio tensors are silently skipped so callers can pass placeholders.
+        if (audio.get_size() == 0) {
+            continue;
+        }
+
+        auto features = m_audio_encoder->encode(audio);
+
+        const ov::Shape& feature_shape = features.get_shape();
+        OPENVINO_ASSERT(feature_shape.size() == 2,
+                        "Audio encoder output must be rank-2 [num_tokens, hidden_size], got shape rank ",
+                        feature_shape.size());
+        OPENVINO_ASSERT(features.get_element_type() == ov::element::f32,
+                        "Audio encoder output element type must be f32, got ",
+                        features.get_element_type());
+
+        const size_t num_tokens = feature_shape[0];
+        const size_t current_hidden_size = feature_shape[1];
+        if (all_features.empty()) {
+            hidden_size = current_hidden_size;
+        } else {
+            OPENVINO_ASSERT(current_hidden_size == hidden_size,
+                            "All audio feature tensors must have the same hidden_size. Expected ",
+                            hidden_size,
+                            ", got ",
+                            current_hidden_size);
+        }
+
+        total_tokens += num_tokens;
+        all_features.push_back(features);
+    }
+
+    m_audio_embeddings = ov::Tensor(ov::element::f32, {total_tokens, hidden_size});
+    auto* dst = m_audio_embeddings.data<float>();
+    for (const auto& feat : all_features) {
+        auto byte_size = feat.get_byte_size();
+        std::memcpy(dst, feat.data<float>(), byte_size);
+        dst += feat.get_size();
+    }
+}
+
+ov::Tensor InputsEmbedderQwen3Omni::get_inputs_embeds(
+    const std::string& prompt,
+    const std::vector<ov::genai::EncodedImage>& images,
+    const std::vector<ov::genai::EncodedVideo>& videos,
+    ov::genai::VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& image_sequence,
+    const std::vector<size_t>& videos_sequence,
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
+    auto input_embeds = InputsEmbedderQwen3VL::get_inputs_embeds(prompt,
+                                                                 images,
+                                                                 videos,
+                                                                 metrics,
+                                                                 recalculate_merged_embeddings,
+                                                                 image_sequence,
+                                                                 videos_sequence,
+                                                                 history_vision_count);
+
+    // Capture input_ids set by parent's get_inputs_embeds() into a local variable,
+    // making the cross-class data dependency explicit rather than relying on
+    // implicit ordering of m_last_input_ids population.
+    std::vector<int64_t> input_ids_vec(m_last_input_ids.data<int64_t>(),
+                                       m_last_input_ids.data<int64_t>() + m_last_input_ids.get_size());
+
+    // If we have audio embeddings, replace audio token positions
+    if (m_audio_embeddings && m_audio_embeddings.get_size() > 0 && m_audio_token_id >= 0) {
+        merge_audio_embeddings(input_embeds, input_ids_vec);
+    }
+
+    return input_embeds;
+}
+
+void InputsEmbedderQwen3Omni::merge_audio_embeddings(ov::Tensor& input_embeds, const std::vector<int64_t>& input_ids) {
+    if (!m_audio_embeddings || m_audio_embeddings.get_size() == 0) {
+        return;
+    }
+
+    const auto& shape = input_embeds.get_shape();
+    const auto seq_len = shape[1];
+    const auto hidden_size = shape[2];
+
+    const auto audio_hidden_size = m_audio_embeddings.get_shape()[1];
+    OPENVINO_ASSERT(audio_hidden_size == hidden_size,
+                    "Audio embedding hidden_size (",
+                    audio_hidden_size,
+                    ") must match input embedding hidden_size (",
+                    hidden_size,
+                    "). Check that audio encoder output dimension matches the language model.");
+
+    OPENVINO_ASSERT(input_ids.size() >= seq_len,
+                    "input_ids size (",
+                    input_ids.size(),
+                    ") must be >= embedding seq_len (",
+                    seq_len,
+                    "). Ensure input_ids are not from a stale or re-tokenized source.");
+
+    auto* embed_data = input_embeds.data<float>();
+    const auto* audio_data = m_audio_embeddings.data<const float>();
+    const auto audio_total_tokens = m_audio_embeddings.get_shape()[0];
+    const size_t bytes_per_token = hidden_size * sizeof(float);
+    size_t audio_idx = 0;
+
+    for (size_t i = 0; i < seq_len && audio_idx < audio_total_tokens; i++) {
+        if (input_ids[i] == m_audio_token_id) {
+            std::memcpy(embed_data + i * hidden_size, audio_data + audio_idx * hidden_size, bytes_per_token);
+            audio_idx++;
+        }
+    }
+
+    OPENVINO_ASSERT(audio_idx == audio_total_tokens,
+                    "Audio token count mismatch: placed ",
+                    audio_idx,
+                    " embeddings but encoder produced ",
+                    audio_total_tokens,
+                    " tokens. Ensure the prompt contains exactly ",
+                    audio_total_tokens,
+                    " audio placeholder tokens.");
+}
+
+NormalizedPrompt InputsEmbedderQwen3Omni::normalize_prompt(const std::string& prompt,
+                                                           size_t base_id,
+                                                           const std::vector<EncodedImage>& images) const {
+    auto result = normalize_prompt(prompt, base_id, 0, images, {});
+    return {result.unified_prompt, result.images_sequence};
+}
+
+NormalizedPrompt InputsEmbedderQwen3Omni::normalize_prompt(const std::string& prompt,
+                                                           size_t image_base_id,
+                                                           size_t video_base_id,
+                                                           const std::vector<EncodedImage>& images,
+                                                           const std::vector<EncodedVideo>& videos) const {
+    auto result = InputsEmbedderQwen3VL::normalize_prompt(prompt, image_base_id, video_base_id, images, videos);
+
+    if (m_audio_embeddings && m_audio_embeddings.get_size() > 0) {
+        const auto num_audio_tokens = m_audio_embeddings.get_shape()[0];
+
+        const std::string audio_start = "<|audio_start|>";
+        const std::string audio_pad = "<|audio_pad|>";
+        const std::string audio_end = "<|audio_end|>";
+
+        if (result.unified_prompt.find(audio_start) == std::string::npos) {
+            std::string audio_tag;
+            audio_tag.reserve(audio_start.size() + audio_pad.size() * num_audio_tokens + audio_end.size());
+            audio_tag.append(audio_start);
+            for (size_t i = 0; i < num_audio_tokens; ++i) {
+                audio_tag.append(audio_pad);
+            }
+            audio_tag.append(audio_end);
+            result.unified_prompt = audio_tag + result.unified_prompt;
+        }
+    }
+
+    return result;
+}
+
+std::pair<ov::Tensor, ov::Tensor> InputsEmbedderQwen3Omni::run_video_image_embeddings_merger(
+    const std::vector<EncodedImage>& images,
+    const std::vector<size_t>& images_sequence,
+    const std::vector<EncodedVideo>& videos,
+    const std::vector<size_t>& videos_sequence) {
+    OPENVINO_ASSERT(has_merged_vision_model(),
+                    "Merged vision model not loaded but images/videos were provided. "
+                    "Ensure openvino_vision_embeddings_model.xml is present in the model directory.");
+
+    auto [reordered_image_embeds, reordered_images_grid_thw] =
+        qwen2_vl_utils::reorder_image_embeds_and_grid_thw(images, images_sequence);
+    auto [reordered_video_embeds, reordered_videos_grid_thw] =
+        qwen2_vl_utils::reorder_video_embeds_and_grid_thw(videos, videos_sequence);
+
+    // These are raw patches now (not features) — shape [total_patches, patch_dim]
+    auto concatenated_patches =
+        qwen2_vl_utils::concatenate_video_image_embeds(reordered_video_embeds, reordered_image_embeds);
+
+    std::vector<std::array<size_t, 3>> combined_grid_thw;
+    combined_grid_thw.insert(combined_grid_thw.end(),
+                             reordered_videos_grid_thw.begin(),
+                             reordered_videos_grid_thw.end());
+    combined_grid_thw.insert(combined_grid_thw.end(),
+                             reordered_images_grid_thw.begin(),
+                             reordered_images_grid_thw.end());
+
+    // Compute pos_embeds as separate input (model adds them internally after Conv3d)
+    ov::Tensor pos_embeds;
+    if (!combined_grid_thw.empty()) {
+        pos_embeds = get_interpolated_pos_embeds(combined_grid_thw);
+    }
+
+    auto attention_mask = qwen2_vl_utils::get_attention_mask(reordered_images_grid_thw, reordered_videos_grid_thw);
+    auto rotary_pos_emb = get_rotary_pos_emb(combined_grid_thw);
+
+    CircularBufferQueueElementGuard<ov::InferRequest> guard(m_ireq_queue_merged_vision.get());
+    auto& ireq = guard.get();
+
+    ireq.set_tensor("hidden_states", concatenated_patches);
+    if (pos_embeds) {
+        ireq.set_tensor("pos_embeds", pos_embeds);
+    }
+    ireq.set_tensor("attention_mask", attention_mask);
+    ireq.set_tensor("rotary_pos_emb", rotary_pos_emb);
+    ireq.infer();
+
+    auto vision_embeds = ireq.get_tensor("last_hidden_state");
+    m_lm_extra_inputs["deepstack_visual_embeds"] = ireq.get_tensor("deepstack_feature_lists");
+
+    const auto& vision_embeds_shape = vision_embeds.get_shape();
+
+    const auto video_tokens = calc_vec_tokens_num(reordered_videos_grid_thw);
+    const auto image_tokens = calc_vec_tokens_num(reordered_images_grid_thw);
+    const auto total_tokens = video_tokens + image_tokens;
+
+    size_t video_count = 0;
+    if (total_tokens > 0) {
+        video_count = vision_embeds_shape[0] * video_tokens / total_tokens;
+    }
+    const auto image_count = vision_embeds_shape[0] - video_count;
+
+    ov::Tensor video_embeds{vision_embeds.get_element_type(), {video_count, vision_embeds_shape[1]}};
+    ov::Tensor image_embeds{vision_embeds.get_element_type(), {image_count, vision_embeds_shape[1]}};
+
+    std::memcpy(video_embeds.data(), vision_embeds.data(), video_embeds.get_byte_size());
+    std::memcpy(image_embeds.data(),
+                static_cast<uint8_t*>(vision_embeds.data()) + video_embeds.get_byte_size(),
+                image_embeds.get_byte_size());
+
+    return {video_embeds, image_embeds};
+}
+
+ov::Tensor InputsEmbedderQwen3Omni::get_rotary_pos_emb(const std::vector<std::array<size_t, 3>>& grids_thw) const {
+    const auto spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
+
+    std::vector<std::vector<size_t>> all_pos_ids;
+    size_t max_grid_size = 0;
+
+    for (const auto& grid_thw : grids_thw) {
+        const auto t = grid_thw.at(0);
+        const auto h = grid_thw.at(1);
+        const auto w = grid_thw.at(2);
+
+        max_grid_size = std::max({max_grid_size, h, w});
+
+        std::vector<size_t> hpos_ids;
+        std::vector<size_t> wpos_ids;
+        const auto h_blocks = h / spatial_merge_size;
+        const auto w_blocks = w / spatial_merge_size;
+        hpos_ids.reserve(h * w);
+        wpos_ids.reserve(h * w);
+
+        for (size_t hb = 0; hb < h_blocks; ++hb) {
+            for (size_t wb = 0; wb < w_blocks; ++wb) {
+                for (size_t hs = 0; hs < spatial_merge_size; ++hs) {
+                    for (size_t ws = 0; ws < spatial_merge_size; ++ws) {
+                        hpos_ids.push_back(hb * spatial_merge_size + hs);
+                        wpos_ids.push_back(wb * spatial_merge_size + ws);
+                    }
+                }
+            }
+        }
+
+        for (size_t i = 0; i < t; ++i) {
+            for (size_t j = 0; j < hpos_ids.size(); ++j) {
+                all_pos_ids.push_back({hpos_ids[j], wpos_ids[j]});
+            }
+        }
+    }
+
+    // Use cached rotary dim — Qwen3Omni uses a merged vision model instead of the separate
+    // merger model that Qwen2VL/Qwen3VL use, so we cannot reuse the parent get_rotary_pos_emb()
+    // which obtains dim via queue lock on m_ireq_queue_vision_embeddings_merger.
+    OPENVINO_ASSERT(m_rotary_dim > 0, "Rotary dim not initialized — merged vision model not loaded");
+    const auto dim = m_rotary_dim;
+    const auto half_dim = dim / 2;
+    constexpr float theta = 10000.0f;
+
+    std::vector<float> inv_freq(half_dim);
+    for (size_t i = 0; i < half_dim; ++i) {
+        inv_freq[i] = 1.0f / std::pow(theta, static_cast<float>(i) / static_cast<float>(half_dim));
+    }
+
+    std::vector<std::vector<float>> freqs(max_grid_size);
+    for (size_t i = 0; i < max_grid_size; ++i) {
+        freqs[i].resize(half_dim);
+        for (size_t j = 0; j < half_dim; ++j) {
+            freqs[i][j] = static_cast<float>(i) * inv_freq[j];
+        }
+    }
+
+    const size_t half_dim_bytes = half_dim * sizeof(float);
+    ov::Tensor rotary_pos_emb(ov::element::f32, {all_pos_ids.size(), dim});
+    auto* output_data = rotary_pos_emb.data<float>();
+
+    for (size_t i = 0; i < all_pos_ids.size(); ++i) {
+        const auto& pos = all_pos_ids[i];
+        const auto h_idx = pos[0];
+        const auto w_idx = pos[1];
+        std::memcpy(output_data + i * dim, freqs[h_idx].data(), half_dim_bytes);
+        std::memcpy(output_data + i * dim + half_dim, freqs[w_idx].data(), half_dim_bytes);
+    }
+
+    return rotary_pos_emb;
+}
+
+void InputsEmbedderQwen3Omni::start_chat(const std::string& system_message) {
+    InputsEmbedderQwen3VL::start_chat(system_message);
+    m_audio_embeddings = ov::Tensor();
+}
+
+void InputsEmbedderQwen3Omni::finish_chat() {
+    InputsEmbedderQwen3VL::finish_chat();
+    m_audio_embeddings = ov::Tensor();
+}
+
+std::pair<ov::Tensor, int64_t> InputsEmbedderQwen3Omni::create_position_ids(
+    const ov::Tensor& input_ids_tensor,
+    const std::vector<std::array<size_t, 3>>& images_grid_thw,
+    const std::vector<size_t>& images_sequence,
+    const size_t image_id,
+    const std::vector<std::array<size_t, 3>>& videos_grid_thw,
+    const std::vector<size_t>& videos_sequence,
+    const size_t video_id,
+    const int64_t vision_start_token_id,
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
+    // Create 4D position_ids for Qwen3-Omni's multimodal RoPE: [temporal, height, width, text]
+    const size_t spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
+    const size_t tokens_per_second = m_vlm_config.vision_config_tokens_per_second;
+
+    auto reordered_vision_grid_thw = get_vision_grid_thw_for_position_ids(images_grid_thw,
+                                                                          images_sequence,
+                                                                          image_id,
+                                                                          videos_grid_thw,
+                                                                          videos_sequence,
+                                                                          video_id,
+                                                                          history_vision_count);
+
+    const auto* input_ids = input_ids_tensor.data<int64_t>();
+    size_t batch_size = input_ids_tensor.get_shape().at(0);
+    size_t seq_len = input_ids_tensor.get_shape().at(1);
+
+    OPENVINO_ASSERT(batch_size == 1, "create_position_ids currently supports only batch_size == 1");
+
+    std::vector<size_t> vision_start_indices;
+    for (size_t i = 0; i < seq_len; ++i) {
+        if (input_ids[i] == vision_start_token_id) {
+            vision_start_indices.push_back(i);
+        }
+    }
+
+    // 4 dimensions: temporal, height, width, text
+    ov::Tensor position_ids{ov::element::i64, {4, batch_size, seq_len}};
+    auto* pos_data = position_ids.data<int64_t>();
+
+    size_t st = 0;
+    int64_t next_pos = 0;
+    size_t grid_idx = 0;
+
+    for (size_t i = 0; i < vision_start_indices.size(); ++i) {
+        size_t ed = vision_start_indices.at(i);
+
+        // Text tokens before vision: all 4 dims get the same sequential position
+        if (st < ed) {
+            for (size_t pos = st; pos < ed; ++pos) {
+                pos_data[pos] = next_pos;                // temporal
+                pos_data[seq_len + pos] = next_pos;      // height
+                pos_data[2 * seq_len + pos] = next_pos;  // width
+                pos_data[3 * seq_len + pos] = next_pos;  // text
+                next_pos++;
+            }
+        }
+
+        // Vision start token
+        pos_data[ed] = next_pos;
+        pos_data[seq_len + ed] = next_pos;
+        pos_data[2 * seq_len + ed] = next_pos;
+        pos_data[3 * seq_len + ed] = next_pos;
+        next_pos++;
+        ed++;
+
+        // Vision tokens with spatial grid
+        if (grid_idx < reordered_vision_grid_thw.size()) {
+            const auto& grid = reordered_vision_grid_thw.at(grid_idx);
+            size_t llm_grid_t = grid.at(0);
+            size_t llm_grid_h = grid.at(1) / spatial_merge_size;
+            size_t llm_grid_w = grid.at(2) / spatial_merge_size;
+            size_t llm_grid_sz = llm_grid_h * llm_grid_w;
+            size_t ed_image = ed + llm_grid_t * llm_grid_sz;
+
+            // Temporal dimension
+            for (size_t t = 0; t < llm_grid_t; t++) {
+                std::fill_n(pos_data + ed + t * llm_grid_sz, llm_grid_sz, next_pos + t * tokens_per_second);
+            }
+
+            // Height and width dimensions
+            int64_t* height_data = pos_data + seq_len + ed;
+            int64_t* width_data = pos_data + 2 * seq_len + ed;
+            for (size_t t = 0; t < llm_grid_t; t++) {
+                size_t offset_sz = t * llm_grid_sz;
+                for (size_t h = 0; h < llm_grid_h; ++h) {
+                    size_t offset = h * llm_grid_w + offset_sz;
+                    std::fill_n(height_data + offset, llm_grid_w, next_pos + h);
+                    for (size_t w = 0; w < llm_grid_w; ++w) {
+                        width_data[offset + w] = next_pos + w;
+                    }
+                }
+            }
+
+            // Text dimension: sequential position for all vision tokens
+            int64_t* text_data = pos_data + 3 * seq_len + ed;
+            for (size_t j = 0; j < llm_grid_t * llm_grid_sz; ++j) {
+                text_data[j] = next_pos + static_cast<int64_t>(j);
+            }
+
+            next_pos += std::max(((llm_grid_t - 1) * tokens_per_second + 1), std::max(llm_grid_h, llm_grid_w));
+            st = ed_image;
+            grid_idx++;
+        }
+    }
+
+    // Remaining text tokens
+    if (st < seq_len) {
+        for (size_t pos = st; pos < seq_len; ++pos) {
+            pos_data[pos] = next_pos;
+            pos_data[seq_len + pos] = next_pos;
+            pos_data[2 * seq_len + pos] = next_pos;
+            pos_data[3 * seq_len + pos] = next_pos;
+            next_pos++;
+        }
+    }
+
+    // Calculate rope delta from maximum position value 
+    // (exclude text dimension which tracks sequence position but isn't consumed by RoPE)
+    const size_t num_position_dims = position_ids.get_shape().at(0);
+    const size_t num_spatial_dims = num_position_dims - 1;
+    const int64_t position_ids_max_element = *std::max_element(
+        position_ids.data<int64_t>(),
+        position_ids.data<int64_t>() + num_spatial_dims * seq_len
+    );
+    const int64_t rope_delta = position_ids_max_element + 1 - static_cast<int64_t>(seq_len);
+
+    return {position_ids, rope_delta};
+}
+
+std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedderQwen3Omni::get_generation_phase_position_ids(
+    const size_t inputs_embeds_size,
+    const size_t history_size,
+    int64_t rope_delta) {
+    OPENVINO_ASSERT(history_size != 0,
+                    "get_generation_phase_position_ids() should only be called when history_size is non-zero.");
+    // 4 dimensions for Qwen3-Omni's multimodal RoPE
+    ov::Tensor position_ids{ov::element::i64, {4, 1, inputs_embeds_size}};
+    int64_t new_pos_id = static_cast<int64_t>(history_size + rope_delta);
+    for (size_t dim = 0; dim < 4; ++dim) {
+        auto* pos_data = position_ids.data<int64_t>() + dim * inputs_embeds_size;
+        std::iota(pos_data, pos_data + inputs_embeds_size, new_pos_id);
+    }
+    return {position_ids, rope_delta};
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.hpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "visual_language/qwen3_omni/audio_encoder.hpp"
+#include "visual_language/qwen3_vl/classes.hpp"
+
+namespace ov::genai {
+
+/// @brief Vision encoder for Qwen3-Omni.
+/// Does NOT load the vision_embeddings model (it's merged with the merger in the new export format).
+/// Only does image preprocessing (resize, normalize, create raw patches).
+/// The merged vision model is loaded and used by InputsEmbedderQwen3Omni.
+class VisionEncoderQwen3Omni : public VisionEncoderQwen3VL {
+public:
+    explicit VisionEncoderQwen3Omni(const std::filesystem::path& model_dir,
+                                    const std::string& device,
+                                    const ov::AnyMap properties);
+    explicit VisionEncoderQwen3Omni(const ModelsMap& models_map,
+                                    const std::filesystem::path& config_dir_path,
+                                    const std::string& device,
+                                    const ov::AnyMap properties);
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+    EncodedVideo encode_frames(const std::vector<ov::Tensor>& frames) override;
+
+private:
+    /// @brief Preprocess a set of frames into raw flattened patches without running inference.
+    /// Writes flattened patches [total_patches, patch_dim] to out_tensor and grid dims to out_rsz_size.
+    void preprocess_to_patches(const std::vector<ov::Tensor>& images,
+                               const ProcessorConfig& config,
+                               ov::Tensor& out_tensor,
+                               ImageSize& out_rsz_size,
+                               size_t frame_num,
+                               size_t frame_id);
+};
+
+/// @brief InputsEmbedder for Qwen3-Omni. Extends Qwen3-VL with audio encoding support.
+class InputsEmbedderQwen3Omni : public InputsEmbedderQwen3VL {
+public:
+    InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
+                            const std::filesystem::path& model_dir,
+                            const std::string& device,
+                            const ov::AnyMap device_config);
+
+    InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
+                            const ModelsMap& models_map,
+                            const Tokenizer& tokenizer,
+                            const std::filesystem::path& config_dir_path,
+                            const std::string& device,
+                            const ov::AnyMap device_config);
+
+    /// @brief Override to merge audio embeddings into the input embeds
+    /// alongside image/video embeddings.
+    ov::Tensor get_inputs_embeds(
+        const std::string& prompt,
+        const std::vector<ov::genai::EncodedImage>& images,
+        const std::vector<ov::genai::EncodedVideo>& videos,
+        ov::genai::VLMPerfMetrics& metrics,
+        bool recalculate_merged_embeddings = true,
+        const std::vector<size_t>& image_sequence = {},
+        const std::vector<size_t>& videos_sequence = {},
+        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count = {}) override;
+
+    /// @brief Encode raw audio tensors and cache the embeddings.
+    /// Must be called before get_inputs_embeds() if audio is present.
+    void encode_audios(const std::vector<ov::Tensor>& audios) override;
+
+    /// @brief Check if audio encoder model was loaded and is ready for inference.
+    bool has_audio_encoder() const {
+        return m_audio_encoder != nullptr && m_audio_encoder->is_available();
+    }
+
+    /// @brief Override to inject audio placeholder tokens into the prompt
+    /// when audio embeddings are available.
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t base_id,
+                                      const std::vector<EncodedImage>& images) const override;
+
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t image_base_id,
+                                      size_t video_base_id,
+                                      const std::vector<EncodedImage>& images,
+                                      const std::vector<EncodedVideo>& videos) const override;
+
+    void start_chat(const std::string& system_message) override;
+    void finish_chat() override;
+
+protected:
+    /// @brief Check if the merged vision model was loaded and is ready for inference.
+    /// The merged vision model is optional — it is only needed when images or videos are provided.
+    bool has_merged_vision_model() const {
+        return m_ireq_queue_merged_vision != nullptr;
+    }
+
+    /// @brief Override to use the merged vision model (patch_embed + transformer + merger in one).
+    std::pair<ov::Tensor, ov::Tensor> run_video_image_embeddings_merger(
+        const std::vector<EncodedImage>& images,
+        const std::vector<size_t>& images_sequence,
+        const std::vector<EncodedVideo>& videos,
+        const std::vector<size_t>& videos_sequence) override;
+
+    /// @brief Override to use merged vision model for rotary dim instead of separate merger.
+    ov::Tensor get_rotary_pos_emb(const std::vector<std::array<size_t, 3>>& grids_thw) const override;
+
+    /// @brief Override Qwen2VL's create_position_ids to produce 4D position_ids for Qwen3-Omni's
+    /// multimodal RoPE (temporal, height, width, text). Plain Qwen3-VL uses the 3D variant from
+    /// Qwen2VL — only Omni's exported language model expects shape [4, batch, seq].
+    std::pair<ov::Tensor, int64_t> create_position_ids(
+        const ov::Tensor& input_ids_tensor,
+        const std::vector<std::array<size_t, 3>>& images_grid_thw,
+        const std::vector<size_t>& images_sequence,
+        const size_t image_id,
+        const std::vector<std::array<size_t, 3>>& videos_grid_thw,
+        const std::vector<size_t>& videos_sequence,
+        const size_t video_id,
+        const int64_t vision_start_token_id,
+        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
+    ) override;
+
+    std::pair<ov::Tensor, std::optional<int64_t>> get_generation_phase_position_ids(const size_t inputs_embeds_size,
+                                                                                    const size_t history_size,
+                                                                                    int64_t rope_delta) override;
+
+private:
+    std::unique_ptr<AudioEncoderQwen3Omni> m_audio_encoder;
+    // Cached audio embeddings from last encode_audios() call
+    ov::Tensor m_audio_embeddings;
+    // Audio token ID used to identify audio placeholder positions
+    int64_t m_audio_token_id = -1;
+
+    // Merged vision model (patch_embed + transformer + merger)
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_merged_vision;
+    // Cached rotary embedding dimension from merged vision model (avoids queue lock in get_rotary_pos_emb)
+    size_t m_rotary_dim = 0;
+
+    /// @brief Replace audio token positions in input_embeds with audio features.
+    void merge_audio_embeddings(ov::Tensor& input_embeds, const std::vector<int64_t>& input_ids);
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.cpp
@@ -1,0 +1,1026 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/qwen3_omni/speech_pipeline.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <numeric>
+#include <random>
+
+#include "json_utils.hpp"
+#include "logger.hpp"
+#include "openvino/openvino.hpp"
+#include "utils.hpp"
+
+namespace {
+
+ov::genai::StreamingStatus invoke_speech_streamer(const ov::genai::OmniSpeechStreamerVariant& streamer,
+                                                  const ov::Tensor& chunk) {
+    return std::visit(
+        [&chunk](auto&& arg) -> ov::genai::StreamingStatus {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, std::function<ov::genai::StreamingStatus(const ov::Tensor&)>>) {
+                return arg(chunk);
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<ov::genai::OmniSpeechStreamerBase>>) {
+                return arg->write(chunk);
+            } else {
+                return ov::genai::StreamingStatus::RUNNING;
+            }
+        },
+        streamer);
+}
+
+void end_speech_streamer(const ov::genai::OmniSpeechStreamerVariant& streamer) {
+    std::visit(
+        [](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, std::shared_ptr<ov::genai::OmniSpeechStreamerBase>>) {
+                arg->end();
+            }
+        },
+        streamer);
+}
+
+bool is_speech_streamer_active(const ov::genai::OmniSpeechStreamerVariant& streamer) {
+    return !std::holds_alternative<std::monostate>(streamer);
+}
+
+}  // namespace
+
+namespace ov::genai {
+
+// --- Qwen3OmniSpeechConfig ---
+
+Qwen3OmniSpeechConfig Qwen3OmniSpeechConfig::from_vlm_config(const VLMConfig& config) {
+    Qwen3OmniSpeechConfig sc;
+    sc.codec_bos_id = config.talker_codec_bos_id;
+    sc.codec_eos_token_id = config.talker_codec_eos_token_id;
+    sc.codec_pad_id = config.talker_codec_pad_id;
+    sc.codec_nothink_id = config.talker_codec_nothink_id;
+    sc.codec_think_bos_id = config.talker_codec_think_bos_id;
+    sc.codec_think_eos_id = config.talker_codec_think_eos_id;
+    sc.tts_bos_token_id = config.tts_bos_token_id;
+    sc.tts_eos_token_id = config.tts_eos_token_id;
+    sc.tts_pad_token_id = config.tts_pad_token_id;
+    sc.im_start_token_id = config.im_start_token_id;
+    sc.system_token_id = config.system_token_id;
+    sc.user_token_id = config.user_token_id;
+    sc.assistant_token_id = config.assistant_token_id;
+    sc.audio_token_id = config.audio_token_id;
+    sc.image_token_id = config.image_token_id;
+    sc.video_token_id = config.video_token_id;
+    sc.num_code_groups = config.talker_num_code_groups;
+    sc.speaker_ids = config.speaker_ids;
+
+    OPENVINO_ASSERT(sc.codec_bos_id >= 0 && sc.codec_eos_token_id >= 0 && sc.codec_pad_id >= 0 &&
+                        sc.codec_nothink_id >= 0 && sc.codec_think_bos_id >= 0 && sc.codec_think_eos_id >= 0,
+                    "Qwen3-Omni speech: talker_config codec IDs missing from config.json "
+                    "(codec_bos_id / codec_eos_token_id / codec_pad_id / codec_nothink_id / "
+                    "codec_think_bos_id / codec_think_eos_id are required for speech generation).");
+    return sc;
+}
+
+// --- Qwen3OmniSpeechPipeline ---
+
+Qwen3OmniSpeechPipeline::Qwen3OmniSpeechPipeline(const std::filesystem::path& model_dir,
+                                                 const VLMConfig& config,
+                                                 const std::string& device,
+                                                 const ov::AnyMap& properties)
+    : m_config(Qwen3OmniSpeechConfig::from_vlm_config(config)) {
+    // Load all 6 speech sub-models (all optional)
+    auto load_model = [&](const std::string& filename) -> ov::InferRequest {
+        auto path = model_dir / (filename + ".xml");
+        if (!std::filesystem::exists(path)) {
+            return {};
+        }
+        auto model = utils::singleton_core().read_model(path);
+
+        // Force FP32 inference precision on GPU for talker models to match CPU behavior
+        // GPU FP16 causes numerical differences in logits → different sampled tokens → wrong speech length
+        ov::AnyMap compilation_props = properties;
+        if (device == "GPU" || device.find("GPU") == 0) {
+            compilation_props["INFERENCE_PRECISION_HINT"] = "f32";
+            GENAI_DEBUG("Speech: forcing FP32 precision for %s on GPU", filename.c_str());
+        }
+
+        auto compiled = utils::singleton_core().compile_model(model, device, compilation_props);
+        return compiled.create_infer_request();
+    };
+
+    // Load thinker text embeddings for TTS special token embedding
+    m_thinker_text_embeddings = load_model("openvino_text_embeddings_model");
+
+    m_talker = load_model("openvino_talker_model");
+    m_talker_text_embeddings = load_model("openvino_talker_text_embeddings_model");
+    m_talker_projections = load_model("openvino_talker_projections_model");
+    m_code_predictor = load_model("openvino_code_predictor_model");
+    m_code2wav = load_model("openvino_code2wav_model");
+
+    // All speech models must be present for speech generation
+    m_talker_available = m_talker && m_talker_text_embeddings && m_talker_projections && m_code_predictor &&
+                         m_code2wav && m_thinker_text_embeddings;
+
+    if (!m_talker_available) {
+        return;
+    }
+    auto output_pshape = m_talker_projections.get_compiled_model().output("text_projection").get_partial_shape();
+    OPENVINO_ASSERT(output_pshape.rank().is_static() && output_pshape.rank().get_length() >= 2,
+                    "Talker text projection output must have at least 2 dimensions");
+    auto last_dim = output_pshape[output_pshape.rank().get_length() - 1];
+    OPENVINO_ASSERT(last_dim.is_static(), "Talker text projection output last dimension must be static");
+    m_config.talker_hidden_size = static_cast<size_t>(last_dim.get_length());
+    OPENVINO_ASSERT(m_config.talker_hidden_size > 0,
+                    "Failed to detect talker hidden size from text projection model");
+
+    {
+        auto cp_inputs = m_code_predictor.get_compiled_model().inputs();
+        auto has_cp_input = [&](const std::string& name) {
+            return std::any_of(cp_inputs.begin(), cp_inputs.end(), [&](const ov::Output<const ov::Node>& port) {
+                return port.get_any_name() == name;
+            });
+        };
+        auto cp_outputs = m_code_predictor.get_compiled_model().outputs();
+        auto has_cp_output = [&](const std::string& name) {
+            return std::any_of(cp_outputs.begin(), cp_outputs.end(), [&](const ov::Output<const ov::Node>& port) {
+                return port.get_any_name() == name;
+            });
+        };
+
+        // Single-step stateful CodePredictor API: the graph runs one inner step per infer() and
+        // hides its KV cache as state; this pipeline drives the num_code_groups-1 step loop.
+        // Sampling and codec embedding are in-graph, so the graph emits the sampled `code` and its
+        // `token_embed` directly (no separate codec_embedding weights file needed).
+        OPENVINO_ASSERT(has_cp_input("inputs_embeds"), "CodePredictor: missing 'inputs_embeds' input");
+        OPENVINO_ASSERT(has_cp_input("attention_mask"), "CodePredictor: missing 'attention_mask' input");
+        OPENVINO_ASSERT(has_cp_input("position_ids"), "CodePredictor: missing 'position_ids' input");
+        OPENVINO_ASSERT(has_cp_input("step"), "CodePredictor: missing 'step' input (expected single-step API)");
+        OPENVINO_ASSERT(has_cp_input("seed"), "CodePredictor: missing 'seed' input");
+        OPENVINO_ASSERT(has_cp_input("temperature"), "CodePredictor: missing 'temperature' input");
+        OPENVINO_ASSERT(has_cp_input("top_k"), "CodePredictor: missing 'top_k' input");
+        OPENVINO_ASSERT(has_cp_output("code"), "CodePredictor: missing 'code' output");
+        OPENVINO_ASSERT(has_cp_output("token_embed"), "CodePredictor: missing 'token_embed' output");
+    }
+
+    // Pre-allocate scratch buffers that are reused across generate_speech() calls
+    m_cp_embed_sum = ov::Tensor(ov::element::f32, {1, 1, m_config.talker_hidden_size});
+
+    if (m_config.speaker_ids.empty()) {
+        m_talker_available = false;
+    }
+
+    // Load talker and CodePredictor generation parameters from generation_config.json.
+    // CP defaults (1.0 / 50 / 1.0) match the reference Qwen3-Omni implementation; json keys
+    // cp_temperature / cp_top_k / cp_repetition_penalty may override them if present.
+    auto gen_config_path = model_dir / "generation_config.json";
+    if (std::filesystem::exists(gen_config_path)) {
+        std::ifstream f(gen_config_path);
+        auto gen_data = nlohmann::json::parse(f);
+        utils::read_json_param(gen_data, "talker_temperature", m_config.talker_temperature);
+        utils::read_json_param(gen_data, "talker_top_k", m_config.talker_top_k);
+        utils::read_json_param(gen_data, "talker_repetition_penalty", m_config.talker_repetition_penalty);
+        utils::read_json_param(gen_data, "talker_max_new_tokens", m_config.talker_max_new_tokens);
+        utils::read_json_param(gen_data, "cp_temperature", m_config.cp_temperature);
+        utils::read_json_param(gen_data, "cp_top_k", m_config.cp_top_k);
+        utils::read_json_param(gen_data, "cp_repetition_penalty", m_config.cp_repetition_penalty);
+        GENAI_INFO("Speech: talker params: temp=%.2f, top_k=%zu, rep_penalty=%.2f, max_tokens=%zu",
+                    m_config.talker_temperature,
+                    m_config.talker_top_k,
+                    m_config.talker_repetition_penalty,
+                    m_config.talker_max_new_tokens);
+        GENAI_INFO("Speech: code_predictor params: temp=%.2f, top_k=%zu, rep_penalty=%.2f",
+                    m_config.cp_temperature,
+                    m_config.cp_top_k,
+                    m_config.cp_repetition_penalty);
+    }
+
+    // Detect vocab_size from talker logits output and build suppress_tokens list
+    // Suppress tokens in [vocab_size-1024, vocab_size) except codec_eos_token_id
+    auto logits_pshape = m_talker.get_compiled_model().output("logits").get_partial_shape();
+    if (logits_pshape.rank().is_static()) {
+        auto vocab_dim = logits_pshape[logits_pshape.rank().get_length() - 1];
+        if (vocab_dim.is_static()) {
+            m_config.talker_vocab_size = static_cast<size_t>(vocab_dim.get_length());
+            auto suppress_start = static_cast<int64_t>(m_config.talker_vocab_size) - 1024;
+            if (suppress_start < 0)
+                suppress_start = 0;
+            for (int64_t i = suppress_start; i < static_cast<int64_t>(m_config.talker_vocab_size); i++) {
+                if (i != m_config.codec_eos_token_id) {
+                    m_config.talker_suppress_tokens.push_back(i);
+                }
+            }
+            GENAI_INFO("Speech: suppressing %zu special tokens in range [%lld, %zu)",
+                        m_config.talker_suppress_tokens.size(),
+                        (long long)suppress_start,
+                        m_config.talker_vocab_size);
+        }
+    }
+
+    // Pre-compute constant embeddings. These depend only on model weights and
+    // static config, so hoisting them out of generate_speech() saves ~12 inference
+    // calls per call at the cost of a one-shot warm-up during pipeline construction.
+    if (m_talker_available) {
+        m_tts_bos_embed = project_text(embed_thinker_token(m_config.tts_bos_token_id));
+        m_tts_eos_embed = project_text(embed_thinker_token(m_config.tts_eos_token_id));
+        m_tts_pad_embed = project_text(embed_thinker_token(m_config.tts_pad_token_id));
+
+        const std::array<int64_t, 5> codec_specials{m_config.codec_nothink_id,
+                                                    m_config.codec_think_bos_id,
+                                                    m_config.codec_think_eos_id,
+                                                    m_config.codec_pad_id,
+                                                    m_config.codec_bos_id};
+        for (auto id : codec_specials) {
+            m_codec_special_embed.emplace(id, embed_talker_token(id));
+        }
+
+        for (const auto& [name, id] : m_config.speaker_ids) {
+            m_speaker_embed.emplace(id, embed_talker_token(id));
+            std::string lower_name = name;
+            std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), [](unsigned char c) {
+                return std::tolower(c);
+            });
+            m_lower_speaker_ids.emplace(std::move(lower_name), id);
+        }
+    }
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::get_speaker_embedding(const std::string& name) const {
+    OPENVINO_ASSERT(!m_lower_speaker_ids.empty(),
+                    "Talker::get_speaker_embedding: model has no named speakers; "
+                    "ensure 'talker_config.speaker_id' is defined in config.json");
+    std::string lower = name;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+        return std::tolower(c);
+    });
+    auto it = m_lower_speaker_ids.find(lower);
+    OPENVINO_ASSERT(it != m_lower_speaker_ids.end(),
+                    "Talker::get_speaker_embedding: unknown speaker '",
+                    name,
+                    "'. Use list_speakers() to enumerate available names.");
+    // Copy so caller can blend without mutating our internal cache.
+    const auto& cached = m_speaker_embed.at(it->second);
+    ov::Tensor copy(cached.get_element_type(), cached.get_shape());
+    cached.copy_to(copy);
+    return copy;
+}
+
+std::vector<std::string> Qwen3OmniSpeechPipeline::list_speakers() const {
+    std::vector<std::string> names;
+    names.reserve(m_config.speaker_ids.size());
+    for (const auto& [name, id] : m_config.speaker_ids) {
+        names.push_back(name);
+    }
+    return names;
+}
+
+int64_t Qwen3OmniSpeechPipeline::resolve_speaker_id(const std::string& speaker) const {
+    if (!speaker.empty() && !m_lower_speaker_ids.empty()) {
+        std::string lower_speaker = speaker;
+        std::transform(lower_speaker.begin(), lower_speaker.end(), lower_speaker.begin(), [](unsigned char c) {
+            return std::tolower(c);
+        });
+        auto it = m_lower_speaker_ids.find(lower_speaker);
+        if (it != m_lower_speaker_ids.end()) {
+            return it->second;
+        }
+    }
+    // Fallback: use first available speaker
+    if (!m_config.speaker_ids.empty()) {
+        return m_config.speaker_ids.begin()->second;
+    }
+    OPENVINO_THROW("No speaker IDs available in model config. "
+                   "Ensure 'talker_config.speaker_id' is defined in config.json");
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::embed_thinker_token(int64_t token_id) {
+    ov::Tensor input(ov::element::i64, {1, 1});
+    input.data<int64_t>()[0] = token_id;
+    m_thinker_text_embeddings.set_tensor("input", input);
+    m_thinker_text_embeddings.infer();
+    auto result = m_thinker_text_embeddings.get_tensor("inputs_embeds");
+    ov::Tensor copy(result.get_element_type(), result.get_shape());
+    result.copy_to(copy);
+    return copy;
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::embed_talker_token(int64_t token_id) {
+    auto map_it = m_embedding_lru_map.find(token_id);
+    if (map_it != m_embedding_lru_map.end()) {
+        // Move to front (most recently used)
+        m_embedding_lru_list.splice(m_embedding_lru_list.begin(), m_embedding_lru_list, map_it->second);
+        return map_it->second->second;  // ref-counted handle, not a data copy
+    }
+
+    ov::Tensor input(ov::element::i64, {1, 1});
+    input.data<int64_t>()[0] = token_id;
+    m_talker_text_embeddings.set_tensor("input", input);
+    m_talker_text_embeddings.infer();
+    auto result = m_talker_text_embeddings.get_tensor("inputs_embeds");
+
+    // One copy from inference output to owned cache entry
+    ov::Tensor cached(result.get_element_type(), result.get_shape());
+    result.copy_to(cached);
+
+    // Evict least recently used if cache is full
+    if (m_embedding_lru_list.size() >= kMaxEmbeddingCacheSize) {
+        auto& evicted = m_embedding_lru_list.back();
+        m_embedding_lru_map.erase(evicted.first);
+        m_embedding_lru_list.pop_back();
+    }
+
+    m_embedding_lru_list.emplace_front(token_id, cached);
+    m_embedding_lru_map[token_id] = m_embedding_lru_list.begin();
+    return cached;
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::project_text(const ov::Tensor& hidden_state) {
+    m_talker_projections.set_tensor("hidden_state", hidden_state);
+    m_talker_projections.infer();
+    auto result = m_talker_projections.get_tensor("text_projection");
+    ov::Tensor copy(result.get_element_type(), result.get_shape());
+    result.copy_to(copy);
+    return copy;
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::project_hidden(const ov::Tensor& hidden_state) {
+    m_talker_projections.set_tensor("hidden_state", hidden_state);
+    m_talker_projections.infer();
+    auto result = m_talker_projections.get_tensor("hidden_projection");
+    ov::Tensor copy(result.get_element_type(), result.get_shape());
+    result.copy_to(copy);
+    return copy;
+}
+
+void Qwen3OmniSpeechPipeline::reset_talker() {
+    if (m_talker) {
+        for (auto& state : m_talker.query_state()) {
+            state.reset();
+        }
+    }
+}
+
+int64_t Qwen3OmniSpeechPipeline::sample_top_k(const float* logits,
+                                              size_t vocab_size,
+                                              float temperature,
+                                              size_t top_k,
+                                              float repetition_penalty,
+                                              const std::vector<int64_t>& generated_tokens,
+                                              const std::vector<int64_t>& suppress_tokens) {
+    OPENVINO_ASSERT(vocab_size > 0, "Logits tensor has zero vocab dimension");
+    OPENVINO_ASSERT(temperature > 0.0f, "sample_top_k: temperature must be > 0");
+    OPENVINO_ASSERT(top_k > 0, "sample_top_k: top_k must be > 0");
+    OPENVINO_ASSERT(static_cast<size_t>(top_k) <= vocab_size, "sample_top_k: top_k exceeds logits size");
+
+    // Per-instance scratch buffers — not thread-safe, matching the contract of the rest of the
+    // pipeline (single-threaded per Qwen3OmniSpeechPipeline instance).
+    m_sample_scaled.assign(logits, logits + vocab_size);
+    m_sample_indices.resize(vocab_size);
+
+    // Suppress forbidden tokens (set to -inf before any other processing)
+    for (auto token_id : suppress_tokens) {
+        if (token_id >= 0 && static_cast<size_t>(token_id) < vocab_size) {
+            m_sample_scaled[token_id] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    // Apply repetition penalty to previously generated tokens
+    if (repetition_penalty != 1.0f && !generated_tokens.empty()) {
+        for (auto token_id : generated_tokens) {
+            if (token_id < 0 || static_cast<size_t>(token_id) >= vocab_size)
+                continue;
+            if (m_sample_scaled[token_id] >= 0.0f) {
+                m_sample_scaled[token_id] /= repetition_penalty;
+            } else {
+                m_sample_scaled[token_id] *= repetition_penalty;
+            }
+        }
+    }
+
+    // Apply temperature
+    for (size_t i = 0; i < vocab_size; i++) {
+        m_sample_scaled[i] /= temperature;
+    }
+
+    // Find top-k threshold using nth_element (O(n) vs O(n + k log k) for partial_sort)
+    size_t k = std::min(top_k, vocab_size);
+    std::iota(m_sample_indices.begin(), m_sample_indices.end(), 0);
+    auto* scaled_ptr = m_sample_scaled.data();
+    std::nth_element(m_sample_indices.begin(),
+                     m_sample_indices.begin() + k - 1,
+                     m_sample_indices.end(),
+                     [scaled_ptr](size_t a, size_t b) {
+                         return scaled_ptr[a] > scaled_ptr[b];
+                     });
+    float threshold = m_sample_scaled[m_sample_indices[k - 1]];
+
+    // Collect top-k indices (values >= threshold) and compute softmax only over them
+    m_sample_topk_indices.clear();
+    for (size_t i = 0; i < vocab_size; i++) {
+        if (m_sample_scaled[i] >= threshold) {
+            m_sample_topk_indices.push_back(i);
+        }
+    }
+
+    float max_val = m_sample_scaled[m_sample_topk_indices[0]];
+    for (size_t i = 1; i < m_sample_topk_indices.size(); i++) {
+        max_val = std::max(max_val, m_sample_scaled[m_sample_topk_indices[i]]);
+    }
+
+    m_sample_topk_probs.resize(m_sample_topk_indices.size());
+    float sum = 0.0f;
+    for (size_t i = 0; i < m_sample_topk_indices.size(); i++) {
+        m_sample_topk_probs[i] = std::exp(m_sample_scaled[m_sample_topk_indices[i]] - max_val);
+        sum += m_sample_topk_probs[i];
+    }
+    OPENVINO_ASSERT(sum > 0.0f, "sample_top_k: sum of probabilities is zero");
+    for (size_t i = 0; i < m_sample_topk_probs.size(); i++) {
+        m_sample_topk_probs[i] /= sum;
+    }
+
+    // Multinomial sampling over top-k entries using the pipeline's seeded RNG
+    std::discrete_distribution<size_t> dist(m_sample_topk_probs.begin(), m_sample_topk_probs.end());
+    return static_cast<int64_t>(m_sample_topk_indices[dist(m_rng)]);
+}
+
+std::pair<ov::Tensor, ov::Tensor> Qwen3OmniSpeechPipeline::build_talker_input(
+    const std::vector<int64_t>& full_token_ids,
+    const std::vector<ov::Tensor>& all_intermediate_hidden_states,
+    const ov::Tensor& speaker_embed) {
+    // Find <|im_start|> positions to identify segments
+    std::vector<size_t> im_start_positions;
+    for (size_t i = 0; i < full_token_ids.size(); i++) {
+        if (full_token_ids[i] == m_config.im_start_token_id) {
+            im_start_positions.push_back(i);
+        }
+    }
+
+    GENAI_DEBUG("Speech: found %zu im_start segments, total_tokens=%zu, intermediate_hs=%zu",
+                im_start_positions.size(),
+                full_token_ids.size(),
+                all_intermediate_hidden_states.size());
+
+    auto hidden_size = m_config.talker_hidden_size;
+
+    // TTS special embeddings were pre-computed at pipeline construction (see ctor).
+    const auto& tts_bos_embed = m_tts_bos_embed;
+    const auto& tts_eos_embed = m_tts_eos_embed;
+    const auto& tts_pad_embed = m_tts_pad_embed;
+
+    // Reuse pre-allocated member buffer (avoids heap allocation per call)
+    m_talker_buf.clear();
+    m_talker_buf.reserve(full_token_ids.size() * hidden_size);
+
+    // Append a projected tensor's data to the flat buffer
+    auto append_tensor = [this, hidden_size](const ov::Tensor& t) {
+        const auto* data = t.data<const float>();
+        m_talker_buf.insert(m_talker_buf.end(), data, data + hidden_size);
+    };
+
+    // Element-wise addition of two embedding tensors, appended to flat buffer
+    auto add_embeddings = [this, hidden_size](const ov::Tensor& a, const ov::Tensor& b) {
+        size_t offset = m_talker_buf.size();
+        m_talker_buf.resize(offset + hidden_size);
+        const auto* a_data = a.data<const float>();
+        const auto* b_data = b.data<const float>();
+        for (size_t i = 0; i < hidden_size; i++) {
+            m_talker_buf[offset + i] = a_data[i] + b_data[i];
+        }
+    };
+
+    // Process each segment
+    int last_assistant_seg_idx = -1;
+    for (int seg = static_cast<int>(im_start_positions.size()) - 1; seg >= 0; seg--) {
+        auto pos = im_start_positions[seg];
+        if (pos + 1 < full_token_ids.size() && full_token_ids[pos + 1] == m_config.assistant_token_id) {
+            last_assistant_seg_idx = seg;
+            break;
+        }
+    }
+
+    // For simplicity in initial implementation: process user segments and last assistant segment
+    for (size_t seg = 0; seg < im_start_positions.size(); seg++) {
+        auto seg_start = im_start_positions[seg];
+        auto seg_end = (seg + 1 < im_start_positions.size()) ? im_start_positions[seg + 1] : full_token_ids.size();
+
+        if (seg_start + 1 >= full_token_ids.size())
+            continue;
+        auto role_token = full_token_ids[seg_start + 1];
+
+        // Skip system segments
+        if (role_token == m_config.system_token_id) {
+            continue;
+        }
+
+        // Skip non-last assistant segments
+        if (role_token == m_config.assistant_token_id && static_cast<int>(seg) != last_assistant_seg_idx) {
+            continue;
+        }
+
+        if (role_token == m_config.user_token_id) {
+            // User segment: text tokens use word_embedding -> text_projection,
+            // multimodal tokens use LLM intermediate hidden states -> hidden_projection
+            size_t mm_count = 0, mm_with_hs = 0, mm_without_hs = 0;
+            for (size_t pos = seg_start; pos < seg_end; pos++) {
+                bool is_multimodal =
+                    (full_token_ids[pos] == m_config.audio_token_id || full_token_ids[pos] == m_config.image_token_id ||
+                     full_token_ids[pos] == m_config.video_token_id);
+
+                ov::Tensor projected;
+                if (is_multimodal && pos < all_intermediate_hidden_states.size()) {
+                    projected = project_hidden(all_intermediate_hidden_states[pos]);
+                    mm_with_hs++;
+                } else if (is_multimodal) {
+                    // Multimodal token but no hidden state — fall back to word embedding
+                    auto word_embed = embed_thinker_token(full_token_ids[pos]);
+                    projected = project_text(word_embed);
+                    mm_without_hs++;
+                } else {
+                    auto word_embed = embed_thinker_token(full_token_ids[pos]);
+                    projected = project_text(word_embed);
+                }
+                if (is_multimodal)
+                    mm_count++;
+
+                append_tensor(projected);
+            }
+            GENAI_DEBUG("Speech: user seg [%zu, %zu): %zu tokens, %zu multimodal (%zu with HS, %zu without)",
+                        seg_start,
+                        seg_end,
+                        seg_end - seg_start,
+                        mm_count,
+                        mm_with_hs,
+                        mm_without_hs);
+        } else if (role_token == m_config.assistant_token_id) {
+            // Last assistant segment: build input with codec tokens
+            // Positions in assistant segment (relative to seg_start):
+            // 0: <|im_start|>, 1: assistant, 2: \n, 3+: text tokens
+
+            // Project all assistant positions: word_embedding -> text_projection
+            std::vector<ov::Tensor> assistant_projected;
+            for (size_t pos = seg_start; pos < seg_end; pos++) {
+                auto word_embed = embed_thinker_token(full_token_ids[pos]);
+                assistant_projected.push_back(project_text(word_embed));
+            }
+
+            if (assistant_projected.size() < 3)
+                continue;
+
+            // Build text_hidden + codec_hidden (element-wise addition)
+            // Positions 0-2: projected header tokens + zeros (no codec)
+            for (size_t i = 0; i < 3 && i < assistant_projected.size(); i++) {
+                append_tensor(assistant_projected[i]);
+            }
+
+            // Positions 3-6: tts_pad + codec token embeddings
+            add_embeddings(tts_pad_embed, m_codec_special_embed.at(m_config.codec_nothink_id));
+            add_embeddings(tts_pad_embed, m_codec_special_embed.at(m_config.codec_think_bos_id));
+            add_embeddings(tts_pad_embed, m_codec_special_embed.at(m_config.codec_think_eos_id));
+            add_embeddings(tts_pad_embed, speaker_embed);
+
+            // Position 7: tts_bos + codec_pad
+            add_embeddings(tts_bos_embed, m_codec_special_embed.at(m_config.codec_pad_id));
+
+            // Position 8: first text token + codec_bos
+            if (assistant_projected.size() > 3) {
+                add_embeddings(assistant_projected[3], m_codec_special_embed.at(m_config.codec_bos_id));
+            }
+
+            // Build trailing_text_hidden: remaining projected text tokens (positions 4+)
+            // plus tts_eos at the end — write directly into flat tensor
+            size_t trailing_start = 4;  // Skip im_start, assistant, \n, first_text
+            size_t trailing_len =
+                (assistant_projected.size() > trailing_start ? assistant_projected.size() - trailing_start : 0) +
+                1;  // +1 for tts_eos
+            ov::Tensor trailing_hidden(ov::element::f32, {1, trailing_len, hidden_size});
+            auto* trailing_ptr = trailing_hidden.data<float>();
+            size_t t_idx = 0;
+            for (size_t i = trailing_start; i < assistant_projected.size(); i++) {
+                std::memcpy(trailing_ptr + t_idx * hidden_size,
+                            assistant_projected[i].data<float>(),
+                            hidden_size * sizeof(float));
+                t_idx++;
+            }
+            std::memcpy(trailing_ptr + t_idx * hidden_size, tts_eos_embed.data<float>(), hidden_size * sizeof(float));
+
+            // Build the talker input tensor from flat buffer (already contiguous)
+            size_t total_len = m_talker_buf.size() / hidden_size;
+            ov::Tensor talker_input(ov::element::f32, {1, total_len, hidden_size});
+            std::memcpy(talker_input.data<float>(), m_talker_buf.data(), m_talker_buf.size() * sizeof(float));
+
+            return {talker_input, trailing_hidden};
+        }
+    }
+
+    // Fallback: empty input (should not happen with valid ChatML)
+    ov::Tensor empty_input(ov::element::f32, {1, 0, hidden_size});
+    ov::Tensor empty_trailing(ov::element::f32, {1, 0, hidden_size});
+    return {empty_input, empty_trailing};
+}
+
+std::pair<std::vector<int64_t>, ov::Tensor> Qwen3OmniSpeechPipeline::predict_codes(
+    const ov::Tensor& talker_hidden_state,
+    int64_t first_code,
+    float cp_temperature,
+    size_t cp_top_k) {
+    const size_t num_cp_steps = m_config.num_code_groups - 1;
+    std::vector<int64_t> codes;
+    codes.reserve(num_cp_steps);
+
+    auto hs_size = talker_hidden_state.get_shape().back();
+
+    // codec_hiddens_sum starts from the first-code embedding; each step's codec embedding is added.
+    // Mirrors the reference accumulation (first_code_embed + sum(step codec embeds)).
+    auto first_code_embed = embed_talker_token(first_code);
+    auto* sum_data = m_cp_embed_sum.data<float>();
+    std::memcpy(sum_data, first_code_embed.data<float>(), hs_size * sizeof(float));
+
+    // Fresh KV state per talker step: the single-step graph grows its cache across the inner loop.
+    for (auto& state : m_code_predictor.query_state()) {
+        state.reset();
+    }
+
+    // Prefill input: [1, 2, hidden] = [talker_hidden_state, embed(first_code)].
+    // Decode inputs (steps > 0): [1, 1, hidden] = previous step's codec embedding (from the graph).
+    ov::Tensor prefill_embeds(ov::element::f32, {1, 2, hs_size});
+    auto* pf_data = prefill_embeds.data<float>();
+    std::memcpy(pf_data, talker_hidden_state.data<float>(), hs_size * sizeof(float));
+    std::memcpy(pf_data + hs_size, first_code_embed.data<float>(), hs_size * sizeof(float));
+
+    ov::Tensor beam_idx(ov::element::i32, {1});
+    beam_idx.data<int32_t>()[0] = 0;
+
+    // Sampling is in-graph (Gumbel-max); these scalars parameterize it per step.
+    ov::Tensor step_tensor(ov::element::i64, {});
+    ov::Tensor seed_tensor(ov::element::i64, {});
+    ov::Tensor temp_tensor(ov::element::f32, {});
+    temp_tensor.data<float>()[0] = cp_temperature;
+    ov::Tensor topk_tensor(ov::element::i64, {});
+    topk_tensor.data<int64_t>()[0] = static_cast<int64_t>(cp_top_k);
+
+    // step_embeds is filled from the graph's token_embed output and fed back as the next input.
+    ov::Tensor step_embeds(ov::element::f32, {1, 1, hs_size});
+
+    size_t history_len = 0;  // KV positions already cached
+    for (size_t step = 0; step < num_cp_steps; step++) {
+        const auto& input_embeds = (step == 0) ? prefill_embeds : step_embeds;
+        const size_t seq_len = input_embeds.get_shape()[1];
+
+        ov::Tensor attn_mask(ov::element::i64, {1, history_len + seq_len});
+        std::fill_n(attn_mask.data<int64_t>(), history_len + seq_len, 1);
+
+        ov::Tensor pos_ids(ov::element::i64, {1, seq_len});
+        auto* pos_data = pos_ids.data<int64_t>();
+        for (size_t i = 0; i < seq_len; i++) {
+            pos_data[i] = static_cast<int64_t>(history_len + i);
+        }
+
+        step_tensor.data<int64_t>()[0] = static_cast<int64_t>(step);
+        // Per-step seed drawn from the shared RNG so one rng_seed reproduces the whole audio.
+        seed_tensor.data<int64_t>()[0] = static_cast<int64_t>(m_rng());
+
+        m_code_predictor.set_tensor("inputs_embeds", input_embeds);
+        m_code_predictor.set_tensor("attention_mask", attn_mask);
+        m_code_predictor.set_tensor("position_ids", pos_ids);
+        m_code_predictor.set_tensor("step", step_tensor);
+        m_code_predictor.set_tensor("seed", seed_tensor);
+        m_code_predictor.set_tensor("temperature", temp_tensor);
+        m_code_predictor.set_tensor("top_k", topk_tensor);
+        m_code_predictor.set_tensor("beam_idx", beam_idx);
+        m_code_predictor.infer();
+        history_len += seq_len;
+
+        // Graph emits the sampled code and its codec embedding (baked-in codec_embedding weights).
+        codes.push_back(m_code_predictor.get_tensor("code").data<int64_t>()[0]);
+
+        auto token_embed = m_code_predictor.get_tensor("token_embed");
+        const auto* te_data = token_embed.data<float>();
+        auto* se_data = step_embeds.data<float>();
+        for (size_t i = 0; i < hs_size; i++) {
+            se_data[i] = te_data[i];
+            sum_data[i] += te_data[i];
+        }
+    }
+
+    return {codes, m_cp_embed_sum};
+}
+
+ov::Tensor Qwen3OmniSpeechPipeline::codes_to_wav(const ov::Tensor& codes) {
+    auto codes_shape = codes.get_shape();
+    GENAI_DEBUG("Speech: code2wav input codes shape=[%zu, %zu, %zu]",
+                codes_shape[0], codes_shape[1], codes_shape[2]);
+
+    m_code2wav.set_tensor("codes", codes);
+    m_code2wav.infer();
+    auto waveform = m_code2wav.get_tensor("waveform");
+    auto wav_shape = waveform.get_shape();
+
+    GENAI_INFO("Speech: code2wav output waveform shape=[%zu, %zu, %zu], total_samples=%zu",
+               wav_shape[0], wav_shape[1], wav_shape[2], waveform.get_size());
+
+    ov::Tensor result(waveform.get_element_type(), waveform.get_shape());
+    waveform.copy_to(result);
+    return result;
+}
+
+TalkerResults Qwen3OmniSpeechPipeline::generate_speech(const std::vector<int64_t>& full_token_ids,
+                                                       const std::vector<ov::Tensor>& all_intermediate_hidden_states,
+                                                       const OmniSpeechStreamerVariant& audio_streamer,
+                                                       const OmniTalkerSpeechConfig& talker_speech_config) {
+    // Stamp start_time for the speech-side perf record.
+    const auto speech_start_time = std::chrono::steady_clock::now();
+    auto build_result = [&](ov::Tensor waveform) -> TalkerResults {
+        TalkerResults result;
+        if (waveform && waveform.get_size() > 0) {
+            result.perf_metrics.num_generated_samples = waveform.get_size();
+            result.waveforms.push_back(std::move(waveform));
+        }
+        const auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - speech_start_time).count();
+        result.perf_metrics.generation_time_ms = static_cast<float>(duration_us) / 1000.0f;
+        return result;
+    };
+
+    // Resolve sampling overrides up front: caller-supplied std::optional<...> takes precedence
+    // over the JSON-loaded checkpoint defaults at m_config.{talker,cp}_*.
+    const float talker_temp = talker_speech_config.talker_temperature.value_or(m_config.talker_temperature);
+    const size_t talker_top_k_resolved = talker_speech_config.talker_top_k.value_or(m_config.talker_top_k);
+    const float talker_rep_penalty =
+        talker_speech_config.talker_repetition_penalty.value_or(m_config.talker_repetition_penalty);
+    const float cp_temp = talker_speech_config.cp_temperature.value_or(m_config.cp_temperature);
+    const size_t cp_top_k_resolved = talker_speech_config.cp_top_k.value_or(m_config.cp_top_k);
+    if (talker_speech_config.cp_repetition_penalty) {
+        // The single-step CodePredictor graph samples in-graph (Gumbel-max) and exposes only
+        // step / seed / temperature / top_k, so a per-call repetition-penalty override has no
+        // effect. Warn once so users don't silently assume it took.
+        GENAI_WARN("Speech: cp_repetition_penalty override is ignored — the CodePredictor model "
+                   "samples in-graph and has no repetition-penalty input.");
+    }
+
+    const size_t chunk_frames = talker_speech_config.audio_chunk_frames;
+    OPENVINO_ASSERT(chunk_frames >= 1, "audio_chunk_frames must be >= 1 (got ", chunk_frames, ")");
+    bool streaming = is_speech_streamer_active(audio_streamer);
+
+    if (!m_talker_available) {
+        GENAI_WARN("Speech: talker not available");
+        if (streaming)
+            end_speech_streamer(audio_streamer);
+        return build_result(ov::Tensor{});
+    }
+
+    // Reseed at every entry so output depends only on inputs + seed, not prior call history.
+    // Single shared stream across talker first-code sampling and all CodePredictor steps — one
+    // seed fully reproduces the generated audio. Matches the reference torch.Generator contract.
+    m_rng.seed(static_cast<std::mt19937::result_type>(talker_speech_config.rng_seed));
+
+    GENAI_DEBUG("Speech: tokens=%zu, intermediate=%zu",
+                full_token_ids.size(),
+                all_intermediate_hidden_states.size());
+
+    // Resolve speaker embedding from the variant: Tensor path takes the embedding directly;
+    // string path looks up the named speaker in precomputed embeddings.
+    ov::Tensor speaker_embed_to_use;
+    if (std::holds_alternative<ov::Tensor>(talker_speech_config.speaker)) {
+        const auto& tensor = std::get<ov::Tensor>(talker_speech_config.speaker);
+        const auto& shape = tensor.get_shape();
+        OPENVINO_ASSERT(shape.size() == 3 && shape[0] == 1 && shape[1] == 1 &&
+                            shape[2] == m_config.talker_hidden_size,
+                        "speaker embedding must have shape [1, 1, ",
+                        m_config.talker_hidden_size,
+                        "], got ",
+                        shape);
+        speaker_embed_to_use = tensor;
+    } else {
+        const auto& speaker_name = std::get<std::string>(talker_speech_config.speaker);
+        int64_t speaker_codec_id = resolve_speaker_id(speaker_name);
+        speaker_embed_to_use = m_speaker_embed.at(speaker_codec_id);
+    }
+
+    auto [talker_input, trailing_text_hidden] =
+        build_talker_input(full_token_ids, all_intermediate_hidden_states, speaker_embed_to_use);
+
+    if (talker_input.get_shape()[1] == 0) {
+        GENAI_WARN("Speech: build_talker_input returned empty, cannot generate speech");
+        if (streaming)
+            end_speech_streamer(audio_streamer);
+        return build_result(ov::Tensor{});
+    }
+
+    GENAI_DEBUG("Speech: talker_input=[1, %zu, %zu], trailing=[1, %zu, ...], streaming=%s, chunk_frames=%zu",
+                talker_input.get_shape()[1],
+                talker_input.get_shape()[2],
+                trailing_text_hidden.get_shape()[1],
+                streaming ? "true" : "false",
+                chunk_frames);
+
+    reset_talker();
+
+    // Prefill: run talker on constructed input
+    auto input_len = talker_input.get_shape()[1];
+    auto hidden_size = talker_input.get_shape()[2];
+
+    m_talker.set_tensor("inputs_embeds", talker_input);
+
+    // Use talker generation parameters from config
+    auto talker_max_tokens = talker_speech_config.max_new_tokens;
+    if (talker_max_tokens == std::numeric_limits<std::size_t>::max()) {
+        talker_max_tokens = m_config.talker_max_new_tokens;
+    } else if (talker_max_tokens > m_config.talker_max_new_tokens) {
+        GENAI_WARN("Speech: max_new_tokens (%zu) exceeds model maximum (%zu) — may degrade output quality or produce excess tokens",
+                   talker_max_tokens, m_config.talker_max_new_tokens);
+    }
+
+    // F2: Pre-allocate attention mask at max size (input_len + talker_max_tokens)
+    auto talker_max_len = input_len + talker_max_tokens;
+    ov::Tensor talker_attn_mask(ov::element::i64, {1, talker_max_len});
+    std::fill_n(talker_attn_mask.data<int64_t>(), talker_max_len, 1);
+
+    talker_attn_mask.set_shape({1, input_len});
+    m_talker.set_tensor("attention_mask", talker_attn_mask);
+
+    ov::Tensor pos_ids(ov::element::i64, {1, input_len});
+    auto* pos_data = pos_ids.data<int64_t>();
+    for (size_t i = 0; i < input_len; i++) {
+        pos_data[i] = static_cast<int64_t>(i);
+    }
+    m_talker.set_tensor("position_ids", pos_ids);
+
+    ov::Tensor beam_idx(ov::element::i32, {1});
+    beam_idx.data<int32_t>()[0] = 0;
+    m_talker.set_tensor("beam_idx", beam_idx);
+
+    m_talker.infer();
+
+    // Collect all codec codes: [num_steps, num_code_groups]
+    std::vector<std::vector<int64_t>> all_codes;
+    all_codes.reserve(talker_max_tokens);
+
+    // Streaming cursor: index into all_codes for next chunk start
+    size_t chunk_cursor = 0;
+
+    auto trailing_len = trailing_text_hidden.get_shape()[1];
+    size_t trailing_idx = 0;
+    auto history_len = input_len;
+    auto num_quantizers = m_config.num_code_groups;
+    bool early_stop = false;
+
+    // Reuse the pre-computed tts_pad embedding (talker space) for per-step padding below.
+    const auto& tts_pad_proj = m_tts_pad_embed;
+
+    // Pre-allocate codes stacking buffer at max possible size, then use set_shape per call
+    m_stack_codes_buf = ov::Tensor(ov::element::i64, {1, num_quantizers, talker_max_tokens});
+
+    auto stack_codes_range = [&](size_t begin, size_t end) -> ov::Tensor {
+        size_t n_steps = end - begin;
+        m_stack_codes_buf.set_shape({1, num_quantizers, n_steps});
+        auto* data = m_stack_codes_buf.data<int64_t>();
+        for (size_t s = 0; s < n_steps; s++) {
+            const auto& frame = all_codes[begin + s];
+            for (size_t q = 0; q < num_quantizers && q < frame.size(); q++) {
+                data[q * n_steps + s] = frame[q];
+            }
+        }
+        return m_stack_codes_buf;
+    };
+
+    // talker_temp / talker_top_k_resolved / talker_rep_penalty resolved at function entry
+    // from the OmniTalkerSpeechConfig overrides (or m_config defaults if unset).
+    const auto& suppress_tokens = m_config.talker_suppress_tokens;
+    std::vector<int64_t> generated_first_codes;
+
+    // Reusable tensors for decode steps
+    ov::Tensor next_input(ov::element::f32, {1, 1, hidden_size});
+    ov::Tensor next_pos(ov::element::i64, {1, 1});
+
+    GENAI_INFO("Speech: generating codec tokens (max %zu steps, temp=%.2f, top_k=%zu, rep_penalty=%.2f)...",
+               talker_max_tokens,
+               talker_temp,
+               talker_top_k_resolved,
+               talker_rep_penalty);
+
+    for (size_t step = 0; step < talker_max_tokens; step++) {
+        auto logits = m_talker.get_tensor("logits");
+        auto talker_hidden = m_talker.get_tensor("hidden_states");
+
+        // Sample first codec token from talker with repetition penalty
+        auto vocab_size = logits.get_shape().back();
+        const auto* logits_data = logits.data<float>() + (logits.get_size() - vocab_size);
+        auto first_code = sample_top_k(logits_data,
+                                       vocab_size,
+                                       talker_temp,
+                                       talker_top_k_resolved,
+                                       talker_rep_penalty,
+                                       generated_first_codes,
+                                       suppress_tokens);
+
+        if (step < 3 || step % 100 == 0) {
+            GENAI_DEBUG("Speech: step %zu, code=%lld (EOS=%lld)", step, (long long)first_code, (long long)m_config.codec_eos_token_id);
+        }
+
+        if (first_code == m_config.codec_eos_token_id) {
+            GENAI_INFO("Speech: completed at step %zu (code=%lld matched EOS=%lld)", step, (long long)first_code, (long long)m_config.codec_eos_token_id);
+            break;
+        }
+
+        generated_first_codes.push_back(first_code);
+
+        // Get talker's last hidden state for CodePredictor
+        auto hs_size = talker_hidden.get_shape().back();
+        ov::Tensor last_hidden(ov::element::f32, {1, 1, hs_size});
+        const auto* hs_data = talker_hidden.data<float>() + (talker_hidden.get_size() - hs_size);
+        std::memcpy(last_hidden.data<float>(), hs_data, hs_size * sizeof(float));
+
+        // Run CodePredictor for additional code groups
+        auto [additional_codes, cp_embed_sum] =
+            predict_codes(last_hidden, first_code, cp_temp, cp_top_k_resolved);
+
+        // F8: Emplace directly into all_codes (no intermediate step_codes copy)
+        all_codes.emplace_back();
+        auto& current_codes = all_codes.back();
+        current_codes.reserve(1 + additional_codes.size());
+        current_codes.push_back(first_code);
+        current_codes.insert(current_codes.end(), additional_codes.begin(), additional_codes.end());
+
+        // F9: Streaming uses cursor into all_codes instead of separate chunk_codes
+        if (streaming && all_codes.size() - chunk_cursor >= chunk_frames) {
+            auto chunk_tensor = stack_codes_range(chunk_cursor, all_codes.size());
+            auto chunk_wav = codes_to_wav(chunk_tensor);
+            chunk_cursor = all_codes.size();
+
+            auto status = invoke_speech_streamer(audio_streamer, chunk_wav);
+            if (status == StreamingStatus::STOP || status == StreamingStatus::CANCEL) {
+                GENAI_INFO("Speech: streaming %s at step %zu",
+                           status == StreamingStatus::STOP ? "stopped" : "cancelled",
+                           step);
+                early_stop = true;
+                break;
+            }
+        }
+
+        // Build next talker input: sum of all codec representations + trailing text
+        auto first_code_embed = embed_talker_token(first_code);
+        auto* next_data = next_input.data<float>();
+        auto* fc_data = first_code_embed.data<float>();
+        auto* cp_data = cp_embed_sum.data<float>();
+        for (size_t i = 0; i < hidden_size; i++) {
+            next_data[i] = fc_data[i] + cp_data[i];
+        }
+
+        if (trailing_idx < trailing_len) {
+            const auto* trail_data = trailing_text_hidden.data<float>() + trailing_idx * hidden_size;
+            for (size_t i = 0; i < hidden_size; i++) {
+                next_data[i] += trail_data[i];
+            }
+            trailing_idx++;
+        } else {
+            auto* pad_data = tts_pad_proj.data<float>();
+            for (size_t i = 0; i < hidden_size; i++) {
+                next_data[i] += pad_data[i];
+            }
+        }
+
+        // F2: Reuse pre-allocated attention mask with set_shape
+        history_len++;
+        talker_attn_mask.set_shape({1, history_len});
+        m_talker.set_tensor("attention_mask", talker_attn_mask);
+
+        next_pos.data<int64_t>()[0] = static_cast<int64_t>(history_len - 1);
+        m_talker.set_tensor("position_ids", next_pos);
+
+        m_talker.set_tensor("inputs_embeds", next_input);
+        m_talker.set_tensor("beam_idx", beam_idx);
+        m_talker.infer();
+    }
+
+    // Flush remaining frames if streaming
+    if (streaming && chunk_cursor < all_codes.size() && !early_stop) {
+        auto chunk_tensor = stack_codes_range(chunk_cursor, all_codes.size());
+        auto chunk_wav = codes_to_wav(chunk_tensor);
+        invoke_speech_streamer(audio_streamer, chunk_wav);
+    }
+
+    // Always call end() on active streamer
+    if (streaming) {
+        end_speech_streamer(audio_streamer);
+    }
+
+    if (all_codes.size() == talker_max_tokens) {
+        GENAI_WARN("Speech: reached max tokens (%zu) without EOS", talker_max_tokens);
+    }
+
+    if (all_codes.empty()) {
+        GENAI_WARN("Speech: no codes generated");
+        return build_result(ov::Tensor{});
+    }
+
+    GENAI_INFO("Speech: %zu codec steps generated, converting to waveform...", all_codes.size());
+
+    auto full_codes = stack_codes_range(0, all_codes.size());
+    return build_result(codes_to_wav(full_codes));
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.hpp
@@ -1,0 +1,216 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+#include <list>
+#include <map>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+#include "openvino/genai/omni/talker.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "openvino/runtime/infer_request.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "visual_language/vlm_config.hpp"
+
+namespace ov::genai {
+
+/// @brief Configuration for Qwen3-Omni speech generation.
+struct Qwen3OmniSpeechConfig {
+    int64_t codec_bos_id = -1;
+    int64_t codec_eos_token_id = -1;
+    int64_t codec_pad_id = -1;
+    int64_t codec_nothink_id = -1;
+    int64_t codec_think_bos_id = -1;
+    int64_t codec_think_eos_id = -1;
+    int64_t tts_bos_token_id = -1;
+    int64_t tts_eos_token_id = -1;
+    int64_t tts_pad_token_id = -1;
+    int64_t im_start_token_id = -1;
+    int64_t system_token_id = -1;
+    int64_t user_token_id = -1;
+    int64_t assistant_token_id = -1;
+    int64_t audio_token_id = -1;
+    int64_t image_token_id = -1;
+    int64_t video_token_id = -1;
+    size_t num_code_groups = 16;
+    size_t talker_hidden_size = 1024;
+    std::map<std::string, int64_t> speaker_ids;
+
+    // Talker generation parameters (loaded from generation_config.json)
+    float talker_temperature = 0.9f;
+    size_t talker_top_k = 50;
+    float talker_repetition_penalty = 1.0f;
+    size_t talker_max_new_tokens = 4096;
+    size_t talker_vocab_size = 3072;
+    // Token IDs in [vocab_size-1024, vocab_size) except codec_eos are suppressed
+    std::vector<int64_t> talker_suppress_tokens;
+
+    // CodePredictor sampling parameters (defaults match reference Qwen3-Omni;
+    // overridable via generation_config.json keys: cp_temperature, cp_top_k, cp_repetition_penalty)
+    float cp_temperature = 1.0f;
+    size_t cp_top_k = 50;
+    float cp_repetition_penalty = 1.0f;
+
+    /// @brief Initialize from VLMConfig.
+    static Qwen3OmniSpeechConfig from_vlm_config(const VLMConfig& config);
+};
+
+/// @brief Speech generation pipeline for Qwen3-Omni.
+/// Runs Talker + CodePredictor + Code2Wav after the Thinker completes text generation.
+class Qwen3OmniSpeechPipeline {
+public:
+    Qwen3OmniSpeechPipeline(const std::filesystem::path& model_dir,
+                            const VLMConfig& config,
+                            const std::string& device,
+                            const ov::AnyMap& properties);
+
+    /// @brief Check if all speech models were loaded successfully.
+    bool is_available() const {
+        return m_talker_available;
+    }
+
+    /// @brief Generate speech from thinker generation results.
+    /// @param full_token_ids All token IDs from the full sequence (prompt + generated).
+    /// @param all_intermediate_hidden_states Accumulated layer-14 hidden states [one tensor per step].
+    /// @param audio_streamer Callback or OmniSpeechStreamerBase for streaming (monostate = batch mode).
+    /// @param talker_speech_config Speech generation knobs. Reads `audio_chunk_frames`, `speaker`
+    ///                              (variant: name or embedding tensor), `max_new_tokens`, `rng_seed`,
+    ///                              and the `talker_*` / `cp_*` optional sampling overrides. Unset
+    ///                              overrides keep the checkpoint defaults from `generation_config.json`.
+    /// @return TalkerResults with `waveforms` (the [1, 1, audio_samples] waveform; empty
+    ///         on no-op or failure) and `perf_metrics` (talker-side timing + sample count).
+    /// @note Not thread-safe per instance — shares the pipeline's owned std::mt19937 and
+    ///       ov::InferRequests across talker and CodePredictor sampling.
+    TalkerResults generate_speech(const std::vector<int64_t>& full_token_ids,
+                                 const std::vector<ov::Tensor>& all_intermediate_hidden_states,
+                                 const OmniSpeechStreamerVariant& audio_streamer,
+                                 const OmniTalkerSpeechConfig& talker_speech_config);
+
+    /// @brief Return precomputed speaker embedding for the named speaker. Throws if the model
+    /// has no `talker_config.speaker_id` or the name doesn't match. Tensor shape is
+    /// `[1, 1, talker_hidden_size]`, f32. Use to blend voices: weight-sum two named embeddings
+    /// and assign the result to `OmniTalkerSpeechConfig::speaker` (the Tensor alternative).
+    ov::Tensor get_speaker_embedding(const std::string& name) const;
+
+    /// @brief List names of speakers available in the loaded model's `talker_config.speaker_id`.
+    /// Returns an empty vector when the model exposes no named speakers.
+    std::vector<std::string> list_speakers() const;
+
+private:
+    Qwen3OmniSpeechConfig m_config;
+    bool m_talker_available = false;
+
+    // Thinker text embeddings (for embedding TTS special tokens)
+    ov::InferRequest m_thinker_text_embeddings;
+
+    ov::InferRequest m_talker;
+    ov::InferRequest m_talker_text_embeddings;
+    ov::InferRequest m_talker_projections;  // dual-output: text_projection + hidden_projection
+    ov::InferRequest m_code_predictor;
+    ov::InferRequest m_code2wav;
+
+    // LRU cache for talker token embeddings to avoid redundant inference.
+    // Bounded to kMaxEmbeddingCacheSize entries; evicts least recently used on overflow.
+    static constexpr size_t kMaxEmbeddingCacheSize = 256;
+    std::list<std::pair<int64_t, ov::Tensor>> m_embedding_lru_list;
+    std::unordered_map<int64_t, std::list<std::pair<int64_t, ov::Tensor>>::iterator> m_embedding_lru_map;
+
+    // Pre-allocated scratch buffers reused across generate_speech() calls
+    std::vector<float> m_talker_buf;
+    ov::Tensor m_cp_embed_sum;
+    ov::Tensor m_stack_codes_buf;
+
+    // Constant embeddings pre-computed at pipeline construction. TTS specials are in
+    // talker space (thinker embed -> text projection). Codec specials and speaker IDs
+    // are in talker-embedding space. All are invariant for the life of the pipeline.
+    ov::Tensor m_tts_bos_embed;
+    ov::Tensor m_tts_eos_embed;
+    ov::Tensor m_tts_pad_embed;
+    std::unordered_map<int64_t, ov::Tensor> m_codec_special_embed;
+    std::unordered_map<int64_t, ov::Tensor> m_speaker_embed;
+
+    // Lowercased speaker name -> codec id. Built once at ctor time so resolve_speaker_id
+    // does not rescan-and-lowercase the whole map on every generate_speech() call.
+    std::unordered_map<std::string, int64_t> m_lower_speaker_ids;
+
+    // Owned RNG for deterministic sampling. Reseeded at generate_speech() entry from the
+    // caller-supplied rng_seed; shared across talker first-code sampling and all CodePredictor
+    // steps so a single seed fully reproduces the audio output.
+    std::mt19937 m_rng{0};
+
+    // Per-instance scratch buffers for sample_top_k(). Previously thread_local statics inside
+    // the function; now members because the function is no longer static (needs m_rng).
+    std::vector<float> m_sample_scaled;
+    std::vector<size_t> m_sample_indices;
+    std::vector<size_t> m_sample_topk_indices;
+    std::vector<float> m_sample_topk_probs;
+
+    /// @brief Resolve speaker name to codec token ID.
+    int64_t resolve_speaker_id(const std::string& speaker) const;
+
+    /// @brief Embed a token via thinker word embeddings (for TTS special tokens).
+    /// @return Tensor [1, 1, thinker_hidden_size].
+    ov::Tensor embed_thinker_token(int64_t token_id);
+
+    /// @brief Embed a single token via talker text embeddings.
+    /// @return Tensor [1, 1, talker_hidden_size].
+    ov::Tensor embed_talker_token(int64_t token_id);
+
+    /// @brief Project thinker hidden state through text projection.
+    /// @param hidden_state [1, seq_len, thinker_hidden_size]
+    /// @return [1, seq_len, talker_hidden_size]
+    ov::Tensor project_text(const ov::Tensor& hidden_state);
+
+    /// @brief Project thinker intermediate hidden state through hidden projection.
+    /// @param hidden_state [1, seq_len, thinker_hidden_size]
+    /// @return [1, seq_len, talker_hidden_size]
+    ov::Tensor project_hidden(const ov::Tensor& hidden_state);
+
+    /// @brief Build the talker input embeddings from thinker outputs.
+    /// @param speaker_embed Speaker embedding `[1, 1, talker_hidden_size]` summed with tts_pad in
+    ///                      the talker prefix. Caller owns shape validation.
+    /// @return Pair of (talker_input_embeds, trailing_text_hidden).
+    std::pair<ov::Tensor, ov::Tensor> build_talker_input(const std::vector<int64_t>& full_token_ids,
+                                                         const std::vector<ov::Tensor>& all_intermediate_hidden_states,
+                                                         const ov::Tensor& speaker_embed);
+
+    /// @brief Run the CodePredictor mini-loop for one talker step.
+    /// Drives the single-step stateful CodePredictor graph num_code_groups-1 times. Sampling and
+    /// codec embedding are in-graph: each call returns the sampled code and its embedding, which is
+    /// fed back as the next step's input.
+    /// @param talker_hidden_state The last hidden state from talker [1, 1, talker_hidden_size].
+    /// @param first_code The first codec code from talker sampling.
+    /// @param cp_temperature Resolved CodePredictor temperature for this call.
+    /// @param cp_top_k Resolved CodePredictor top-k for this call.
+    /// @return Pair of (additional_codes, codec_embeddings_sum) where codec_embeddings_sum is the
+    ///         first-code embedding plus all step-specific codec embeddings [1, 1, hidden_size].
+    std::pair<std::vector<int64_t>, ov::Tensor> predict_codes(const ov::Tensor& talker_hidden_state,
+                                                              int64_t first_code,
+                                                              float cp_temperature,
+                                                              size_t cp_top_k);
+
+    /// @brief Convert codec codes to waveform.
+    ov::Tensor codes_to_wav(const ov::Tensor& codes);
+
+    /// @brief Reset talker KV cache state.
+    void reset_talker();
+
+    /// @brief Sample from logits with temperature, top-k, repetition penalty, and token suppression.
+    /// @note Member function (mutates m_rng and scratch buffers). Uses this instance's RNG so
+    ///       talker and CodePredictor draws come from a single seeded stream.
+    int64_t sample_top_k(const float* logits,
+                         size_t vocab_size,
+                         float temperature,
+                         size_t top_k,
+                         float repetition_penalty,
+                         const std::vector<int64_t>& generated_tokens,
+                         const std::vector<int64_t>& suppress_tokens = {});
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "visual_language/qwen3_vl/classes.hpp"
+
 #include <algorithm>
 #include <numeric>
+
 #include "utils.hpp"
 #include "logger.hpp"
 
@@ -59,18 +61,23 @@ std::vector<float> calculate_timestamps(const VideoMetadata& video_metadata, siz
     return timestamps;
 }
 
+}  // namespace
+
 /**
  * @brief Populates video metadata and computes frame sampling indices based on video processor config.
  */
-void fill_video_metadata(VideoMetadata& video_metadata, size_t total_num_frames, const VideoProcessorConfig& video_config) {
+void fill_video_metadata(EncodedVideo& encoded_video,
+                         size_t total_num_frames,
+                         const VideoProcessorConfig& video_config) {
+    auto& video_metadata = encoded_video.metadata;
     if (!video_metadata.frames_indices.empty()) {
         GENAI_WARN("Frames indices already provided in video metadata, skipping Qwen3-VL model-specific sampling.");
         return;
     }
 
     OPENVINO_ASSERT(!(video_config.fps != 0.0f && video_config.num_frames != 0),
-        "num_frames and fps are mutually exclusive video config arguments.");
-    
+                    "num_frames and fps are mutually exclusive video config arguments.");
+
     if (!video_config.do_sample_frames) {
         // frames_indices is still needed for timestamp calculation
         video_metadata.frames_indices.resize(total_num_frames);
@@ -80,7 +87,7 @@ void fill_video_metadata(VideoMetadata& video_metadata, size_t total_num_frames,
 
     // Sample frame indices if needed
     size_t num_frames = video_config.num_frames;
-    
+
     if (num_frames == 0 && video_config.fps != 0.0f) {
         if (video_metadata.fps == 0.0f) {
             GENAI_WARN("Requested to sample frames by fps, but video metadata fps is not set. "
@@ -98,7 +105,7 @@ void fill_video_metadata(VideoMetadata& video_metadata, size_t total_num_frames,
     }
 
     OPENVINO_ASSERT(num_frames > 1 && num_frames <= total_num_frames,
-        "Invalid number of frames (" + std::to_string(num_frames) +") for video sampling.");
+                    "Invalid number of frames (" + std::to_string(num_frames) + ") for video sampling.");
 
     video_metadata.frames_indices.reserve(num_frames);
     for (size_t i = 0; i < num_frames; ++i) {
@@ -108,6 +115,8 @@ void fill_video_metadata(VideoMetadata& video_metadata, size_t total_num_frames,
         video_metadata.frames_indices.push_back(frame_idx);
     }
 }
+
+namespace {
 
 /**
  * @brief Computes indices and weights for bilinear position embedding interpolation.
@@ -247,11 +256,9 @@ void permute_with_spatial_merge_and_add(
  * @brief Create visual position mask from input_ids by finding vision pad tokens.
  * @return Boolean tensor [batch, seq_len] with true at vision token positions
  */
-ov::Tensor create_visual_pos_masks(
-    const ov::Tensor& input_ids,
-    int64_t image_pad_token_id,
-    int64_t video_pad_token_id
-) {
+ov::Tensor create_visual_pos_masks(const ov::Tensor& input_ids,
+                                   int64_t image_pad_token_id,
+                                   int64_t video_pad_token_id) {
     const auto input_ids_shape = input_ids.get_shape();
     ov::Tensor result{ov::element::boolean, input_ids_shape};
     bool* result_data = result.data<bool>();
@@ -326,7 +333,21 @@ std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
 
 EncodedVideo VisionEncoderQwen3VL::encode_frames(const std::vector<ov::Tensor>& frames) {
     EncodedVideo encoded_video;
-    VisionEncoderQwen2VL::encode_frames_with_config(encoded_video, frames, m_video_processor_config);
+
+    fill_video_metadata(encoded_video, frames.size(), m_video_processor_config);
+
+    std::vector<ov::Tensor> sampled_frames;
+    if (!m_video_processor_config.do_sample_frames) {
+        sampled_frames = frames;
+    } else {
+        sampled_frames.reserve(encoded_video.metadata.frames_indices.size());
+        for (size_t idx : encoded_video.metadata.frames_indices) {
+            OPENVINO_ASSERT(idx < frames.size(), "Frame index ", idx, " out of range for ", frames.size(), " frames.");
+            sampled_frames.push_back(frames.at(idx));
+        }
+    }
+
+    VisionEncoderQwen2VL::encode_frames_with_config(encoded_video, sampled_frames, m_video_processor_config);
     return encoded_video;
 }
 
@@ -344,13 +365,11 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     }
     auto pos_compiled = utils::singleton_core().compile_model(
         pos_model, device, utils::get_model_properties(device_config, "vision_embeddings_pos", device));
-    
     m_ireq_queue_vision_embeddings_pos = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
         pos_compiled.get_property(ov::optimal_number_of_infer_requests),
         [&pos_compiled]() -> ov::InferRequest {
             return pos_compiled.create_infer_request();
-        }
-    );
+        });
 }
 
 InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
@@ -362,7 +381,7 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const ov::AnyMap device_config
 ) : InputsEmbedderQwen2VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config),
     m_use_patched_pos_model(!is_cpp_pos_embeds_fallback_requested()) {
-    const auto& [pos_model_str, pos_weights] = 
+    const auto& [pos_model_str, pos_weights] =
         utils::get_model_weights_pair(models_map, "vision_embeddings_pos");
     auto pos_model = utils::singleton_core().read_model(pos_model_str, pos_weights);
     if (m_use_patched_pos_model) {
@@ -370,13 +389,11 @@ InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     }
     auto pos_compiled = utils::singleton_core().compile_model(
         pos_model, device, utils::get_model_properties(device_config, "vision_embeddings_pos", device));
-    
     m_ireq_queue_vision_embeddings_pos = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
         pos_compiled.get_property(ov::optimal_number_of_infer_requests),
         [&pos_compiled]() -> ov::InferRequest {
             return pos_compiled.create_infer_request();
-        }
-    );
+        });
 }
 
 std::vector<ov::genai::EncodedVideo> InputsEmbedderQwen3VL::encode_videos(
@@ -390,13 +407,16 @@ std::vector<ov::genai::EncodedVideo> InputsEmbedderQwen3VL::encode_videos(
     for (size_t i = 0; i < videos.size(); ++i) {
         const ov::Tensor& video = videos[i];
         const size_t video_num_frames = video.get_shape()[0];
-        VideoMetadata video_metadata = i < videos_metadata.size() ? videos_metadata[i] : VideoMetadata{};
-        fill_video_metadata(video_metadata, video_num_frames, m_vision_encoder->get_video_processor_config());
-        const auto sampled_video = sample_video_if_needed(video, video_metadata);
+        EncodedVideo encoded_video;
+        encoded_video.metadata = i < videos_metadata.size() ? videos_metadata[i] : VideoMetadata{};
+        fill_video_metadata(encoded_video, video_num_frames, m_vision_encoder->get_video_processor_config());
+        const auto sampled_video = sample_video_if_needed(video, encoded_video.metadata);
         std::vector<ov::Tensor> frames = to_single_image_tensors({sampled_video});
-        auto encoded_video = m_vision_encoder->encode_frames(frames);
-        encoded_video.metadata = video_metadata;
-        encoded_videos.emplace_back(encoded_video);
+        auto per_frame_encoded = m_vision_encoder->encode_frames(frames);
+        encoded_video.video_features = std::move(per_frame_encoded.video_features);
+        encoded_video.resized_source_size = per_frame_encoded.resized_source_size;
+        encoded_video.frame_num = per_frame_encoded.frame_num;
+        encoded_videos.emplace_back(std::move(encoded_video));
     }
     return encoded_videos;
 }
@@ -505,76 +525,145 @@ void InputsEmbedderQwen3VL::add_interpolated_pos_embeds(
     permute_with_spatial_merge_and_add(weighted_sum, concatenated_embeds.data<float>(), grids_thw, spatial_merge_size);
 }
 
+ov::Tensor InputsEmbedderQwen3VL::get_interpolated_pos_embeds(
+    const std::vector<std::array<size_t, 3>>& grids_thw
+) {
+    if (grids_thw.empty()) {
+        return ov::Tensor{ov::element::f32, {0, 0}};
+    }
+
+    size_t total_out_positions = 0;
+    for (const auto& thw : grids_thw) {
+        total_out_positions += thw[0] * thw[1] * thw[2];
+    }
+
+    const size_t num_grid_per_side = static_cast<size_t>(
+        std::sqrt(static_cast<double>(m_vlm_config.vision_config_num_position_embeddings)));
+
+    auto [indices, weights] = get_position_interpolation_indices_and_weights(grids_thw, num_grid_per_side);
+
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(m_ireq_queue_vision_embeddings_pos.get());
+    ov::InferRequest& vision_embeddings_pos = infer_request_guard.get();
+
+    vision_embeddings_pos.set_tensor("input", indices);
+
+    ov::Tensor weighted_sum;
+    if (m_use_patched_pos_model) {
+        vision_embeddings_pos.set_tensor("weights", weights);
+        vision_embeddings_pos.infer();
+        weighted_sum = vision_embeddings_pos.get_output_tensor();
+    } else {
+        vision_embeddings_pos.infer();
+        ov::Tensor raw_pos_embeds = vision_embeddings_pos.get_output_tensor();
+
+        const size_t num_positions = raw_pos_embeds.get_shape()[1];
+        const size_t dim = raw_pos_embeds.get_shape()[2];
+
+        weighted_sum = ov::Tensor{ov::element::f32, {num_positions, dim}};
+        float* weighted_sum_data = weighted_sum.data<float>();
+        std::fill_n(weighted_sum_data, num_positions * dim, 0.0f);
+
+        const float* raw_data = raw_pos_embeds.data<const float>();
+        const float* weights_data = weights.data<const float>();
+
+        for (size_t corner = 0; corner < 4; ++corner) {
+            for (size_t pos = 0; pos < num_positions; ++pos) {
+                float w = weights_data[corner * num_positions + pos];
+                const float* src = raw_data + (corner * num_positions + pos) * dim;
+                float* dst = weighted_sum_data + pos * dim;
+                for (size_t d = 0; d < dim; ++d) {
+                    dst[d] += w * src[d];
+                }
+            }
+        }
+    }
+
+    const size_t dim = weighted_sum.get_shape()[1];
+    ov::Tensor result{ov::element::f32, {total_out_positions, dim}};
+    std::fill_n(result.data<float>(), total_out_positions * dim, 0.0f);
+
+    size_t spatial_merge_size = m_vision_encoder->get_processor_config().merge_size;
+    permute_with_spatial_merge_and_add(weighted_sum, result.data<float>(), grids_thw, spatial_merge_size);
+
+    return result;
+}
+
 std::pair<ov::Tensor, ov::Tensor> InputsEmbedderQwen3VL::run_video_image_embeddings_merger(
     const std::vector<EncodedImage>& images,
     const std::vector<size_t>& images_sequence,
     const std::vector<EncodedVideo>& videos,
-    const std::vector<size_t>& videos_sequence
-) {
-    auto [reordered_image_embeds, reordered_images_grid_thw] = 
+    const std::vector<size_t>& videos_sequence) {
+    auto [reordered_image_embeds, reordered_images_grid_thw] =
         qwen2_vl_utils::reorder_image_embeds_and_grid_thw(images, images_sequence);
-    auto [reordered_video_embeds, reordered_videos_grid_thw] = 
+    auto [reordered_video_embeds, reordered_videos_grid_thw] =
         qwen2_vl_utils::reorder_video_embeds_and_grid_thw(videos, videos_sequence);
-    
-    ov::Tensor concatenated_embeds = 
+
+    ov::Tensor concatenated_embeds =
         qwen2_vl_utils::concatenate_video_image_embeds(reordered_video_embeds, reordered_image_embeds);
-    
+
     // Combined grid for position computation
     std::vector<std::array<size_t, 3>> combined_grid_thw;
-    combined_grid_thw.insert(combined_grid_thw.end(), 
-        reordered_videos_grid_thw.begin(), reordered_videos_grid_thw.end());
-    combined_grid_thw.insert(combined_grid_thw.end(), 
-        reordered_images_grid_thw.begin(), reordered_images_grid_thw.end());
-    
+    combined_grid_thw.insert(combined_grid_thw.end(),
+                             reordered_videos_grid_thw.begin(),
+                             reordered_videos_grid_thw.end());
+    combined_grid_thw.insert(combined_grid_thw.end(),
+                             reordered_images_grid_thw.begin(),
+                             reordered_images_grid_thw.end());
+
     if (!combined_grid_thw.empty()) {
         add_interpolated_pos_embeds(combined_grid_thw, concatenated_embeds);
     }
-    
+
     ov::Tensor rotary_pos_emb = get_rotary_pos_emb(combined_grid_thw);
-    
+
     CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(m_ireq_queue_vision_embeddings_merger.get());
     ov::InferRequest& vision_embeddings_merger = infer_request_guard.get();
-    
+
     vision_embeddings_merger.set_tensor("hidden_states", concatenated_embeds);
-    
+
     if (m_with_cu_seqlens_input) {
-        vision_embeddings_merger.set_tensor("cu_seq_lens", 
+        vision_embeddings_merger.set_tensor(
+            "cu_seq_lens",
             qwen2_vl_utils::get_cu_seqlens(reordered_images_grid_thw, reordered_videos_grid_thw));
     } else {
-        vision_embeddings_merger.set_tensor("attention_mask",
+        vision_embeddings_merger.set_tensor(
+            "attention_mask",
             qwen2_vl_utils::get_attention_mask(reordered_images_grid_thw, reordered_videos_grid_thw));
     }
-    
+
     vision_embeddings_merger.set_tensor("rotary_pos_emb", rotary_pos_emb);
     vision_embeddings_merger.infer();
-    
+
     ov::Tensor vision_embeds = vision_embeddings_merger.get_tensor("last_hidden_state");
-    
+
     if (has_lm_extra_input("deepstack_visual_embeds")) {
-        m_lm_extra_inputs["deepstack_visual_embeds"] = vision_embeddings_merger.get_tensor("deepstack_feature_lists");
+        ov::Tensor deepstack_view = vision_embeddings_merger.get_tensor("deepstack_feature_lists");
+        ov::Tensor deepstack_owned(deepstack_view.get_element_type(), deepstack_view.get_shape());
+        deepstack_view.copy_to(deepstack_owned);
+        m_lm_extra_inputs["deepstack_visual_embeds"] = std::move(deepstack_owned);
     }
-    
+
     auto vision_embeds_shape = vision_embeds.get_shape();
-    
+
     // Split vision embeddings
     size_t video_tokens = calc_vec_tokens_num(reordered_videos_grid_thw);
     size_t image_tokens = calc_vec_tokens_num(reordered_images_grid_thw);
     size_t total_tokens = video_tokens + image_tokens;
-    
+
     size_t video_count = 0;
     if (total_tokens > 0) {
         video_count = vision_embeds_shape[0] * video_tokens / total_tokens;
     }
     size_t image_count = vision_embeds_shape[0] - video_count;
-    
+
     ov::Tensor video_embeds{vision_embeds.get_element_type(), {video_count, vision_embeds_shape[1]}};
     ov::Tensor image_embeds{vision_embeds.get_element_type(), {image_count, vision_embeds_shape[1]}};
-    
+
     std::memcpy(video_embeds.data(), vision_embeds.data(), video_embeds.get_byte_size());
     std::memcpy(image_embeds.data(),
                 static_cast<uint8_t*>(vision_embeds.data()) + video_embeds.get_byte_size(),
                 image_embeds.get_byte_size());
-    
+
     return {video_embeds, image_embeds};
 }
 
@@ -585,17 +674,14 @@ std::vector<std::array<size_t, 3>> InputsEmbedderQwen3VL::get_vision_grid_thw_fo
     const std::vector<std::array<size_t, 3>>& videos_grid_thw,
     const std::vector<size_t>& videos_sequence,
     const size_t video_id,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
-) const {
-    auto reordered_vision_grid_thw = InputsEmbedderQwen2VL::get_vision_grid_thw_for_position_ids(
-        images_grid_thw,
-        images_sequence,
-        image_id,
-        videos_grid_thw,
-        videos_sequence,
-        video_id,
-        history_vision_count
-    );
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) const {
+    auto reordered_vision_grid_thw = InputsEmbedderQwen2VL::get_vision_grid_thw_for_position_ids(images_grid_thw,
+                                                                                                 images_sequence,
+                                                                                                 image_id,
+                                                                                                 videos_grid_thw,
+                                                                                                 videos_sequence,
+                                                                                                 video_id,
+                                                                                                 history_vision_count);
 
     // Split video grids per each frame for position_ids calculation as Qwen3-VL uses timestamp tokens between frames.
     std::vector<std::array<size_t, 3>> flattened_vision_grid_thw;
@@ -622,29 +708,24 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
     bool recalculate_merged_embeddings,
     const std::vector<size_t>& images_sequence,
     const std::vector<size_t>& videos_sequence,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
-) {
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
     std::vector<std::array<size_t, 3>> images_grid_thw;
     images_grid_thw.reserve(images.size());
     for (const auto& encoded_image : images) {
-        images_grid_thw.push_back({
-            1,
-            encoded_image.resized_source_size.height,
-            encoded_image.resized_source_size.width
-        });
+        images_grid_thw.push_back(
+            {1, encoded_image.resized_source_size.height, encoded_image.resized_source_size.width});
     }
 
     std::vector<std::array<size_t, 3>> videos_grid_thw;
     videos_grid_thw.reserve(videos.size());
     for (const auto& encoded_video : videos) {
-        videos_grid_thw.push_back({
-            encoded_video.frame_num,
-            encoded_video.resized_source_size.height,
-            encoded_video.resized_source_size.width
-        });
+        videos_grid_thw.push_back({encoded_video.frame_num,
+                                   encoded_video.resized_source_size.height,
+                                   encoded_video.resized_source_size.width});
     }
 
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    m_last_input_ids = input_ids;
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
     ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
@@ -688,7 +769,7 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
     }
 
     if (recalculate_merged_embeddings) {
-        std::tie(m_merged_video_embeddings, m_merged_image_embeddings) = 
+        std::tie(m_merged_video_embeddings, m_merged_image_embeddings) =
             run_video_image_embeddings_merger(images, images_sequence, videos, videos_sequence);
     }
 
@@ -738,9 +819,12 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
         m_lm_extra_inputs["visual_pos_masks"] = create_visual_pos_masks(input_ids, image_pad_token_id, video_pad_token_id);
     }
 
-    return qwen2_vl_utils::merge_text_and_video_image_embeddings(
-        input_ids, text_embeds, m_merged_image_embeddings, m_merged_video_embeddings,
-        image_pad_token_id, video_pad_token_id);
+    return qwen2_vl_utils::merge_text_and_video_image_embeddings(input_ids,
+                                                                 text_embeds,
+                                                                 m_merged_image_embeddings,
+                                                                 m_merged_video_embeddings,
+                                                                 image_pad_token_id,
+                                                                 video_pad_token_id);
 }
 
 void InputsEmbedderQwen3VL::start_chat(const std::string& system_message) {
@@ -772,4 +856,4 @@ bool InputsEmbedderQwen3VL::has_lm_extra_input(const std::string& input_name) co
     return lm_extra_inputs.find(input_name) != lm_extra_inputs.end();
 }
 
-} // namespace ov::genai
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -5,10 +5,10 @@
 
 #include <filesystem>
 
-#include "visual_language/vlm_config.hpp"
-#include "visual_language/vision_encoder.hpp"
 #include "visual_language/inputs_embedder.hpp"
 #include "visual_language/qwen2vl/classes.hpp"
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/vlm_config.hpp"
 
 namespace ov::genai {
 
@@ -21,19 +21,17 @@ public:
 
 class InputsEmbedderQwen3VL : public InputsEmbedderQwen2VL {
 public:
-    InputsEmbedderQwen3VL(
-        const VLMConfig& vlm_config,
-        const std::filesystem::path& model_dir,
-        const std::string& device,
-        const ov::AnyMap device_config);
+    InputsEmbedderQwen3VL(const VLMConfig& vlm_config,
+                          const std::filesystem::path& model_dir,
+                          const std::string& device,
+                          const ov::AnyMap device_config);
 
-    InputsEmbedderQwen3VL(
-        const VLMConfig& vlm_config,
-        const ModelsMap& models_map,
-        const Tokenizer& tokenizer,
-        const std::filesystem::path& config_dir_path,
-        const std::string& device,
-        const ov::AnyMap device_config);
+    InputsEmbedderQwen3VL(const VLMConfig& vlm_config,
+                          const ModelsMap& models_map,
+                          const Tokenizer& tokenizer,
+                          const std::filesystem::path& config_dir_path,
+                          const std::string& device,
+                          const ov::AnyMap device_config);
 
     ov::Tensor get_inputs_embeds(
         const std::string& prompt,
@@ -57,14 +55,16 @@ public:
     void finish_chat() override;
 
 protected:
-    // Vision embeddings position model
+    // Cached input_ids from last get_encoded_input_ids() call within get_inputs_embeds().
+    // Allows subclasses to access input_ids without re-tokenizing (which corrupts cache state).
+    ov::Tensor m_last_input_ids;
+
     std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_embeddings_pos;
     // By default the vision_embeddings_pos model is patched to perform the weighted sum on the
     // device (faster, deterministic on GPU). Setting the VISION_POS_EMBEDS=CPP environment
     // variable disables the patch and falls back to a C++ weighted sum on the host.
     bool m_use_patched_pos_model = true;
 
-    // Cached extra inputs for language model
     std::unordered_map<std::string, ov::Tensor> m_lm_extra_inputs{
         {"deepstack_visual_embeds", ov::Tensor()},
         {"visual_pos_masks", ov::Tensor()}
@@ -90,12 +90,21 @@ protected:
 
     /**
      * @brief Computes interpolated position embeddings and adds them in-place.
-     * 
+     *
      * Calculates position interpolation indices and weights, runs vision_embeddings_pos model,
      * applies bilinear interpolation weights, sums corners, permutes for spatial merge,
      * and adds the result directly into concatenated_embeds (fused permute + addition).
      */
     void add_interpolated_pos_embeds(const std::vector<std::array<size_t, 3>>& grids_thw, ov::Tensor& concatenated_embeds);
+
+    /**
+     * @brief Computes interpolated position embeddings and returns them as a new tensor.
+     *
+     * Like add_interpolated_pos_embeds, but returns the permuted pos_embeds tensor instead of
+     * fusing it into concatenated_embeds. Used by subclasses whose vision model accepts
+     * pos_embeds as a separate input (e.g. Qwen3-Omni's merged vision model).
+     */
+    ov::Tensor get_interpolated_pos_embeds(const std::vector<std::array<size_t, 3>>& grids_thw);
 
     std::vector<std::array<size_t, 3>> get_vision_grid_thw_for_position_ids(
         const std::vector<std::array<size_t, 3>>& images_grid_thw,
@@ -104,8 +113,12 @@ protected:
         const std::vector<std::array<size_t, 3>>& videos_grid_thw,
         const std::vector<size_t>& videos_sequence,
         const size_t video_id,
-        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
-    ) const override;
+        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) const override;
 };
 
-} // namespace ov::genai
+/// @brief Populates video metadata (frame sampling indices) in encoded_video struct.
+void fill_video_metadata(EncodedVideo& encoded_video,
+                         size_t total_num_frames,
+                         const VideoProcessorConfig& video_config);
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -12,6 +12,7 @@
 #include "visual_language/qwen2_5_vl/classes.hpp"
 #include "visual_language/qwen3_vl/classes.hpp"
 #include "visual_language/qwen3_5/classes.hpp"
+#include "visual_language/qwen3_omni/classes.hpp"
 #include "visual_language/phi3_vision/classes.hpp"
 #include "visual_language/phi4mm/classes.hpp"
 #include "visual_language/minicpm/classes.hpp"
@@ -45,8 +46,7 @@ VisionEncoder::VisionEncoder(
     const std::filesystem::path& config_dir_path,
     const std::string& device,
     const ov::AnyMap device_config) {
-    const auto& vision_encoder_model = utils::get_model_weights_pair(models_map, "vision_embeddings").first;
-    const auto& vision_encoder_weights = utils::get_model_weights_pair(models_map, "vision_embeddings").second;
+    const auto& [vision_encoder_model, vision_encoder_weights] = utils::get_model_weights_pair(models_map, "vision_embeddings");
     auto compiled_model = utils::singleton_core().compile_model(
         vision_encoder_model, vision_encoder_weights, device,
         utils::get_model_properties(device_config, "vision_embeddings", device));
@@ -94,6 +94,13 @@ void VisionEncoder::resolve_processor_configs(const std::filesystem::path& confi
     }
 }
 
+VisionEncoder::VisionEncoder(const std::filesystem::path& config_dir, ConfigOnlyTag) {
+    resolve_processor_configs(config_dir);
+}
+
+VisionEncoder::VisionEncoder(const ModelsMap&, const std::filesystem::path& config_dir, ConfigOnlyTag tag)
+    : VisionEncoder(config_dir, tag) {}
+
 ProcessorConfig VisionEncoder::get_processor_config() const {
     return m_processor_config;
 }
@@ -127,6 +134,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderQwen3VL>(model_dir, device, properties);
     } else if (model_type == VLMModelType::QWEN3_5 || model_type == VLMModelType::QWEN3_5_MOE) {
         return std::make_shared<VisionEncoderQwen3_5>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::QWEN3_OMNI) {
+        return std::make_shared<VisionEncoderQwen3Omni>(model_dir, device, properties);
     } else if (model_type == VLMModelType::GEMMA3) {
         return std::make_shared<VisionEncoderGemma3>(model_dir, device, properties);
     } else if (model_type == VLMModelType::GEMMA3N) {
@@ -172,6 +181,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderQwen3VL>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::QWEN3_5 || model_type == VLMModelType::QWEN3_5_MOE) {
         return std::make_shared<VisionEncoderQwen3_5>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::QWEN3_OMNI) {
+        return std::make_shared<VisionEncoderQwen3Omni>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::GEMMA3) {
         return std::make_shared<VisionEncoderGemma3>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::GEMMA3N) {

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -158,6 +158,11 @@ protected:
     void resolve_processor_configs(const std::filesystem::path& config_dir_path);
     
     VisionEncoder() = default;
+    // Config-only constructor tag for subclasses where vision encoder is merged
+    // into a single model (loads only config files, skips model compilation)
+    struct ConfigOnlyTag {};
+    VisionEncoder(const std::filesystem::path& config_dir, ConfigOnlyTag);
+    VisionEncoder(const ModelsMap& models_map, const std::filesystem::path& config_dir, ConfigOnlyTag);
 
 public:
     VisionEncoder(

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -32,6 +32,8 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"gemma4", VLMModelType::GEMMA4},
         {"gemma4_unified", VLMModelType::GEMMA4_UNIFIED},
         {"videochat_flash_qwen", VLMModelType::VIDEOCHAT_FLASH_QWEN},
+        {"qwen3_omni", VLMModelType::QWEN3_OMNI},
+        {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
     };
 
     auto it = model_types_map.find(value);
@@ -60,7 +62,6 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
     read_json_param(parsed, "query_num", query_num);
     read_json_param(parsed, "use_image_id", use_image_id);
 
-    // Setting llava_next specific config params
     read_json_param(parsed, "image_newline", image_newline);
     read_json_param(parsed, "vision_config.patch_size", vision_config_patch_size);
 
@@ -88,6 +89,39 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
     if (parsed.contains("text_config") && parsed.at("text_config").contains("use_bidirectional_attention") &&
         parsed.at("text_config").at("use_bidirectional_attention").is_string()) {
         read_json_param(parsed, "text_config.use_bidirectional_attention", use_bidirectional_attention);
+    }
+
+    // Qwen3-Omni: vision/audio configs are nested under thinker_config
+    if (model_type == VLMModelType::QWEN3_OMNI) {
+        read_json_param(parsed, "thinker_config.text_config.hidden_size", hidden_size);
+        read_json_param(parsed, "thinker_config.vision_config.num_position_embeddings", vision_config_num_position_embeddings);
+        read_json_param(parsed, "thinker_config.vision_config.deepstack_visual_indexes", vision_config_deepstack_visual_indexes);
+        read_json_param(parsed, "thinker_config.audio_config.num_mel_bins", audio_config_num_mel_bins);
+        read_json_param(parsed, "thinker_config.audio_config.n_window", audio_config_n_window);
+        read_json_param(parsed, "thinker_config.audio_config.n_window_infer", audio_config_n_window_infer);
+        read_json_param(parsed, "enable_audio_output", enable_audio_output);
+        read_json_param(parsed, "tts_bos_token_id", tts_bos_token_id);
+        read_json_param(parsed, "tts_eos_token_id", tts_eos_token_id);
+        read_json_param(parsed, "tts_pad_token_id", tts_pad_token_id);
+        read_json_param(parsed, "im_start_token_id", im_start_token_id);
+        read_json_param(parsed, "system_token_id", system_token_id);
+        read_json_param(parsed, "user_token_id", user_token_id);
+        read_json_param(parsed, "assistant_token_id", assistant_token_id);
+        read_json_param(parsed, "thinker_config.audio_token_id", audio_token_id);
+        read_json_param(parsed, "thinker_config.image_token_id", image_token_id);
+        read_json_param(parsed, "thinker_config.video_token_id", video_token_id);
+        read_json_param(parsed, "talker_config.num_code_groups", talker_num_code_groups);
+        read_json_param(parsed, "talker_config.codec_bos_id", talker_codec_bos_id);
+        read_json_param(parsed, "talker_config.codec_eos_token_id", talker_codec_eos_token_id);
+        read_json_param(parsed, "talker_config.codec_pad_id", talker_codec_pad_id);
+        read_json_param(parsed, "talker_config.codec_nothink_id", talker_codec_nothink_id);
+        read_json_param(parsed, "talker_config.codec_think_bos_id", talker_codec_think_bos_id);
+        read_json_param(parsed, "talker_config.codec_think_eos_id", talker_codec_think_eos_id);
+        if (parsed.contains("talker_config") && parsed["talker_config"].contains("speaker_id")) {
+            for (auto& [key, val] : parsed["talker_config"]["speaker_id"].items()) {
+                speaker_ids[key] = val.get<int64_t>();
+            }
+        }
     }
 }
 

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <filesystem>
+#include <map>
+
 #include <openvino/runtime/properties.hpp>
 
 #include "openvino/genai/visibility.hpp"
@@ -29,6 +31,7 @@ enum class VLMModelType {
     GEMMA4,
     GEMMA4_UNIFIED,
     VIDEOCHAT_FLASH_QWEN,
+    QWEN3_OMNI,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -124,6 +127,39 @@ public:
     size_t vision_config_num_position_embeddings = 2304;
     /// @brief DeepStack visual indexes for Qwen3-VL model.
     std::vector<size_t> vision_config_deepstack_visual_indexes;
+
+    // Qwen3-Omni specific config
+    /// @brief Whether audio output (speech) is enabled.
+    bool enable_audio_output = false;
+    /// @brief Audio encoder: number of mel spectrogram bins.
+    size_t audio_config_num_mel_bins = 128;
+    /// @brief Audio encoder: window size for training.
+    size_t audio_config_n_window = 50;
+    /// @brief Audio encoder: window size for inference.
+    size_t audio_config_n_window_infer = 200;
+    /// @brief Talker: number of codec quantizer groups.
+    size_t talker_num_code_groups = 16;
+    // Codec special token IDs (model-specific; -1 until loaded from talker_config in config.json)
+    int64_t talker_codec_bos_id = -1;
+    int64_t talker_codec_eos_token_id = -1;
+    int64_t talker_codec_pad_id = -1;
+    int64_t talker_codec_nothink_id = -1;
+    int64_t talker_codec_think_bos_id = -1;
+    int64_t talker_codec_think_eos_id = -1;
+    // TTS special token IDs (in thinker vocabulary)
+    int64_t tts_bos_token_id = -1;
+    int64_t tts_eos_token_id = -1;
+    int64_t tts_pad_token_id = -1;
+    // ChatML role token IDs for talker input construction
+    int64_t im_start_token_id = -1;
+    int64_t system_token_id = -1;
+    int64_t user_token_id = -1;
+    int64_t assistant_token_id = -1;
+    int64_t audio_token_id = -1;
+    int64_t image_token_id = -1;
+    int64_t video_token_id = -1;
+    // Speaker name-to-codec-token mapping
+    std::map<std::string, int64_t> speaker_ids;
 
     /// @brief Default constructor.
     VLMConfig() = default;

--- a/src/cpp/src/whisper/feature_extractor.cpp
+++ b/src/cpp/src/whisper/feature_extractor.cpp
@@ -450,6 +450,21 @@ WhisperFeatureExtractor::WhisperFeatureExtractor(const std::filesystem::path& pr
     init_mel_filter();
 }
 
+WhisperFeatureExtractor::WhisperFeatureExtractor(size_t feature_size,
+                                                 size_t sampling_rate,
+                                                 size_t n_fft,
+                                                 size_t hop_length)
+    : feature_size(feature_size),
+      sampling_rate(sampling_rate),
+      hop_length(hop_length),
+      n_fft(n_fft),
+      chunk_length(0),
+      n_samples(0),
+      nb_max_frames(0) {
+    fill_sin_cos_table(sin_vals, cos_vals, n_fft);
+    init_mel_filter();
+}
+
 void WhisperFeatureExtractor::init_parameters(const std::filesystem::path& preprocessor_json_path) {
     // preprocessor_config.json not found. Skip parameters initialization from file, use defaults.
     if (!std::filesystem::exists(preprocessor_json_path)) {
@@ -484,6 +499,11 @@ void WhisperFeatureExtractor::init_mel_filter() {
 }
 
 WhisperFeatures WhisperFeatureExtractor::extract(const std::vector<float>& raw_speech, bool pad_to_max_duration) {
+    OPENVINO_ASSERT(raw_speech.size() > n_fft / 2,
+                    "raw_speech too short for reflect padding: size=",
+                    raw_speech.size(),
+                    ", required > ",
+                    n_fft / 2);
     size_t n_threads = std::min(4, (int32_t)std::thread::hardware_concurrency());
     return mel_spectrogram_convert_audio(raw_speech,
                                          sampling_rate,

--- a/src/cpp/src/whisper/feature_extractor.hpp
+++ b/src/cpp/src/whisper/feature_extractor.hpp
@@ -48,6 +48,12 @@ public:
 
     explicit WhisperFeatureExtractor(const std::filesystem::path& preprocessor_json_path);
 
+    // Construct with explicit numeric configuration (no preprocessor_config.json). Used by
+    // pipelines that declare WhisperFeatureExtractor in their preprocessor config but do not
+    // fix a chunk_length (e.g. Qwen3-Omni). n_samples is set to 0, disabling pre-padding so
+    // the produced frame count tracks the raw signal length.
+    WhisperFeatureExtractor(size_t feature_size, size_t sampling_rate, size_t n_fft, size_t hop_length);
+
     /**
      * @brief Create a flattened 2d log-mel spectrogram [feature_size, n_frames] from raw speech data
      *

--- a/src/python/openvino_genai/__init__.py
+++ b/src/python/openvino_genai/__init__.py
@@ -16,6 +16,7 @@ from .py_openvino_genai import (
     RawPerfMetrics,
     PerfMetrics,
     StreamerBase,
+    OmniSpeechStreamerBase,
     get_version,
     StreamingStatus,
     TextStreamer,
@@ -42,7 +43,21 @@ __version__ = get_version()
 
 from .py_openvino_genai import (
     VLMPipeline,
+    VLMPipelineBase,
+    VLMDecodedResults,
     VideoMetadata,
+)
+
+# Omni pipeline (Qwen3-Omni text + speech)
+
+from .py_openvino_genai import (
+    OmniDecodedResults,
+    OmniPipeline,
+    OmniTalkerSpeechConfig,
+    Talker,
+    TalkerBase,
+    TalkerPerfMetrics,
+    TalkerResults,
 )
 
 # LLM pipeline

--- a/src/python/openvino_genai/__init__.pyi
+++ b/src/python/openvino_genai/__init__.pyi
@@ -44,6 +44,10 @@ from openvino_genai.py_openvino_genai import LLMPipeline
 from openvino_genai.py_openvino_genai import LTXVideoTransformer3DModel
 from openvino_genai.py_openvino_genai import Llama3JsonToolParser
 from openvino_genai.py_openvino_genai import Llama3PythonicToolParser
+from openvino_genai.py_openvino_genai import OmniDecodedResults
+from openvino_genai.py_openvino_genai import OmniPipeline
+from openvino_genai.py_openvino_genai import OmniSpeechStreamerBase
+from openvino_genai.py_openvino_genai import OmniTalkerSpeechConfig
 from openvino_genai.py_openvino_genai import Parser
 from openvino_genai.py_openvino_genai import PerfMetrics
 from openvino_genai.py_openvino_genai import Phi4ReasoningIncrementalParser
@@ -67,6 +71,10 @@ from openvino_genai.py_openvino_genai import StructuralTagItem
 from openvino_genai.py_openvino_genai import StructuralTagsConfig
 from openvino_genai.py_openvino_genai import StructuredOutputConfig
 from openvino_genai.py_openvino_genai import T5EncoderModel
+from openvino_genai.py_openvino_genai import Talker
+from openvino_genai.py_openvino_genai import TalkerBase
+from openvino_genai.py_openvino_genai import TalkerPerfMetrics
+from openvino_genai.py_openvino_genai import TalkerResults
 from openvino_genai.py_openvino_genai import TaylorSeerCacheConfig
 from openvino_genai.py_openvino_genai import Text2ImagePipeline
 from openvino_genai.py_openvino_genai import Text2SpeechDecodedResults
@@ -81,7 +89,9 @@ from openvino_genai.py_openvino_genai import Tokenizer
 from openvino_genai.py_openvino_genai import TorchGenerator
 from openvino_genai.py_openvino_genai import UNet2DConditionModel
 from openvino_genai.py_openvino_genai import VLLMParserWrapper
+from openvino_genai.py_openvino_genai import VLMDecodedResults
 from openvino_genai.py_openvino_genai import VLMPipeline
+from openvino_genai.py_openvino_genai import VLMPipelineBase
 from openvino_genai.py_openvino_genai import VideoGenerationConfig
 from openvino_genai.py_openvino_genai import VideoGenerationPerfMetrics
 from openvino_genai.py_openvino_genai import VideoGenerationResult
@@ -95,5 +105,5 @@ from openvino_genai.py_openvino_genai import draft_model
 from openvino_genai.py_openvino_genai import get_version
 import os as os
 from . import py_openvino_genai
-__all__: list[str] = ['ASRDecodedResultChunk', 'ASRDecodedResults', 'ASRGenerationConfig', 'ASRPerfMetrics', 'ASRPipeline', 'ASRRawPerfMetrics', 'Adapter', 'AdapterConfig', 'AggregationMode', 'AutoencoderKL', 'AutoencoderKLLTXVideo', 'CLIPTextModel', 'CLIPTextModelWithProjection', 'CacheEvictionConfig', 'ChatHistory', 'ContinuousBatchingPipeline', 'CppStdGenerator', 'DecodedResults', 'DeepSeekR1ReasoningIncrementalParser', 'DeepSeekR1ReasoningParser', 'EmbedResult', 'EmbeddingPipeline', 'EncodedResults', 'Flux2Transformer2DModel', 'FluxTransformer2DModel', 'GenerationConfig', 'GenerationFinishReason', 'GenerationResult', 'GenerationStatus', 'Generator', 'Image2ImagePipeline', 'ImageGenerationConfig', 'ImageGenerationPerfMetrics', 'IncrementalParser', 'InpaintingPipeline', 'KVCrushAnchorPointMode', 'KVCrushConfig', 'LLMPipeline', 'LTXVideoTransformer3DModel', 'Llama3JsonToolParser', 'Llama3PythonicToolParser', 'Parser', 'PerfMetrics', 'Phi4ReasoningIncrementalParser', 'Phi4ReasoningParser', 'Qwen3TextEncoder', 'RawImageGenerationPerfMetrics', 'RawPerfMetrics', 'ReasoningIncrementalParser', 'ReasoningParser', 'SD3Transformer2DModel', 'Scheduler', 'SchedulerConfig', 'SparseAttentionConfig', 'SparseAttentionMode', 'SpeechGenerationConfig', 'SpeechGenerationPerfMetrics', 'StopCriteria', 'StreamerBase', 'StreamingStatus', 'StructuralTagItem', 'StructuralTagsConfig', 'StructuredOutputConfig', 'T5EncoderModel', 'TaylorSeerCacheConfig', 'Text2ImagePipeline', 'Text2SpeechDecodedResults', 'Text2SpeechPipeline', 'Text2VideoPipeline', 'TextEmbeddingPipeline', 'TextParserStreamer', 'TextRerankPipeline', 'TextStreamer', 'TokenizedInputs', 'Tokenizer', 'TorchGenerator', 'UNet2DConditionModel', 'VLLMParserWrapper', 'VLMPipeline', 'VideoGenerationConfig', 'VideoGenerationPerfMetrics', 'VideoGenerationResult', 'VideoMetadata', 'WhisperGenerationConfig', 'WhisperPerfMetrics', 'WhisperPipeline', 'WhisperRawPerfMetrics', 'WhisperWordTiming', 'draft_model', 'get_version', 'openvino', 'os', 'py_openvino_genai']
+__all__: list[str] = ['ASRDecodedResultChunk', 'ASRDecodedResults', 'ASRGenerationConfig', 'ASRPerfMetrics', 'ASRPipeline', 'ASRRawPerfMetrics', 'Adapter', 'AdapterConfig', 'AggregationMode', 'AutoencoderKL', 'AutoencoderKLLTXVideo', 'CLIPTextModel', 'CLIPTextModelWithProjection', 'CacheEvictionConfig', 'ChatHistory', 'ContinuousBatchingPipeline', 'CppStdGenerator', 'DecodedResults', 'DeepSeekR1ReasoningIncrementalParser', 'DeepSeekR1ReasoningParser', 'EmbedResult', 'EmbeddingPipeline', 'EncodedResults', 'Flux2Transformer2DModel', 'FluxTransformer2DModel', 'GenerationConfig', 'GenerationFinishReason', 'GenerationResult', 'GenerationStatus', 'Generator', 'Image2ImagePipeline', 'ImageGenerationConfig', 'ImageGenerationPerfMetrics', 'IncrementalParser', 'InpaintingPipeline', 'KVCrushAnchorPointMode', 'KVCrushConfig', 'LLMPipeline', 'LTXVideoTransformer3DModel', 'Llama3JsonToolParser', 'Llama3PythonicToolParser', 'OmniDecodedResults', 'OmniPipeline', 'OmniSpeechStreamerBase', 'OmniTalkerSpeechConfig', 'Parser', 'PerfMetrics', 'Phi4ReasoningIncrementalParser', 'Phi4ReasoningParser', 'Qwen3TextEncoder', 'RawImageGenerationPerfMetrics', 'RawPerfMetrics', 'ReasoningIncrementalParser', 'ReasoningParser', 'SD3Transformer2DModel', 'Scheduler', 'SchedulerConfig', 'SparseAttentionConfig', 'SparseAttentionMode', 'SpeechGenerationConfig', 'SpeechGenerationPerfMetrics', 'StopCriteria', 'StreamerBase', 'StreamingStatus', 'StructuralTagItem', 'StructuralTagsConfig', 'StructuredOutputConfig', 'T5EncoderModel', 'Talker', 'TalkerBase', 'TalkerPerfMetrics', 'TalkerResults', 'TaylorSeerCacheConfig', 'Text2ImagePipeline', 'Text2SpeechDecodedResults', 'Text2SpeechPipeline', 'Text2VideoPipeline', 'TextEmbeddingPipeline', 'TextParserStreamer', 'TextRerankPipeline', 'TextStreamer', 'TokenizedInputs', 'Tokenizer', 'TorchGenerator', 'UNet2DConditionModel', 'VLLMParserWrapper', 'VLMDecodedResults', 'VLMPipeline', 'VLMPipelineBase', 'VideoGenerationConfig', 'VideoGenerationPerfMetrics', 'VideoGenerationResult', 'VideoMetadata', 'WhisperGenerationConfig', 'WhisperPerfMetrics', 'WhisperPipeline', 'WhisperRawPerfMetrics', 'WhisperWordTiming', 'draft_model', 'get_version', 'openvino', 'os', 'py_openvino_genai']
 __version__: str

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -5,7 +5,7 @@ from __future__ import annotations
 import collections.abc
 import openvino._pyopenvino
 import typing
-__all__: list[str] = ['ASRDecodedResultChunk', 'ASRDecodedResults', 'ASRGenerationConfig', 'ASRPerfMetrics', 'ASRPipeline', 'ASRRawPerfMetrics', 'Adapter', 'AdapterConfig', 'AdaptiveRKVConfig', 'AggregationMode', 'AutoencoderKL', 'AutoencoderKLLTXVideo', 'CLIPTextModel', 'CLIPTextModelWithProjection', 'CacheEvictionConfig', 'ChatHistory', 'ContinuousBatchingPipeline', 'CppStdGenerator', 'DecodedResults', 'DeepSeekR1ReasoningIncrementalParser', 'DeepSeekR1ReasoningParser', 'EmbedResult', 'EmbeddingPipeline', 'EncodedGenerationResult', 'EncodedResults', 'ExtendedPerfMetrics', 'Flux2Transformer2DModel', 'FluxTransformer2DModel', 'GenerationConfig', 'GenerationFinishReason', 'GenerationHandle', 'GenerationOutput', 'GenerationResult', 'GenerationStatus', 'Generator', 'Image2ImagePipeline', 'ImageGenerationConfig', 'ImageGenerationPerfMetrics', 'IncrementalParser', 'InpaintingPipeline', 'KVCrushAnchorPointMode', 'KVCrushConfig', 'LLMPipeline', 'LTXVideoTransformer3DModel', 'Llama3JsonToolParser', 'Llama3PythonicToolParser', 'MeanStdPair', 'Parser', 'PerfMetrics', 'Phi4ReasoningIncrementalParser', 'Phi4ReasoningParser', 'PipelineMetrics', 'Qwen3TextEncoder', 'RawImageGenerationPerfMetrics', 'RawPerfMetrics', 'ReasoningIncrementalParser', 'ReasoningParser', 'SD3Transformer2DModel', 'SDPerModelsPerfMetrics', 'SDPerfMetrics', 'Scheduler', 'SchedulerConfig', 'SparseAttentionConfig', 'SparseAttentionMode', 'SpeechGenerationConfig', 'SpeechGenerationPerfMetrics', 'StopCriteria', 'StreamerBase', 'StreamingStatus', 'StructuralTagItem', 'StructuralTagsConfig', 'StructuredOutputConfig', 'SummaryStats', 'T5EncoderModel', 'TaylorSeerCacheConfig', 'Text2ImagePipeline', 'Text2SpeechDecodedResults', 'Text2SpeechPipeline', 'Text2VideoPipeline', 'TextEmbeddingPipeline', 'TextParserStreamer', 'TextRerankPipeline', 'TextStreamer', 'TokenizedInputs', 'Tokenizer', 'TorchGenerator', 'UNet2DConditionModel', 'VLLMParserWrapper', 'VLMDecodedResults', 'VLMPerfMetrics', 'VLMPipeline', 'VLMRawPerfMetrics', 'VideoGenerationConfig', 'VideoGenerationPerfMetrics', 'VideoGenerationResult', 'VideoMetadata', 'WhisperDecodedResultChunk', 'WhisperDecodedResults', 'WhisperGenerationConfig', 'WhisperPerfMetrics', 'WhisperPipeline', 'WhisperRawPerfMetrics', 'WhisperWordTiming', 'draft_model', 'get_version']
+__all__: list[str] = ['ASRDecodedResultChunk', 'ASRDecodedResults', 'ASRGenerationConfig', 'ASRPerfMetrics', 'ASRPipeline', 'ASRRawPerfMetrics', 'Adapter', 'AdapterConfig', 'AdaptiveRKVConfig', 'AggregationMode', 'AutoencoderKL', 'AutoencoderKLLTXVideo', 'CLIPTextModel', 'CLIPTextModelWithProjection', 'CacheEvictionConfig', 'ChatHistory', 'ContinuousBatchingPipeline', 'CppStdGenerator', 'DecodedResults', 'DeepSeekR1ReasoningIncrementalParser', 'DeepSeekR1ReasoningParser', 'EmbedResult', 'EmbeddingPipeline', 'EncodedGenerationResult', 'EncodedResults', 'ExtendedPerfMetrics', 'Flux2Transformer2DModel', 'FluxTransformer2DModel', 'GenerationConfig', 'GenerationFinishReason', 'GenerationHandle', 'GenerationOutput', 'GenerationResult', 'GenerationStatus', 'Generator', 'Image2ImagePipeline', 'ImageGenerationConfig', 'ImageGenerationPerfMetrics', 'IncrementalParser', 'InpaintingPipeline', 'KVCrushAnchorPointMode', 'KVCrushConfig', 'LLMPipeline', 'LTXVideoTransformer3DModel', 'Llama3JsonToolParser', 'Llama3PythonicToolParser', 'MeanStdPair', 'OmniDecodedResults', 'OmniPipeline', 'OmniSpeechStreamerBase', 'OmniTalkerSpeechConfig', 'Parser', 'PerfMetrics', 'Phi4ReasoningIncrementalParser', 'Phi4ReasoningParser', 'PipelineMetrics', 'Qwen3TextEncoder', 'RawImageGenerationPerfMetrics', 'RawPerfMetrics', 'ReasoningIncrementalParser', 'ReasoningParser', 'SD3Transformer2DModel', 'SDPerModelsPerfMetrics', 'SDPerfMetrics', 'Scheduler', 'SchedulerConfig', 'SparseAttentionConfig', 'SparseAttentionMode', 'SpeechGenerationConfig', 'SpeechGenerationPerfMetrics', 'StopCriteria', 'StreamerBase', 'StreamingStatus', 'StructuralTagItem', 'StructuralTagsConfig', 'StructuredOutputConfig', 'SummaryStats', 'T5EncoderModel', 'Talker', 'TalkerBase', 'TalkerPerfMetrics', 'TalkerResults', 'TaylorSeerCacheConfig', 'Text2ImagePipeline', 'Text2SpeechDecodedResults', 'Text2SpeechPipeline', 'Text2VideoPipeline', 'TextEmbeddingPipeline', 'TextParserStreamer', 'TextRerankPipeline', 'TextStreamer', 'TokenizedInputs', 'Tokenizer', 'TorchGenerator', 'UNet2DConditionModel', 'VLLMParserWrapper', 'VLMDecodedResults', 'VLMPerfMetrics', 'VLMPipeline', 'VLMPipelineBase', 'VLMRawPerfMetrics', 'VideoGenerationConfig', 'VideoGenerationPerfMetrics', 'VideoGenerationResult', 'VideoMetadata', 'WhisperDecodedResultChunk', 'WhisperDecodedResults', 'WhisperGenerationConfig', 'WhisperPerfMetrics', 'WhisperPipeline', 'WhisperRawPerfMetrics', 'WhisperWordTiming', 'draft_model', 'get_version']
 class ASRDecodedResultChunk:
     """
     
@@ -1634,6 +1634,7 @@ class GenerationConfig:
     echo: bool
     ignore_eos: bool
     include_stop_str_in_output: bool
+    return_omni_outputs: bool
     stop_criteria: StopCriteria
     structured_output_config: openvino_genai.py_openvino_genai.StructuredOutputConfig | None
     @typing.overload
@@ -2750,6 +2751,273 @@ class MeanStdPair:
         ...
     @property
     def std(self) -> float:
+        ...
+class OmniDecodedResults(VLMDecodedResults):
+    """
+    Omni-specific decoded results including speech outputs.
+    
+            Extends VLMDecodedResults with a TalkerResults that holds speech waveforms and perf metrics.
+    
+            Parameters:
+            texts:           vector of resulting sequences (inherited from DecodedResults).
+            scores:          scores for each sequence (inherited from DecodedResults).
+            perf_metrics:    text-side perf metrics (inherited from VLMDecodedResults).
+            speech_result:   TalkerResults with waveforms and perf_metrics.
+            
+    """
+    def __init__(self) -> None:
+        ...
+    @property
+    def speech_result(self) -> TalkerResults:
+        ...
+class OmniPipeline:
+    """
+    
+        OmniPipeline — Qwen3-Omni text + speech pipeline.
+    
+        Composes a VLM pipeline (text generation with hidden-state collection) with a Qwen3-Omni
+        speech pipeline (Talker + CodePredictor + Code2Wav). Each `generate` call takes two
+        configs: a `GenerationConfig text_config` (thinker) and an `OmniTalkerSpeechConfig
+        talker_speech_config` (talker + speech). Speech generation is gated per-call by
+        `talker_speech_config.return_audio`.
+    
+        Two construction paths:
+    
+          - Path-based: OmniPipeline(models_path, device, **properties) loads VLM and speech
+            models from a single directory.
+    
+          - DI: OmniPipeline(vlm_pipeline, talker) reuses an externally-loaded VLMPipeline
+            and a TalkerBase subclass for independent device choices or custom backends.
+    
+        Both ctors enforce that the loaded model is Qwen3-Omni capable (model_type == QWEN3_OMNI
+        and enable_audio_output) — non-Omni models throw at construction time.
+    """
+    @typing.overload
+    def __init__(self, models_path: os.PathLike | str | bytes, device: str, **kwargs) -> None:
+        """
+                        OmniPipeline path-based constructor.
+                        models_path (os.PathLike): Path to the folder with exported Qwen3-Omni model files.
+                        device (str): Device to run the model on (e.g., CPU, GPU).
+                        kwargs: Device properties.
+        """
+    @typing.overload
+    def __init__(self, vlm: VLMPipelineBase, talker: TalkerBase) -> None:
+        """
+                        OmniPipeline dependency-injection constructor.
+                        Compose a pre-built VLM (thinker) and Talker (speech) so the two stages can use
+                        independent devices/properties, or so a custom TalkerBase subclass can be injected.
+                        vlm (VLMPipeline): Backing VLM pipeline. Must be a Qwen3-Omni-capable model loaded
+                            with the continuous-batching backend (attention_backend=PA).
+                        talker (TalkerBase): Backing speech generator (default impl is Talker).
+        """
+    @typing.overload
+    def generate(self, prompt: str, images: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos_metadata: collections.abc.Sequence[VideoMetadata] = [], audios: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], text_config: openvino_genai.py_openvino_genai.GenerationConfig | None = None, talker_speech_config: openvino_genai.py_openvino_genai.OmniTalkerSpeechConfig | None = None, streamer: collections.abc.Callable[[str], int | None] | openvino_genai.py_openvino_genai.StreamerBase | None = None, speech_streamer: collections.abc.Callable[[openvino._pyopenvino.Tensor], int | None] | openvino_genai.py_openvino_genai.OmniSpeechStreamerBase | None = None) -> OmniDecodedResults:
+        """
+            Generate text and (optionally) speech from a flat prompt.
+        
+            :param prompt: Input prompt
+            :type prompt: str
+        
+            :param images: image tensors to be prepended to the prompt
+            :type images: list[ov.Tensor]
+        
+            :param videos: video tensors to be prepended to the prompt
+            :type videos: list[ov.Tensor]
+        
+            :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
+            :type videos_metadata: list[VideoMetadata]
+        
+            :param audios: audio tensors to be prepended to the prompt
+            :type audios: list[ov.Tensor]
+        
+            :param text_config: thinker text-decode config. None = use the VLM's default
+                GenerationConfig loaded from generation_config.json.
+            :type text_config: GenerationConfig | None
+        
+            :param talker_speech_config: talker + speech-output config. None = a default-
+                constructed OmniTalkerSpeechConfig (return_audio=True, model-default speaker).
+            :type talker_speech_config: OmniTalkerSpeechConfig | None
+        
+            :param streamer: optional streamer for text tokens.
+            :type streamer: Callable[[str], bool] | StreamerBase | None
+        
+            :param speech_streamer: optional callback or OmniSpeechStreamerBase to receive audio chunks
+                during speech generation. Lambda receives ov.Tensor [1, 1, N_samples] and returns
+                StreamingStatus (or bool/None).
+            :type speech_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None] | OmniSpeechStreamerBase | None
+        
+            :return: OmniDecodedResults with `speech_result.waveforms` populated when
+                `talker_speech_config.return_audio` is True.
+            :rtype: OmniDecodedResults
+        """
+    @typing.overload
+    def generate(self, history: ChatHistory, images: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos_metadata: collections.abc.Sequence[VideoMetadata] = [], audios: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], text_config: openvino_genai.py_openvino_genai.GenerationConfig | None = None, talker_speech_config: openvino_genai.py_openvino_genai.OmniTalkerSpeechConfig | None = None, streamer: collections.abc.Callable[[str], int | None] | openvino_genai.py_openvino_genai.StreamerBase | None = None, speech_streamer: collections.abc.Callable[[openvino._pyopenvino.Tensor], int | None] | openvino_genai.py_openvino_genai.OmniSpeechStreamerBase | None = None) -> OmniDecodedResults:
+        """
+            Generate text and (optionally) speech from a chat history. Same parameter semantics as the
+            prompt overload.
+        
+            :param history: Chat history
+            :type history: ChatHistory
+        
+            :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
+            :type videos_metadata: list[VideoMetadata]
+        """
+    def get_talker(self) -> TalkerBase:
+        """
+                        Return the underlying TalkerBase. Speaker enumeration and embedding retrieval
+                        live here: pipe.get_talker().list_speakers(),
+                        pipe.get_talker().get_speaker_embedding(name).
+        """
+    def get_vlm(self) -> VLMPipelineBase:
+        """
+                        Return the underlying VLM (thinker) as a VLMPipelineBase. Useful for inspecting
+                        model metadata or reusing the same VLM across pipelines via the DI constructor.
+        """
+class OmniSpeechStreamerBase:
+    """
+    
+        Base class for audio streamers. Inherit and implement write() and end()
+        to receive audio chunks during speech generation.
+    
+        write(audio_chunk: ov.Tensor) -> StreamingStatus:
+            Called with each audio chunk [1, 1, N_samples] float32 PCM at 24kHz.
+            Return StreamingStatus.RUNNING to continue or STOP/CANCEL to halt.
+    
+        end():
+            Called when speech generation completes (always, even on early stop).
+    """
+    def __init__(self) -> None:
+        ...
+    def end(self) -> None:
+        """
+        Called when speech generation completes.
+        """
+    def write(self, audio_chunk: openvino._pyopenvino.Tensor) -> StreamingStatus:
+        """
+        Called with each audio chunk tensor [1, 1, N_samples]. Return StreamingStatus.
+        """
+class OmniTalkerSpeechConfig:
+    """
+    
+        OmniTalkerSpeechConfig
+    
+        Standalone speech-side generation config for the Qwen3-Omni talker. Does NOT inherit
+        from GenerationConfig — the thinker text decode is steered by a separate
+        GenerationConfig argument to OmniPipeline.generate. This struct only carries fields
+        the talker actually consumes:
+    
+        :param return_audio: Enable speech output. Default True. Set False to short-circuit
+            the talker and produce text only.
+        :type return_audio: bool
+    
+        :param speaker: Speaker identity — either a name (str) looked up in
+            `talker_config.speaker_id`, or an explicit embedding tensor
+            ([1, 1, talker_hidden_size], f32). Empty string selects the model's default.
+        :type speaker: str | openvino.Tensor
+    
+        :param audio_chunk_frames: Number of codec frames accumulated before streaming each
+            audio chunk. Must be >= 1. Each frame is 80ms of audio at 24 kHz (1920 samples).
+        :type audio_chunk_frames: int
+    
+        :param max_new_tokens: Cap on talker AR steps. Independent of
+            `text_config.max_new_tokens` (which caps the thinker text decode). The talker
+            pipeline takes the min of this value and the model's
+            `talker_config.talker_max_new_tokens`.
+        :type max_new_tokens: int
+    
+        :param rng_seed: RNG seed for deterministic talker + CodePredictor sampling.
+        :type rng_seed: int
+    
+        :param talker_temperature, talker_top_k, talker_repetition_penalty: Talker sampling
+            overrides. None = keep the checkpoint default loaded from generation_config.json.
+        :type talker_temperature: float | None
+        :type talker_top_k: int | None
+        :type talker_repetition_penalty: float | None
+    
+        :param cp_temperature, cp_top_k, cp_repetition_penalty: CodePredictor sampling
+            overrides. Same semantics as talker_*.
+        :type cp_temperature: float | None
+        :type cp_top_k: int | None
+        :type cp_repetition_penalty: float | None
+    """
+    return_audio: bool
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, models_path: os.PathLike | str | bytes) -> None:
+        """
+        folder with config.json (talker_config) for default speaker resolution
+        """
+    @property
+    def audio_chunk_frames(self) -> int:
+        ...
+    @audio_chunk_frames.setter
+    def audio_chunk_frames(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def cp_repetition_penalty(self) -> float | None:
+        ...
+    @cp_repetition_penalty.setter
+    def cp_repetition_penalty(self, arg0: typing.SupportsFloat | None) -> None:
+        ...
+    @property
+    def cp_temperature(self) -> float | None:
+        ...
+    @cp_temperature.setter
+    def cp_temperature(self, arg0: typing.SupportsFloat | None) -> None:
+        ...
+    @property
+    def cp_top_k(self) -> int | None:
+        ...
+    @cp_top_k.setter
+    def cp_top_k(self, arg0: typing.SupportsInt | None) -> None:
+        ...
+    @property
+    def max_new_tokens(self) -> int:
+        ...
+    @max_new_tokens.setter
+    def max_new_tokens(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def rng_seed(self) -> int:
+        ...
+    @rng_seed.setter
+    def rng_seed(self, arg0: typing.SupportsInt) -> None:
+        ...
+    @property
+    def speaker(self) -> typing.Any:
+        """
+        Speaker identity: a name (str) looked up in talker_config.speaker_id, or an explicit embedding tensor ([1, 1, talker_hidden_size], f32).
+        """
+    @speaker.setter
+    def speaker(self, arg1: typing.Any) -> None:
+        ...
+    @property
+    def speaker_embedding(self) -> typing.Any:
+        """
+        Legacy alias. Reading returns the Tensor if speaker holds one, else None. Writing sets the Tensor alternative of the speaker variant.
+        """
+    @speaker_embedding.setter
+    def speaker_embedding(self, arg1: typing.Any) -> None:
+        ...
+    @property
+    def talker_repetition_penalty(self) -> float | None:
+        ...
+    @talker_repetition_penalty.setter
+    def talker_repetition_penalty(self, arg0: typing.SupportsFloat | None) -> None:
+        ...
+    @property
+    def talker_temperature(self) -> float | None:
+        ...
+    @talker_temperature.setter
+    def talker_temperature(self, arg0: typing.SupportsFloat | None) -> None:
+        ...
+    @property
+    def talker_top_k(self) -> int | None:
+        ...
+    @talker_top_k.setter
+    def talker_top_k(self, arg0: typing.SupportsInt | None) -> None:
         ...
 class Parser:
     def __init__(self) -> None:
@@ -4164,6 +4432,68 @@ class T5EncoderModel:
         ...
     def reshape(self, batch_size: typing.SupportsInt, max_sequence_length: typing.SupportsInt) -> T5EncoderModel:
         ...
+class Talker(TalkerBase):
+    """
+    Default OmniPipeline talker for the Qwen3-Omni Talker + CodePredictor + Code2Wav stack.
+    
+            Loads the speech submodels from a directory containing
+            openvino_talker_model.xml, openvino_code_predictor_model.xml,
+            openvino_code2wav_model.xml, plus the talker text-embedding and projection
+            submodels and config.json.
+    """
+    def __init__(self, model_dir: os.PathLike | str | bytes, device: str, **kwargs) -> None:
+        """
+                        Talker constructor.
+                        model_dir (os.PathLike): Folder with Qwen3-Omni speech submodels + config.json.
+                        device (str): Device to run inference on (e.g., CPU, GPU).
+                        kwargs: Device properties.
+        """
+class TalkerBase:
+    """
+    Abstract speech-output backend for OmniPipeline.
+    
+            Subclass to plug a custom talker into OmniPipeline. The default implementation
+            is Talker. Subclasses must override generate(), list_speakers(), and
+            get_speaker_embedding().
+    """
+    def get_speaker_embedding(self, name: str) -> openvino._pyopenvino.Tensor:
+        ...
+    def list_speakers(self) -> list[str]:
+        ...
+class TalkerPerfMetrics:
+    """
+    Performance metrics for Talker speech generation.
+    
+            Parameters:
+            num_generated_samples:  number of audio samples generated (waveform length).
+            generation_time_ms:     total speech generation time in milliseconds.
+            
+    """
+    def __init__(self) -> None:
+        ...
+    @property
+    def generation_time_ms(self) -> float:
+        ...
+    @property
+    def num_generated_samples(self) -> int:
+        ...
+class TalkerResults:
+    """
+    Output of the talker speech backend. Holds speech waveforms and perf metrics.
+    
+            Parameters:
+            waveforms:       speech waveform tensors (one per result, present when return_audio=True).
+            perf_metrics:    speech-side perf metrics (TalkerPerfMetrics).
+            
+    """
+    def __init__(self) -> None:
+        ...
+    @property
+    def perf_metrics(self) -> TalkerPerfMetrics:
+        ...
+    @property
+    def waveforms(self) -> list[openvino._pyopenvino.Tensor]:
+        ...
 class TaylorSeerCacheConfig:
     """
     Configuration for TaylorSeer cache mechanism in diffusion transformers.
@@ -4970,13 +5300,19 @@ class VLMDecodedResults(DecodedResults):
         The first num_return_sequences elements correspond to the first batch element.
     
         Parameters:
-        texts:      vector of resulting sequences.
-        scores:     scores for each sequence.
-        metrics:    performance metrics with tpot, ttft, etc. of type openvino_genai.VLMPerfMetrics.
+        texts:            vector of resulting sequences.
+        scores:           scores for each sequence.
+        metrics:          performance metrics with tpot, ttft, etc. of type openvino_genai.VLMPerfMetrics.
     """
     def __init__(self) -> None:
         ...
     def __str__(self) -> str:
+        ...
+    @property
+    def full_token_ids(self) -> list[list[int]]:
+        ...
+    @property
+    def intermediate_hidden_states(self) -> list[list[openvino._pyopenvino.Tensor]]:
         ...
     @property
     def perf_metrics(self) -> VLMPerfMetrics:
@@ -5005,7 +5341,7 @@ class VLMPerfMetrics(PerfMetrics):
     @property
     def vlm_raw_metrics(self) -> VLMRawPerfMetrics:
         ...
-class VLMPipeline:
+class VLMPipeline(VLMPipelineBase):
     """
     This class is used for generation with VLMs
     """
@@ -5046,14 +5382,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5074,14 +5421,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5102,14 +5460,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5130,14 +5499,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5158,9 +5538,12 @@ class VLMPipeline:
             image: ov.Tensor - input image,
             images: list[ov.Tensor] - input images,
             videos: list[ov.Tensor] - input videos,
+            audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
             videos_metadata: list[VideoMetadata] - metadata for each video,
             generation_config: GenerationConfig,
-            streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped
+            streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,
+            audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None] or OmniSpeechStreamerBase - callback to receive audio chunks during speech generation,
+            audio_chunk_frames: int - number of codec frames per streaming chunk (default 1, must be >= 1). Ignored when audio_streamer is not provided.
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5181,14 +5564,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5209,14 +5603,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5237,14 +5642,25 @@ class VLMPipeline:
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
+            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :type audios: list[ov.Tensor]
+        
             :param generation_config: generation_config
             :type generation_config: GenerationConfig or a dict
         
             :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-            :type : Callable[[str], bool], ov.genai.StreamerBase
+            :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+        
+            :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+                Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+            :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+        
+            :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+                Ignored when audio_streamer is not provided.
+            :type audio_chunk_frames: int
         
             :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-            :type : dict
+            :type kwargs: dict
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5265,9 +5681,12 @@ class VLMPipeline:
             image: ov.Tensor - input image,
             images: list[ov.Tensor] - input images,
             videos: list[ov.Tensor] - input videos,
+            audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
             videos_metadata: list[VideoMetadata] - metadata for each video,
             generation_config: GenerationConfig,
-            streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped
+            streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,
+            audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None] or OmniSpeechStreamerBase - callback to receive audio chunks during speech generation,
+            audio_chunk_frames: int - number of codec frames per streaming chunk (default 1, must be >= 1). Ignored when audio_streamer is not provided.
         
             :return: return results in decoded form
             :rtype: VLMDecodedResults
@@ -5282,6 +5701,10 @@ class VLMPipeline:
         ...
     def start_chat(self, system_message: str = '') -> None:
         ...
+class VLMPipelineBase:
+    """
+    Abstract base of VLM-style pipelines.
+    """
 class VLMRawPerfMetrics:
     """
     

--- a/src/python/py_generation_config.cpp
+++ b/src/python/py_generation_config.cpp
@@ -459,6 +459,7 @@ void init_generation_config(py::module_& m) {
         .def_readwrite("parsers", &GenerationConfig::parsers, py::keep_alive<1, 2>())
         .def_readwrite("adapters", &GenerationConfig::adapters)
         .def_readwrite("apply_chat_template", &GenerationConfig::apply_chat_template)
+        .def_readwrite("return_omni_outputs", &GenerationConfig::return_omni_outputs)
         .def("set_eos_token_id", &GenerationConfig::set_eos_token_id, py::arg("tokenizer_eos_token_id"))
         .def("is_beam_search", &GenerationConfig::is_beam_search)
         .def("is_greedy_decoding", &GenerationConfig::is_greedy_decoding)

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -1,0 +1,462 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <optional>
+#include <variant>
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
+#include <pybind11/stl_bind.h>
+
+#include "openvino/genai/generation_config.hpp"
+#include "openvino/genai/omni/pipeline.hpp"
+#include "openvino/genai/omni/speech_streamer_base.hpp"
+#include "openvino/genai/omni/talker.hpp"
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "omni/talker_speech_config_utils.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
+#include "py_utils.hpp"
+#include "tokenizer/tokenizers_path.hpp"
+
+namespace py = pybind11;
+namespace pyutils = ov::genai::pybind::utils;
+
+using ov::genai::ChatHistory;
+using ov::genai::GenerationConfig;
+using ov::genai::OmniDecodedResults;
+using ov::genai::OmniPipeline;
+using ov::genai::OmniTalkerSpeechConfig;
+using ov::genai::Talker;
+using ov::genai::TalkerBase;
+using ov::genai::VideoMetadata;
+using ov::genai::VLMDecodedResults;
+using ov::genai::VLMPipeline;
+using ov::genai::VLMPipelineBase;
+
+namespace {
+
+auto omni_talker_speech_config_docstring = R"(
+    OmniTalkerSpeechConfig
+
+    Standalone speech-side generation config for the Qwen3-Omni talker. Does NOT inherit
+    from GenerationConfig — the thinker text decode is steered by a separate
+    GenerationConfig argument to OmniPipeline.generate. This struct only carries fields
+    the talker actually consumes:
+
+    :param return_audio: Enable speech output. Default True. Set False to short-circuit
+        the talker and produce text only.
+    :type return_audio: bool
+
+    :param speaker: Speaker identity — either a name (str) looked up in
+        `talker_config.speaker_id`, or an explicit embedding tensor
+        ([1, 1, talker_hidden_size], f32). Empty string selects the model's default.
+    :type speaker: str | openvino.Tensor
+
+    :param audio_chunk_frames: Number of codec frames accumulated before streaming each
+        audio chunk. Must be >= 1. Each frame is 80ms of audio at 24 kHz (1920 samples).
+    :type audio_chunk_frames: int
+
+    :param max_new_tokens: Cap on talker AR steps. Independent of
+        `text_config.max_new_tokens` (which caps the thinker text decode). The talker
+        pipeline takes the min of this value and the model's
+        `talker_config.talker_max_new_tokens`.
+    :type max_new_tokens: int
+
+    :param rng_seed: RNG seed for deterministic talker + CodePredictor sampling.
+    :type rng_seed: int
+
+    :param talker_temperature, talker_top_k, talker_repetition_penalty: Talker sampling
+        overrides. None = keep the checkpoint default loaded from generation_config.json.
+    :type talker_temperature: float | None
+    :type talker_top_k: int | None
+    :type talker_repetition_penalty: float | None
+
+    :param cp_temperature, cp_top_k, cp_repetition_penalty: CodePredictor sampling
+        overrides. Same semantics as talker_*.
+    :type cp_temperature: float | None
+    :type cp_top_k: int | None
+    :type cp_repetition_penalty: float | None
+)";
+
+auto omni_pipeline_docstring = R"(
+    OmniPipeline — Qwen3-Omni text + speech pipeline.
+
+    Composes a VLM pipeline (text generation with hidden-state collection) with a Qwen3-Omni
+    speech pipeline (Talker + CodePredictor + Code2Wav). Each `generate` call takes two
+    configs: a `GenerationConfig text_config` (thinker) and an `OmniTalkerSpeechConfig
+    talker_speech_config` (talker + speech). Speech generation is gated per-call by
+    `talker_speech_config.return_audio`.
+
+    Two construction paths:
+
+      - Path-based: OmniPipeline(models_path, device, **properties) loads VLM and speech
+        models from a single directory.
+
+      - DI: OmniPipeline(vlm_pipeline, talker) reuses an externally-loaded VLMPipeline
+        and a TalkerBase subclass for independent device choices or custom backends.
+
+    Both ctors enforce that the loaded model is Qwen3-Omni capable (model_type == QWEN3_OMNI
+    and enable_audio_output) — non-Omni models throw at construction time.
+)";
+
+auto omni_generate_prompt_docstring = R"(
+    Generate text and (optionally) speech from a flat prompt.
+
+    :param prompt: Input prompt
+    :type prompt: str
+
+    :param images: image tensors to be prepended to the prompt
+    :type images: list[ov.Tensor]
+
+    :param videos: video tensors to be prepended to the prompt
+    :type videos: list[ov.Tensor]
+
+    :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
+    :type videos_metadata: list[VideoMetadata]
+
+    :param audios: audio tensors to be prepended to the prompt
+    :type audios: list[ov.Tensor]
+
+    :param text_config: thinker text-decode config. None = use the VLM's default
+        GenerationConfig loaded from generation_config.json.
+    :type text_config: GenerationConfig | None
+
+    :param talker_speech_config: talker + speech-output config. None = a default-
+        constructed OmniTalkerSpeechConfig (return_audio=True, model-default speaker).
+    :type talker_speech_config: OmniTalkerSpeechConfig | None
+
+    :param streamer: optional streamer for text tokens.
+    :type streamer: Callable[[str], bool] | StreamerBase | None
+
+    :param speech_streamer: optional callback or OmniSpeechStreamerBase to receive audio chunks
+        during speech generation. Lambda receives ov.Tensor [1, 1, N_samples] and returns
+        StreamingStatus (or bool/None).
+    :type speech_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None] | OmniSpeechStreamerBase | None
+
+    :return: OmniDecodedResults with `speech_result.waveforms` populated when
+        `talker_speech_config.return_audio` is True.
+    :rtype: OmniDecodedResults
+)";
+
+auto omni_generate_history_docstring = R"(
+    Generate text and (optionally) speech from a chat history. Same parameter semantics as the
+    prompt overload.
+
+    :param history: Chat history
+    :type history: ChatHistory
+
+    :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
+    :type videos_metadata: list[VideoMetadata]
+)";
+
+py::object call_omni_generate(OmniPipeline& pipe,
+                              const std::string& prompt,
+                              const std::vector<ov::Tensor>& images,
+                              const std::vector<ov::Tensor>& videos,
+                              const std::vector<VideoMetadata>& videos_metadata,
+                              const std::vector<ov::Tensor>& audios,
+                              const GenerationConfig& text_config,
+                              const OmniTalkerSpeechConfig& talker_speech_config,
+                              const pyutils::PyBindStreamerVariant& py_streamer,
+                              const pyutils::PyBindOmniSpeechStreamerVariant& py_speech_streamer) {
+    auto streamer = pyutils::pystreamer_to_streamer(py_streamer);
+    auto speech_streamer = pyutils::py_speech_streamer_to_streamer(py_speech_streamer);
+    OmniDecodedResults res;
+    {
+        py::gil_scoped_release rel;
+        res = pipe.generate(prompt,
+                            images,
+                            videos,
+                            videos_metadata,
+                            audios,
+                            text_config,
+                            talker_speech_config,
+                            streamer,
+                            speech_streamer);
+    }
+    return py::cast(res);
+}
+
+py::object call_omni_generate_history(OmniPipeline& pipe,
+                                      const ChatHistory& history,
+                                      const std::vector<ov::Tensor>& images,
+                                      const std::vector<ov::Tensor>& videos,
+                                      const std::vector<VideoMetadata>& videos_metadata,
+                                      const std::vector<ov::Tensor>& audios,
+                                      const GenerationConfig& text_config,
+                                      const OmniTalkerSpeechConfig& talker_speech_config,
+                                      const pyutils::PyBindStreamerVariant& py_streamer,
+                                      const pyutils::PyBindOmniSpeechStreamerVariant& py_speech_streamer) {
+    auto streamer = pyutils::pystreamer_to_streamer(py_streamer);
+    auto speech_streamer = pyutils::py_speech_streamer_to_streamer(py_speech_streamer);
+    OmniDecodedResults res;
+    {
+        py::gil_scoped_release rel;
+        res = pipe.generate(history,
+                            images,
+                            videos,
+                            videos_metadata,
+                            audios,
+                            text_config,
+                            talker_speech_config,
+                            streamer,
+                            speech_streamer);
+    }
+    return py::cast(res);
+}
+
+}  // namespace
+
+void init_omni_pipeline(py::module_& m) {
+    py::class_<TalkerBase, std::shared_ptr<TalkerBase>>(m, "TalkerBase",
+        R"(Abstract speech-output backend for OmniPipeline.
+
+        Subclass to plug a custom talker into OmniPipeline. The default implementation
+        is Talker. Subclasses must override generate(), list_speakers(), and
+        get_speaker_embedding().)")
+        .def("list_speakers", &TalkerBase::list_speakers)
+        .def("get_speaker_embedding", &TalkerBase::get_speaker_embedding, py::arg("name"));
+
+    py::class_<Talker, TalkerBase, std::shared_ptr<Talker>>(m, "Talker",
+        R"(Default OmniPipeline talker for the Qwen3-Omni Talker + CodePredictor + Code2Wav stack.
+
+        Loads the speech submodels from a directory containing
+        openvino_talker_model.xml, openvino_code_predictor_model.xml,
+        openvino_code2wav_model.xml, plus the talker text-embedding and projection
+        submodels and config.json.)")
+        .def(py::init([](const std::filesystem::path& model_dir,
+                         const std::string& device,
+                         const py::kwargs& kwargs) {
+                 ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
+                 ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
+                 py::gil_scoped_release rel;
+                 return std::make_shared<Talker>(model_dir, device, properties);
+             }),
+             py::arg("model_dir"),
+             "folder with Qwen3-Omni speech submodels + config.json",
+             py::arg("device"),
+             "device on which inference will be done",
+             R"(
+                Talker constructor.
+                model_dir (os.PathLike): Folder with Qwen3-Omni speech submodels + config.json.
+                device (str): Device to run inference on (e.g., CPU, GPU).
+                kwargs: Device properties.
+             )");
+
+    py::class_<OmniTalkerSpeechConfig>(m, "OmniTalkerSpeechConfig", omni_talker_speech_config_docstring)
+        .def(py::init<>())
+        .def(py::init<std::filesystem::path>(),
+             py::arg("models_path"),
+             "folder with config.json (talker_config) for default speaker resolution")
+        .def_readwrite("return_audio", &OmniTalkerSpeechConfig::return_audio)
+        .def_property(
+            "speaker",
+            [](const OmniTalkerSpeechConfig& self) -> py::object {
+                if (std::holds_alternative<ov::Tensor>(self.speaker)) {
+                    return py::cast(std::get<ov::Tensor>(self.speaker));
+                }
+                return py::cast(std::get<std::string>(self.speaker));
+            },
+            [](OmniTalkerSpeechConfig& self, py::object value) {
+                if (py::isinstance<py::str>(value)) {
+                    self.speaker = value.cast<std::string>();
+                } else {
+                    self.speaker = value.cast<ov::Tensor>();
+                }
+            },
+            "Speaker identity: a name (str) looked up in talker_config.speaker_id, "
+            "or an explicit embedding tensor ([1, 1, talker_hidden_size], f32).")
+        .def_property(
+            "speaker_embedding",
+            [](const OmniTalkerSpeechConfig& self) -> py::object {
+                if (std::holds_alternative<ov::Tensor>(self.speaker)) {
+                    return py::cast(std::get<ov::Tensor>(self.speaker));
+                }
+                return py::none();
+            },
+            [](OmniTalkerSpeechConfig& self, py::object value) {
+                if (value.is_none()) {
+                    // Setting speaker_embedding to None reverts to the string default
+                    if (!std::holds_alternative<std::string>(self.speaker)) {
+                        self.speaker = std::string{};
+                    }
+                } else {
+                    self.speaker = value.cast<ov::Tensor>();
+                }
+            },
+            "Legacy alias. Reading returns the Tensor if speaker holds one, else None. "
+            "Writing sets the Tensor alternative of the speaker variant.")
+        .def_readwrite("audio_chunk_frames", &OmniTalkerSpeechConfig::audio_chunk_frames)
+        .def_readwrite("max_new_tokens", &OmniTalkerSpeechConfig::max_new_tokens)
+        .def_readwrite("rng_seed", &OmniTalkerSpeechConfig::rng_seed)
+        .def_readwrite("talker_temperature", &OmniTalkerSpeechConfig::talker_temperature)
+        .def_readwrite("talker_top_k", &OmniTalkerSpeechConfig::talker_top_k)
+        .def_readwrite("talker_repetition_penalty", &OmniTalkerSpeechConfig::talker_repetition_penalty)
+        .def_readwrite("cp_temperature", &OmniTalkerSpeechConfig::cp_temperature)
+        .def_readwrite("cp_top_k", &OmniTalkerSpeechConfig::cp_top_k)
+        .def_readwrite("cp_repetition_penalty", &OmniTalkerSpeechConfig::cp_repetition_penalty);
+
+    py::class_<ov::genai::TalkerPerfMetrics>(m, "TalkerPerfMetrics",
+        R"(Performance metrics for Talker speech generation.
+
+        Parameters:
+        num_generated_samples:  number of audio samples generated (waveform length).
+        generation_time_ms:     total speech generation time in milliseconds.
+        )")
+        .def(py::init<>())
+        .def_readonly("num_generated_samples", &ov::genai::TalkerPerfMetrics::num_generated_samples)
+        .def_readonly("generation_time_ms", &ov::genai::TalkerPerfMetrics::generation_time_ms);
+
+    py::class_<ov::genai::TalkerResults>(m, "TalkerResults",
+        R"(Output of the talker speech backend. Holds speech waveforms and perf metrics.
+
+        Parameters:
+        waveforms:       speech waveform tensors (one per result, present when return_audio=True).
+        perf_metrics:    speech-side perf metrics (TalkerPerfMetrics).
+        )")
+        .def(py::init<>())
+        .def_readonly("waveforms", &ov::genai::TalkerResults::waveforms)
+        .def_readonly("perf_metrics", &ov::genai::TalkerResults::perf_metrics);
+
+    py::class_<OmniDecodedResults, VLMDecodedResults>(m, "OmniDecodedResults",
+        R"(Omni-specific decoded results including speech outputs.
+
+        Extends VLMDecodedResults with a TalkerResults that holds speech waveforms and perf metrics.
+
+        Parameters:
+        texts:           vector of resulting sequences (inherited from DecodedResults).
+        scores:          scores for each sequence (inherited from DecodedResults).
+        perf_metrics:    text-side perf metrics (inherited from VLMDecodedResults).
+        speech_result:   TalkerResults with waveforms and perf_metrics.
+        )")
+        .def(py::init<>())
+        .def_readonly("speech_result", &OmniDecodedResults::speech_result);
+
+    py::class_<OmniPipeline>(m, "OmniPipeline", omni_pipeline_docstring)
+        .def(py::init([](const std::filesystem::path& models_path,
+                         const std::string& device,
+                         const py::kwargs& kwargs) {
+                 ScopedVar env_manager(pyutils::ov_tokenizers_module_path());
+                 ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
+                 py::gil_scoped_release rel;
+                 return std::make_unique<OmniPipeline>(models_path, device, properties);
+             }),
+             py::arg("models_path"),
+             "folder with exported Qwen3-Omni model files (VLM + speech)",
+             py::arg("device"),
+             "device on which inference will be done",
+             R"(
+                OmniPipeline path-based constructor.
+                models_path (os.PathLike): Path to the folder with exported Qwen3-Omni model files.
+                device (str): Device to run the model on (e.g., CPU, GPU).
+                kwargs: Device properties.
+             )")
+
+        .def(py::init([](const std::shared_ptr<VLMPipelineBase>& vlm,
+                         const std::shared_ptr<TalkerBase>& talker) {
+                 py::gil_scoped_release rel;
+                 return std::make_unique<OmniPipeline>(vlm, talker);
+             }),
+             py::arg("vlm"),
+             py::arg("talker"),
+             R"(
+                OmniPipeline dependency-injection constructor.
+                Compose a pre-built VLM (thinker) and Talker (speech) so the two stages can use
+                independent devices/properties, or so a custom TalkerBase subclass can be injected.
+                vlm (VLMPipeline): Backing VLM pipeline. Must be a Qwen3-Omni-capable model loaded
+                    with the continuous-batching backend (attention_backend=PA).
+                talker (TalkerBase): Backing speech generator (default impl is Talker).
+             )")
+
+        .def(
+            "generate",
+            [](OmniPipeline& pipe,
+               const std::string& prompt,
+               const std::vector<ov::Tensor>& images,
+               const std::vector<ov::Tensor>& videos,
+               const std::vector<VideoMetadata>& videos_metadata,
+               const std::vector<ov::Tensor>& audios,
+               const std::optional<GenerationConfig>& text_config,
+               const std::optional<OmniTalkerSpeechConfig>& talker_speech_config,
+               const pyutils::PyBindStreamerVariant& streamer,
+               const pyutils::PyBindOmniSpeechStreamerVariant& speech_streamer)
+                -> py::typing::Union<OmniDecodedResults> {
+                GenerationConfig resolved_text_config = text_config.value_or(GenerationConfig{});
+                OmniTalkerSpeechConfig resolved_talker_config = talker_speech_config.value_or(OmniTalkerSpeechConfig{});
+                return call_omni_generate(pipe,
+                                          prompt,
+                                          images,
+                                          videos,
+                                          videos_metadata,
+                                          audios,
+                                          resolved_text_config,
+                                          resolved_talker_config,
+                                          streamer,
+                                          speech_streamer);
+            },
+            py::arg("prompt"),
+            py::arg("images") = std::vector<ov::Tensor>{},
+            py::arg("videos") = std::vector<ov::Tensor>{},
+            py::arg("videos_metadata") = std::vector<VideoMetadata>{},
+            py::arg("audios") = std::vector<ov::Tensor>{},
+            py::arg("text_config") = py::none(),
+            py::arg("talker_speech_config") = py::none(),
+            py::arg("streamer") = std::monostate(),
+            py::arg("speech_streamer") = std::monostate(),
+            omni_generate_prompt_docstring)
+
+        .def(
+            "generate",
+            [](OmniPipeline& pipe,
+               const ChatHistory& history,
+               const std::vector<ov::Tensor>& images,
+               const std::vector<ov::Tensor>& videos,
+               const std::vector<VideoMetadata>& videos_metadata,
+               const std::vector<ov::Tensor>& audios,
+               const std::optional<GenerationConfig>& text_config,
+               const std::optional<OmniTalkerSpeechConfig>& talker_speech_config,
+               const pyutils::PyBindStreamerVariant& streamer,
+               const pyutils::PyBindOmniSpeechStreamerVariant& speech_streamer)
+                -> py::typing::Union<OmniDecodedResults> {
+                GenerationConfig resolved_text_config = text_config.value_or(GenerationConfig{});
+                OmniTalkerSpeechConfig resolved_talker_config = talker_speech_config.value_or(OmniTalkerSpeechConfig{});
+                return call_omni_generate_history(pipe,
+                                                  history,
+                                                  images,
+                                                  videos,
+                                                  videos_metadata,
+                                                  audios,
+                                                  resolved_text_config,
+                                                  resolved_talker_config,
+                                                  streamer,
+                                                  speech_streamer);
+            },
+            py::arg("history"),
+            py::arg("images") = std::vector<ov::Tensor>{},
+            py::arg("videos") = std::vector<ov::Tensor>{},
+            py::arg("videos_metadata") = std::vector<VideoMetadata>{},
+            py::arg("audios") = std::vector<ov::Tensor>{},
+            py::arg("text_config") = py::none(),
+            py::arg("talker_speech_config") = py::none(),
+            py::arg("streamer") = std::monostate(),
+            py::arg("speech_streamer") = std::monostate(),
+            omni_generate_history_docstring)
+
+        .def("get_vlm",
+             &OmniPipeline::get_vlm,
+             R"(
+                Return the underlying VLM (thinker) as a VLMPipelineBase. Useful for inspecting
+                model metadata or reusing the same VLM across pipelines via the DI constructor.
+             )")
+
+        .def("get_talker",
+             &OmniPipeline::get_talker,
+             R"(
+                Return the underlying TalkerBase. Speaker enumeration and embedding retrieval
+                live here: pipe.get_talker().list_speakers(),
+                pipe.get_talker().get_speaker_embedding(name).
+             )");
+}

--- a/src/python/py_openvino_genai.cpp
+++ b/src/python/py_openvino_genai.cpp
@@ -45,6 +45,7 @@ void init_image_generation_pipelines(py::module_& m);
 void init_video_generation_models(py::module_& m);
 void init_video_generation_pipelines(py::module_& m);
 void init_vlm_pipeline(py::module_& m);
+void init_omni_pipeline(py::module_& m);
 void init_whisper_pipeline(py::module_& m);
 void init_asr_pipeline(py::module_& m);
 void init_rag_pipelines(py::module_& m);
@@ -154,6 +155,7 @@ PYBIND11_MODULE(py_openvino_genai, m) {
 
     init_llm_pipeline(m);
     init_vlm_pipeline(m);
+    init_omni_pipeline(m);
     init_continuous_batching_pipeline(m);
     init_image_generation_pipelines(m);
     init_video_generation_models(m);

--- a/src/python/py_streamers.cpp
+++ b/src/python/py_streamers.cpp
@@ -1,12 +1,11 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include <filesystem>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 #include <pybind11/functional.h>
 
+#include "openvino/genai/omni/speech_streamer_base.hpp"
 #include "openvino/genai/streamer_base.hpp"
 #include "openvino/genai/text_streamer.hpp"
 #include "openvino/genai/parsers.hpp"
@@ -88,6 +87,29 @@ public:
     }
 };
 
+class ConstructableOmniSpeechStreamer : public ov::genai::OmniSpeechStreamerBase {
+    ov::genai::StreamingStatus write(const ov::Tensor& audio_chunk) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::StreamingStatus, ov::genai::OmniSpeechStreamerBase, write, audio_chunk);
+    }
+    void end() override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, ov::genai::OmniSpeechStreamerBase, end);
+    }
+};
+
+auto omni_speech_streamer_base_docstring = R"(
+    Base class for audio streamers. Inherit and implement write() and end()
+    to receive audio chunks during speech generation.
+
+    write(audio_chunk: ov.Tensor) -> StreamingStatus:
+        Called with each audio chunk [1, 1, N_samples] float32 PCM at 24kHz.
+        Return StreamingStatus.RUNNING to continue or STOP/CANCEL to halt.
+
+    end():
+        Called when speech generation completes (always, even on early stop).
+)";
+
 } // namespace
 
 void init_streamers(py::module_& m) {
@@ -158,4 +180,13 @@ void init_streamers(py::module_& m) {
             }, "Returns the accumulated message.")
         
         .def("reset", &TextParserStreamer::reset, "Resets the internal state of the parser streamer.");
+
+    py::class_<ov::genai::OmniSpeechStreamerBase, ConstructableOmniSpeechStreamer,
+               std::shared_ptr<ov::genai::OmniSpeechStreamerBase>>(m, "OmniSpeechStreamerBase", omni_speech_streamer_base_docstring)
+        .def(py::init<>())
+        .def("write", &ov::genai::OmniSpeechStreamerBase::write,
+             "Called with each audio chunk tensor [1, 1, N_samples]. Return StreamingStatus.",
+             py::arg("audio_chunk"))
+        .def("end", &ov::genai::OmniSpeechStreamerBase::end,
+             "Called when speech generation completes.");
 }

--- a/src/python/py_utils.cpp
+++ b/src/python/py_utils.cpp
@@ -3,26 +3,26 @@
 
 #include "py_utils.hpp"
 
-#include <memory>
-
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 #include <pybind11/stl/filesystem.h>
-#include <pybind11/functional.h>
+#include <pybind11/stl_bind.h>
 
+#include <memory>
 #include <openvino/runtime/auto/properties.hpp>
 
-#include "tokenizer/tokenizers_path.hpp"
-#include "openvino/genai/llm_pipeline.hpp"
-#include "openvino/genai/visual_language/pipeline.hpp"
-#include "openvino/genai/image_generation/generation_config.hpp"
+#include <iostream>
+#include "openvino/core/extension.hpp"
 #include "openvino/genai/extensions.hpp"
+#include "openvino/genai/image_generation/generation_config.hpp"
+#include "openvino/genai/llm_pipeline.hpp"
+#include "openvino/genai/rag/text_embedding_pipeline.hpp"
 #include "openvino/genai/taylorseer_config.hpp"
+#include "openvino/genai/visual_language/pipeline.hpp"
 #include "openvino/genai/whisper_generation_config.hpp"
 #include "openvino/genai/whisper_pipeline.hpp"
-#include "openvino/genai/rag/text_embedding_pipeline.hpp"
-#include "openvino/core/extension.hpp"
+#include "tokenizer/tokenizers_path.hpp"
 #include "utils.hpp"
 
 namespace py = pybind11;
@@ -35,7 +35,8 @@ class GilSafeGeneratorWrapper : public ov::genai::Generator {
 
 public:
     GilSafeGeneratorWrapper(std::shared_ptr<ov::genai::Generator>&& impl, py::object&& py_ref)
-        : m_impl(std::move(impl)), m_py_ref(std::move(py_ref)) {}
+        : m_impl(std::move(impl)),
+          m_py_ref(std::move(py_ref)) {}
 
     ~GilSafeGeneratorWrapper() override {
         if (Py_IsInitialized()) {
@@ -50,10 +51,31 @@ public:
         m_py_ref.release();
     }
 
-    float next() override { return m_impl->next(); }
-    ov::Tensor randn_tensor(const ov::Shape& shape) override { return m_impl->randn_tensor(shape); }
-    void seed(size_t new_seed) override { m_impl->seed(new_seed); }
+    float next() override {
+        return m_impl->next();
+    }
+    ov::Tensor randn_tensor(const ov::Shape& shape) override {
+        return m_impl->randn_tensor(shape);
+    }
+    void seed(size_t new_seed) override {
+        m_impl->seed(new_seed);
+    }
 };
+
+// Permissive mapping: any value outside {RUNNING, CANCEL, TOOL_CALL_STOP} (including legacy
+// `True`/non-zero ints from older Python callbacks that returned bool) is treated as STOP so
+// we don't break user code that returned bools to mean "stop streaming".
+ov::genai::StreamingStatus map_py_status(const std::optional<uint16_t>& result) {
+    if (!result.has_value())
+        return ov::genai::StreamingStatus::RUNNING;
+    if (*result == static_cast<uint16_t>(ov::genai::StreamingStatus::RUNNING))
+        return ov::genai::StreamingStatus::RUNNING;
+    if (*result == static_cast<uint16_t>(ov::genai::StreamingStatus::CANCEL))
+        return ov::genai::StreamingStatus::CANCEL;
+    if (*result == static_cast<uint16_t>(ov::genai::StreamingStatus::TOOL_CALL_STOP))
+        return ov::genai::StreamingStatus::TOOL_CALL_STOP;
+    return ov::genai::StreamingStatus::STOP;
+}
 
 }  // namespace
 
@@ -70,7 +92,7 @@ py::str handle_utf8(const std::string& text) {
 
 py::list handle_utf8(const std::vector<std::string>& decoded_res) {
     py::list res;
-    for (const auto s: decoded_res) {
+    for (const auto& s : decoded_res) {
         py::str r = handle_utf8(s);
         res.append(r);
     }
@@ -105,7 +127,7 @@ ov::AnyMap py_object_to_any_map(const py::object& py_obj) {
 }
 
 ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
-    // These properties should be casted to ov::AnyMap, instead of std::map. 
+    // These properties should be casted to ov::AnyMap, instead of std::map.
     std::set<std::string> any_map_properties = {
         "GENERATE_CONFIG",
         "PREFILL_CONFIG",
@@ -126,8 +148,8 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
     py::object float_32_type = py::module_::import("numpy").attr("float32");
     if (py::isinstance<py::str>(py_obj)) {
         if (property_name == "structural_tags_config") {
-            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value =
-                py_obj.cast<std::string>();
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag>
+                variant_value = py_obj.cast<std::string>();
             return variant_value;
         }
         return py_obj.cast<std::string>();
@@ -172,9 +194,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
                 py::gil_scoped_acquire acquire;
                 return (*py_decrypt)(py::bytes(in_str)).cast<std::string>();
             };
-            ov::EncryptionCallbacks encryption_callbacks{
-                std::move(encrypt_func), std::move(decrypt_func)
-            };
+            ov::EncryptionCallbacks encryption_callbacks{std::move(encrypt_func), std::move(decrypt_func)};
             return encryption_callbacks;
         } else if (property_name == "structural_tags") {
             // this impl is based on OpenVINO python bindings impl.
@@ -205,7 +225,8 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
             py::object pathlib_path = py::module_::import("pathlib").attr("Path");
             py::object op_extension_ctor = py::module_::import("openvino").attr("OpExtension");
             for (const auto& item : property_list) {
-                if (py::isinstance<py::str>(item) || py::isinstance<py::bytes>(item) || py::isinstance(item, pathlib_path)) {
+                if (py::isinstance<py::str>(item) || py::isinstance<py::bytes>(item) ||
+                    py::isinstance(item, pathlib_path)) {
                     extensions.push_back(item.cast<std::filesystem::path>());
                     continue;
                 }
@@ -222,9 +243,10 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
                         e.clear();
                     }
                 }
-                OPENVINO_THROW("Incorrect value in \"",
-                               property_name,
-                               "\". Expected extension path (str/bytes/pathlib.Path), ov::Extension object, or custom op type.");
+                OPENVINO_THROW(
+                    "Incorrect value in \"",
+                    property_name,
+                    "\". Expected extension path (str/bytes/pathlib.Path), ov::Extension object, or custom op type.");
             }
             return extensions;
         } else if (property_name == ov::genai::videos_metadata.name()) {
@@ -238,7 +260,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
             return videos_metadata;
         } else {
             auto _list = py_obj.cast<py::list>();
-            enum class PY_TYPE : int { UNKNOWN = 0, STR, INT, FLOAT, BOOL, PARTIAL_SHAPE, TENSOR, DICT};
+            enum class PY_TYPE : int { UNKNOWN = 0, STR, INT, FLOAT, BOOL, PARTIAL_SHAPE, TENSOR, DICT };
             PY_TYPE detected_type = PY_TYPE::UNKNOWN;
             for (const auto& it : _list) {
                 auto check_type = [&](PY_TYPE type) {
@@ -246,7 +268,8 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
                         detected_type = type;
                         return;
                     }
-                    OPENVINO_THROW("Incorrect value in \"" + property_name + "\". Mixed types in the list are not allowed.");
+                    OPENVINO_THROW("Incorrect value in \"" + property_name +
+                                   "\". Mixed types in the list are not allowed.");
                 };
                 if (py::isinstance<py::str>(it)) {
                     check_type(PY_TYPE::STR);
@@ -295,7 +318,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
 
     } else if (py::isinstance<py::dict>(py_obj) && any_map_properties.find(property_name) == any_map_properties.end()) {
         auto _dict = py_obj.cast<py::dict>();
-        enum class PY_TYPE : int { UNKNOWN = 0, STR, INT};
+        enum class PY_TYPE : int { UNKNOWN = 0, STR, INT };
         PY_TYPE detected_key_type = PY_TYPE::UNKNOWN;
         PY_TYPE detected_value_type = PY_TYPE::UNKNOWN;
         for (const auto& it : _dict) {
@@ -304,7 +327,8 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
                     detected_type = type;
                     return;
                 }
-                OPENVINO_THROW("Incorrect value in \"" + property_name + "\". Mixed types in the dict are not allowed.");
+                OPENVINO_THROW("Incorrect value in \"" + property_name +
+                               "\". Mixed types in the dict are not allowed.");
             };
             // check key type
             if (py::isinstance<py::str>(it.first)) {
@@ -333,7 +357,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
         }
     } else if (py::isinstance<py::set>(py_obj)) {
         auto _set = py_obj.cast<py::set>();
-        enum class PY_TYPE : int { UNKNOWN = 0, STR, INT, FLOAT, BOOL};
+        enum class PY_TYPE : int { UNKNOWN = 0, STR, INT, FLOAT, BOOL };
         PY_TYPE detected_type = PY_TYPE::UNKNOWN;
         for (const auto& it : _set) {
             auto check_type = [&](PY_TYPE type) {
@@ -370,7 +394,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
             OPENVINO_THROW("Property \"" + property_name + "\" got unsupported type.");
         }
 
-    // OV types
+        // OV types
     } else if (py_object_is_any_map(py_obj)) {
         return py_object_to_any_map(py_obj);
     } else if (py::isinstance<ov::Any>(py_obj)) {
@@ -410,27 +434,27 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
     } else if (py::isinstance<ov::genai::StructuralTagsConfig>(py_obj)) {
         // For structural_tags_config property, wrap in variant
         if (property_name == "structural_tags_config") {
-            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value = 
-                py::cast<ov::genai::StructuralTagsConfig>(py_obj);
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag>
+                variant_value = py::cast<ov::genai::StructuralTagsConfig>(py_obj);
             return variant_value;
         }
         return py::cast<ov::genai::StructuralTagsConfig>(py_obj);
-    } else if (py::isinstance<ov::genai::StructuredOutputConfig::Regex>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::EBNF>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::ConstString>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::AnyText>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::QwenXMLParametersFormat>(py_obj)
+    } else if (py::isinstance<ov::genai::StructuredOutputConfig::Regex>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::EBNF>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::JSONSchema>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::ConstString>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::AnyText>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::QwenXMLParametersFormat>(py_obj)
                // python does not use std::shared_ptr to obj
-               || py::isinstance<ov::genai::StructuredOutputConfig::Union>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::Concat>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::Tag>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::TriggeredTags>(py_obj)
-               || py::isinstance<ov::genai::StructuredOutputConfig::TagsWithSeparator>(py_obj)) {
+               || py::isinstance<ov::genai::StructuredOutputConfig::Union>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::Concat>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::Tag>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::TriggeredTags>(py_obj) ||
+               py::isinstance<ov::genai::StructuredOutputConfig::TagsWithSeparator>(py_obj)) {
         // For structural_tags_config property, wrap in variant
         if (property_name == "structural_tags_config") {
-            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag> variant_value = 
-                py_obj_to_structural_tag(py_obj);
+            std::variant<ov::genai::StructuralTagsConfig, ov::genai::StructuredOutputConfig::StructuralTag>
+                variant_value = py_obj_to_structural_tag(py_obj);
             return variant_value;
         }
         return py_obj_to_structural_tag(py_obj);
@@ -455,27 +479,35 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
         return wrapper;
     } else if (py::isinstance<py::function>(py_obj) && property_name == "callback") {
         auto py_callback = py::cast<py::function>(py_obj);
-        auto shared_callback = std::shared_ptr<py::function>(
-            new py::function(py_callback),
-            [](py::function* f) {
-                if (Py_IsInitialized()) {
-                    py::gil_scoped_acquire acquire;
-                    delete f;
-                } else {
-                    delete f;
-                }
+        auto shared_callback = std::shared_ptr<py::function>(new py::function(py_callback), [](py::function* f) {
+            if (Py_IsInitialized()) {
+                py::gil_scoped_acquire acquire;
+                delete f;
+            } else {
+                delete f;
             }
-        );
+        });
 
         return std::function<bool(size_t, size_t, ov::Tensor&)>(
             [shared_callback](size_t step, size_t num_steps, ov::Tensor& latent) -> bool {
                 py::gil_scoped_acquire acquire;
                 return (*shared_callback)(step, num_steps, latent).cast<bool>();
-            }
-        );
-    } else if ((py::isinstance<py::function>(py_obj) || py::isinstance<ov::genai::StreamerBase>(py_obj) || py::isinstance<std::monostate>(py_obj)) && property_name == "streamer") {
+            });
+    } else if ((py::isinstance<py::function>(py_obj) || py::isinstance<ov::genai::StreamerBase>(py_obj) ||
+                py::isinstance<std::monostate>(py_obj)) &&
+               property_name == "streamer") {
         auto streamer = py::cast<ov::genai::pybind::utils::PyBindStreamerVariant>(py_obj);
         return ov::genai::streamer(pystreamer_to_streamer(streamer)).second;
+    } else if ((py::isinstance<py::function>(py_obj) || py::isinstance<ov::genai::OmniSpeechStreamerBase>(py_obj)) &&
+               property_name == "audio_streamer") {
+        auto audio_streamer = py::cast<ov::genai::pybind::utils::PyBindOmniSpeechStreamerVariant>(py_obj);
+        auto converted = py_speech_streamer_to_streamer(audio_streamer);
+        // Store the unwrapped concrete type so get_audio_streamer_from_map can .is<T>() it
+        return std::visit(
+            [](auto&& val) -> ov::Any {
+                return ov::Any(val);
+            },
+            converted);
     } else if (py::isinstance(py_obj, py::module_::import("pathlib").attr("Path"))) {
         return py::cast<std::filesystem::path>(py_obj);
     }
@@ -509,7 +541,6 @@ ov::AnyMap kwargs_to_any_map(const py::kwargs& kwargs) {
             OPENVINO_ASSERT(!value.is_none(), "Property \"", key, "\" can't be None.");
             params[key] = utils::py_object_to_any(value, key);
         }
-
     }
     return params;
 }
@@ -526,50 +557,83 @@ std::filesystem::path ov_tokenizers_module_path() {
 ov::genai::StreamerVariant pystreamer_to_streamer(const PyBindStreamerVariant& py_streamer) {
     ov::genai::StreamerVariant streamer = std::monostate();
 
-    std::visit(overloaded {
-        [&streamer](const std::function<std::optional<uint16_t>(py::str)>& py_callback){
-            auto shared_callback = std::shared_ptr<std::function<std::optional<uint16_t>(py::str)>>(
-                new std::function<std::optional<uint16_t>(py::str)>(py_callback),
-                [](std::function<std::optional<uint16_t>(py::str)>* f) {
-                    if (Py_IsInitialized()) {
-                        py::gil_scoped_acquire acquire;
-                        delete f;
-                    } else {
-                        delete f;
-                    }
-                }
-            );
+    std::visit(overloaded{[&streamer](const std::function<std::optional<uint16_t>(py::str)>& py_callback) {
+                              auto shared_callback = std::shared_ptr<std::function<std::optional<uint16_t>(py::str)>>(
+                                  new std::function<std::optional<uint16_t>(py::str)>(py_callback),
+                                  [](std::function<std::optional<uint16_t>(py::str)>* f) {
+                                      if (Py_IsInitialized()) {
+                                          py::gil_scoped_acquire acquire;
+                                          delete f;
+                                      } else {
+                                          delete f;
+                                      }
+                                  });
 
-            auto callback_wrapped = [shared_callback = std::move(shared_callback)](std::string subword) -> ov::genai::StreamingStatus {
-                py::gil_scoped_acquire acquire;
-                PyObject* py_str = PyUnicode_DecodeUTF8(subword.data(), subword.length(), "replace");
-                if (!py_str) {
-                    PyErr_WriteUnraisable(nullptr);
-                    return StreamingStatus::RUNNING;
-                }
-                auto py_str_obj = py::reinterpret_steal<py::str>(py_str);
-                std::optional<uint16_t> callback_output;
-                try {
-                    callback_output = (*shared_callback)(py_str_obj);
-                } catch (const py::error_already_set&) {
-                    return StreamingStatus::RUNNING;
-                }
-                if (callback_output.has_value()) {
-                    if (*callback_output == static_cast<uint16_t>(StreamingStatus::RUNNING))
-                        return StreamingStatus::RUNNING;
-                    else if (*callback_output == static_cast<uint16_t>(StreamingStatus::CANCEL))
-                        return StreamingStatus::CANCEL;
-                    return StreamingStatus::STOP;
-                }
-                return StreamingStatus::RUNNING;
-            };
-            streamer = callback_wrapped;
-        },
-        [&streamer](std::shared_ptr<StreamerBase> streamer_cls){
-            streamer = streamer_cls;
-        },
-        [](std::monostate none){ /*streamer is already a monostate */ }
-    }, py_streamer);
+                              auto callback_wrapped = [shared_callback = std::move(shared_callback)](
+                                                          std::string subword) -> ov::genai::StreamingStatus {
+                                  py::gil_scoped_acquire acquire;
+                                  PyObject* py_str = PyUnicode_DecodeUTF8(subword.data(), subword.length(), "replace");
+                                  if (!py_str) {
+                                      PyErr_WriteUnraisable(nullptr);
+                                      return StreamingStatus::RUNNING;
+                                  }
+                                  auto py_str_obj = py::reinterpret_steal<py::str>(py_str);
+                                  try {
+                                      return map_py_status((*shared_callback)(py_str_obj));
+                                  } catch (const py::error_already_set& e) {
+                                      // Surface the failure but keep generation alive — historical
+                                      // behavior is RUNNING so user callbacks that raise transiently
+                                      // don't abort. Log to stderr so the error stops being invisible.
+                                      std::cerr << "[GenAI] Text streamer callback raised exception: " << e.what()
+                                                << std::endl;
+                                      return StreamingStatus::RUNNING;
+                                  }
+                              };
+                              streamer = callback_wrapped;
+                          },
+                          [&streamer](std::shared_ptr<StreamerBase> streamer_cls) {
+                              streamer = streamer_cls;
+                          },
+                          [](std::monostate none) { /*streamer is already a monostate */ }},
+               py_streamer);
+    return streamer;
+}
+
+ov::genai::OmniSpeechStreamerVariant py_speech_streamer_to_streamer(const PyBindOmniSpeechStreamerVariant& py_streamer) {
+    ov::genai::OmniSpeechStreamerVariant streamer = std::monostate();
+
+    std::visit(overloaded{[&streamer](const std::function<std::optional<uint16_t>(ov::Tensor)>& py_callback) {
+                              // shared_ptr so the destructor runs with GIL held
+                              auto shared_callback =
+                                  std::shared_ptr<std::function<std::optional<uint16_t>(ov::Tensor)>>(
+                                      new std::function<std::optional<uint16_t>(ov::Tensor)>(py_callback),
+                                      [](std::function<std::optional<uint16_t>(ov::Tensor)>* f) {
+                                          if (Py_IsInitialized()) {
+                                              py::gil_scoped_acquire acquire;
+                                              delete f;
+                                          } else {
+                                              delete f;
+                                          }
+                                      });
+
+                              auto callback_wrapped = [shared_callback = std::move(shared_callback)](
+                                                          const ov::Tensor& audio_chunk) -> StreamingStatus {
+                                  py::gil_scoped_acquire acquire;
+                                  try {
+                                      return map_py_status((*shared_callback)(audio_chunk));
+                                  } catch (const py::error_already_set& e) {
+                                      std::cerr << "[GenAI] Audio streamer callback raised exception: " << e.what()
+                                                << std::endl;
+                                      return StreamingStatus::STOP;
+                                  }
+                              };
+                              streamer = callback_wrapped;
+                          },
+                          [&streamer](std::shared_ptr<ov::genai::OmniSpeechStreamerBase> streamer_cls) {
+                              streamer = streamer_cls;
+                          },
+                          [](std::monostate) { /* already monostate */ }},
+               py_streamer);
     return streamer;
 }
 

--- a/src/python/py_utils.hpp
+++ b/src/python/py_utils.hpp
@@ -7,6 +7,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
+#include "openvino/genai/omni/speech_streamer_base.hpp"
 #include "openvino/genai/streamer_base.hpp"
 #include "openvino/genai/llm_pipeline.hpp"
 #include "openvino/genai/json_container.hpp"
@@ -50,6 +51,13 @@ std::vector<std::vector<ov::genai::VideoMetadata>> get_videos_metadata_batches_f
 ov::genai::GenerationConfig update_config_from_kwargs(ov::genai::GenerationConfig config, const py::kwargs& kwargs);
 
 ov::genai::StreamerVariant pystreamer_to_streamer(const PyBindStreamerVariant& py_streamer);
+
+using PyBindOmniSpeechStreamerVariant = std::variant<
+    std::function<std::optional<uint16_t>(ov::Tensor)>,
+    std::shared_ptr<ov::genai::OmniSpeechStreamerBase>,
+    std::monostate>;
+
+ov::genai::OmniSpeechStreamerVariant py_speech_streamer_to_streamer(const PyBindOmniSpeechStreamerVariant& py_streamer);
 
 ov::AnyMap py_object_to_any_map(const py::object& py_obj);
 

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -46,14 +46,25 @@ auto vlm_generate_common_params = R"(
     :param videos: list of frames
     :type videos: list[ov.Tensor]
 
+    :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+    :type audios: list[ov.Tensor]
+
     :param generation_config: generation_config
     :type generation_config: GenerationConfig or a dict
 
     :param streamer: streamer either as a lambda with a boolean returning flag whether generation should be stopped
-    :type : Callable[[str], bool], ov.genai.StreamerBase
+    :type streamer: Callable[[str], bool], ov.genai.StreamerBase
+
+    :param audio_streamer: callback or OmniSpeechStreamerBase to receive audio chunks during speech generation.
+        Lambda receives ov.Tensor [1, 1, N_samples] and returns StreamingStatus (or bool/None).
+    :type audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None], ov.genai.OmniSpeechStreamerBase
+
+    :param audio_chunk_frames: number of codec frames per streaming chunk (default 1 = ~80ms). Must be >= 1.
+        Ignored when audio_streamer is not provided.
+    :type audio_chunk_frames: int
 
     :param kwargs: arbitrary keyword arguments with keys corresponding to GenerationConfig fields.
-    :type : dict
+    :type kwargs: dict
 
     :return: return results in decoded form
     :rtype: VLMDecodedResults
@@ -66,9 +77,12 @@ auto vlm_generate_kwargs_param = R"(
     image: ov.Tensor - input image,
     images: list[ov.Tensor] - input images,
     videos: list[ov.Tensor] - input videos,
+    audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
     videos_metadata: list[VideoMetadata] - metadata for each video,
     generation_config: GenerationConfig,
-    streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped
+    streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,
+    audio_streamer: Callable[[ov.Tensor], StreamingStatus | bool | None] or OmniSpeechStreamerBase - callback to receive audio chunks during speech generation,
+    audio_chunk_frames: int - number of codec frames per streaming chunk (default 1, must be >= 1). Ignored when audio_streamer is not provided.
 
     :return: return results in decoded form
     :rtype: VLMDecodedResults
@@ -112,9 +126,9 @@ auto decoded_results_docstring = R"(
     The first num_return_sequences elements correspond to the first batch element.
 
     Parameters:
-    texts:      vector of resulting sequences.
-    scores:     scores for each sequence.
-    metrics:    performance metrics with tpot, ttft, etc. of type openvino_genai.VLMPerfMetrics.
+    texts:            vector of resulting sequences.
+    scores:           scores for each sequence.
+    metrics:          performance metrics with tpot, ttft, etc. of type openvino_genai.VLMPerfMetrics.
 )";
 
 auto video_metadata_docstring = R"(
@@ -139,6 +153,29 @@ py::object call_vlm_generate(
     const pyutils::PyBindStreamerVariant& py_streamer,
     const py::kwargs& kwargs
 ) {
+    // Route through AnyMap overload when audio kwargs are present, since only the AnyMap path
+    // extracts the audio tensors and sets up the speech streamer for the underlying pipeline.
+    if (kwargs.contains("audios") || kwargs.contains("audio_streamer")) {
+        auto map = pyutils::kwargs_to_any_map(kwargs);
+        if (!images.empty()) {
+            map[ov::genai::images.name()] = images;
+        }
+        if (!videos.empty()) {
+            map[ov::genai::videos.name()] = videos;
+        }
+        map["generation_config"] = generation_config;
+        ov::genai::StreamerVariant streamer = pyutils::pystreamer_to_streamer(py_streamer);
+        if (!std::holds_alternative<std::monostate>(streamer)) {
+            map.insert(ov::genai::streamer(std::move(streamer)));
+        }
+        ov::genai::VLMDecodedResults res;
+        {
+            py::gil_scoped_release rel;
+            res = pipe.generate(prompt, map);
+        }
+        return py::cast(res);
+    }
+
     auto updated_config = pyutils::update_config_from_kwargs(generation_config, kwargs);
     ov::genai::StreamerVariant streamer = pyutils::pystreamer_to_streamer(py_streamer);
     const auto videos_metadata = pyutils::get_videos_metadata_from_kwargs(kwargs);
@@ -167,6 +204,27 @@ py::object call_vlm_generate_with_chat_history(
     const pyutils::PyBindStreamerVariant& py_streamer,
     const py::kwargs& kwargs
 ) {
+    if (kwargs.contains("audios") || kwargs.contains("audio_streamer")) {
+        auto map = pyutils::kwargs_to_any_map(kwargs);
+        if (!images.empty()) {
+            map[ov::genai::images.name()] = images;
+        }
+        if (!videos.empty()) {
+            map[ov::genai::videos.name()] = videos;
+        }
+        map["generation_config"] = generation_config;
+        ov::genai::StreamerVariant streamer = pyutils::pystreamer_to_streamer(py_streamer);
+        if (!std::holds_alternative<std::monostate>(streamer)) {
+            map.insert(ov::genai::streamer(std::move(streamer)));
+        }
+        ov::genai::VLMDecodedResults res;
+        {
+            py::gil_scoped_release rel;
+            res = pipe.generate(history, map);
+        }
+        return py::cast(res);
+    }
+
     auto updated_config = pyutils::update_config_from_kwargs(generation_config, kwargs);
     ov::genai::StreamerVariant streamer = pyutils::pystreamer_to_streamer(py_streamer);
     const auto videos_metadata = pyutils::get_videos_metadata_from_kwargs(kwargs);
@@ -210,6 +268,8 @@ void init_vlm_pipeline(py::module_& m) {
         .def_property_readonly("texts", [](const ov::genai::VLMDecodedResults &dr) -> py::typing::List<py::str> { return pyutils::handle_utf8(dr.texts); })
         .def_readonly("scores", &ov::genai::VLMDecodedResults::scores)
         .def_readonly("perf_metrics", &ov::genai::VLMDecodedResults::perf_metrics)
+        .def_readonly("intermediate_hidden_states", &ov::genai::VLMDecodedResults::intermediate_hidden_states)
+        .def_readonly("full_token_ids", &ov::genai::VLMDecodedResults::full_token_ids)
         .def("__str__", [](const ov::genai::VLMDecodedResults &dr) -> py::str {
             auto valid_utf8_strings = pyutils::handle_utf8(dr.texts);
             py::str res;
@@ -223,7 +283,12 @@ void init_vlm_pipeline(py::module_& m) {
             return res;
         });
 
-    py::class_<ov::genai::VLMPipeline>(m, "VLMPipeline", "This class is used for generation with VLMs")
+    // Abstract public base. Registered (without a constructor) so that a VLMPipeline can be
+    // passed to OmniPipeline's DI constructor as a shared_ptr<VLMPipelineBase>.
+    py::class_<ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipelineBase>>(
+        m, "VLMPipelineBase", "Abstract base of VLM-style pipelines.");
+
+    py::class_<ov::genai::VLMPipeline, ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipeline>>(m, "VLMPipeline", "This class is used for generation with VLMs")
         .def(py::init([](
             const std::filesystem::path& models_path,
             const std::string& device,
@@ -260,7 +325,7 @@ void init_vlm_pipeline(py::module_& m) {
         py::arg("tokenizer"), "genai Tokenizers",
         py::arg("config_dir_path"), "Path to folder with model configs",
         py::arg("device"), "device on which inference will be done",
-        py::arg("generation_config")  = std::nullopt, "generation config",
+        py::arg("generation_config") = std::nullopt, "generation config",
         R"(
             VLMPipeline class constructor.
             models (dict[str, tuple[str, openvino.Tensor]]): A map where key is model name (e.g. "vision_embeddings", "text_embeddings", "language", "resampler")

--- a/tests/cpp/test_audio_chunk_frames_validation.cpp
+++ b/tests/cpp/test_audio_chunk_frames_validation.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for audio_chunk_frames bounds validation in
+// validate_omni_talker_speech_config(). The criterion requires:
+//   - audio_chunk_frames >= 1 when return_audio is true
+//   - audio_chunk_frames <= 4096 when return_audio is true
+
+#include <gtest/gtest.h>
+
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "omni/talker_speech_config_utils.hpp"
+
+namespace {
+
+ov::genai::OmniTalkerSpeechConfig make_config_with_audio(std::size_t chunk_frames) {
+    ov::genai::OmniTalkerSpeechConfig cfg;
+    cfg.return_audio = true;
+    cfg.audio_chunk_frames = chunk_frames;
+    return cfg;
+}
+
+}  // namespace
+
+TEST(AudioChunkFramesValidation, RejectsZeroChunkFramesWhenReturnAudioTrue) {
+    auto cfg = make_config_with_audio(0);
+    EXPECT_THROW(ov::genai::validate_omni_talker_speech_config(cfg), ov::Exception);
+}
+
+TEST(AudioChunkFramesValidation, RejectsExcessiveChunkFramesWhenReturnAudioTrue) {
+    auto cfg = make_config_with_audio(9999);
+    EXPECT_THROW(ov::genai::validate_omni_talker_speech_config(cfg), ov::Exception);
+}

--- a/tests/cpp/test_audio_encoder_validation.cpp
+++ b/tests/cpp/test_audio_encoder_validation.cpp
@@ -1,0 +1,115 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for unbounded audio tensor / chunk_frames input
+// validation in AudioEncoderQwen3Omni and validate_omni_talker_speech_config().
+//
+// These tests pre-validate inputs at the API boundary before allocation, so they do
+// not need a fully-constructed pipeline. We test the boundary-validation helper
+// directly. The helper is exposed for testing via the impl header; production code
+// invokes it from AudioEncoderQwen3Omni::preprocess_audio().
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+#include "openvino/genai/omni/talker_speech_config.hpp"
+#include "omni/talker_speech_config_utils.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "visual_language/qwen3_omni/audio_encoder.hpp"
+
+namespace {
+
+constexpr size_t kMaxAudioSamples = 480'000'000;  // ~500 min @ 16 kHz, matches impl
+
+// Build a float32 audio tensor with the given shape filled with silence. Used to
+// exercise the validate_audio_input() boundary check; we do not run the encoder
+// (which requires a compiled model) — only the validation entry point.
+ov::Tensor make_audio(std::initializer_list<size_t> shape) {
+    return ov::Tensor(ov::element::f32, ov::Shape(shape));
+}
+
+}  // namespace
+
+// ---- C6 audio tensor validation ----
+
+TEST(AudioEncoderValidation, RejectsRank2Audio) {
+    // 2-D tensor must be rejected before any allocation; impl currently passes
+    // through silently and only fails deep inside WhisperFeatureExtractor.
+    auto t = make_audio({2, 100});
+    EXPECT_THROW({ ov::genai::AudioEncoderQwen3Omni::validate_audio_input(t); }, ov::Exception);
+}
+
+TEST(AudioEncoderValidation, RejectsEmptyAudio) {
+    // Shape {0} is rank-1 but has 0 samples. Empty input must be rejected at the
+    // boundary, not allowed to construct an empty std::vector and underflow later.
+    auto t = make_audio({0});
+    EXPECT_THROW({ ov::genai::AudioEncoderQwen3Omni::validate_audio_input(t); }, ov::Exception);
+}
+
+TEST(AudioEncoderValidation, RejectsHugeAudio) {
+    // Use the shape-only overload so we never allocate kMaxAudioSamples + 1 floats:
+    // the validator must reject based on the declared shape, before allocation.
+    ov::Shape too_big{kMaxAudioSamples + 1};
+    EXPECT_THROW({ ov::genai::AudioEncoderQwen3Omni::validate_audio_shape(too_big, ov::element::f32); },
+                 ov::Exception);
+}
+
+TEST(AudioEncoderValidation, AcceptsValidShape) {
+    // 1 second of audio at 16 kHz: 1-D, 16 000 samples, well within bounds.
+    auto t = make_audio({16000});
+    EXPECT_NO_THROW({ ov::genai::AudioEncoderQwen3Omni::validate_audio_input(t); });
+}
+
+TEST(AudioEncoderValidation, RejectsWrongElementType) {
+    // PCM contract is f32; reject other types at the boundary so callers see a
+    // clear error instead of a confusing "audio_data is null" deep inside.
+    ov::Tensor t(ov::element::i16, {16000});
+    EXPECT_THROW({ ov::genai::AudioEncoderQwen3Omni::validate_audio_input(t); }, ov::Exception);
+}
+
+// ---- audio_chunk_frames validation in validate_omni_talker_speech_config() ----
+
+// Helper: the standalone OmniTalkerSpeechConfig has no GenerationConfig
+// termination invariant to satisfy, so a default-constructed instance is valid
+// out of the gate. All chunk-frame tests reuse this factory so the contract
+// stays explicit.
+ov::genai::OmniTalkerSpeechConfig make_speech_config() {
+    return ov::genai::OmniTalkerSpeechConfig{};
+}
+
+TEST(OmniTalkerSpeechConfigAudioChunkFrames, RejectsZeroWhenReturnAudioTrue) {
+    auto cfg = make_speech_config();
+    cfg.return_audio = true;
+    cfg.audio_chunk_frames = 0;
+    EXPECT_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); }, ov::Exception);
+}
+
+TEST(OmniTalkerSpeechConfigAudioChunkFrames, RejectsHugeChunkFramesWhenReturnAudioTrue) {
+    auto cfg = make_speech_config();
+    cfg.return_audio = true;
+    cfg.audio_chunk_frames = std::numeric_limits<size_t>::max() / 2;
+    EXPECT_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); }, ov::Exception);
+}
+
+TEST(OmniTalkerSpeechConfigAudioChunkFrames, AcceptsValidChunkFrames) {
+    auto cfg = make_speech_config();
+    cfg.return_audio = true;
+    cfg.audio_chunk_frames = 1;
+    EXPECT_NO_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); });
+    cfg.audio_chunk_frames = 100;
+    EXPECT_NO_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); });
+}
+
+TEST(OmniTalkerSpeechConfigAudioChunkFrames, IgnoresChunkFramesWhenReturnAudioFalse) {
+    // When return_audio is false, audio_chunk_frames is unused;
+    // validate_omni_talker_speech_config() must not reject 0 / huge values
+    // (they're irrelevant to text-only generation).
+    auto cfg = make_speech_config();
+    cfg.return_audio = false;
+    cfg.audio_chunk_frames = 0;
+    EXPECT_NO_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); });
+    cfg.audio_chunk_frames = std::numeric_limits<size_t>::max();
+    EXPECT_NO_THROW({ ov::genai::validate_omni_talker_speech_config(cfg); });
+}

--- a/tests/cpp/test_whisper_feature_extractor.cpp
+++ b/tests/cpp/test_whisper_feature_extractor.cpp
@@ -1,0 +1,201 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "whisper/feature_extractor.hpp"
+
+namespace {
+
+using ov::genai::WhisperFeatureExtractor;
+using ov::genai::WhisperFeatures;
+
+constexpr float kPi = 3.14159265358979323846f;
+constexpr size_t kWhisperBins = 80;
+constexpr size_t kQwen3OmniBins = 128;
+constexpr size_t kSamplingRate = 16000;
+constexpr size_t kNFft = 400;
+constexpr size_t kHopLength = 160;
+constexpr size_t kWhisperNSamples = kSamplingRate * 30;  // 480000
+
+std::vector<float> make_sine_wave(size_t num_samples, float freq_hz, float sample_rate) {
+    std::vector<float> out(num_samples);
+    const float two_pi = 2.0f * kPi;
+    for (size_t i = 0; i < num_samples; ++i) {
+        const float t = static_cast<float>(i) / sample_rate;
+        const float envelope = 1.0f - static_cast<float>(i) / static_cast<float>(num_samples);
+        out[i] = envelope * std::sin(two_pi * freq_hz * t);
+    }
+    return out;
+}
+
+// Frame count formula. Matches WhisperFeatureExtractor semantics:
+//   padded_size = max(raw_size, n_samples) + 2 * (n_fft / 2)
+//   n_frames    = (padded_size - n_fft) / hop
+constexpr size_t expected_n_frames(size_t raw_size, size_t n_samples, size_t n_fft, size_t hop) {
+    const size_t effective = raw_size > n_samples ? raw_size : n_samples;
+    const size_t padded = effective + 2 * (n_fft / 2);
+    return (padded - n_fft) / hop;
+}
+
+// Build a Whisper-style extractor that pre-pads to 30 s by overriding n_samples
+// on top of the explicit-numeric ctor (which defaults to n_samples = 0).
+WhisperFeatureExtractor make_whisper_extractor(size_t feature_size = kWhisperBins) {
+    WhisperFeatureExtractor ex(feature_size, kSamplingRate, kNFft, kHopLength);
+    ex.n_samples = kWhisperNSamples;
+    return ex;
+}
+
+}  // namespace
+
+TEST(WhisperFeatureExtractor, ConstructsWithWhisperDefaults) {
+    WhisperFeatureExtractor ex(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    EXPECT_EQ(ex.feature_size, kWhisperBins);
+    EXPECT_EQ(ex.sampling_rate, kSamplingRate);
+    EXPECT_EQ(ex.n_fft, kNFft);
+    EXPECT_EQ(ex.hop_length, kHopLength);
+    // Explicit-numeric ctor disables pre-padding (matches the Qwen3-Omni configuration
+    // where preprocessor_config.json declares WhisperFeatureExtractor without fixing
+    // chunk_length).
+    EXPECT_EQ(ex.n_samples, 0u);
+}
+
+TEST(WhisperFeatureExtractor, ConstructsWithQwen3OmniDefaults) {
+    WhisperFeatureExtractor ex(kQwen3OmniBins, kSamplingRate, kNFft, kHopLength);
+    EXPECT_EQ(ex.feature_size, kQwen3OmniBins);
+    EXPECT_EQ(ex.sampling_rate, kSamplingRate);
+    EXPECT_EQ(ex.n_fft, kNFft);
+    EXPECT_EQ(ex.hop_length, kHopLength);
+}
+
+TEST(WhisperFeatureExtractor, ExtractProducesExpectedShape_ShortAudio) {
+    // 1s of 440 Hz sine: 16000 samples. Qwen3-style (n_samples = 0): no pre-pad.
+    const size_t raw_size = 16000;
+    const auto raw = make_sine_wave(raw_size, 440.0f, 16000.0f);
+    WhisperFeatureExtractor ex(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    const auto features = ex.extract(raw);
+    EXPECT_EQ(features.feature_size, kWhisperBins);
+    EXPECT_EQ(features.n_frames, expected_n_frames(raw_size, 0, kNFft, kHopLength));
+    EXPECT_EQ(features.data.size(), kWhisperBins * features.n_frames);
+}
+
+TEST(WhisperFeatureExtractor, ExtractAssertsOnEmptyInput) {
+    WhisperFeatureExtractor ex(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    EXPECT_ANY_THROW({ (void)ex.extract({}); });
+}
+
+TEST(WhisperFeatureExtractor, ExtractWithWhisperPrepadAssertsOnEmptyInput) {
+    auto ex = make_whisper_extractor();
+    EXPECT_ANY_THROW({ (void)ex.extract({}); });
+}
+
+TEST(WhisperFeatureExtractor, ExtractAssertsOnAudioShorterThanReflectPad) {
+    // n_fft=400 -> reflect_pad_size = 200. Audio of 100 samples is too short
+    // for reflect padding; extract() (n_samples=0) must assert to avoid UB.
+    const auto raw = make_sine_wave(100, 440.0f, 16000.0f);
+    WhisperFeatureExtractor ex(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    EXPECT_ANY_THROW({ (void)ex.extract(raw); });
+}
+
+TEST(WhisperFeatureExtractor, ExtractAppliesPrepadForShortAudio) {
+    // 0.5s of audio; Whisper-style n_samples forces up to 30s worth of frames.
+    const size_t raw_size = 8000;
+    const auto raw = make_sine_wave(raw_size, 440.0f, 16000.0f);
+    auto ex = make_whisper_extractor();
+    const auto features = ex.extract(raw);
+    EXPECT_EQ(features.n_frames, expected_n_frames(raw_size, kWhisperNSamples, kNFft, kHopLength));
+    EXPECT_EQ(features.n_active_frames, raw_size / kHopLength);  // 50
+    EXPECT_EQ(features.data.size(), kWhisperBins * features.n_frames);
+}
+
+TEST(WhisperFeatureExtractor, ExtractWithAudioExactlyNSamples) {
+    // Boundary: raw_size == n_samples exactly. Neither zero-pads nor truncates.
+    auto ex = make_whisper_extractor();
+    const auto raw = make_sine_wave(kWhisperNSamples, 440.0f, 16000.0f);
+    const auto features = ex.extract(raw);
+    EXPECT_EQ(features.n_frames, expected_n_frames(kWhisperNSamples, kWhisperNSamples, kNFft, kHopLength));
+    EXPECT_EQ(features.n_active_frames, kWhisperNSamples / kHopLength);
+    EXPECT_EQ(features.n_frames, features.n_active_frames);  // aligned lengths: should match exactly
+    EXPECT_EQ(features.data.size(), kWhisperBins * features.n_frames);
+}
+
+TEST(WhisperFeatureExtractor, ExtractWithLongAudio) {
+    // 40s of audio > n_samples=30s. n_samples is ignored by max() in pad_with_reflect.
+    const size_t raw_size = 640000;
+    const auto raw = make_sine_wave(raw_size, 440.0f, 16000.0f);
+    auto ex = make_whisper_extractor();
+    const auto features = ex.extract(raw);
+    EXPECT_EQ(features.n_frames, expected_n_frames(raw_size, kWhisperNSamples, kNFft, kHopLength));
+    EXPECT_EQ(features.n_active_frames, raw_size / kHopLength);  // 4000
+    EXPECT_EQ(features.data.size(), kWhisperBins * features.n_frames);
+}
+
+TEST(WhisperFeatureExtractor, ExtractMatchesAcrossExtractorsWithSameConfig) {
+    // Two extractors with identical config must produce identical output for the
+    // same input — guards constructor determinism (sin/cos/mel tables are rebuilt
+    // from scratch and must agree bit-for-bit).
+    const auto raw = make_sine_wave(32000, 220.0f, 16000.0f);
+    WhisperFeatureExtractor ex_a(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    WhisperFeatureExtractor ex_b(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    const auto fa = ex_a.extract(raw);
+    const auto fb = ex_b.extract(raw);
+    EXPECT_EQ(fa.n_frames, fb.n_frames);
+    ASSERT_EQ(fa.data.size(), fb.data.size());
+    for (size_t i = 0; i < fa.data.size(); ++i) {
+        EXPECT_FLOAT_EQ(fa.data[i], fb.data[i]) << "mismatch at index " << i;
+    }
+}
+
+TEST(WhisperFeatureExtractor, ExtractIsDeterministic) {
+    // Internal parallelism partitions frames across threads, but each frame's
+    // reduction order is thread-local and deterministic, so repeated calls
+    // must produce bit-identical output.
+    const auto raw = make_sine_wave(16000, 440.0f, 16000.0f);
+    WhisperFeatureExtractor ex(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    const auto f1 = ex.extract(raw);
+    const auto f2 = ex.extract(raw);
+    EXPECT_EQ(f1.n_frames, f2.n_frames);
+    ASSERT_EQ(f1.data.size(), f2.data.size());
+    for (size_t i = 0; i < f1.data.size(); ++i) {
+        EXPECT_FLOAT_EQ(f1.data[i], f2.data[i]);
+    }
+}
+
+TEST(WhisperFeatureExtractor, ExtractNormalizationRange) {
+    // Whisper normalization: clamp values below (max - 8), then apply (x + 4) / 4.
+    // After normalization, all values must lie in [(max - 4) / 4, (max + 4) / 4]
+    // — a tight algebraic bound, not a sanity range.
+    const auto raw = make_sine_wave(16000, 440.0f, 16000.0f);
+    auto ex = make_whisper_extractor();
+    const auto features = ex.extract(raw);
+    ASSERT_FALSE(features.data.empty());
+
+    const float out_max = *std::max_element(features.data.begin(), features.data.end());
+    const float out_min = *std::min_element(features.data.begin(), features.data.end());
+    // After the (x + 4) / 4 step, the max of the output equals (orig_max + 4) / 4,
+    // and the min equals (orig_max - 4) / 4. So out_max - out_min must equal 2.0
+    // exactly (for unclamped distributions) or be strictly less than 2.0 if the
+    // actual range was narrower than 8 before clamping.
+    EXPECT_LE(out_max - out_min, 2.0f + 1e-5f);
+    // orig_max = 4 * out_max - 4 (inverse of (x + 4) / 4).
+    const float orig_max = 4.0f * out_max - 4.0f;
+    const float expected_min = (orig_max - 4.0f) / 4.0f;
+    const float expected_max = (orig_max + 4.0f) / 4.0f;
+    EXPECT_GE(out_min, expected_min - 1e-5f);
+    EXPECT_LE(out_max, expected_max + 1e-5f);
+}
+
+TEST(WhisperFeatureExtractor, ShapeDependsOnFeatureSize) {
+    const auto raw = make_sine_wave(16000, 440.0f, 16000.0f);
+    WhisperFeatureExtractor wh(kWhisperBins, kSamplingRate, kNFft, kHopLength);
+    WhisperFeatureExtractor qw(kQwen3OmniBins, kSamplingRate, kNFft, kHopLength);
+    const auto fw = wh.extract(raw);
+    const auto fq = qw.extract(raw);
+    EXPECT_EQ(fw.n_frames, fq.n_frames);  // n_frames depends only on n_fft/hop, not bins
+    EXPECT_EQ(fw.data.size(), kWhisperBins * fw.n_frames);
+    EXPECT_EQ(fq.data.size(), kQwen3OmniBins * fq.n_frames);
+}

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the public OmniPipeline API.
+
+Public surface under test:
+
+    openvino_genai.OmniPipeline
+    openvino_genai.OmniTalkerSpeechConfig
+    openvino_genai.OmniSpeechStreamerBase
+
+The pybind variant alias OmniSpeechStreamerVariant is intentionally not in
+the smoke import — variant aliases are not re-exported in __init__.py per the
+existing AudioStreamerVariant convention.
+
+This file covers only the parts of the surface that can be exercised without
+loading a multi-GB Qwen3-Omni checkpoint: imports, config defaults, AnyMap
+update, and validate() invariants. Cross-config validation that requires a
+loaded pipeline (return_audio incompatible with beam search etc.) lives in
+the nightly real-model suites — here we only assert that the standalone
+config validate() and the field round-trip behave.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import openvino_genai as ov_genai
+
+
+class TestOmniPipelineImports:
+    """Smoke tests: do the new public symbols exist at all?"""
+
+    def test_omni_pipeline_imports(self) -> None:
+        """All new public symbols must be importable from the top-level module."""
+        from openvino_genai import (  # noqa: F401
+            OmniPipeline,
+            OmniSpeechStreamerBase,
+            OmniTalkerSpeechConfig,
+        )
+
+    def test_old_symbol_is_gone(self) -> None:
+        """The pre-migration OmniSpeechGenerationConfig symbol must not exist anymore.
+
+        The rename to OmniTalkerSpeechConfig is a clean break with no deprecation
+        alias. If this attribute survives, somebody re-exported the old name against
+        the migration contract.
+        """
+        assert not hasattr(ov_genai, "OmniSpeechGenerationConfig"), (
+            "OmniSpeechGenerationConfig was renamed to OmniTalkerSpeechConfig and must not be re-exported as an alias."
+        )
+
+
+class TestOmniTalkerSpeechConfig:
+    """OmniTalkerSpeechConfig — defaults, validate(), AnyMap update, MRO shape."""
+
+    def test_no_generation_config_inheritance(self) -> None:
+        """Standalone struct: MRO must NOT contain GenerationConfig.
+
+        The whole point of the migration is to break the historical
+        `OmniSpeechGenerationConfig : public GenerationConfig` inheritance so a future
+        omni model with a non-LLM talker doesn't drag GenerationConfig fields it
+        doesn't use. pybind11 inserts its own `pybind11_object` into the MRO above
+        `object`; that's a wrapping artifact, not the load-bearing inheritance check.
+        """
+        assert ov_genai.GenerationConfig not in ov_genai.OmniTalkerSpeechConfig.__mro__, (
+            "OmniTalkerSpeechConfig must NOT inherit from GenerationConfig — that's the whole point of the migration."
+        )
+
+        cfg = ov_genai.OmniTalkerSpeechConfig()
+        assert not isinstance(cfg, ov_genai.GenerationConfig), (
+            "OmniTalkerSpeechConfig instances must not be GenerationConfig instances."
+        )
+
+    def test_defaults(self) -> None:
+        """Default ctor exposes the speech-side fields with sane defaults."""
+        cfg = ov_genai.OmniTalkerSpeechConfig()
+
+        assert cfg.return_audio is True, "return_audio default must be True"
+        assert cfg.speaker == "", "speaker default must be empty (model default)"
+        assert cfg.audio_chunk_frames == 1, "audio_chunk_frames default must be 1"
+        assert cfg.rng_seed == 0, "rng_seed default must be 0"
+        # talker_*/cp_* sampling overrides are std::optional<T> — exposed as None when unset.
+        assert cfg.talker_temperature is None
+        assert cfg.talker_top_k is None
+        assert cfg.talker_repetition_penalty is None
+        assert cfg.cp_temperature is None
+        assert cfg.cp_top_k is None
+        assert cfg.cp_repetition_penalty is None
+
+    def test_direct_field_assignment(self) -> None:
+        """Direct field assignment sets the speech-side fields."""
+        cfg = ov_genai.OmniTalkerSpeechConfig()
+        cfg.return_audio = False
+        cfg.speaker = "any_voice_id"
+        cfg.audio_chunk_frames = 2
+        cfg.rng_seed = 7
+        cfg.talker_temperature = 0.7
+        cfg.talker_top_k = 20
+        cfg.cp_temperature = 0.5
+        cfg.cp_top_k = 10
+
+        assert cfg.return_audio is False
+        assert cfg.speaker == "any_voice_id"
+        assert cfg.audio_chunk_frames == 2
+        assert cfg.rng_seed == 7
+        assert cfg.talker_temperature == pytest.approx(0.7)
+        assert cfg.talker_top_k == 20
+        assert cfg.cp_temperature == pytest.approx(0.5)
+        assert cfg.cp_top_k == 10
+
+    def test_max_new_tokens_field(self) -> None:
+        """OmniTalkerSpeechConfig carries its own max_new_tokens (talker AR cap).
+
+        Independent of GenerationConfig.max_new_tokens (which caps the thinker text
+        decode). Both can be set simultaneously to different values when the caller
+        constructs typed configs explicitly.
+        """
+        cfg = ov_genai.OmniTalkerSpeechConfig()
+        cfg.max_new_tokens = 128
+        assert cfg.max_new_tokens == 128
+
+
+class TestOmniPipelineAccessors:
+    """OmniPipeline getter/setter surface — methods must exist with the right signatures.
+
+    No model is loaded here, so we only assert presence and signatures via the unbound
+    method handle. End-to-end behavior (get/set round-trip on a live pipeline) lives in
+    the temp/ scripts that load the MoE checkpoint.
+    """
+
+    def test_methods_exist(self) -> None:
+        assert hasattr(ov_genai.OmniPipeline, "get_talker"), "OmniPipeline.get_talker() missing from public surface"
+
+        # Speaker APIs live on the Talker, accessed via get_talker()
+        for method in ("list_speakers", "get_speaker_embedding"):
+            assert hasattr(ov_genai.TalkerBase, method), f"TalkerBase.{method}() missing from public surface"


### PR DESCRIPTION
## Description                                                                                                                                                                                                           
  Adds `Qwen3-Omni` VLM pipeline (Dense and MoE) with audio input/output support:
  - New `qwen3_omni/` classes, audio encoder, and speech pipeline                                                                                                                                                          
  - Audio streaming via `AudioStreamerBase` + `audio_utils`                                                                                                                                                                
  - Python/C++ samples (`qwen3_omni_chat`, `audio_to_text`) and pytest coverage                                                                                                                                            
  - Wires audio config/token IDs into `VLMConfig`, extends VLM and CB pipelines with audio plumbing    
                                                      
  ## Checklist:                                                                                                                                                                                                            
  - [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
  - [x] Tests have been updated or added to cover the new code. <!-- tests/python_tests/test_qwen3_omni.py -->                                                                                                             
  - [x] This PR fully addresses the ticket.                                                                                                                                                                                
  - [x] I have made corresponding changes to the documentation.      