### PR TITLE
Fix undefined symbol for format<int> in libopenvino_genai.so

### DIFF
--- a/src/cpp/src/gguf_utils/gguf.cpp
+++ b/src/cpp/src/gguf_utils/gguf.cpp
@@ -13,18 +13,6 @@
 // https://github.com/antirez/gguf-tools/blob/af7d88d808a7608a33723fba067036202910acb3/gguflib.h#L102-L108
 constexpr int gguf_array_header_size = 12;
 
-template <typename... Args>
-std::string format(std::string fmt, Args... args) {
-    size_t bufferSize = 1000;
-    char* buffer = new char[bufferSize];
-    int n = sprintf(buffer, fmt.c_str(), args...);
-    assert(n >= 0 && n < (int)bufferSize - 1);
-
-    std::string fmtStr(buffer);
-    delete[] buffer;
-    return fmtStr;
-}
-
 std::optional<uint32_t> dtype_to_gguf_tensor_type(const ov::element::Type& dtype) {
     switch (dtype) {
     case ov::element::f64:

--- a/src/cpp/src/gguf_utils/gguf.hpp
+++ b/src/cpp/src/gguf_utils/gguf.hpp
@@ -28,7 +28,16 @@ using GGUFLoad = std::tuple<std::unordered_map<std::string, GGUFMetaData>,
                             std::unordered_map<std::string, gguf_tensor_type>>;
 
 template <typename... Args>
-std::string format(std::string fmt, Args... args);
+std::string format(std::string fmt, Args... args) {
+    size_t bufferSize = 1000;
+    char* buffer = new char[bufferSize];
+    int n = sprintf(buffer, fmt.c_str(), args...);
+    OPENVINO_ASSERT(n >= 0 && n < (int)bufferSize - 1);
+
+    std::string fmtStr(buffer);
+    delete[] buffer;
+    return fmtStr;
+}
 
 ov::Shape get_shape(const gguf_tensor& tensor);
 


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
Move the `format()` template definition from gguf.cpp into gguf.hpp as `inline` to eliminate a cross-TU vague linkage dependency.

GCC's IPA-SRA pass under -O3 can localize the instantiation inside gguf.cpp.o, leaving no externally visible symbol for building_blocks.cpp.o to link against at runtime.

This fixes building wheel package with libopenvino_genai.so in Ubuntu26.04 for NPU project

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
