### PR TITLE
Fix TRAILING timestep loop

### DIFF
--- a/src/cpp/src/image_generation/schedulers/ddim.cpp
+++ b/src/cpp/src/image_generation/schedulers/ddim.cpp
@@ -108,7 +108,7 @@ void DDIMScheduler::set_timesteps(size_t num_inference_steps, float strength) {
         {
             float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
             for (size_t s = 0; s < num_inference_steps; ++s) {
-                float i = m_config.num_train_timesteps - s * step_ratio;
+                const float i = static_cast<float>(m_config.num_train_timesteps) - static_cast<float>(s) * step_ratio;
                 m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
             }
             break;

--- a/src/cpp/src/image_generation/schedulers/ddim.cpp
+++ b/src/cpp/src/image_generation/schedulers/ddim.cpp
@@ -107,7 +107,8 @@ void DDIMScheduler::set_timesteps(size_t num_inference_steps, float strength) {
         case TimestepSpacing::TRAILING:
         {
             float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
-            for (float i = m_config.num_train_timesteps; i > 0; i-=step_ratio){
+            for (size_t s = 0; s < num_inference_steps; ++s) {
+                float i = m_config.num_train_timesteps - s * step_ratio;
                 m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
             }
             break;

--- a/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
@@ -120,7 +120,7 @@ void EulerAncestralDiscreteScheduler::set_timesteps(size_t num_inference_steps, 
     case TimestepSpacing::TRAILING: {
         float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
         for (size_t s = 0; s < num_inference_steps; ++s) {
-            float i = m_config.num_train_timesteps - s * step_ratio;
+            const float i = static_cast<float>(m_config.num_train_timesteps) - static_cast<float>(s) * step_ratio;
             m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
         }
         break;

--- a/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
@@ -119,7 +119,8 @@ void EulerAncestralDiscreteScheduler::set_timesteps(size_t num_inference_steps, 
     }
     case TimestepSpacing::TRAILING: {
         float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
-        for (float i = m_config.num_train_timesteps; i > 0; i -= step_ratio) {
+        for (size_t s = 0; s < num_inference_steps; ++s) {
+            float i = m_config.num_train_timesteps - s * step_ratio;
             m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
         }
         break;

--- a/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_ancestral_discrete.cpp
@@ -97,6 +97,10 @@ void EulerAncestralDiscreteScheduler::set_timesteps(size_t num_inference_steps, 
     m_timesteps.clear();
     m_sigmas.clear();
     m_step_index = m_begin_index = -1;
+
+    OPENVINO_ASSERT(num_inference_steps <= m_config.num_train_timesteps,
+                    "`num_inference_steps` cannot be larger than `num_train_timesteps`");
+
     m_num_inference_steps = num_inference_steps;
     std::vector<float> sigmas;
 

--- a/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
@@ -139,7 +139,8 @@ void EulerDiscreteScheduler::set_timesteps(size_t num_inference_steps, float str
     }
     case TimestepSpacing::TRAILING: {
         float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
-        for (float i = m_config.num_train_timesteps; i > 0; i -= step_ratio) {
+        for (size_t s = 0; s < num_inference_steps; ++s) {
+            float i = m_config.num_train_timesteps - s * step_ratio;
             m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
         }
         break;

--- a/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
@@ -140,7 +140,7 @@ void EulerDiscreteScheduler::set_timesteps(size_t num_inference_steps, float str
     case TimestepSpacing::TRAILING: {
         float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
         for (size_t s = 0; s < num_inference_steps; ++s) {
-            float i = m_config.num_train_timesteps - s * step_ratio;
+            const float i = static_cast<float>(m_config.num_train_timesteps) - static_cast<float>(s) * step_ratio;
             m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
         }
         break;

--- a/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
+++ b/src/cpp/src/image_generation/schedulers/euler_discrete.cpp
@@ -112,6 +112,9 @@ void EulerDiscreteScheduler::set_timesteps(size_t num_inference_steps, float str
     m_sigmas.clear();
     m_step_index = m_begin_index = -1;
 
+    OPENVINO_ASSERT(num_inference_steps <= m_config.num_train_timesteps,
+                    "`num_inference_steps` cannot be larger than `num_train_timesteps`");
+
     m_num_inference_steps = num_inference_steps;
     std::vector<float> sigmas;
 

--- a/src/cpp/src/image_generation/schedulers/pndm.cpp
+++ b/src/cpp/src/image_generation/schedulers/pndm.cpp
@@ -106,7 +106,8 @@ void PNDMScheduler::set_timesteps(size_t num_inference_steps, float strength) {
         case TimestepSpacing::TRAILING:
         {
             float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
-            for (float i = m_config.num_train_timesteps; i > 0; i-=step_ratio){
+            for (size_t s = 0; s < num_inference_steps; ++s) {
+                float i = m_config.num_train_timesteps - s * step_ratio;
                 m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
             }
             std::reverse(m_timesteps.begin(), m_timesteps.end());

--- a/src/cpp/src/image_generation/schedulers/pndm.cpp
+++ b/src/cpp/src/image_generation/schedulers/pndm.cpp
@@ -107,7 +107,7 @@ void PNDMScheduler::set_timesteps(size_t num_inference_steps, float strength) {
         {
             float step_ratio = static_cast<float>(m_config.num_train_timesteps) / static_cast<float>(m_num_inference_steps);
             for (size_t s = 0; s < num_inference_steps; ++s) {
-                float i = m_config.num_train_timesteps - s * step_ratio;
+                const float i = static_cast<float>(m_config.num_train_timesteps) - static_cast<float>(s) * step_ratio;
                 m_timesteps.push_back(static_cast<int64_t>(std::round(i)) - 1);
             }
             std::reverse(m_timesteps.begin(), m_timesteps.end());

--- a/tests/python_tests/test_image_generation.py
+++ b/tests/python_tests/test_image_generation.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import pytest
 import numpy as np
 import openvino as ov
 import openvino_genai as ov_genai
+from pathlib import Path
 
 from utils.constants import NPUW_CPU_PROPERTIES
 from utils.ov_genai_pipelines import should_skip_npuw_tests
@@ -341,3 +343,51 @@ class TestFlux2KleinImageGeneration:
 
         assert len(callback_calls) > 0, "Callback should be called at least once"
         assert image is not None
+
+
+class TestTrailingTimestepSpacing:
+    @pytest.mark.parametrize("num_inference_steps", [9, 11, 12, 18, 22, 30])
+    @pytest.mark.parametrize("image_generation_model", [SDXL_MODEL_ID], indirect=True)
+    def test_trailing_spacing_step_count(self, image_generation_model, num_inference_steps):
+        """Regression test: TRAILING spacing with non-divisible step counts must not produce extra steps."""
+        model_dir = Path(image_generation_model)
+        scheduler_config_path = model_dir / "scheduler" / "scheduler_config.json"
+
+        with open(scheduler_config_path) as f:
+            original_config = json.load(f)
+
+        patched_config = original_config.copy()
+        patched_config["timestep_spacing"] = "trailing"
+        patched_config["steps_offset"] = 0
+
+        try:
+            with open(scheduler_config_path, "w") as f:
+                json.dump(patched_config, f)
+
+            pipe = ov_genai.Text2ImagePipeline(str(model_dir), "CPU")
+
+            callback_calls = []
+
+            def callback(step, num_steps, latent):
+                callback_calls.append((step, num_steps))
+                return False
+
+            pipe.generate(
+                "test",
+                width=64,
+                height=64,
+                num_inference_steps=num_inference_steps,
+                rng_seed=42,
+                callback=callback,
+            )
+
+            assert len(callback_calls) == num_inference_steps, (
+                f"Expected {num_inference_steps} callback calls, got {len(callback_calls)}"
+            )
+            for step, num_steps in callback_calls:
+                assert num_steps == num_inference_steps, (
+                    f"Callback reported num_steps={num_steps}, expected {num_inference_steps}"
+                )
+        finally:
+            with open(scheduler_config_path, "w") as f:
+                json.dump(original_config, f, indent=2)


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
The TRAILING timestep loop used for (float i = N; i > 0; i -= ratio) which sometimes produces one extra iteration due to float rounding. This causes wrong sigma values and broken images for some step counts (e.g. 9, 11, 12, 18, 22, 30...).

Fixed by using a counted loop instead. 

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-188993

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. --> - no changes needed
