### PR TITLE
Adjust KV cache capacity calculation with NPUW plugin

### DIFF
--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -24,8 +24,6 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         OPENVINO_ASSERT(execution_devices.size() == 1u);
         m_is_npu = true;
         m_max_prompt_len = compiled_model.get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>();
-        const auto min_response_len = compiled_model.get_property("NPUW_LLM_MIN_RESPONSE_LEN").as<uint32_t>();
-        m_max_kv_cache_size = m_max_prompt_len + min_response_len;
     }
 }
 
@@ -76,7 +74,6 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         utils::KVDesc kv_desc;
         std::tie(compiled_model, kv_desc) = utils::compile_decoder_for_npu(model, *filtered_properties, kv_pos);
         m_max_prompt_len = kv_desc.max_prompt_len;
-        m_max_kv_cache_size = kv_desc.max_prompt_len + kv_desc.min_response_len;
     } else {
        compiled_model = utils::singleton_core().compile_model(model, device, *filtered_properties);
     }
@@ -265,7 +262,7 @@ DecodedResults StatefulLLMPipeline::generate(
     StreamerVariant streamer
 ) {
     is_chat_conversation = true;
-    
+
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::UNDEF)
         m_chat_input_type = ov::genai::utils::GenerationChatInputsType::CHAT_HISTORY;
 
@@ -274,7 +271,7 @@ DecodedResults StatefulLLMPipeline::generate(
                         "Chat doesn't support switching between input types. Please, continue using ChatHistory or restart the chat.");
 
     auto start_time = std::chrono::steady_clock::now();
-    
+
     GenerationConfig config = resolve_generation_config(generation_config);
 
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
@@ -373,7 +370,7 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
-    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) 
+    if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
 
     size_t real_input_ids_size = input_ids.get_shape().at(1);
@@ -488,8 +485,12 @@ EncodedResults StatefulLLMPipeline::generate(
         m_sampler.set_seed(config.rng_seed);
     }
 
+    size_t max_kv_cache_size = std::numeric_limits<size_t>::max();
+    if (m_is_npu) {
+        max_kv_cache_size = ov::genai::utils::get_npu_kv_cache_capacity(m_model_runner.get_compiled_model());
+    }
     ov::genai::utils::GenerationFinishInfo finish_info = get_lm_encoded_results(m_model_runner, input_ids, concatenated_attention_mask, streamer_ptr, m_sampler,
-                                                                                requests, position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, m_max_kv_cache_size);
+                                                                                requests, position_ids, std::nullopt, m_cache_state, nullptr, std::nullopt, max_kv_cache_size);
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -27,7 +27,6 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // if True, full history will be used as prompt on each chat generation
     bool m_use_full_chat_history = false;
     size_t m_max_prompt_len = std::numeric_limits<size_t>::max();
-    size_t m_max_kv_cache_size = std::numeric_limits<size_t>::max();
     bool m_is_npu = false;
     // include reflection of tokens contained in the kv cache and amount of tokens, which are needed to trim from kv cache on the next step of chat
     utils::CacheState m_cache_state;

--- a/src/cpp/src/llm/pipeline_static.cpp
+++ b/src/cpp/src/llm/pipeline_static.cpp
@@ -109,7 +109,7 @@ StatefulLLMPipeline::StatefulLLMPipeline(
     auto kv_pos = ov::genai::utils::get_kv_axes_pos(model);
     auto [compiled, kv_desc] = utils::compile_decoder_for_npu(model, properties, kv_pos);
     m_max_prompt_len = kv_desc.max_prompt_len;
-    m_kvcache_total = kv_desc.max_prompt_len + kv_desc.min_response_len;
+    m_kvcache_total = ov::genai::utils::get_npu_kv_cache_capacity(compiled);
     m_request = compiled.create_infer_request();
     m_sampler.set_seed(m_generation_config.rng_seed);
 }
@@ -206,7 +206,7 @@ DecodedResults StatefulLLMPipeline::generate(
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
     OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(), "Chat template must not be empty when using ChatHistory in generate method.");
     OPENVINO_ASSERT(!history.empty(), "Chat history must not be empty when using ChatHistory in generate method.");
-    
+
     constexpr bool add_generation_prompt = true;
     const auto template_start_time = std::chrono::steady_clock::now();
     auto templated_chat_history = m_tokenizer.apply_chat_template(history, add_generation_prompt);
@@ -223,7 +223,7 @@ DecodedResults StatefulLLMPipeline::generate(
     decoded_results.scores = encoded_results.scores;
     decoded_results.finish_reasons = encoded_results.finish_reasons;
     auto decode_stop_time =  std::chrono::steady_clock::now();
-    
+
     // Update perf metrics
     decoded_results.perf_metrics = encoded_results.perf_metrics;
     auto& raw_counters = decoded_results.perf_metrics.raw_metrics;
@@ -235,7 +235,7 @@ DecodedResults StatefulLLMPipeline::generate(
     raw_counters.detokenization_durations.emplace_back(PerfMetrics::get_microsec(decode_stop_time - decode_start_time));
     decoded_results.perf_metrics.m_evaluated = false;
     decoded_results.perf_metrics.evaluate_statistics(start_time);
-    
+
     return decoded_results;
 }
 

--- a/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.cpp
@@ -60,7 +60,7 @@ namespace genai {
     if (m_device == "NPU") {
         auto [compiled, kv_desc] = utils::compile_decoder_for_npu(model_desc.model, m_properties, m_kv_pos);
         m_max_prompt_len = kv_desc.max_prompt_len;
-        m_kvcache_total = kv_desc.max_prompt_len + kv_desc.min_response_len;
+        m_kvcache_total = ov::genai::utils::get_npu_kv_cache_capacity(compiled);
         m_request = compiled.create_infer_request();
     } else {
         // TODO: We might need it for manipulations with indices
@@ -205,7 +205,7 @@ int64_t LLMInferWrapper::infer_next(int64_t token, bool append_perf_stat) {
     } else {
         raw_perf_metrics.m_durations.back() +=
             ov::genai::MicroSeconds(infer_next_timer.get_duration_microsec());
-        raw_perf_metrics.m_inference_durations[0] += 
+        raw_perf_metrics.m_inference_durations[0] +=
             ov::genai::MicroSeconds(ov::genai::PerfMetrics::get_microsec(infer_end - infer_start));
     }
 
@@ -369,7 +369,7 @@ StatefulSpeculativeLLMPipeline::StatefulSpeculativeLLMPipeline(const ov::genai::
     // todo: remove this condition after support of CVS-154103
     OPENVINO_ASSERT(are_tokenizers_equal(main_model_tokenizer, draft_model_tokenizer), "Tokenizers for draft and main models are different!");
     m_tokenizer = main_model_tokenizer;
-    
+
     // Draft model (which is smaller, less accurate but faster)
     auto draft_model_desc_copy = draft_model_desc;
     if (draft_model_desc_copy.device.empty()) {
@@ -533,7 +533,7 @@ EncodedResults StatefulSpeculativeLLMPipeline::generate_tokens(const EncodedInpu
             // then we need to preserve this one spot in main kvcache for previous
             // output.
             m_main_request->get_kvcache_capacity() - 1);
-        int64_t generation_room_for_candidates = 
+        int64_t generation_room_for_candidates =
             // Take into the account output token, generated on candidates.
             // If we accept all candidates by the main model, then we will generate
             // output of length equal to number of candidates + one output token from
@@ -579,7 +579,7 @@ EncodedResults StatefulSpeculativeLLMPipeline::generate_tokens(const EncodedInpu
         // Note: If `draft_prefix_exists == true`, then we append performance metrics of
         // newly generated candidate to the previously generated token on draft prefix prompt,
         // as we are only interested in one output from these two inference operations.
-        int64_t candidate = m_draft_request->infer_next(out_token, draft_prefix_exists); 
+        int64_t candidate = m_draft_request->infer_next(out_token, draft_prefix_exists);
         candidates.push_back(candidate);
 
         for (size_t i = 1; i < candidates_to_generate; i++) {
@@ -624,7 +624,7 @@ EncodedResults StatefulSpeculativeLLMPipeline::generate_tokens(const EncodedInpu
         auto mismatched_candidates = candidates.size() - accepted_tokens_number;
         std::vector<int64_t> validated_tokens(ref_tokens.begin(), ref_tokens.end() - mismatched_candidates);
         out_token = validated_tokens.back();
-    
+
         // Phase 4: Update inference wrappers based on found matches and mismatches
         if (mismatched_candidates > 0) {
             m_draft_request->trim_kv_cache(mismatched_candidates - 1);

--- a/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/stateful/fast_draft_strategy.hpp
@@ -84,7 +84,7 @@ private:
 class StatefulSpeculativeLLMPipeline : public StatefulSpeculativePipelineBase {
 public:
     StatefulSpeculativeLLMPipeline(
-    const ov::genai::ModelDesc& main_model_desc, 
+    const ov::genai::ModelDesc& main_model_desc,
     const ov::genai::ModelDesc& draft_model_desc
     );
 

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -92,8 +92,8 @@ void update_npu_config(ov::AnyMap& config,
     rename_key(config, "PREFILL_HINT", "NPUW_LLM_PREFILL_HINT");
     rename_key(config, "GENERATE_CONFIG", "NPUW_LLM_GENERATE_CONFIG");
     rename_key(config, "GENERATE_HINT", "NPUW_LLM_GENERATE_HINT");
-    rename_key(config, "SHARED_HEAD_CONFIG", "NPUW_LLM_SHARED_HEAD_CONFIG"); 
-    
+    rename_key(config, "SHARED_HEAD_CONFIG", "NPUW_LLM_SHARED_HEAD_CONFIG");
+
     rename_key(config, "++PREFILL_CONFIG", "++NPUW_LLM_PREFILL_CONFIG");
     rename_key(config, "++GENERATE_CONFIG", "++NPUW_LLM_GENERATE_CONFIG");
     rename_key(config, "++SHARED_HEAD_CONFIG", "++NPUW_LLM_SHARED_HEAD_CONFIG");
@@ -489,7 +489,7 @@ CacheTypes get_cache_types(const ov::Model& model) {
         } else if (
             (rank == 3 && dynamic_axis_count == 1)  // conv state
             || (rank == 4 && dynamic_axis_count == 1 && zero_axis_count == 0)  // ssm state
-        ) {  
+        ) {
             cache_types.add_linear();
         }
     }
@@ -774,6 +774,19 @@ std::pair<ov::CompiledModel, KVDesc> compile_decoder_for_npu_text_embedding(cons
                                                                             const KVAxesPosition& kv_pos,
                                                                             const TextEmbeddingPipeline::Config& text_embed_config) {
     return compile_decoder_for_npu_impl(model, config, kv_pos, ModelType::TextEmbedding, text_embed_config);
+}
+
+size_t get_npu_kv_cache_capacity(const ov::CompiledModel& compiled_model) {
+    const size_t max_prompt_len = compiled_model.get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>();
+    const size_t min_response_len = compiled_model.get_property("NPUW_LLM_MIN_RESPONSE_LEN").as<uint32_t>();
+    // for proper support need to expose NPUW_LLM_MAX_GENERATION_TOKEN_LEN property in NPU model
+    const size_t max_generation_token_len = 1u;
+
+    OPENVINO_ASSERT(max_prompt_len + min_response_len >= max_generation_token_len,
+                     "Invalid NPU KV-cache capacity: MAX_PROMPT_LEN + MIN_RESPONSE_LEN must be >= ",
+                     max_generation_token_len, ", got ", max_prompt_len, " + ", min_response_len);
+
+    return max_prompt_len + min_response_len - max_generation_token_len;
 }
 
 std::optional<ov::Any> pop_option(ov::AnyMap& config, const std::string& option_name) {

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -248,6 +248,8 @@ std::pair<ov::CompiledModel, KVDesc> compile_decoder_for_npu_text_embedding(cons
                                                                             const KVAxesPosition& kv_pos,
                                                                             const ov::genai::TextEmbeddingPipeline::Config& text_embed_config);
 
+size_t get_npu_kv_cache_capacity(const ov::CompiledModel& compiled_model);
+
 /// @brief SharedOptional is a wrapper around a reference to an existing object and an optional shared alternative value.
 /// The difference from std::optional is that the default state is not empty and contains a reference to an existing object outside the class.
 /// Another difference is that the alternative value is shared between all instances of SharedOptional like std::shared_ptr.

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -80,7 +80,6 @@ class VLMPipeline::VLMPipelineImpl : public VLMPipelineBase{
     // Component for applying sampling to lm outputs
     Sampler m_sampler;
     size_t m_max_prompt_len = std::numeric_limits<size_t>::max();
-    size_t m_max_kv_cache_size = std::numeric_limits<size_t>::max();
     bool m_is_npu = false;
     size_t m_image_id = 0;
     size_t m_video_id = 0;
@@ -168,7 +167,6 @@ private:
                 lm_properties,
                 kv_pos);
             m_max_prompt_len = kv_desc.max_prompt_len;
-            m_max_kv_cache_size = kv_desc.max_prompt_len + kv_desc.min_response_len;
             npu_auto_default_properties(device_properties);
         } else {
             // Slice-before-matmul rewrites LM logits to be produced only for the last token.
@@ -580,7 +578,7 @@ public:
         );
 
         EncodedResults& encoded_result = generation_finish_info.results;
-        
+
         // Update pruned content after generation (CDPruner has run during prepare_inputs_and_generate)
         if (generation_config.pruning_ratio > 0) {
             chat_context.apply_pruning_to_last_message();
@@ -753,7 +751,7 @@ private:
         } else {
             inputs_embeds = m_inputs_embedder->get_inputs_embeds(
                 unified_prompt,
-                encoded_images, 
+                encoded_images,
                 encoded_videos,
                 perf_metrics,
                 recalculate_merged_embeddings,
@@ -832,6 +830,10 @@ private:
             m_sampler.set_seed(generation_config.rng_seed);
         }
 
+        size_t max_kv_cache_size = std::numeric_limits<size_t>::max();
+        if (m_is_npu) {
+            max_kv_cache_size = ov::genai::utils::get_npu_kv_cache_capacity(m_language.get_compiled_model());
+        }
         return ov::genai::get_lm_encoded_results(m_language,
                                                  inputs_embeds,
                                                  new_atten_mask,
@@ -843,7 +845,7 @@ private:
                                                  cache_state,
                                                  m_embedding,
                                                  rope_delta,
-                                                 m_max_kv_cache_size,
+                                                 max_kv_cache_size,
                                                  use_intermediate_remote_tensor,
                                                  lm_extra_inputs,
                                                  std::move(per_layer_callback));

--- a/tests/python_tests/test_llm_pipeline_static.py
+++ b/tests/python_tests/test_llm_pipeline_static.py
@@ -23,30 +23,28 @@ import logging
 from utils.constants import get_default_llm_properties
 from utils.tokenizers import model_tmp_path
 from utils.hugging_face import download_and_convert_model, OVConvertedModelSchema
-from utils.generation_config import                     \
-    get_greedy,                                         \
-    get_greedy_with_penalties,                          \
-    get_multinomial_all_parameters,                     \
-    get_multinomial_temperature_and_presence_penalty,   \
-    get_beam_search
+from utils.generation_config import (
+    get_greedy,
+    get_greedy_with_penalties,
+    get_multinomial_all_parameters,
+    get_multinomial_temperature_and_presence_penalty,
+    get_beam_search,
+)
 from data.models import get_models_list
 
 
-if sys.platform == 'darwin' or platform.machine() in ["aarch64", "arm64", "ARM64"]:
+if sys.platform == "darwin" or platform.machine() in ["aarch64", "arm64", "ARM64"]:
     pytest.skip("NPU plugin is available only on Linux and Windows x86_64", allow_module_level=True)
 
 
-DEFAULT_CONFIG: dict = {
-    'NPUW_DEVICES': 'CPU',
-    'NPUW_ONLINE_PIPELINE': 'NONE'
-} | get_default_llm_properties()
+DEFAULT_CONFIG: dict = {"NPUW_DEVICES": "CPU", "NPUW_ONLINE_PIPELINE": "NONE"} | get_default_llm_properties()
 
-STATIC_CONFIG: dict  = { **DEFAULT_CONFIG, 'STATIC_PIPELINE': 'STATEFUL' }
+STATIC_CONFIG: dict = {**DEFAULT_CONFIG, "STATIC_PIPELINE": "STATEFUL"}
 
 # Test both, static and generic pipelines
 PIPELINE_CONFIGS: list[dict] = [
-    pytest.param(DEFAULT_CONFIG, id="generic_pipeline"), 
-    pytest.param(STATIC_CONFIG, id="static_pipeline")
+    pytest.param(DEFAULT_CONFIG, id="generic_pipeline"),
+    pytest.param(STATIC_CONFIG, id="static_pipeline"),
 ]
 
 BLOB_WITH_WEIGHTS: list[bool] = [True, False]
@@ -62,8 +60,8 @@ def llm_model(request: pytest.FixtureRequest) -> OVConvertedModelSchema:
 @pytest.fixture(scope="module")
 def ov_model(llm_model: OVConvertedModelSchema) -> LLMPipeline:
     return LLMPipeline(
-        llm_model.models_path, 
-        "CPU", 
+        llm_model.models_path,
+        "CPU",
         **get_default_llm_properties(),
     )
 
@@ -81,8 +79,8 @@ def npu_config(request: pytest.FixtureRequest) -> LLMPipeline:
 @pytest.fixture(scope="module")
 def npu_model(llm_model: OVConvertedModelSchema, npu_config: dict) -> LLMPipeline:
     return LLMPipeline(
-        llm_model.models_path, 
-        "NPU", 
+        llm_model.models_path,
+        "NPU",
         **npu_config,
     )
 
@@ -91,25 +89,25 @@ def npu_model(llm_model: OVConvertedModelSchema, npu_config: dict) -> LLMPipelin
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 @pytest.mark.parametrize("with_weights", BLOB_WITH_WEIGHTS)
 def test_pipeline_from_blob(
-    llm_model: OVConvertedModelSchema, 
-    ov_model: LLMPipeline, 
-    npu_config: dict, 
+    llm_model: OVConvertedModelSchema,
+    ov_model: LLMPipeline,
+    npu_config: dict,
     model_tmp_path: tuple[str, Path],
-    with_weights: bool
+    with_weights: bool,
 ):
-    prompt = 'What is OpenVINO?'
+    prompt = "What is OpenVINO?"
     model_path = llm_model.models_path
     _, temp_path = model_tmp_path
 
     blob_path = temp_path / "compiled_model.blob"
 
     ref_out = ov_model.generate(prompt, max_new_tokens=30)
-    
+
     blob_path = str(blob_path)
     model_path_bin = str(model_path / "openvino_model.bin")
 
     # NB: Generate the blob
-    cfg = { "EXPORT_BLOB": "YES", "BLOB_PATH": blob_path}
+    cfg = {"EXPORT_BLOB": "YES", "BLOB_PATH": blob_path}
     cfg |= npu_config
     if with_weights:
         cfg |= {"CACHE_MODE": "OPTIMIZE_SPEED"}
@@ -119,7 +117,7 @@ def test_pipeline_from_blob(
     del npu_pipe
 
     # Import blob and check accuracy
-    import_cfg = {"BLOB_PATH": blob_path, "WEIGHTS_PATH": model_path_bin }
+    import_cfg = {"BLOB_PATH": blob_path, "WEIGHTS_PATH": model_path_bin}
     import_cfg |= npu_config
     if with_weights:
         import_cfg.pop("WEIGHTS_PATH")
@@ -130,21 +128,21 @@ def test_pipeline_from_blob(
 
 
 @pytest.mark.parametrize(
-    "generation_config", 
+    "generation_config",
     [
         pytest.param(get_greedy(), id="greedy"),
         pytest.param(get_greedy_with_penalties(), id="greedy_with_penalties"),
-    ]
+    ],
 )
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 @pytest.mark.xfail(reason="Generation result mismatch. Ticket 171117", raises=AssertionError)
 def test_generation_compare_with_stateful_list_input(
-    ov_model: LLMPipeline, 
+    ov_model: LLMPipeline,
     npu_model: LLMPipeline,
     generation_config: GenerationConfig,
 ):
-    input_data = ['What is OpenVINO?']
+    input_data = ["What is OpenVINO?"]
     ref_out = ov_model.generate(input_data, generation_config)
     actual_out = npu_model.generate(input_data, generation_config)
 
@@ -152,11 +150,11 @@ def test_generation_compare_with_stateful_list_input(
 
 
 @pytest.mark.parametrize(
-    "generation_config", 
+    "generation_config",
     [
         pytest.param(get_greedy(), id="greedy"),
         pytest.param(get_greedy_with_penalties(), id="greedy_with_penalties"),
-    ]
+    ],
 )
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
@@ -167,11 +165,11 @@ def test_generation_compare_with_stateful_chat_history(
     generation_config: GenerationConfig,
 ):
     # ChatHistory input sets internal chat state that conflicts with other input types
-    input_data = ChatHistory([{"role": "user", "content": 'What is OpenVINO?'}])
-    
+    input_data = ChatHistory([{"role": "user", "content": "What is OpenVINO?"}])
+
     ov_model_chat = LLMPipeline(llm_model.models_path, "CPU", **get_default_llm_properties())
     ref_out = ov_model_chat.generate(input_data, generation_config)
-    
+
     npu_model_chat = LLMPipeline(llm_model.models_path, "NPU", **npu_config)
     actual_out = npu_model_chat.generate(input_data, generation_config)
 
@@ -182,13 +180,13 @@ def test_generation_compare_with_stateful_chat_history(
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 @pytest.mark.parametrize("with_weights", BLOB_WITH_WEIGHTS)
 def test_pipeline_cache_dir(
-    llm_model: OVConvertedModelSchema, 
-    ov_model: LLMPipeline, 
-    model_tmp_path: tuple[str, Path], 
-    npu_config: dict, 
+    llm_model: OVConvertedModelSchema,
+    ov_model: LLMPipeline,
+    model_tmp_path: tuple[str, Path],
+    npu_config: dict,
     with_weights: bool,
 ):
-    prompt = 'What is OpenVINO?'
+    prompt = "What is OpenVINO?"
     model_path = llm_model.models_path
     _, temp_path = model_tmp_path
     temp_path = Path(temp_path)
@@ -196,7 +194,7 @@ def test_pipeline_cache_dir(
     ref_out = ov_model.generate(prompt, max_new_tokens=30)
 
     # NB: Generate the blob
-    cfg = { "NPUW_DEVICES": "CPU", "CACHE_DIR": str(temp_path) }
+    cfg = {"NPUW_DEVICES": "CPU", "CACHE_DIR": str(temp_path)}
     cfg |= npu_config
     if with_weights:
         cfg |= {"CACHE_MODE": "OPTIMIZE_SPEED"}
@@ -206,25 +204,25 @@ def test_pipeline_cache_dir(
     del npu_pipe
 
     # Check that blob was cached
-    blobs = [file for file in temp_path.iterdir() if file.suffix == ".blob"]    
+    blobs = [file for file in temp_path.iterdir() if file.suffix == ".blob"]
     assert len(blobs) > 0, "Blob was not cached"
 
     # Import blob and check accuracy
-    npu_pipe = LLMPipeline(model_path, "NPU", **(npu_config | { "CACHE_DIR": str(temp_path) }))
+    npu_pipe = LLMPipeline(model_path, "NPU", **(npu_config | {"CACHE_DIR": str(temp_path)}))
     actual_out = npu_pipe.generate(prompt, max_new_tokens=30)
 
     # Check that blob was used from cache
-    blobs = [file for file in temp_path.iterdir() if file.suffix == ".blob"]    
+    blobs = [file for file in temp_path.iterdir() if file.suffix == ".blob"]
     assert len(blobs) > 0, "Blob was not cached"
 
     assert ref_out == actual_out
 
 
 @pytest.mark.parametrize(
-    "generation_config", 
+    "generation_config",
     [
         pytest.param(get_multinomial_temperature_and_presence_penalty(), id="temp+presence"),
-    ]
+    ],
 )
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
@@ -238,19 +236,16 @@ def test_multinomial_sampling(
     # different optimizations due to differences in provided topologies, leading to slight
     # variations in raw logits. Therefore, there is no reliable reference for validation,
     # so only ensure that no exceptions are raised.
-    prompt = 'What is OpenVINO?'
+    prompt = "What is OpenVINO?"
     npu_model.generate(prompt, generation_config)
 
 
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
-def test_length_properties_set_no_exception(
-    llm_model: OVConvertedModelSchema, 
-    npu_config: dict
-):
+def test_length_properties_set_no_exception(llm_model: OVConvertedModelSchema, npu_config: dict):
     model_path = llm_model.models_path
     # NB: Check it doesn't throw any exception
-    pipeline_config = { "MAX_PROMPT_LEN": 256, "MIN_RESPONSE_LEN": 64 }
+    pipeline_config = {"MAX_PROMPT_LEN": 256, "MIN_RESPONSE_LEN": 64}
     pipeline_config |= npu_config
     LLMPipeline(model_path, "NPU", **pipeline_config)
 
@@ -258,18 +253,18 @@ def test_length_properties_set_no_exception(
 @pytest.mark.parametrize(
     "length_config",
     [
-        { "MAX_PROMPT_LEN":   -1  },
-        { "MAX_PROMPT_LEN":   "1" },
-        { "MIN_RESPONSE_LEN": -1  },
-        { "MIN_RESPONSE_LEN": "1" },
-    ]
+        {"MAX_PROMPT_LEN": -1},
+        {"MAX_PROMPT_LEN": "1"},
+        {"MIN_RESPONSE_LEN": -1},
+        {"MIN_RESPONSE_LEN": "1"},
+    ],
 )
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 def test_invalid_length_properties_raise_error(
-    llm_model: OVConvertedModelSchema, 
+    llm_model: OVConvertedModelSchema,
     npu_config: dict,
-    length_config: dict, 
+    length_config: dict,
 ):
     model_path = llm_model.models_path
     length_config |= npu_config
@@ -296,20 +291,20 @@ def test_batch_raise_error(npu_model: LLMPipeline):
 
 # TODO: For the further sampling support
 @pytest.mark.parametrize(
-    "generation_config", 
+    "generation_config",
     [
         pytest.param(get_beam_search(), id="beam_search"),
         # NB: Only num_return_sequences=1 is supported!
-        pytest.param(get_multinomial_all_parameters(), id="multinomial")
-    ]
+        pytest.param(get_multinomial_all_parameters(), id="multinomial"),
+    ],
 )
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 def test_unsupported_sampling_raise_error(
-    npu_model: LLMPipeline, 
-    generation_config: GenerationConfig, 
+    npu_model: LLMPipeline,
+    generation_config: GenerationConfig,
 ):
-    prompt = 'What is OpenVINO?'
+    prompt = "What is OpenVINO?"
 
     with pytest.raises(RuntimeError):
         npu_model.generate(prompt, generation_config)
@@ -318,7 +313,7 @@ def test_unsupported_sampling_raise_error(
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 def test_terminate_by_max_number_of_tokens(
-    npu_model: LLMPipeline, 
+    npu_model: LLMPipeline,
     tokenizer: Tokenizer,
 ):
     prompt = "The Sun is yellow because"
@@ -339,9 +334,9 @@ def test_terminate_by_out_of_memory(
 ):
     model_path = llm_model.models_path
     prompt = "The Sun is yellow because"
-    pipeline_config = { "MAX_PROMPT_LEN": 256, "MIN_RESPONSE_LEN": 64 }
+    pipeline_config = {"MAX_PROMPT_LEN": 256, "MIN_RESPONSE_LEN": 64}
     pipeline_config |= npu_config
-    kv_cache_size = pipeline_config['MAX_PROMPT_LEN'] + pipeline_config['MIN_RESPONSE_LEN']
+    kv_cache_size = pipeline_config["MAX_PROMPT_LEN"] + pipeline_config["MIN_RESPONSE_LEN"] - 1
 
     tokenized_input = tokenizer.encode(prompt)
     input_len = tokenized_input.input_ids.get_shape()[1]
@@ -371,15 +366,16 @@ def test_terminate_by_sampler(
             nonlocal current_iter
             current_iter += 1
             return StreamingStatus.RUNNING if current_iter != num_iters else StreamingStatus.STOP
+
         def end(self):
             pass
 
     tokenized_input = tokenizer.encode(prompt)
 
     encoded_results = npu_model.generate(
-        tokenized_input, 
-        max_new_tokens=1000, 
-        ignore_eos=True, 
+        tokenized_input,
+        max_new_tokens=1000,
+        ignore_eos=True,
         streamer=TestStreamer(),
     )
 
@@ -447,10 +443,10 @@ def test_chat_generation(
 ):
     def generate_with_chat_mode(pipe: LLMPipeline, questions: list[str]) -> list[str]:
         pipe.start_chat()
-        answers = [ pipe.generate(question, max_new_tokens=50, do_sample=False) for question in questions ]
+        answers = [pipe.generate(question, max_new_tokens=50, do_sample=False) for question in questions]
         pipe.finish_chat()
         return answers
-    
+
     def generate_with_chat_history(pipe: LLMPipeline, questions: list[str]) -> ChatHistory:
         chat_history = ChatHistory()
         for question in questions:
@@ -458,30 +454,24 @@ def test_chat_generation(
             decoded_results = pipe.generate(chat_history, max_new_tokens=50, do_sample=False)
             chat_history.append({"role": "assistant", "content": decoded_results.texts[0]})
         return chat_history
-    
-    questions = [
-        '1+1=',
-        'What is the previous answer?',
-        'Why is the Sun yellow?',
-        'What was my first question?'
-    ]
+
+    questions = ["1+1=", "What is the previous answer?", "Why is the Sun yellow?", "What was my first question?"]
 
     answers_chat_mode_stateful = generate_with_chat_mode(ov_model, questions)
     answers_chat_mode_static = generate_with_chat_mode(npu_model, questions)
-    assert answers_chat_mode_stateful == answers_chat_mode_static, \
+    assert answers_chat_mode_stateful == answers_chat_mode_static, (
         f"CPU output:\n{answers_chat_mode_stateful}\nNPU output:\n{answers_chat_mode_static}"
+    )
 
     chat_history_stateful = generate_with_chat_history(ov_model, questions)
     messages_stateful = chat_history_stateful.get_messages()
     chat_history_static = generate_with_chat_history(npu_model, questions)
     messages_static = chat_history_static.get_messages()
-    assert messages_stateful == messages_static, \
-        f"CPU output:\n{messages_stateful}\nNPU output:\n{messages_static}"
+    assert messages_stateful == messages_static, f"CPU output:\n{messages_stateful}\nNPU output:\n{messages_static}"
 
     answers_chat_history_static = [msg["content"] for msg in messages_static if msg["role"] == "assistant"]
     assert answers_chat_mode_static == answers_chat_history_static, (
-        f"NPU chat mode output:\n{answers_chat_mode_static}\n"
-        f"NPU chat history output:\n{answers_chat_history_static}"
+        f"NPU chat mode output:\n{answers_chat_mode_static}\nNPU chat history output:\n{answers_chat_history_static}"
     )
 
 


### PR DESCRIPTION
## Description
Changes are in `src/cpp/src/llm/pipeline_stateful.cpp`, `src/cpp/src/visual_language/pipeline.cpp`, `llm/pipeline_static.cpp` and `speculative_decoding/stateful/fast_draft_strategy.cpp`. In `tests/python_tests/test_llm_pipeline_static.py` only `test_terminate_by_out_of_memory` is updated and the rest is done by pre-commit hook. 
Specifically it is `max_prompt_len + min_response_len - 1` instead of `max_prompt_len + min_response_len`.

NPUW plugin modified KV cache capacity calculation. This changes needs to be reflected here too.

PR to master:
https://github.com/openvinotoolkit/openvino.genai/pull/4136

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-190518
CVS-190788

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
