### PR TITLE
[Gemma3] Enable PA, fix prompt normalization, unskip tests

### DIFF
--- a/src/cpp/src/visual_language/gemma3/classes.cpp
+++ b/src/cpp/src/visual_language/gemma3/classes.cpp
@@ -96,23 +96,22 @@ NormalizedPrompt InputsEmbedderGemma3::normalize_prompt(const std::string& promp
     
     auto [unified_prompt, images_sequence] = normalize(prompt, start_of_image, start_of_image, base_id, images.size());
 
-    std::vector<ov::Tensor> image_embeds;
-    image_embeds.reserve(images_sequence.size());
-    size_t searched_pos = 0;
+    size_t search_offset = 0;
     for (size_t new_image_id : images_sequence) {
-        image_embeds.push_back(images.at(new_image_id - base_id).resized_source);
+        const size_t num_image_tokens = images.at(new_image_id - base_id).resized_source.get_shape().at(1);
 
-        size_t num_image_tokens = image_embeds.back().get_shape().at(1);
-
-        std::string expanded_tag = "\n\n" + start_of_image;
+        std::string expanded_tag;
+        expanded_tag.reserve(2 + start_of_image.size() + num_image_tokens * image_token.size() + end_of_image.size() + 2);
+        expanded_tag = "\n\n" + start_of_image;
         for (size_t i = 0; i < num_image_tokens; i++) {
             expanded_tag += image_token;
         }
         expanded_tag += end_of_image + "\n\n";
 
-        // fixme: there seems to be an issue with how image_token is replaced. unified_prompt.find needs search_offset.
-        // refer to gemma4 implementation.
-        unified_prompt.replace(unified_prompt.find(start_of_image), start_of_image.length(), expanded_tag);
+        size_t pos = unified_prompt.find(start_of_image, search_offset);
+        OPENVINO_ASSERT(pos != std::string::npos, "Failed to find image token in prompt during normalization");
+        unified_prompt.replace(pos, start_of_image.length(), expanded_tag);
+        search_offset = pos + expanded_tag.size();
     }
     return {std::move(unified_prompt), std::move(images_sequence), {}};
 }

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -880,9 +880,10 @@ private:
 };
 
 bool requires_sdpa(const std::filesystem::path& models_dir) {
-    auto vlm_config = utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json");
-    // TODO: remove it when GEMMA3 ticket-171180 is fixed
-    return vlm_config.model_type == VLMModelType::GEMMA3;
+    // Force models to use SDPA backend by default until PA is supported. Example:
+    // auto vlm_config = utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json");
+    // vlm_config.model_type == VLMModelType::GEMMA3;
+    return false;
 }
 
 VLMPipeline::VLMPipeline(

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -1068,9 +1068,6 @@ def test_vlm_pipeline_start_chat_vs_chat_history(
     ov_pipe_model: VlmModelInfo,
     iteration_images: list[list[PIL.Image]],
 ):
-    if "gemma3" in ov_pipe_model.model_id and ov_pipe_model.ov_backend == "PA":
-        pytest.xfail("Outputs don't match for Gemma3 with PA. CVS-188205")
-
     ov_pipe = ov_pipe_model.pipeline
 
     generation_config = _setup_generation_config(ov_pipe, do_sample=False, prompt_lookup=ov_pipe_model.prompt_lookup)
@@ -2252,8 +2249,6 @@ OPTIMUM_VS_GENAI_PER_MODEL_VIDEO_RESOLUTIONS = {
 # test-id's are of the form:
 # "<model_id>/<attn_backend>/<preprocessing>/image-<W>x<H>/video-<W>x<H>"
 OPTIMUM_VS_GENAI_MODEL_EXPECTED_FAIL_CASES = {
-    # gemma3 PA cases
-    "*tiny-random-gemma3/PA/*": "CVS-167316",
     # gemma3n cases
     "*tiny-random-gemma3n/PA/CPP/image*": "CVS-190429",
     "*tiny-random-gemma3n/SDPA/CPP/image*": "CVS-190429",


### PR DESCRIPTION
## Description
This PR switches Gemma3 default backend to PA, fixes prompt normalization for multiple images and unskips Gemma3 + PA python tests.

CVS-171180
CVS-188205

Accuracy WWB results:
| `google/Gemma-3-4B-it` (FP16) | SDPA | PA |
|-----------------------|------|----|
| GenAI vs Optimum | 0.976712 | 1.0 |
| GenAI vs HF | 0.97756 | 0.998798 |
| Optimum vs HF | 0.998798 | N/A |

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] I have made corresponding changes to the documentation - **N/A**.
