### PR TITLE
[EXPERIMENT][WIP] Add Cosmos3Omni (Reasoner) support to VLMPipeline and WWB

### DIFF
--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -25,6 +25,10 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"qwen2_vl", VLMModelType::QWEN2_VL},
         {"qwen2_5_vl", VLMModelType::QWEN2_5_VL},
         {"qwen3_vl", VLMModelType::QWEN3_VL},
+        // Cosmos3Omni's Reasoner surface is architecturally identical to Qwen3-VL upstream
+        // (transformers defines Cosmos3OmniForConditionalGeneration as a subclass of
+        // Qwen3VLForConditionalGeneration with no overrides); reuse the same pipeline.
+        {"cosmos3_omni", VLMModelType::QWEN3_VL},
         {"qwen3_5", VLMModelType::QWEN3_5},
         {"qwen3_5_moe", VLMModelType::QWEN3_5_MOE},
         {"gemma3", VLMModelType::GEMMA3},

--- a/tools/who_what_benchmark/whowhatbench/chat_visualtext_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/chat_visualtext_evaluator.py
@@ -35,6 +35,7 @@ full_chat_types = [
     "llava",
     "phi4mm",
     "qwen3_vl",
+    "cosmos3_omni",
     "qwen3_5",
     "qwen3_5_moe",
     "llava_next",

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -12,6 +12,8 @@ from .vlm_inputs_preprocessor import VLMInputsPreprocessor
 
 MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_vl": Qwen3VLInputsPreprocessor,
+    # Cosmos3Omni's Reasoner surface is architecturally identical to Qwen3-VL.
+    "cosmos3_omni": Qwen3VLInputsPreprocessor,
     "qwen3_5_moe": Qwen3_5VLInputsPreprocessor,
     "qwen3_5": Qwen3_5VLInputsPreprocessor,
     "qwen2_vl_text": Qwen2VLInputsPreprocessor,


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds `VLMPipeline` C++ support for `nvidia/Cosmos3-Nano` / `nvidia/Cosmos3-Super`'s **Reasoner**
tower (`Cosmos3OmniForConditionalGeneration`, `model_type=cosmos3_omni`), by mapping it onto the
existing `VLMModelType::QWEN3_VL` code path, since the Reasoner internally reuses Qwen3-VL's
text/vision configuration. Also registers `cosmos3_omni` in WhoWhatBenchmark's
`Qwen3VLInputsPreprocessor` for accuracy verification.

## Scope

Cosmos3 is a Mixture-of-Transformers (MoT) omnimodal world model with two towers sharing the
same HF repo:
- **Reasoner** — autoregressive, text+vision understanding — **covered by this PR**.
- **Generator** — diffusion transformer for image/video/audio/action synthesis
  (`Cosmos3OmniDiffusersPipeline`) — **explicitly out of scope**. No GenAI pipeline equivalent
  exists for a joint MoT diffusion + video-VAE + audio-tokenizer stack; this would be a
  materially larger, separate effort (logged as a follow-up in the enablement ticket).

## Validation

Built and ran end-to-end against the **real** `nvidia/Cosmos3-Nano` checkpoint exported via the
companion optimum-intel PR (FP16/INT8/INT4 IR). Verified coherent chat-mode generation with
image input on CPU, iGPU, and dGPU (Intel Arc Pro B60). Full accuracy (WWB `visual-text`
similarity) and timing (TTFT / 2nd-token / inter-token latency) results across 3 precisions ×
3 devices are posted in the enablement ticket:
https://github.com/openvinotoolkit/omega/issues/62

## Related

- Companion optimum-intel PR (IR export): https://github.com/huggingface/optimum-intel/pull/1866
- Tracking ticket: https://github.com/openvinotoolkit/omega/issues/62
