### PR TITLE
Adding kv-cache invalidation when generation hits short factor threshold

### DIFF
--- a/src/cpp/src/llm/pipeline.cpp
+++ b/src/cpp/src/llm/pipeline.cpp
@@ -58,7 +58,7 @@ bool should_use_stateful_pipeline(bool is_npu_requested,
 ov::genai::DecodedResults run_generate_with_parsers(const ov::genai::OptionalGenerationConfig& generation_config,
                  const ov::genai::StreamerVariant& streamer,
                 std::function<ov::genai::DecodedResults(void)> generate_callable) {
-                    
+
     std::shared_ptr<ov::genai::TextParserStreamer> parser_streamer;
     // If streamer is of StreamerBase type, and it is TextParserStreamer, get parsed message
     // Streaming is available only for batch size 1 therefore only parsed[0]
@@ -74,7 +74,7 @@ ov::genai::DecodedResults run_generate_with_parsers(const ov::genai::OptionalGen
     }
 
     auto res = generate_callable();
-    
+
     if (parser_streamer) {
         res.parsed.resize(1);
         res.parsed[0] = parser_streamer->get_parsed_message();
@@ -84,10 +84,10 @@ ov::genai::DecodedResults run_generate_with_parsers(const ov::genai::OptionalGen
     if (!generation_config.has_value() || generation_config->parsers.empty()) {
         return res;
     }
-    
+
     std::vector<std::shared_ptr<ov::genai::Parser>> parsers = generation_config->parsers;
     res.parsed.resize(res.texts.size());
-    
+
     // Apply Base parsers sequentially even if IncrementalParser has run.
     for (size_t i = 0; i < res.texts.size(); ++i) {
         auto& msg = res.parsed[i];
@@ -95,7 +95,7 @@ ov::genai::DecodedResults run_generate_with_parsers(const ov::genai::OptionalGen
             // Initialize msg with content
             msg["content"] = res.texts[i];
         }
-        
+
         for (auto& parser: parsers) {
             parser->parse(msg);
         }
@@ -216,11 +216,13 @@ static std::unique_ptr<LLMPipelineImplBase> create(const std::shared_ptr<ov::Mod
         }
     }
 
-    return std::make_unique<StatefulLLMPipeline>(main_model_descr.model,
+    auto stateful_pipeline = std::make_unique<StatefulLLMPipeline>(main_model_descr.model,
                                                  main_model_descr.tokenizer,
                                                  main_model_descr.device,
                                                  main_model_descr.properties,
                                                  main_model_descr.generation_config);
+    stateful_pipeline->set_longrope_threshold(models_path);
+    return stateful_pipeline;
 }
 };
 
@@ -273,7 +275,9 @@ ov::genai::LLMPipeline::LLMPipeline(
     if (m_pimpl == nullptr) {
         // FIXME: Switch to StatefulPipeline::create after resolving issues
         //        with GPU and CPU for StatefulSpeculativeLLMPipeline
-        m_pimpl = std::make_unique<StatefulLLMPipeline>(model, tokenizer, device, properties, generation_config);
+        auto stateful_pipeline = std::make_unique<StatefulLLMPipeline>(model, tokenizer, device, properties, generation_config);
+        stateful_pipeline->set_longrope_threshold(models_path);
+        m_pimpl = std::move(stateful_pipeline);
     }
 
     m_pimpl->save_load_time(start_time);
@@ -319,7 +323,9 @@ ov::genai::LLMPipeline::LLMPipeline(
     if (m_pimpl == nullptr) {
         // FIXME: Switch to StatefulPipeline::create after resolving issues
         //        with GPU and CPU for StatefulSpeculativeLLMPipeline
-        m_pimpl = std::make_unique<StatefulLLMPipeline>(model, tokenizer, device, properties, generation_config);
+        auto stateful_pipeline = std::make_unique<StatefulLLMPipeline>(model, tokenizer, device, properties, generation_config);
+        stateful_pipeline->set_longrope_threshold(models_path);
+        m_pimpl = std::move(stateful_pipeline);
     }
 
     m_pimpl->save_load_time(start_time);
@@ -396,7 +402,7 @@ DecodedResults LLMPipeline::generate(StringInputs text, const ov::AnyMap& config
     GenerationConfig config = config_arg.value_or(get_generation_config());
     config.update_generation_config(config_map);
     auto streamer = utils::get_streamer_from_map(config_map);
-    
+
     return run_generate_with_parsers(config_arg, streamer, [&]() -> DecodedResults {
         return m_pimpl->generate(text, config, streamer);
     });

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -64,8 +64,8 @@ public:
         m_last_write_stopped_by_us = false;
         // total_len == threshold + 1  <=>  the just-appended token's 0-based position
         // (total_len - 1) equals `threshold`.
-        if (status == ov::genai::StreamingStatus::RUNNING && m_total_len == m_threshold + 1) {
-            m_threshold_reached = true;
+        m_threshold_reached = m_total_len == m_threshold + 1;
+        if (status == ov::genai::StreamingStatus::RUNNING && m_threshold_reached) {
             m_last_write_stopped_by_us = true;
             return ov::genai::StreamingStatus::STOP;
         }
@@ -90,6 +90,10 @@ public:
 
     bool threshold_reached() const {
         return m_threshold_reached;
+    }
+
+    bool last_write_stopped_by_us() const {
+        return m_last_write_stopped_by_us;
     }
 
 private:
@@ -624,6 +628,8 @@ EncodedResults StatefulLLMPipeline::generate(
 
     std::shared_ptr<LongRopeThresholdStreamer> threshold_streamer;
     std::shared_ptr<StreamerBase> effective_streamer_ptr = streamer_ptr;
+    std::cout << "m_longrope_threshold: " << (m_longrope_threshold.has_value() ? std::to_string(*m_longrope_threshold) : "none") << std::endl;
+    std::cout << "m_max_kv_cache_size: " << m_max_kv_cache_size << std::endl;
     if (m_is_npu && m_longrope_threshold.has_value()) {
         threshold_streamer = std::make_shared<LongRopeThresholdStreamer>(
             streamer_ptr, concatenated_attention_mask.get_shape().at(1), *m_longrope_threshold);
@@ -647,25 +653,16 @@ EncodedResults StatefulLLMPipeline::generate(
         size_t remaining_new_tokens = total_max_new_tokens > generated_so_far.size() ?
             total_max_new_tokens - generated_so_far.size() : 0;
 
-        if (remaining_new_tokens == 0) {
-            // The threshold-crossing token was also the last one allowed by max_new_tokens, so
-            // no continuation phase runs below - the KV cache is left holding that token still
-            // encoded under the pre-crossing RoPE factor. Nothing else will call end() on the
-            // wrapped streamer, so flush it now. Record that a reprefill is still owed so the
-            // very next call for this conversation forces one (see should_force_longrope_reprefill()).
+        // if threshold is reached but not stoped by us we need to postone the reprefill until the next call to generate
+        m_longrope_reprefill_pending = remaining_new_tokens == 0 || !threshold_streamer->last_write_stopped_by_us();
+        if (remaining_new_tokens == 0 && threshold_streamer->last_write_stopped_by_us()) {
+            // notify base streamer that generation is finished, so it can flush the last token
             threshold_streamer->flush_end();
-            m_longrope_reprefill_pending = true;
 
-            // The internal LongRopeThresholdStreamer's own STOP is what stopped generation
-            // (StreamingStatus::STOP -> GenerationStatus::STOP via GenerationStream::stop()),
-            // even though generation actually completed normally by exhausting max_new_tokens
-            // (that's exactly what remaining_new_tokens == 0 means). The per-sequence
-            // GenerationFinishReason is unaffected (the sampler already marks it LENGTH before
-            // this streamer ever runs, and that's only overwritten when still NONE) - but the
-            // overall stream status needs the same normalization so it doesn't leak our
-            // internal implementation detail to callers.
+            // Generation was stopped right after the token at the LongRoPE threshold position
+            // need set correct finish status
             finish_info.streaming_finish_status = ov::genai::GenerationStatus::FINISHED;
-        } else {
+        } else if (threshold_streamer->last_write_stopped_by_us()){
             PerfMetrics first_phase_metrics = finish_info.results.perf_metrics;
 
             reset_state();

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -121,7 +121,8 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         m_is_npu = true;
         m_max_prompt_len = compiled_model.get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>();
         const auto min_response_len = compiled_model.get_property("NPUW_LLM_MIN_RESPONSE_LEN").as<uint32_t>();
-        m_max_kv_cache_size = m_max_prompt_len + min_response_len;
+        const auto max_generation_token_len = std::max(1u, compiled_model.get_property("NPUW_LLM_MAX_GENERATION_TOKEN_LEN").as<uint32_t>());
+        m_max_kv_cache_size = m_max_prompt_len + min_response_len - max_generation_token_len;
     }
 }
 
@@ -628,8 +629,6 @@ EncodedResults StatefulLLMPipeline::generate(
 
     std::shared_ptr<LongRopeThresholdStreamer> threshold_streamer;
     std::shared_ptr<StreamerBase> effective_streamer_ptr = streamer_ptr;
-    std::cout << "m_longrope_threshold: " << (m_longrope_threshold.has_value() ? std::to_string(*m_longrope_threshold) : "none") << std::endl;
-    std::cout << "m_max_kv_cache_size: " << m_max_kv_cache_size << std::endl;
     if (m_is_npu && m_longrope_threshold.has_value()) {
         threshold_streamer = std::make_shared<LongRopeThresholdStreamer>(
             streamer_ptr, concatenated_attention_mask.get_shape().at(1), *m_longrope_threshold);
@@ -653,7 +652,8 @@ EncodedResults StatefulLLMPipeline::generate(
         size_t remaining_new_tokens = total_max_new_tokens > generated_so_far.size() ?
             total_max_new_tokens - generated_so_far.size() : 0;
 
-        // if threshold is reached but not stoped by us we need to postone the reprefill until the next call to generate
+        // If the threshold is reached but generation was not stopped by us,
+        // postpone the reprefill until the next call to generate.
         m_longrope_reprefill_pending = remaining_new_tokens == 0 || !threshold_streamer->last_write_stopped_by_us();
         if (remaining_new_tokens == 0 && threshold_streamer->last_write_stopped_by_us()) {
             // notify base streamer that generation is finished, so it can flush the last token

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -17,17 +17,15 @@
 
 namespace {
 
-// Step 1 (still not the final fix - see models/phi-4-mini/LONGROPE_GENERATION_BORDER_BUG.md)
-// towards a less invasive mitigation for the LongRoPE short/long-factor KV-cache-consistency
-// bug: once the cumulative sequence length reaches this boundary (== the model's
-// original_max_position_embeddings), the model's internal RoPE branch selection flips
-// (short -> long factor) but previously cached KV entries remain encoded with the OLD
-// (short) factor, corrupting attention.
+// Mitigates a LongRoPE short/long-factor KV-cache-consistency issue: once the cumulative
+// sequence length reaches original_max_position_embeddings, the model's RoPE branch
+// selection switches from the "short" to the "long" factor table, but previously cached KV
+// entries remain encoded with the "short" factor, corrupting attention. NPU only (see the
+// m_is_npu checks at the two call sites below).
 //
-// Reads the threshold straight out of the model's config.json instead of hardcoding it -
-// present whenever the model uses LongRoPE (HF "rope_parameters"/"rope_scaling" with
-// rope_type/type == "longrope", e.g. Phi-4-mini). Returns std::nullopt for any other model,
-// or if config.json isn't present/parseable.
+// Detects the threshold from the model's config.json ("rope_parameters", rope_type/type ==
+// "longrope", e.g. Phi-4-mini). Returns std::nullopt for models that don't use LongRoPE, or
+// if config.json isn't present/parseable.
 std::optional<size_t> detect_longrope_threshold(const std::filesystem::path& models_path) {
     std::ifstream config_file(models_path / "config.json");
     if (!config_file.is_open())
@@ -53,10 +51,8 @@ std::optional<size_t> detect_longrope_threshold(const std::filesystem::path& mod
 
 // Wraps the caller-supplied streamer (if any) and, in addition to forwarding every token to
 // it, requests ov::genai::StreamingStatus::STOP once the newly generated token's 0-based
-// position reaches `threshold` - i.e. it is the very first token that falls into the "long"
-// RoPE regime. This lets the call site (StatefulLLMPipeline::generate) detect the crossing
-// via threshold_reached() and re-run generation from a fully re-prefilled, consistent KV-cache,
-// instead of reaching into get_lm_encoded_results()'s generation loop directly.
+// position reaches `threshold`. Lets the caller detect a mid-generation LongRoPE crossing via
+// threshold_reached() and re-run generation from a fully re-prefilled, consistent KV-cache.
 class LongRopeThresholdStreamer : public ov::genai::StreamerBase {
 public:
     LongRopeThresholdStreamer(std::shared_ptr<ov::genai::StreamerBase> base, size_t prompt_length, size_t threshold)
@@ -127,18 +123,16 @@ StatefulLLMPipeline::StatefulLLMPipeline(
 }
 
 void StatefulLLMPipeline::set_longrope_threshold(const std::filesystem::path& models_path) {
-    if (models_path.empty())
+    if (models_path.empty()) {
+        m_longrope_threshold = std::nullopt;
+        m_force_longrope_reprefill = false;
         return;
+    }
     m_longrope_threshold = detect_longrope_threshold(models_path);
-    // Deliberately NOT forcing m_use_full_chat_history here (unlike the NPU case above) -
-    // that would force a full reset + full-history resend on EVERY turn, which is wasteful
-    // for CPU/GPU incremental caching. Instead, should_force_longrope_reprefill() decides,
-    // per turn, whether THIS turn actually crosses the threshold and only then forces a
-    // one-off full reprefill - see its use in the StringInputs/ChatHistory generate() overloads.
 }
 
 bool StatefulLLMPipeline::should_force_longrope_reprefill(size_t new_total_len) {
-    if (!m_longrope_threshold.has_value())
+    if (!m_is_npu || !m_longrope_threshold.has_value())
         return false;
     const size_t prev_total_len = m_cache_state.get_state().size();
     return prev_total_len < *m_longrope_threshold && new_total_len >= *m_longrope_threshold;
@@ -439,11 +433,9 @@ EncodedResults StatefulLLMPipeline::generate(
         OPENVINO_ASSERT(m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS || m_history.last()["role"] == "user",
                         "Chat doesn't support switching between input types. Please, continue using StringInputs or restart the chat.");
 
-    // Single-use: set by the StringInputs/ChatHistory overloads right before calling into this
-    // one, when THIS turn's cumulative history was detected to cross the LongRoPE threshold.
-    // Consumed here so it doesn't leak into unrelated future calls (e.g. direct EncodedInputs
-    // calls, which never set it and so always get false/incremental-caching behavior).
-    const bool force_longrope_reprefill = m_force_longrope_reprefill;
+    // Set by the StringInputs/ChatHistory overloads before delegating here; consumed once so
+    // it doesn't leak into unrelated future calls.
+    bool force_longrope_reprefill = m_force_longrope_reprefill;
     m_force_longrope_reprefill = false;
 
     if (!is_chat_conversation) {
@@ -485,8 +477,12 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
-    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
+    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) {
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
+        // Called directly with EncodedInputs (not via StringInputs/ChatHistory), so compute
+        // the crossing check here instead of relying on the caller to have set it.
+        force_longrope_reprefill = force_longrope_reprefill || should_force_longrope_reprefill(m_tokenized_chat_history.size());
+    }
 
     size_t real_input_ids_size = input_ids.get_shape().at(1);
 
@@ -602,7 +598,7 @@ EncodedResults StatefulLLMPipeline::generate(
 
     std::shared_ptr<LongRopeThresholdStreamer> threshold_streamer;
     std::shared_ptr<StreamerBase> effective_streamer_ptr = streamer_ptr;
-    if (m_longrope_threshold.has_value()) {
+    if (m_is_npu && m_longrope_threshold.has_value()) {
         threshold_streamer = std::make_shared<LongRopeThresholdStreamer>(
             streamer_ptr, concatenated_attention_mask.get_shape().at(1), *m_longrope_threshold);
         effective_streamer_ptr = threshold_streamer;
@@ -612,12 +608,11 @@ EncodedResults StatefulLLMPipeline::generate(
                                                                                 requests, position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
 
     if (threshold_streamer && threshold_streamer->threshold_reached()) {
-        // The generation loop was stopped right after the token whose 0-based position
-        // reached the LongRoPE threshold (that token was already sampled/decided - it's part
-        // of the result). Drop the KV cache and re-run a full prefill over the entire
-        // history (original prompt + everything generated so far), so all cached keys get
-        // consistently re-encoded under the "long" RoPE factor, then continue generating
-        // the remaining budget of tokens.
+        // Generation was stopped right after the token at the LongRoPE threshold position
+        // (that token was already sampled - keep it). Reset the KV cache and re-run a full
+        // prefill over the whole history (original prompt + everything generated so far) so
+        // all keys are consistently re-encoded under the "long" RoPE factor, then continue
+        // generating the remaining token budget.
         TokenIds generated_so_far = finish_info.results.tokens.at(0);
         TokenIds full_ids = requests.at(0)->get_prompt_ids();
         full_ids.insert(full_ids.end(), generated_so_far.begin(), generated_so_far.end());
@@ -649,19 +644,13 @@ EncodedResults StatefulLLMPipeline::generate(
             finish_info = get_lm_encoded_results(m_model_runner, continuation_input_ids, continuation_attention_mask, streamer_ptr, m_sampler,
                                                   continuation_requests, continuation_position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
 
-            // PerfMetrics::operator+ (used below) does NOT merge m_new_token_times - it's
-            // designed for combining already-evaluated benchmark stats, where that raw field
-            // is no longer needed. We still need the FULL, correctly-ordered sequence for the
-            // final evaluate_statistics() call (at the end of this function) to compute
-            // ttft/tpot/num_generated_tokens correctly for the whole call, not just the first
-            // phase - so capture the continuation's own entries before they get overwritten by
-            // the merge below, and re-append them manually afterwards.
+            // PerfMetrics::operator+ does not merge m_new_token_times, so capture the
+            // continuation's entries before they're overwritten by the merge below and
+            // re-append them afterwards.
             auto continuation_new_token_times = finish_info.results.perf_metrics.raw_metrics.m_new_token_times;
 
-            // Stitch the two phases together: tokens/perf-metrics generated before the reset,
-            // followed by the post-reset continuation (PerfMetrics::operator+ concatenates
-            // the underlying raw counters, same mechanism used elsewhere to combine metrics
-            // across multiple internal generate() calls).
+            // Stitch tokens/perf-metrics generated before the reset with the post-reset
+            // continuation.
             finish_info.results.tokens[0].insert(finish_info.results.tokens[0].begin(), generated_so_far.begin(), generated_so_far.end());
             finish_info.results.perf_metrics = first_phase_metrics + finish_info.results.perf_metrics;
 
@@ -669,14 +658,10 @@ EncodedResults StatefulLLMPipeline::generate(
             merged_new_token_times.insert(merged_new_token_times.end(),
                 continuation_new_token_times.begin(), continuation_new_token_times.end());
 
-            // m_inference_durations is a single running TOTAL per get_lm_encoded_results()
-            // call (unlike the other, genuinely per-step raw counters), so operator+ above left
-            // it holding both phases' individual totals as two separate entries - which would
-            // then be AVERAGED by calc_mean_and_std() instead of summed, under-reporting total
-            // inference time. Collapse it back into one entry (the sum) so the re-prefill's
-            // time is fully counted towards the reported total inference duration for this
-            // generate() call (the per-token TPOT distribution is intentionally left as-is -
-            // it already includes the re-prefill as one long inter-token gap).
+            // m_inference_durations is a single running total per get_lm_encoded_results()
+            // call, so operator+ above left it holding both phases' totals as two separate
+            // entries, which calc_mean_and_std() would average instead of sum. Collapse it
+            // back into one summed entry.
             auto& merged_inference_durations = finish_info.results.perf_metrics.raw_metrics.m_inference_durations;
             if (merged_inference_durations.size() > 1) {
                 MicroSeconds total_inference_duration{0.0f};

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -61,16 +61,29 @@ public:
     ov::genai::StreamingStatus write(int64_t token) override {
         ov::genai::StreamingStatus status = m_base ? m_base->write(token) : ov::genai::StreamingStatus::RUNNING;
         ++m_total_len;
+        m_last_write_stopped_by_us = false;
         // total_len == threshold + 1  <=>  the just-appended token's 0-based position
         // (total_len - 1) equals `threshold`.
         if (status == ov::genai::StreamingStatus::RUNNING && m_total_len == m_threshold + 1) {
             m_threshold_reached = true;
+            m_last_write_stopped_by_us = true;
             return ov::genai::StreamingStatus::STOP;
         }
         return status;
     }
 
+    // get_lm_encoded_results() calls end() once per call. If OUR own threshold check is what
+    // just stopped generation, a continuation phase follows, so forwarding end() here would
+    // close the wrapped streamer prematurely - suppress it; the call site flushes it via
+    // flush_end() once it knows no continuation will run after all. Otherwise (generation
+    // ended for any other reason - EOS, cancel, etc. - with no continuation to follow),
+    // forward immediately as usual.
     void end() override {
+        if (!m_last_write_stopped_by_us)
+            flush_end();
+    }
+
+    void flush_end() {
         if (m_base)
             m_base->end();
     }
@@ -84,6 +97,7 @@ private:
     size_t m_total_len;
     size_t m_threshold;
     bool m_threshold_reached = false;
+    bool m_last_write_stopped_by_us = false;
 };
 
 }  // namespace
@@ -126,6 +140,7 @@ void StatefulLLMPipeline::set_longrope_threshold(const std::filesystem::path& mo
     if (models_path.empty()) {
         m_longrope_threshold = std::nullopt;
         m_force_longrope_reprefill = false;
+        m_longrope_reprefill_pending = false;
         return;
     }
     m_longrope_threshold = detect_longrope_threshold(models_path);
@@ -134,6 +149,13 @@ void StatefulLLMPipeline::set_longrope_threshold(const std::filesystem::path& mo
 bool StatefulLLMPipeline::should_force_longrope_reprefill(size_t new_total_len) {
     if (!m_is_npu || !m_longrope_threshold.has_value())
         return false;
+    // A previous call's mid-generation crossing landed on the very last allowed token, so no
+    // continuation re-prefill ran then - force one now, unconditionally, regardless of the
+    // transition check below (the cache is known-inconsistent until this fires once).
+    if (m_longrope_reprefill_pending) {
+        m_longrope_reprefill_pending = false;
+        return true;
+    }
     const size_t prev_total_len = m_cache_state.get_state().size();
     return prev_total_len < *m_longrope_threshold && new_total_len >= *m_longrope_threshold;
 }
@@ -393,6 +415,9 @@ DecodedResults StatefulLLMPipeline::generate(
         reset_state();
         m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
         m_cache_state.reset_state();
+        // A brand new/unrelated conversation - any pending LongRoPE reprefill obligation from
+        // whatever conversation was previously in the cache no longer applies.
+        m_longrope_reprefill_pending = false;
     }
 
     m_history = history;
@@ -442,6 +467,7 @@ EncodedResults StatefulLLMPipeline::generate(
         reset_state();
         m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
         m_cache_state.reset_state();
+        m_longrope_reprefill_pending = false;
     }
 
     auto start_time = std::chrono::steady_clock::now();
@@ -621,7 +647,15 @@ EncodedResults StatefulLLMPipeline::generate(
         size_t remaining_new_tokens = total_max_new_tokens > generated_so_far.size() ?
             total_max_new_tokens - generated_so_far.size() : 0;
 
-        if (remaining_new_tokens > 0) {
+        if (remaining_new_tokens == 0) {
+            // The threshold-crossing token was also the last one allowed by max_new_tokens, so
+            // no continuation phase runs below - the KV cache is left holding that token still
+            // encoded under the pre-crossing RoPE factor. Nothing else will call end() on the
+            // wrapped streamer, so flush it now. Record that a reprefill is still owed so the
+            // very next call for this conversation forces one (see should_force_longrope_reprefill()).
+            threshold_streamer->flush_end();
+            m_longrope_reprefill_pending = true;
+        } else {
             PerfMetrics first_phase_metrics = finish_info.results.perf_metrics;
 
             reset_state();
@@ -641,7 +675,7 @@ EncodedResults StatefulLLMPipeline::generate(
                 std::make_shared<SequenceGroup>(0, full_ids, continuation_config)
             };
 
-            finish_info = get_lm_encoded_results(m_model_runner, continuation_input_ids, continuation_attention_mask, streamer_ptr, m_sampler,
+            finish_info = get_lm_encoded_results(m_model_runner, continuation_input_ids, continuation_attention_mask, effective_streamer_ptr, m_sampler,
                                                   continuation_requests, continuation_position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
 
             // PerfMetrics::operator+ does not merge m_new_token_times, so capture the
@@ -733,6 +767,7 @@ void StatefulLLMPipeline::finish_chat() {
         m_history.clear();
         m_tokenized_chat_history.clear();
         m_cache_state.reset_state();
+        m_longrope_reprefill_pending = false;
     }
 }
 

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -655,6 +655,16 @@ EncodedResults StatefulLLMPipeline::generate(
             // very next call for this conversation forces one (see should_force_longrope_reprefill()).
             threshold_streamer->flush_end();
             m_longrope_reprefill_pending = true;
+
+            // The internal LongRopeThresholdStreamer's own STOP is what stopped generation
+            // (StreamingStatus::STOP -> GenerationStatus::STOP via GenerationStream::stop()),
+            // even though generation actually completed normally by exhausting max_new_tokens
+            // (that's exactly what remaining_new_tokens == 0 means). The per-sequence
+            // GenerationFinishReason is unaffected (the sampler already marks it LENGTH before
+            // this streamer ever runs, and that's only overwritten when still NONE) - but the
+            // overall stream status needs the same normalization so it doesn't leak our
+            // internal implementation detail to callers.
+            finish_info.streaming_finish_status = ov::genai::GenerationStatus::FINISHED;
         } else {
             PerfMetrics first_phase_metrics = finish_info.results.perf_metrics;
 

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -2,13 +2,95 @@
 // Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
 #include "llm/pipeline_stateful.hpp"
 
+#include "json_utils.hpp"
 #include "lora/helper.hpp"
 #include "lm_encoding.hpp"
 #include "openvino/genai/text_streamer.hpp"
 
 #include "utils.hpp"
+
+namespace {
+
+// Step 1 (still not the final fix - see models/phi-4-mini/LONGROPE_GENERATION_BORDER_BUG.md)
+// towards a less invasive mitigation for the LongRoPE short/long-factor KV-cache-consistency
+// bug: once the cumulative sequence length reaches this boundary (== the model's
+// original_max_position_embeddings), the model's internal RoPE branch selection flips
+// (short -> long factor) but previously cached KV entries remain encoded with the OLD
+// (short) factor, corrupting attention.
+//
+// Reads the threshold straight out of the model's config.json instead of hardcoding it -
+// present whenever the model uses LongRoPE (HF "rope_parameters"/"rope_scaling" with
+// rope_type/type == "longrope", e.g. Phi-4-mini). Returns std::nullopt for any other model,
+// or if config.json isn't present/parseable.
+std::optional<size_t> detect_longrope_threshold(const std::filesystem::path& models_path) {
+    std::ifstream config_file(models_path / "config.json");
+    if (!config_file.is_open())
+        return std::nullopt;
+
+    nlohmann::json data = nlohmann::json::parse(config_file, nullptr, /* allow_exceptions = */ false);
+    if (data.is_discarded())
+        return std::nullopt;
+
+    std::string rope_type;
+    ov::genai::utils::read_json_param(data, "rope_parameters.rope_type", rope_type);
+    if (rope_type.empty())
+        ov::genai::utils::read_json_param(data, "rope_parameters.type", rope_type);
+    if (rope_type != "longrope")
+        return std::nullopt;
+
+    size_t threshold = 0;
+    ov::genai::utils::read_json_param(data, "rope_parameters.original_max_position_embeddings", threshold);
+    if (threshold == 0)
+        ov::genai::utils::read_json_param(data, "original_max_position_embeddings", threshold);
+    return threshold > 0 ? std::optional<size_t>(threshold) : std::nullopt;
+}
+
+// Wraps the caller-supplied streamer (if any) and, in addition to forwarding every token to
+// it, requests ov::genai::StreamingStatus::STOP once the newly generated token's 0-based
+// position reaches `threshold` - i.e. it is the very first token that falls into the "long"
+// RoPE regime. This lets the call site (StatefulLLMPipeline::generate) detect the crossing
+// via threshold_reached() and re-run generation from a fully re-prefilled, consistent KV-cache,
+// instead of reaching into get_lm_encoded_results()'s generation loop directly.
+class LongRopeThresholdStreamer : public ov::genai::StreamerBase {
+public:
+    LongRopeThresholdStreamer(std::shared_ptr<ov::genai::StreamerBase> base, size_t prompt_length, size_t threshold)
+        : m_base(std::move(base)), m_total_len(prompt_length), m_threshold(threshold) {}
+
+    ov::genai::StreamingStatus write(int64_t token) override {
+        ov::genai::StreamingStatus status = m_base ? m_base->write(token) : ov::genai::StreamingStatus::RUNNING;
+        ++m_total_len;
+        // total_len == threshold + 1  <=>  the just-appended token's 0-based position
+        // (total_len - 1) equals `threshold`.
+        if (status == ov::genai::StreamingStatus::RUNNING && m_total_len == m_threshold + 1) {
+            m_threshold_reached = true;
+            return ov::genai::StreamingStatus::STOP;
+        }
+        return status;
+    }
+
+    void end() override {
+        if (m_base)
+            m_base->end();
+    }
+
+    bool threshold_reached() const {
+        return m_threshold_reached;
+    }
+
+private:
+    std::shared_ptr<ov::genai::StreamerBase> m_base;
+    size_t m_total_len;
+    size_t m_threshold;
+    bool m_threshold_reached = false;
+};
+
+}  // namespace
 
 namespace ov::genai {
 
@@ -40,7 +122,27 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         device,
         properties,
         utils::from_config_json_if_exists(models_path)
-    } {}
+    } {
+    set_longrope_threshold(models_path);
+}
+
+void StatefulLLMPipeline::set_longrope_threshold(const std::filesystem::path& models_path) {
+    if (models_path.empty())
+        return;
+    m_longrope_threshold = detect_longrope_threshold(models_path);
+    // Deliberately NOT forcing m_use_full_chat_history here (unlike the NPU case above) -
+    // that would force a full reset + full-history resend on EVERY turn, which is wasteful
+    // for CPU/GPU incremental caching. Instead, should_force_longrope_reprefill() decides,
+    // per turn, whether THIS turn actually crosses the threshold and only then forces a
+    // one-off full reprefill - see its use in the StringInputs/ChatHistory generate() overloads.
+}
+
+bool StatefulLLMPipeline::should_force_longrope_reprefill(size_t new_total_len) {
+    if (!m_longrope_threshold.has_value())
+        return false;
+    const size_t prev_total_len = m_cache_state.get_state().size();
+    return prev_total_len < *m_longrope_threshold && new_total_len >= *m_longrope_threshold;
+}
 
 StatefulLLMPipeline::StatefulLLMPipeline(
     const std::shared_ptr<ov::Model>& model,
@@ -175,7 +277,8 @@ DecodedResults StatefulLLMPipeline::generate(
             tokenization_start_time = std::chrono::steady_clock::now();
             auto new_chat_tokens = m_tokenizer.encode(new_templated_chat_history, ov::genai::add_special_tokens(false));
 
-            if (m_use_full_chat_history) {
+            m_force_longrope_reprefill = should_force_longrope_reprefill(new_chat_tokens.input_ids.get_size());
+            if (m_use_full_chat_history || m_force_longrope_reprefill) {
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
@@ -211,7 +314,8 @@ DecodedResults StatefulLLMPipeline::generate(
             // Do not add special tokens in chat scenario to be aligned with HF.
             auto new_chat_tokens = m_tokenizer.encode(new_templated_chat_history, ov::genai::add_special_tokens(false));
 
-            if (m_use_full_chat_history) {
+            m_force_longrope_reprefill = should_force_longrope_reprefill(new_chat_tokens.input_ids.get_size());
+            if (m_use_full_chat_history || m_force_longrope_reprefill) {
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
@@ -265,7 +369,7 @@ DecodedResults StatefulLLMPipeline::generate(
     StreamerVariant streamer
 ) {
     is_chat_conversation = true;
-    
+
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::UNDEF)
         m_chat_input_type = ov::genai::utils::GenerationChatInputsType::CHAT_HISTORY;
 
@@ -274,7 +378,7 @@ DecodedResults StatefulLLMPipeline::generate(
                         "Chat doesn't support switching between input types. Please, continue using ChatHistory or restart the chat.");
 
     auto start_time = std::chrono::steady_clock::now();
-    
+
     GenerationConfig config = resolve_generation_config(generation_config);
 
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
@@ -306,7 +410,8 @@ DecodedResults StatefulLLMPipeline::generate(
     auto new_chat_tokens = m_tokenizer.encode(new_templated_chat_history, ov::genai::add_special_tokens(false));
 
     TokenizedInputs encoded_input;
-    if (m_use_full_chat_history) {
+    m_force_longrope_reprefill = should_force_longrope_reprefill(new_chat_tokens.input_ids.get_size());
+    if (m_use_full_chat_history || m_force_longrope_reprefill) {
         encoded_input = new_chat_tokens;
     } else {
         ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
@@ -333,6 +438,13 @@ EncodedResults StatefulLLMPipeline::generate(
         // if chat was run in StringInputs mode, but it was called EncodedInputs generate, last m_history entry will be with assistant role
         OPENVINO_ASSERT(m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS || m_history.last()["role"] == "user",
                         "Chat doesn't support switching between input types. Please, continue using StringInputs or restart the chat.");
+
+    // Single-use: set by the StringInputs/ChatHistory overloads right before calling into this
+    // one, when THIS turn's cumulative history was detected to cross the LongRoPE threshold.
+    // Consumed here so it doesn't leak into unrelated future calls (e.g. direct EncodedInputs
+    // calls, which never set it and so always get false/incremental-caching behavior).
+    const bool force_longrope_reprefill = m_force_longrope_reprefill;
+    m_force_longrope_reprefill = false;
 
     if (!is_chat_conversation) {
         reset_state();
@@ -373,12 +485,12 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
-    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) 
+    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
 
     size_t real_input_ids_size = input_ids.get_shape().at(1);
 
-    if (is_chat_conversation && m_use_full_chat_history)
+    if (is_chat_conversation && (m_use_full_chat_history || force_longrope_reprefill))
         m_cache_state.reset_state();
 
     // Tail of previous output in chat mode is missing in KV cache.
@@ -419,7 +531,7 @@ EncodedResults StatefulLLMPipeline::generate(
                     "but you have '" + std::to_string(num_inputs) + "' inputs");
 
     if (is_chat_conversation) {
-        if (m_use_full_chat_history)
+        if (m_use_full_chat_history || force_longrope_reprefill)
             reset_state();
         else
             ov::genai::utils::trim_kv_cache(m_model_runner, m_cache_state, m_adapter_controller);
@@ -427,7 +539,7 @@ EncodedResults StatefulLLMPipeline::generate(
 
     size_t cache_len = 0;
     ov::Tensor concatenated_attention_mask;
-    if (is_chat_conversation && !m_cache_state.get_state().empty() && !m_use_full_chat_history) {
+    if (is_chat_conversation && !m_cache_state.get_state().empty() && !(m_use_full_chat_history || force_longrope_reprefill)) {
         OPENVINO_ASSERT(batch_size == 1, "continuation of generation is possible only for batch 1");
         // If history is saved in KV cache, concatenate new attention_mask with the already existing.
         // Between subsequent runs attention_mask should not be modified.
@@ -488,8 +600,93 @@ EncodedResults StatefulLLMPipeline::generate(
         m_sampler.set_seed(config.rng_seed);
     }
 
-    ov::genai::utils::GenerationFinishInfo finish_info = get_lm_encoded_results(m_model_runner, input_ids, concatenated_attention_mask, streamer_ptr, m_sampler,
+    std::shared_ptr<LongRopeThresholdStreamer> threshold_streamer;
+    std::shared_ptr<StreamerBase> effective_streamer_ptr = streamer_ptr;
+    if (m_longrope_threshold.has_value()) {
+        threshold_streamer = std::make_shared<LongRopeThresholdStreamer>(
+            streamer_ptr, concatenated_attention_mask.get_shape().at(1), *m_longrope_threshold);
+        effective_streamer_ptr = threshold_streamer;
+    }
+
+    ov::genai::utils::GenerationFinishInfo finish_info = get_lm_encoded_results(m_model_runner, input_ids, concatenated_attention_mask, effective_streamer_ptr, m_sampler,
                                                                                 requests, position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
+
+    if (threshold_streamer && threshold_streamer->threshold_reached()) {
+        // The generation loop was stopped right after the token whose 0-based position
+        // reached the LongRoPE threshold (that token was already sampled/decided - it's part
+        // of the result). Drop the KV cache and re-run a full prefill over the entire
+        // history (original prompt + everything generated so far), so all cached keys get
+        // consistently re-encoded under the "long" RoPE factor, then continue generating
+        // the remaining budget of tokens.
+        TokenIds generated_so_far = finish_info.results.tokens.at(0);
+        TokenIds full_ids = requests.at(0)->get_prompt_ids();
+        full_ids.insert(full_ids.end(), generated_so_far.begin(), generated_so_far.end());
+
+        size_t total_max_new_tokens = requests.at(0)->get_max_new_tokens();
+        size_t remaining_new_tokens = total_max_new_tokens > generated_so_far.size() ?
+            total_max_new_tokens - generated_so_far.size() : 0;
+
+        if (remaining_new_tokens > 0) {
+            PerfMetrics first_phase_metrics = finish_info.results.perf_metrics;
+
+            reset_state();
+            m_cache_state.reset_state();
+
+            ov::Tensor continuation_input_ids(ov::element::i64, {1, full_ids.size()}, full_ids.data());
+            ov::Tensor continuation_attention_mask = utils::init_attention_mask(continuation_input_ids);
+            std::optional<ov::Tensor> continuation_position_ids = std::nullopt;
+            if (position_ids_available) {
+                continuation_position_ids = ov::Tensor{ov::element::i64, continuation_input_ids.get_shape()};
+                utils::initialize_position_ids(*continuation_position_ids, continuation_attention_mask);
+            }
+
+            GenerationConfig continuation_config = config;
+            continuation_config.max_new_tokens = remaining_new_tokens;
+            std::vector<SequenceGroup::Ptr> continuation_requests{
+                std::make_shared<SequenceGroup>(0, full_ids, continuation_config)
+            };
+
+            finish_info = get_lm_encoded_results(m_model_runner, continuation_input_ids, continuation_attention_mask, streamer_ptr, m_sampler,
+                                                  continuation_requests, continuation_position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
+
+            // PerfMetrics::operator+ (used below) does NOT merge m_new_token_times - it's
+            // designed for combining already-evaluated benchmark stats, where that raw field
+            // is no longer needed. We still need the FULL, correctly-ordered sequence for the
+            // final evaluate_statistics() call (at the end of this function) to compute
+            // ttft/tpot/num_generated_tokens correctly for the whole call, not just the first
+            // phase - so capture the continuation's own entries before they get overwritten by
+            // the merge below, and re-append them manually afterwards.
+            auto continuation_new_token_times = finish_info.results.perf_metrics.raw_metrics.m_new_token_times;
+
+            // Stitch the two phases together: tokens/perf-metrics generated before the reset,
+            // followed by the post-reset continuation (PerfMetrics::operator+ concatenates
+            // the underlying raw counters, same mechanism used elsewhere to combine metrics
+            // across multiple internal generate() calls).
+            finish_info.results.tokens[0].insert(finish_info.results.tokens[0].begin(), generated_so_far.begin(), generated_so_far.end());
+            finish_info.results.perf_metrics = first_phase_metrics + finish_info.results.perf_metrics;
+
+            auto& merged_new_token_times = finish_info.results.perf_metrics.raw_metrics.m_new_token_times;
+            merged_new_token_times.insert(merged_new_token_times.end(),
+                continuation_new_token_times.begin(), continuation_new_token_times.end());
+
+            // m_inference_durations is a single running TOTAL per get_lm_encoded_results()
+            // call (unlike the other, genuinely per-step raw counters), so operator+ above left
+            // it holding both phases' individual totals as two separate entries - which would
+            // then be AVERAGED by calc_mean_and_std() instead of summed, under-reporting total
+            // inference time. Collapse it back into one entry (the sum) so the re-prefill's
+            // time is fully counted towards the reported total inference duration for this
+            // generate() call (the per-token TPOT distribution is intentionally left as-is -
+            // it already includes the re-prefill as one long inter-token gap).
+            auto& merged_inference_durations = finish_info.results.perf_metrics.raw_metrics.m_inference_durations;
+            if (merged_inference_durations.size() > 1) {
+                MicroSeconds total_inference_duration{0.0f};
+                for (const auto& duration : merged_inference_durations)
+                    total_inference_duration += duration;
+                merged_inference_durations = {total_inference_duration};
+            }
+        }
+    }
+
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -29,10 +29,28 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     size_t m_max_prompt_len = std::numeric_limits<size_t>::max();
     size_t m_max_kv_cache_size = std::numeric_limits<size_t>::max();
     bool m_is_npu = false;
+    // Set from the model's config.json ("rope_parameters") when it uses LongRoPE - the
+    // 0-based sequence position at which the model switches from its "short" to "long"
+    // RoPE factor table (== "original_max_position_embeddings"). std::nullopt if the model
+    // doesn't use LongRoPE or config.json wasn't available to inspect.
+    std::optional<size_t> m_longrope_threshold;
+    // Transient, single-use: set by the StringInputs/ChatHistory generate() overloads right
+    // before delegating to the EncodedInputs overload, when this specific turn's cumulative
+    // history was detected to cross m_longrope_threshold. Consumed (read then cleared) at the
+    // top of the EncodedInputs overload - unlike m_use_full_chat_history (permanent, NPU-only)
+    // this only forces a full-history resend + cache reset for the ONE turn that actually
+    // crosses the threshold, so CPU/GPU keep using incremental caching otherwise.
+    bool m_force_longrope_reprefill = false;
     // include reflection of tokens contained in the kv cache and amount of tokens, which are needed to trim from kv cache on the next step of chat
     utils::CacheState m_cache_state;
 
     void reset_state();
+    // True if a chat turn whose cumulative token count is `new_total_len` would cross
+    // m_longrope_threshold for the first time (cache is currently entirely below the
+    // threshold, and this turn's total reaches/exceeds it). False if the model isn't
+    // LongRoPE, or the threshold was already crossed by a previous turn (no NEW crossing -
+    // incremental caching remains consistent once fully in one regime).
+    bool should_force_longrope_reprefill(size_t new_total_len);
 public:
 
     StatefulLLMPipeline(
@@ -61,6 +79,18 @@ public:
         const std::string& device,
         const ov::AnyMap& plugin_config
     );
+
+    // Detects whether the model uses LongRoPE (from "rope_parameters" in config.json under
+    // models_path) and, if so, records the short/long-factor switch-over threshold so that a
+    // chat turn crossing it triggers a one-off full-history resend + cache reset (see
+    // should_force_longrope_reprefill) and a mid-generation crossing within a turn triggers
+    // the LongRopeThresholdStreamer mitigation. Unlike NPU's m_use_full_chat_history this does
+    // NOT force full-history resend on every turn - incremental caching is kept otherwise.
+    // No-op if models_path is empty, config.json is missing/unparseable, or the model doesn't
+    // use LongRoPE. Needed because the real construction path (StatefulPipeline::create in
+    // llm/pipeline.cpp) already has models_path available but doesn't go through the
+    // models_path-taking constructor above.
+    void set_longrope_threshold(const std::filesystem::path& models_path);
 
     DecodedResults generate(
         StringInputs inputs,

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -39,6 +39,17 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // m_longrope_threshold. Consumed (read then cleared) at the top of the EncodedInputs
     // overload.
     bool m_force_longrope_reprefill = false;
+    // Set when a mid-generation LongRoPE threshold crossing happens to land on the very last
+    // token allowed by max_new_tokens, so no continuation re-prefill runs within that same
+    // call (see the generate(EncodedInputs...) crossing-handling block). The KV cache is left
+    // holding that last token still encoded under the pre-crossing RoPE factor, so the very
+    // next call for this conversation must force a reprefill regardless of what
+    // should_force_longrope_reprefill()'s normal transition check would otherwise say.
+    // Consumed (read then cleared) inside should_force_longrope_reprefill(). Must be reset to
+    // false anywhere m_cache_state is invalidated/reset for an unrelated conversation (see
+    // finish_chat() and the ChatHistory "not a continuation" branch) so it can never leak into
+    // a different, later conversation.
+    bool m_longrope_reprefill_pending = false;
     // include reflection of tokens contained in the kv cache and amount of tokens, which are needed to trim from kv cache on the next step of chat
     utils::CacheState m_cache_state;
 
@@ -78,8 +89,10 @@ public:
     // Detects whether the model uses LongRoPE (from "rope_parameters" in config.json under
     // models_path) and, if so, records the switch-over threshold in m_longrope_threshold.
     // No-op (leaves m_longrope_threshold unset) if models_path is empty, config.json is
-    // missing/unparseable, or the model doesn't use LongRoPE. Called from llm/pipeline.cpp,
-    // which has models_path available at the point(s) it constructs a StatefulLLMPipeline.
+    // missing/unparseable, or the model doesn't use LongRoPE. Called wherever a
+    // StatefulLLMPipeline is constructed with a models_path available: the
+    // (models_path, tokenizer, device, properties) constructor above, and the
+    // StatefulLLMPipeline construction sites in llm/pipeline.cpp.
     void set_longrope_threshold(const std::filesystem::path& models_path);
 
     DecodedResults generate(

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -29,27 +29,22 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     size_t m_max_prompt_len = std::numeric_limits<size_t>::max();
     size_t m_max_kv_cache_size = std::numeric_limits<size_t>::max();
     bool m_is_npu = false;
-    // Set from the model's config.json ("rope_parameters") when it uses LongRoPE - the
-    // 0-based sequence position at which the model switches from its "short" to "long"
-    // RoPE factor table (== "original_max_position_embeddings"). std::nullopt if the model
-    // doesn't use LongRoPE or config.json wasn't available to inspect.
+    // LongRoPE mitigation, NPU only (see pipeline_stateful.cpp). The 0-based sequence
+    // position at which the model switches from its "short" to "long" RoPE factor table
+    // (model's "original_max_position_embeddings"). std::nullopt if the model doesn't use
+    // LongRoPE or config.json wasn't available.
     std::optional<size_t> m_longrope_threshold;
-    // Transient, single-use: set by the StringInputs/ChatHistory generate() overloads right
-    // before delegating to the EncodedInputs overload, when this specific turn's cumulative
-    // history was detected to cross m_longrope_threshold. Consumed (read then cleared) at the
-    // top of the EncodedInputs overload - unlike m_use_full_chat_history (permanent, NPU-only)
-    // this only forces a full-history resend + cache reset for the ONE turn that actually
-    // crosses the threshold, so CPU/GPU keep using incremental caching otherwise.
+    // Set by the StringInputs/ChatHistory generate() overloads before delegating to the
+    // EncodedInputs overload, when the current turn's cumulative history crosses
+    // m_longrope_threshold. Consumed (read then cleared) at the top of the EncodedInputs
+    // overload.
     bool m_force_longrope_reprefill = false;
     // include reflection of tokens contained in the kv cache and amount of tokens, which are needed to trim from kv cache on the next step of chat
     utils::CacheState m_cache_state;
 
     void reset_state();
-    // True if a chat turn whose cumulative token count is `new_total_len` would cross
-    // m_longrope_threshold for the first time (cache is currently entirely below the
-    // threshold, and this turn's total reaches/exceeds it). False if the model isn't
-    // LongRoPE, or the threshold was already crossed by a previous turn (no NEW crossing -
-    // incremental caching remains consistent once fully in one regime).
+    // True if a chat turn whose cumulative token count is `new_total_len` crosses
+    // m_longrope_threshold for the first time. Always false on non-NPU devices.
     bool should_force_longrope_reprefill(size_t new_total_len);
 public:
 
@@ -81,15 +76,10 @@ public:
     );
 
     // Detects whether the model uses LongRoPE (from "rope_parameters" in config.json under
-    // models_path) and, if so, records the short/long-factor switch-over threshold so that a
-    // chat turn crossing it triggers a one-off full-history resend + cache reset (see
-    // should_force_longrope_reprefill) and a mid-generation crossing within a turn triggers
-    // the LongRopeThresholdStreamer mitigation. Unlike NPU's m_use_full_chat_history this does
-    // NOT force full-history resend on every turn - incremental caching is kept otherwise.
-    // No-op if models_path is empty, config.json is missing/unparseable, or the model doesn't
-    // use LongRoPE. Needed because the real construction path (StatefulPipeline::create in
-    // llm/pipeline.cpp) already has models_path available but doesn't go through the
-    // models_path-taking constructor above.
+    // models_path) and, if so, records the switch-over threshold in m_longrope_threshold.
+    // No-op (leaves m_longrope_threshold unset) if models_path is empty, config.json is
+    // missing/unparseable, or the model doesn't use LongRoPE. Called from llm/pipeline.cpp,
+    // which has models_path available at the point(s) it constructs a StatefulLLMPipeline.
     void set_longrope_threshold(const std::filesystem::path& models_path);
 
     DecodedResults generate(

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -34,7 +34,7 @@ void update_position_ids(ov::Tensor&& position_ids, const ov::Tensor&& attention
 void update_3d_position_ids(ov::Tensor&& position_ids, const ov::Tensor& attention_mask, const int64_t rope_delta) {
     constexpr size_t thw_dim_size = 3;
     constexpr size_t text_thw_dim_size = 4;
-    
+
     const size_t batch_size = attention_mask.get_shape().at(0);
     const size_t sequence_length = attention_mask.get_shape().at(1);
     const size_t dim_0_size = position_ids.get_shape().at(0);
@@ -370,7 +370,7 @@ TokenizedInputs get_chat_encoded_input(const ov::Tensor& new_chat_tokens, utils:
     TokenizedInputs encoded_input;
     size_t cache_len = cache_state.get_state().size();
     if (
-        cache_len == 0 
+        cache_len == 0
         || cache_state.needs_reset()  // models with linear attention need full input if prefix is altered
     ) {
         encoded_input.input_ids = new_chat_tokens;

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -134,10 +134,6 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
     auto free_non_running_requests = [&streamer_ptr, &generations, &active_sequence_groups, &max_kv_cache_size]() {
         for (auto& sg : active_sequence_groups) {
             for (auto& seq : sg->get_sequences()) {
-                std::cout << "Request " << sg->get_request_id() << ", sequence " << seq->get_id() << ", prompt_len: " << sg->get_prompt_len()
-                          << ", generated_len: " << seq->get_generated_len() << ", total_len: " << sg->get_prompt_len() + seq->get_generated_len()
-                          << ", max_kv_cache_size: " << max_kv_cache_size
-                          << std::endl;
                 if (sg->get_prompt_len() + seq->get_generated_len() - 1 == max_kv_cache_size) {
                     seq->set_status(SequenceStatus::OUT_OF_MEMORY);
                 }

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -134,6 +134,10 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
     auto free_non_running_requests = [&streamer_ptr, &generations, &active_sequence_groups, &max_kv_cache_size]() {
         for (auto& sg : active_sequence_groups) {
             for (auto& seq : sg->get_sequences()) {
+                std::cout << "Request " << sg->get_request_id() << ", sequence " << seq->get_id() << ", prompt_len: " << sg->get_prompt_len()
+                          << ", generated_len: " << seq->get_generated_len() << ", total_len: " << sg->get_prompt_len() + seq->get_generated_len()
+                          << ", max_kv_cache_size: " << max_kv_cache_size
+                          << std::endl;
                 if (sg->get_prompt_len() + seq->get_generated_len() - 1 == max_kv_cache_size) {
                     seq->set_status(SequenceStatus::OUT_OF_MEMORY);
                 }


### PR DESCRIPTION
## Description
Add support for short-factor to long-factor RoPe transition via cache invalidation for SDPA backend.
This is a functional support of the feature as cache-invalidation has performance impact.
Tested on CPU and NPU plugins.
Currently this functionality is enabled for NPU only, but can be extended to other plugins.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
EISW-223126

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
