### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/site/docs/supported-models/index.mdx
+++ b/site/docs/supported-models/index.mdx
@@ -105,6 +105,12 @@ The model requires `transformers==5.2` for the export with `optimum-cli`.
 #### nanoLLaVA {#nanollava-notes}
 
 The model requires `transformers>=4.48` for the export with `optimum-cli`.
+
+#### GLM-Edge-V {#glm-edge-v-notes}
+
+GLM-Edge-V (`GlmForCausalLM` with a SigLIP `vision_config`) supports text and image inputs only. Video input is not supported at the moment.
+
+The model requires `trust_remote_code=True` and `transformers>=4.44` for the export with `optimum-cli`.
 :::
 
 ## Speech Recognition Models (Whisper-based)

--- a/src/cpp/src/visual_language/glm_edge_v/classes.cpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/glm_edge_v/classes.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "visual_language/clip.hpp"
+
+#include "utils.hpp"
+
+namespace ov::genai {
+namespace {
+
+// GLM-Edge-V uses an MllamaImageProcessor with a single tile (max_image_tiles=1):
+// the image is resized preserving aspect ratio so the longer side fits the
+// target square, placed at the top-left, and the remaining area is zero-padded.
+// Padding pixels (0) become -1.0 after mean/std=0.5 normalization, matching HF.
+clip_image_u8 resize_and_pad_top_left_glm_edge_v(const clip_image_u8& image, int target_width, int target_height) {
+    float scale_w = static_cast<float>(target_width) / image.nx;
+    float scale_h = static_cast<float>(target_height) / image.ny;
+    float scale = std::min(scale_w, scale_h);
+
+    int new_width = std::min(static_cast<int>(std::lround(image.nx * scale)), target_width);
+    int new_height = std::min(static_cast<int>(std::lround(image.ny * scale)), target_height);
+    new_width = std::max(new_width, 1);
+    new_height = std::max(new_height, 1);
+
+    clip_image_u8 resized_image;
+    bicubic_resize(image, resized_image, new_width, new_height);
+
+    clip_image_u8 padded_image;
+    padded_image.nx = target_width;
+    padded_image.ny = target_height;
+    padded_image.buf.assign(static_cast<size_t>(3) * target_width * target_height, 0);
+
+    // Copy the resized image into the top-left corner of the padded buffer.
+    for (int y = 0; y < new_height; ++y) {
+        for (int x = 0; x < new_width; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                padded_image.buf[3 * (y * target_width + x) + c] = resized_image.buf[3 * (y * new_width + x) + c];
+            }
+        }
+    }
+    return padded_image;
+}
+
+clip_image_f32 preprocess_clip_image_glm_edge_v(const clip_image_u8& image, const ProcessorConfig& config) {
+    // Aspect-preserving resize + top-left zero-pad to a fixed square
+    // (preprocessor_config.json size.height/size.width, default 672x672).
+    clip_image_u8 resized_padded = resize_and_pad_top_left_glm_edge_v(
+        image, static_cast<int>(config.size_width), static_cast<int>(config.size_height));
+
+    // Normalize with image_mean/image_std (0.5/0.5).
+    clip_ctx ctx;
+    std::copy(config.image_mean.begin(), config.image_mean.end(), ctx.image_mean);
+    std::copy(config.image_std.begin(), config.image_std.end(), ctx.image_std);
+
+    clip_image_f32 normalized_image = clip_image_preprocess(ctx, resized_padded);
+    return normalized_image;
+}
+
+ov::Tensor get_pixel_values_glm_edge_v(const ov::Tensor& image, const ProcessorConfig& config) {
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+    clip_image_f32 preprocessed_image = preprocess_clip_image_glm_edge_v(input_image, config);
+    return clip_image_f32_to_tensor(preprocessed_image);
+}
+
+} // namespace
+
+EncodedImage VisionEncoderGLMEdgeV::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+
+    ov::Tensor pixel_values = get_pixel_values_glm_edge_v(image, config);
+
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
+
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
+    ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
+    std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
+
+    // The GLM-Edge-V vision encoder already emits one embedding per image
+    // placeholder token (learned boi/eoi vectors are baked into the output),
+    // so the number of image tokens equals the sequence length of the output.
+    return {std::move(image_features)};
+}
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) { }
+
+std::vector<ov::genai::EncodedImage> InputsEmbedderGLMEdgeV::encode_images(const std::vector<ov::Tensor>& images) {
+    std::vector<EncodedImage> embeds;
+    ov::AnyMap vision_config = {{"patch_size", m_vlm_config.vision_config_patch_size}};
+    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
+    embeds.reserve(single_images.size());
+    for (const ov::Tensor& image : single_images) {
+        embeds.emplace_back(m_vision_encoder->encode(image, vision_config));
+    }
+    return embeds;
+}
+
+NormalizedPrompt InputsEmbedderGLMEdgeV::normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const {
+    std::string image_token = m_vlm_config.glm_edge_v_image_token;
+    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_id, images.size());
+
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    size_t searched_pos = 0;
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(images.at(new_image_id - base_id).resized_source);
+        // Expand a single placeholder tag into as many begin-of-image tokens as
+        // there are image embeddings for this image (e.g. 578 for GLM-Edge-V).
+        std::string expanded_tag;
+        for (size_t idx = 0; idx < image_embeds.back().get_shape().at(1); ++idx) {
+            expanded_tag += image_token;
+        }
+        OPENVINO_ASSERT(searched_pos < unified_prompt.length());
+        searched_pos = unified_prompt.find(image_token, searched_pos);
+        OPENVINO_ASSERT(searched_pos != std::string::npos);
+        unified_prompt.replace(searched_pos, image_token.length(), expanded_tag);
+        searched_pos += expanded_tag.length();
+    }
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderGLMEdgeV::get_inputs_embeds(const std::string& unified_prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(images.at(new_image_id).resized_source);
+    }
+
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+
+    if (images.empty()) {
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+
+    // GLM-Edge-V uses the begin-of-image token id as the image placeholder in
+    // the prompt; image embeddings replace those positions in-place.
+    int64_t image_token_id = m_vlm_config.boi_token_id;
+    return utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, image_token_id);
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/glm_edge_v/classes.hpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+class VisionEncoderGLMEdgeV : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+class InputsEmbedderGLMEdgeV : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings = true, const std::vector<size_t>& image_sequence = {}) override;
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
+
+    NormalizedPrompt normalize_prompt(
+        const std::string& prompt,
+        size_t base_id,
+        const std::vector<EncodedImage>& images
+    ) const override;
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -24,6 +24,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm_edge_v/classes.hpp"
 
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
@@ -362,6 +363,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, model_dir, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -408,6 +411,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config); 
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -386,6 +386,7 @@ private:
     friend class InputsEmbedderGemma3n;
     friend class InputsEmbedderGemma4;
     friend class InputsEmbedderVideoChatFlashQwen;
+    friend class InputsEmbedderGLMEdgeV;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -24,6 +24,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm_edge_v/classes.hpp"
 
 namespace ov::genai {
 
@@ -137,6 +138,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderGemma4>(model_dir, device, properties);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -182,6 +185,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderGemma4>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -32,6 +32,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"gemma4", VLMModelType::GEMMA4},
         {"gemma4_unified", VLMModelType::GEMMA4_UNIFIED},
         {"videochat_flash_qwen", VLMModelType::VIDEOCHAT_FLASH_QWEN},
+        {"glm", VLMModelType::GLM_EDGE_V},
     };
 
     auto it = model_types_map.find(value);
@@ -89,6 +90,10 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
         parsed.at("text_config").at("use_bidirectional_attention").is_string()) {
         read_json_param(parsed, "text_config.use_bidirectional_attention", use_bidirectional_attention);
     }
+
+    // GLM-Edge-V
+    read_json_param(parsed, "boi_token_id", boi_token_id);
+    read_json_param(parsed, "eoi_token_id", eoi_token_id);
 }
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -29,6 +29,7 @@ enum class VLMModelType {
     GEMMA4,
     GEMMA4_UNIFIED,
     VIDEOCHAT_FLASH_QWEN,
+    GLM_EDGE_V,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -124,6 +125,15 @@ public:
     size_t vision_config_num_position_embeddings = 2304;
     /// @brief DeepStack visual indexes for Qwen3-VL model.
     std::vector<size_t> vision_config_deepstack_visual_indexes;
+
+    // GLM-Edge-V specific config params
+    /// @brief A placeholder token (also the begin-of-image marker) whose
+    /// positions in the prompt are replaced by image embeddings for GLM-Edge-V.
+    std::string glm_edge_v_image_token = "<|begin_of_image|>";
+    /// @brief Begin-of-image token id for GLM-Edge-V (config.json boi_token_id).
+    int64_t boi_token_id = 59256;
+    /// @brief End-of-image token id for GLM-Edge-V (config.json eoi_token_id).
+    int64_t eoi_token_id = 59257;
 
     /// @brief Default constructor.
     VLMConfig() = default;

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -162,6 +162,9 @@ else:
 
 MODEL_GEMMA = "optimum-intel-internal-testing/tiny-random-gemma3"
 MODEL_GEMMA3N = "optimum-intel-internal-testing/tiny-random-gemma3n"
+# GLM-Edge-V (model_type="glm" with a SigLIP vision_config). Trust-remote-code
+# VLM that splices image embeddings at <|begin_of_image|> (boi_token_id) positions.
+MODEL_GLM_EDGE_V = "optimum-intel-internal-testing/tiny-random-glm-edge-v"
 
 MODEL_IDS: list[str] = []
 if is_transformers_version("<", "5.0"):
@@ -176,6 +179,7 @@ if is_transformers_version("<", "5.0"):
         "optimum-intel-internal-testing/tiny-random-gemma3",
         MODEL_GEMMA3N,
         "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+        MODEL_GLM_EDGE_V,
         *VIDEO_MODEL_IDS,
     ]
 else:
@@ -206,6 +210,7 @@ IMAGE_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
     "optimum-intel-internal-testing/tiny-random-qwen3.5": lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",
     "optimum-intel-internal-testing/tiny-random-gemma3": lambda idx: "<start_of_image>",
     MODEL_GEMMA3N: lambda idx: "<image_soft_token>",
+    MODEL_GLM_EDGE_V: lambda idx: "<|begin_of_image|>",
     "optimum-intel-internal-testing/tiny-random-internvl2": lambda idx: "<image>\n",
     "optimum-intel-internal-testing/tiny-random-minicpmv-2_6": lambda idx: "<image>./</image>\n",
     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6": lambda idx: "<image>./</image>\n",
@@ -232,6 +237,7 @@ VIDEO_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
 
 RESOLUTION_BY_MODEL: dict[str, int | None] = {
     "optimum-intel-internal-testing/tiny-random-gemma3": 32,
+    MODEL_GLM_EDGE_V: 672,
     "qnguyen3/nanoLLaVA": 384,
     "optimum-intel-internal-testing/tiny-random-llava-next-video": 336,
     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6": 448,
@@ -422,6 +428,7 @@ def _get_ov_model(model_id: str) -> str:
                     "optimum-intel-internal-testing/tiny-random-phi-4-multimodal",
                     "qnguyen3/nanoLLaVA",
                     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+                    MODEL_GLM_EDGE_V,
                     VIDEOCHAT_FLASH_QWEN_MODEL_ID,
                 },
             )
@@ -431,6 +438,11 @@ def _get_ov_model(model_id: str) -> str:
         # For tiny-random-internvl2 processor is actually tokenizer
         elif isinstance(processor, transformers.Qwen2TokenizerFast):
             tokenizer = processor
+            processor = transformers.AutoImageProcessor.from_pretrained(model_cached, trust_remote_code=True)
+        # For GLM-Edge-V AutoProcessor resolves to a tokenizer; the image
+        # processor is a separate MllamaImageProcessor.
+        elif model.config.model_type == "glm":
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
             processor = transformers.AutoImageProcessor.from_pretrained(model_cached, trust_remote_code=True)
         else:
             tokenizer = processor.tokenizer
@@ -2172,6 +2184,16 @@ def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):
         preprocess_inputs = MODEL_TYPE_TO_CLS_MAPPING[optimum_model.config.model_type].preprocess_inputs
         logger.debug("video shape: %s", video.shape if video is not None else None)
         inputs = preprocess_inputs(prompt, None, processor, tokenizer, config=optimum_model.config, video=video)
+    elif optimum_model.config.model_type == "glm":
+        # GLM-Edge-V: AutoProcessor resolves to a tokenizer, so load the image
+        # processor and tokenizer explicitly. Optimum's preprocess_inputs needs
+        # both, and decoding is done via the tokenizer (image processor has no
+        # batch_decode).
+        processor = transformers.AutoImageProcessor.from_pretrained(model_cached, trust_remote_code=True)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
+        inputs = optimum_model.preprocess_inputs(
+            text=prompt, image=image, processor=processor, tokenizer=tokenizer, config=optimum_model.config
+        )
     else:
         processor = transformers.AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
         # Gemma3 input_ids has two bos tokens when running with optimum: one in chat template + "add_bos_token" is set to True in tokenizer_config.json
@@ -2202,6 +2224,9 @@ def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):
         optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True).strip()
     elif optimum_model.config.model_type == "videochat_flash_qwen":
         assert tokenizer is not None, "Tokenizer should be set for videochat_flash_qwen models."
+        optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+    elif optimum_model.config.model_type == "glm":
+        assert tokenizer is not None, "Tokenizer should be set for GLM-Edge-V models."
         optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
     else:
         optimum_output = processor.batch_decode(

--- a/tools/who_what_benchmark/tests/test_glm_edge_v_support.py
+++ b/tools/who_what_benchmark/tests/test_glm_edge_v_support.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused unit tests for GLM-Edge-V (config.model_type == "glm") support in WWB.
+
+These cover the two reusable pieces added to support the GLM-V VLM family:
+  * the HF-path visual-text preprocessor mapping now resolves "glm";
+  * the HF loader forces trust_remote_code when a "glm" config's auto_map
+    references the repository's custom (vision-capable) modeling code, so the
+    text-only built-in GlmForCausalLM is not loaded by mistake.
+"""
+
+from types import SimpleNamespace
+
+from whowhatbench.inputs_preprocessors import MODEL_TYPE_TO_CLS_MAPPING
+from whowhatbench.inputs_preprocessors.glm_edge_v import GLMEdgeVInputsPreprocessor
+
+
+def test_glm_registered_in_visual_text_preprocessor_mapping():
+    assert "glm" in MODEL_TYPE_TO_CLS_MAPPING
+    assert MODEL_TYPE_TO_CLS_MAPPING["glm"] is GLMEdgeVInputsPreprocessor
+
+
+def test_glm_preprocessor_uses_boi_token_as_image_token():
+    model = SimpleNamespace(config=SimpleNamespace(boi_token_id=59256))
+    preprocessor = GLMEdgeVInputsPreprocessor(model=model)
+    assert preprocessor.def_image_token_id == 59256
+    # boi placeholder positions are treated as image tokens
+    assert preprocessor.is_image_token([1, 59256, 2], 1) is True
+    assert preprocessor.is_image_token([1, 59256, 2], 0) is False
+
+
+def _requires_remote_code(auto_map, model_type="glm"):
+    """Mirror the loader decision added in load_visual_text_model."""
+    config = SimpleNamespace(model_type=model_type, auto_map=auto_map)
+    trust_remote_code = False
+    if config.model_type == "glm" and isinstance(getattr(config, "auto_map", None), dict):
+        if any(key.startswith("AutoModel") for key in config.auto_map):
+            trust_remote_code = True
+    return trust_remote_code
+
+
+def test_glm_with_custom_auto_map_forces_remote_code():
+    auto_map = {
+        "AutoConfig": "configuration_glm.GlmConfig",
+        "AutoModel": "modeling_glm.GlmModel",
+        "AutoModelForCausalLM": "modeling_glm.GlmForCausalLM",
+    }
+    assert _requires_remote_code(auto_map) is True
+
+
+def test_glm_without_model_auto_map_stays_builtin():
+    # A plain built-in glm text model (no custom AutoModel* code) must not be
+    # forced into remote-code loading.
+    assert _requires_remote_code({"AutoConfig": "configuration_glm.GlmConfig"}) is False
+    assert _requires_remote_code(None) is False

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -8,6 +8,7 @@ from .qwen2 import Qwen2VLInputsPreprocessor
 from .qwen3 import Qwen3VLInputsPreprocessor, Qwen3_5VLInputsPreprocessor
 from .gemma3 import Gemma3InputsPreprocessor
 from .gemma4 import Gemma4InputsPreprocessor, Gemma4UnifiedInputsPreprocessor
+from .glm_edge_v import GLMEdgeVInputsPreprocessor
 from .vlm_inputs_preprocessor import VLMInputsPreprocessor
 
 MODEL_TYPE_TO_CLS_MAPPING = {
@@ -30,6 +31,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "llava_next": LLAVAInputsPreprocessor,
     "llava-qwen2": NanoLlavaInputsPreprocessor,
     "internvl_chat": InternVLInputsPreprocessor,
+    "glm": GLMEdgeVInputsPreprocessor,
 }
 
 __all__ = ["MODEL_TYPE_TO_CLS_MAPPING", "VLMInputsPreprocessor"]

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm_edge_v.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm_edge_v.py
@@ -1,0 +1,132 @@
+import numpy as np
+import torch
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+)
+from typing import TYPE_CHECKING, Optional, Union, Any
+
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+class GLMEdgeVInputsPreprocessor(VLMInputsPreprocessor):
+    """Inputs preprocessor for the GLM-Edge-V family of VLMs (config.model_type == "glm").
+
+    GLM-Edge-V does not expose a combined multimodal ``AutoProcessor``: loading it
+    returns the text tokenizer only, and images are handled by a separate
+    ``MllamaImageProcessor``. The chat template expands every ``{"type": "image"}``
+    entry into a fixed run of ``<|begin_of_image|>`` (``boi_token_id``) placeholder
+    tokens which the model replaces with vision features during ``forward``.
+    """
+
+    def __init__(self, chat_mode: bool = False, model: Optional[Any] = None):
+        super().__init__(chat_mode)
+        self._image_processor = None
+        if model is not None:
+            self.def_image_token_id = getattr(model.config, "boi_token_id", None)
+        else:
+            self.def_image_token_id = None
+
+    def update_chat_history_with_answer(self, answer):
+        self.chat_history.append({"role": "assistant", "content": [{"type": "text", "text": answer}]})
+
+    def _get_image_processor(self, processor, config):
+        if self._image_processor is not None:
+            return self._image_processor
+
+        # GLM-Edge-V's AutoProcessor resolves to the text tokenizer, so the image
+        # processor must be loaded separately from the same model directory.
+        model_path = getattr(processor, "name_or_path", None)
+        if model_path is None and config is not None:
+            model_path = getattr(config, "_name_or_path", None)
+        if model_path is None:
+            raise ValueError(
+                "Unable to determine model path to load the GLM-Edge-V image processor."
+            )
+        self._image_processor = AutoImageProcessor.from_pretrained(
+            model_path, trust_remote_code=True
+        )
+        return self._image_processor
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[Any] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None and tokenizer is None:
+            raise ValueError("Tokenizer/processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        # For GLM-Edge-V the AutoProcessor loaded by WWB is the text tokenizer.
+        text_tokenizer = tokenizer if tokenizer is not None else processor
+
+        if image is not None and not isinstance(image, list):
+            image = [image]
+        self.update_images(image)
+
+        content = []
+        if image is not None:
+            content.extend([{"type": "image"}] * len(image))
+        content.append({"type": "text", "text": text})
+
+        if self.chat_mode:
+            self.chat_history.append({"role": "user", "content": content})
+            conversation = self.chat_history
+        else:
+            conversation = [{"role": "user", "content": content}]
+
+        prompt = text_tokenizer.apply_chat_template(
+            conversation, add_generation_prompt=True, tokenize=False
+        )
+        inputs = text_tokenizer(prompt, return_tensors="pt")
+
+        if self.images is not None:
+            image_processor = self._get_image_processor(processor, config)
+            image_inputs = image_processor(images=self.images, return_tensors="pt")
+            inputs["pixel_values"] = image_inputs["pixel_values"]
+
+        return inputs
+
+    def align_inputs_with_cache(self, model: Any, inputs: dict, full_tokenized_chat: torch.Tensor, prefix_len: int):
+        if "pixel_values" not in inputs:
+            return inputs
+
+        boi_token_id = getattr(model.config, "boi_token_id", self.def_image_token_id)
+        if boi_token_id is None:
+            return inputs
+
+        full_tokenized_chat_list = full_tokenized_chat[0].tolist()
+
+        total_image_num = inputs["pixel_values"].shape[0]
+        total_image_tokens = full_tokenized_chat_list.count(boi_token_id)
+        boi_per_image = total_image_tokens // total_image_num if total_image_num > 0 else 0
+
+        new_input_ids = full_tokenized_chat_list[prefix_len:]
+        new_image_tokens = new_input_ids.count(boi_token_id)
+        new_image_num = new_image_tokens // boi_per_image if boi_per_image > 0 else 0
+        if new_image_num < total_image_num:
+            if new_image_num == 0:
+                del inputs["pixel_values"]
+            else:
+                cached_image_num = total_image_num - new_image_num
+                inputs["pixel_values"] = inputs["pixel_values"][cached_image_num:]
+
+        return inputs
+
+    def is_image_token(self, tokenized_input: list, idx: int) -> bool:
+        if self.def_image_token_id is None:
+            return True
+        return tokenized_input[idx] == self.def_image_token_id

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -430,6 +430,15 @@ def load_visual_text_model(
 
             AutoImageProcessor.from_pretrained(model_id, trust_remote_code=True)
 
+        # GLM-Edge-V shares the built-in "glm" model_type, but its vision head lives
+        # in the repository's custom modeling code referenced by config.auto_map.
+        # AutoConfig succeeds without remote code, so trust_remote_code stays False
+        # and the text-only built-in GlmForCausalLM (no pixel_values) is loaded.
+        # Force remote code when auto_map provides a custom multimodal model class.
+        if config.model_type == "glm" and isinstance(getattr(config, "auto_map", None), dict):
+            if any(key.startswith("AutoModel") for key in config.auto_map):
+                trust_remote_code = True
+
         model_kwargs = {"trust_remote_code": trust_remote_code}
         try:
             model_cls = None
@@ -443,6 +452,12 @@ def load_visual_text_model(
                 from transformers import AutoModelForMultimodalLM
 
                 model_cls = AutoModelForMultimodalLM
+            elif config.model_type == "glm":
+                # GLM-Edge-V exposes its multimodal head via GlmForCausalLM
+                # (auto_map registers AutoModelForCausalLM only), so the generic
+                # vision-to-seq auto classes resolve to the base GlmModel that
+                # lacks a `generate` method.
+                model_cls = AutoModelForCausalLM
             elif transformers_version < Version("5.0.0"):
                 from transformers import AutoModelForVision2Seq
 


### PR DESCRIPTION
## Description

Sub-agent did not return valid handoff JSON; fields were inferred from text.

## Reproduce generation

```python
from PIL import Image
import openvino_genai

pipe = openvino_genai.VLMPipeline("output_dir", "CPU")
image = Image.new("RGB", (64, 64), "white")
result = pipe.generate("Describe this image.", image=image, max_new_tokens=10)
print(result.texts[0])
```

## Validation

- WWB Optimum similarity: **1.0**
- WWB GenAI similarity: **Not run**
- First-token latency: **Not run**
- Throughput: **Not run**

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1847

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.

## Changed files

- `site/docs/supported-models/index.mdx`
- `src/cpp/src/visual_language/glm_edge_v/classes.cpp`
- `src/cpp/src/visual_language/glm_edge_v/classes.hpp`
- `src/cpp/src/visual_language/inputs_embedder.cpp`
- `src/cpp/src/visual_language/inputs_embedder.hpp`
- `src/cpp/src/visual_language/vision_encoder.cpp`
- `src/cpp/src/visual_language/vlm_config.cpp`
- `src/cpp/src/visual_language/vlm_config.hpp`
- `tests/python_tests/test_vlm_pipeline.py`
- `tools/who_what_benchmark/tests/test_glm_edge_v_support.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm_edge_v.py`
- `tools/who_what_benchmark/whowhatbench/model_loaders.py`
