### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/.model_analysis/glm_analysis.md
+++ b/.model_analysis/glm_analysis.md
@@ -1,0 +1,90 @@
+# Model Analysis: zai-org/glm-edge-v-2b (glm) — local tiny: glm-edge-v-2b-tiny
+
+Package versions: transformers 4.57.6; optimum.intel from
+/home/panas/git/auto-openvino-bot/workspace/optimum-intel.
+
+## Identity
+- model_id (tiny/local): /home/panas/git/auto-openvino-bot/workspace/glm-edge-v-2b-tiny
+- original_model_id: zai-org/glm-edge-v-2b
+- config.json: model_type = "glm", architectures = ["GlmForCausalLM"]
+- auto_map: configuration_glm.GlmConfig / modeling_glm.GlmForCausalLM (remote code)
+- Nested vision_config: model_type = "siglip_vision_model", image_size 672, patch_size 14
+- boi_token_id = 59256 (<|begin_of_image|>), eoi_token_id = 59257
+- eos_token_id = [59246, 59253, 59255], pad_token_id = 59246
+- hidden_size (text) = 256 (tiny); real model larger
+- Modality: image-text-to-text (VLM). model_type "glm" is shared with text-only
+  GLM decoder; GLM-Edge-V is distinguished by presence of nested vision_config.
+
+Real vs tiny: identical architecture identity (model_type glm + siglip
+vision_config + GlmForCausalLM + MllamaImageProcessor + boi_token_id merge).
+Only layer counts / hidden sizes differ. Safe to develop on the tiny model.
+
+## Exported IR (ov_model_glm)
+- openvino_language_model.xml
+  - IN attention_mask [?,?] i64, position_ids [?,?] i64,
+       inputs_embeds [?,?,256] f32, beam_idx [?] i32
+  - OUT logits [?,?,59264] f32
+- openvino_text_embeddings_model.xml
+  - IN input [?,?] i64 -> OUT inputs_embeds [?,?,256] f32
+- openvino_vision_embeddings_model.xml
+  - IN pixel_values [?,3,672,672] f32 -> OUT last_hidden_state [1,578,256] f32
+  (vision tower already includes projection to text hidden size; 578 tokens/image)
+- Standard stateful LM: inputs_embeds + position_ids + attention_mask + beam_idx.
+
+## Transformers (modeling_glm.py, remote code)
+- Prefill merge (GlmModel.forward, ~L772-810):
+  - inputs_embeds = embed_tokens(input_ids)
+  - images_features = self.vision(imgs)  # [num_images, 578, hidden]
+  - For each sample with boi_token_id present: find first boi_token_id position,
+    count num_image_padding_tokens (== 578), replace that contiguous span with
+    image features. i.e. simple placeholder replacement at boi_token_id.
+- Image placeholder token: boi_token_id = 59256 = "<|begin_of_image|>".
+  The processor/chat template emits 578 copies of <|begin_of_image|>.
+- Position IDs: standard sequential (cache_position). No custom RoPE for images.
+- Cache: standard stateful KV cache.
+
+## Optimum-Intel (modeling_visual_language.py :: _OVGlmEdgeVForCausalLM)
+- Registered as "glm" -> _OVGlmEdgeVForCausalLM (L7426).
+- get_vision_embeddings: flattens 6D MllamaImageProcessor output
+  (batch, media, tiles, C, H, W) -> (num_images, C, H, W), runs vision_embeddings
+  -> last_hidden_state.
+- merge_vision_text_embeddings: masked_scatter of image features into
+  inputs_embeds at positions where input_ids == boi_token_id (59256).
+- preprocess_inputs: chat template with {'type':'image'} content, then
+  pixel_values = processor(image).pixel_values.
+
+## Preprocessing (preprocessor_config.json)
+- image_processor_type: MllamaImageProcessor
+- size 672x672, resample=3 (bicubic), do_resize + do_pad + do_rescale + do_normalize
+- image_mean=[0.5,0.5,0.5], image_std=[0.5,0.5,0.5], rescale_factor=1/255
+- max_image_tiles=1 (single tile; effectively resize-to-672 + normalize)
+
+## Notes
+- Vision output token count is fixed (578) per image, read dynamically from the
+  vision IR output shape [1,578,256] (rows).
+- Chat template (chat_template.jinja) expands {'type':'image'} into 578
+  <|begin_of_image|> tokens. In GenAI the prompt is normalized BEFORE the chat
+  template is applied and the template receives a flat string content, so GenAI
+  must expand the native image tag into 578 <|begin_of_image|> tokens itself.
+
+## GenAI Enablement Design
+- Closest GenAI model: InternVLChat — because both use a single repeated image
+  placeholder token (image_context_token / boi_token) with a fixed per-image
+  token count, simple contiguous placeholder replacement (no custom position
+  IDs, standard stateful cache), and a vision IR whose output already projects
+  to text hidden size. LLaVA is also close but expands with a trailing newline
+  and single-token count from vision shape.
+- Required changes:
+  - src/cpp/src/visual_language/vlm_config.hpp: add VLMModelType::GLM_EDGE_V and
+    an image_pad_token default "<|begin_of_image|>" reuse (use existing member).
+  - src/cpp/src/visual_language/vlm_config.cpp: map "glm" -> GLM_EDGE_V.
+  - src/cpp/src/visual_language/glm_edge_v/classes.{hpp,cpp}: VisionEncoderGLMEdgeV
+    (MllamaImageProcessor-equivalent preprocessing: bicubic resize to 672x672 +
+    normalize mean/std 0.5) and InputsEmbedderGLMEdgeV (normalize_prompt expands
+    the native <image> tag into N copies of <|begin_of_image|>; get_inputs_embeds
+    merges vision features at boi_token positions like InternVL).
+  - Register in vision_encoder.cpp (both create overloads) and inputs_embedder.cpp
+    (both constructors) factories.
+  - Add friend class to inputs_embedder.hpp.
+- Gaps: none significant. No custom position IDs, no extra LM inputs, no dynamic
+  tiling (max_image_tiles=1). Preprocessing is plain resize+normalize.

--- a/.model_analysis/inspect_ir.py
+++ b/.model_analysis/inspect_ir.py
@@ -1,0 +1,12 @@
+from openvino import Core
+from pathlib import Path
+import sys
+core = Core()
+d = sys.argv[1] if len(sys.argv)>1 else "../../ov_model_glm"
+for xml in sorted(Path(d).glob("openvino_*.xml")):
+    if "tokenizer" in xml.name or "detokenizer" in xml.name:
+        continue
+    m = core.read_model(xml)
+    print(f"\n=== {xml.name} ===")
+    for i in m.inputs:  print(f"  IN  {i.any_name}: {i.partial_shape} {i.element_type}")
+    for o in m.outputs: print(f"  OUT {o.any_name}: {o.partial_shape} {o.element_type}")

--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -212,6 +212,18 @@ export const VLM_MODELS: VLMModelType[] = [
     ],
   },
   {
+    architecture: 'GlmForCausalLM',
+    models: [
+      {
+        name: 'GLM-Edge-V',
+        links: [
+          'https://huggingface.co/zai-org/glm-edge-v-2b',
+          'https://huggingface.co/zai-org/glm-edge-v-5b',
+        ],
+      },
+    ],
+  },
+  {
     architecture: 'Gemma3ForConditionalGeneration',
     models: [
       {

--- a/src/cpp/src/visual_language/glm_edge_v/classes.cpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.cpp
@@ -1,0 +1,231 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/glm_edge_v/classes.hpp"
+
+#include "visual_language/clip.hpp"
+
+#include "utils.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+// Native tag used by GenAI to mark an image position in the prompt before the
+// chat template is applied. It is expanded into repeated boi tokens below.
+const std::string NATIVE_TAG = "<image>";
+
+// Mllama-style resize (max_image_tiles == 1): fit the image inside a single
+// canvas_size x canvas_size tile preserving aspect ratio, then pad the
+// bottom/right with `pad_value`. Matches HF MllamaImageProcessor when
+// max_image_tiles == 1 (canvas is always one tile).
+clip_image_u8 resize_and_pad_glm(const clip_image_u8& image, int canvas_size, uint8_t pad_value = 0) {
+    // target dimensions are clipped between tile_size and canvas_size; with a
+    // single tile canvas both equal canvas_size.
+    const int target = canvas_size;
+
+    const float scale_h = static_cast<float>(target) / image.ny;
+    const float scale_w = static_cast<float>(target) / image.nx;
+
+    int new_width;
+    int new_height;
+    if (scale_w < scale_h) {
+        new_width = target;
+        new_height = std::min(std::max(static_cast<int>(std::floor(image.ny * scale_w)), 1), target);
+    } else {
+        new_height = target;
+        new_width = std::min(std::max(static_cast<int>(std::floor(image.nx * scale_h)), 1), target);
+    }
+
+    clip_image_u8 resized_image;
+    bicubic_resize(image, resized_image, new_width, new_height);
+
+    clip_image_u8 padded_image;
+    padded_image.nx = target;
+    padded_image.ny = target;
+    padded_image.buf.assign(static_cast<size_t>(3) * target * target, pad_value);
+
+    // Top-left aligned copy; remaining bottom/right stays padded.
+    for (int y = 0; y < new_height; ++y) {
+        for (int x = 0; x < new_width; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                padded_image.buf[3 * (y * target + x) + c] =
+                    resized_image.buf[3 * (y * new_width + x) + c];
+            }
+        }
+    }
+    return padded_image;
+}
+
+ov::Tensor get_pixel_values_glm(const ov::Tensor& image, const ProcessorConfig& config) {
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+
+    // GLM-Edge-V uses a square canvas (size.height == size.width).
+    const int canvas_size = static_cast<int>(config.size_height);
+    clip_image_u8 resized_image = resize_and_pad_glm(input_image, canvas_size);
+
+    clip_ctx ctx;
+    std::copy(config.image_mean.begin(), config.image_mean.end(), ctx.image_mean);
+    std::copy(config.image_std.begin(), config.image_std.end(), ctx.image_std);
+
+    // clip_image_preprocess rescales by 1/255 and normalizes with mean/std.
+    clip_image_f32 normalized_image = clip_image_preprocess(ctx, resized_image);
+    return clip_image_f32_to_tensor(normalized_image);
+}
+
+// Scatter image embeddings into text embeddings at boi_token positions.
+// GLM-Edge-V uses a single repeated placeholder token (boi_token_id), like
+// InternVL's image context token.
+ov::Tensor merge_text_and_image_embeddings_glm(
+    const ov::Tensor& input_ids,
+    const ov::Tensor& text_embeds,
+    const std::vector<ov::Tensor>& image_embeds,
+    int64_t image_pad_token_id) {
+    auto text_embeds_shape = text_embeds.get_shape();
+    size_t batch_size = text_embeds_shape.at(0);
+    size_t seq_len = text_embeds_shape.at(1);
+    size_t embed_dim = text_embeds_shape.at(2);
+
+    ov::Tensor merged_embeds(text_embeds.get_element_type(), text_embeds_shape);
+
+    const float* text_embeds_data = text_embeds.data<float>();
+    const int64_t* input_ids_data = input_ids.data<int64_t>();
+    float* merged_embeds_data = merged_embeds.data<float>();
+
+    size_t flattened_size = batch_size * seq_len;
+    std::vector<bool> image_tokens_mask(flattened_size, false);
+    size_t image_tokens_count = 0;
+    for (size_t i = 0; i < flattened_size; ++i) {
+        if (input_ids_data[i] == image_pad_token_id) {
+            image_tokens_mask[i] = true;
+            ++image_tokens_count;
+        }
+    }
+
+    OPENVINO_ASSERT(image_tokens_count > 0, "input_ids does not contain GLM-Edge-V image placeholder token ids");
+
+    size_t image_idx = 0;
+    size_t image_token_idx = 0;
+    for (size_t flat_idx = 0; flat_idx < flattened_size; ++flat_idx) {
+        size_t offset = flat_idx * embed_dim;
+        if (image_tokens_mask[flat_idx]) {
+            OPENVINO_ASSERT(image_idx < image_embeds.size(), "Not enough image embeddings for image placeholder tokens");
+            const ov::Tensor& single_image_embeds = image_embeds[image_idx];
+            const auto single_shape = single_image_embeds.get_shape();
+            // vision output shape is [num_images(==1), num_tokens, embed_dim]
+            const size_t num_image_tokens = single_shape.at(single_shape.size() - 2);
+            const float* image_embeds_data = single_image_embeds.data<float>();
+            std::copy_n(image_embeds_data + image_token_idx * embed_dim, embed_dim, merged_embeds_data + offset);
+            ++image_token_idx;
+            if (image_token_idx == num_image_tokens) {
+                ++image_idx;
+                image_token_idx = 0;
+            }
+        } else {
+            std::copy_n(text_embeds_data + offset, embed_dim, merged_embeds_data + offset);
+        }
+    }
+
+    return merged_embeds;
+}
+
+} // namespace
+
+EncodedImage VisionEncoderGLMEdgeV::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+
+    ov::Tensor pixel_values = get_pixel_values_glm(image, config);
+
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.infer();
+
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
+    ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
+    std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
+
+    return {std::move(image_features)};
+}
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+
+InputsEmbedderGLMEdgeV::InputsEmbedderGLMEdgeV(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) { }
+
+std::vector<ov::genai::EncodedImage> InputsEmbedderGLMEdgeV::encode_images(const std::vector<ov::Tensor>& images) {
+    std::vector<EncodedImage> embeds;
+    ov::AnyMap vision_config = {{"patch_size", m_vlm_config.vision_config_patch_size}};
+    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
+    embeds.reserve(single_images.size());
+    for (const ov::Tensor& image : single_images) {
+        embeds.emplace_back(m_vision_encoder->encode(image, vision_config));
+    }
+    return embeds;
+}
+
+NormalizedPrompt InputsEmbedderGLMEdgeV::normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const {
+    const std::string& image_pad_token = m_vlm_config.image_pad_token;
+    auto [unified_prompt, images_sequence] = normalize(prompt, NATIVE_TAG, NATIVE_TAG, base_id, images.size());
+
+    size_t searched_pos = 0;
+    for (size_t new_image_id : images_sequence) {
+        const ov::Tensor& image_embeds = images.at(new_image_id - base_id).resized_source;
+        const auto shape = image_embeds.get_shape();
+        // vision output shape is [num_images(==1), num_tokens, embed_dim]
+        const size_t num_image_tokens = shape.at(shape.size() - 2);
+
+        std::string expanded_tag;
+        expanded_tag.reserve(num_image_tokens * image_pad_token.size());
+        for (size_t idx = 0; idx < num_image_tokens; ++idx) {
+            expanded_tag += image_pad_token;
+        }
+        OPENVINO_ASSERT(searched_pos < unified_prompt.length());
+        searched_pos = unified_prompt.find(NATIVE_TAG, searched_pos);
+        OPENVINO_ASSERT(searched_pos != std::string::npos);
+        unified_prompt.replace(searched_pos, NATIVE_TAG.length(), expanded_tag);
+        searched_pos += expanded_tag.length();
+    }
+
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderGLMEdgeV::get_inputs_embeds(const std::string& unified_prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(images.at(new_image_id).resized_source);
+    }
+
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+
+    if (images.empty()) {
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+
+    auto start_tokenizer_time = std::chrono::steady_clock::now();
+    ov::Tensor encoded_image_pad_token = m_tokenizer.encode(m_vlm_config.image_pad_token, ov::genai::add_special_tokens(false)).input_ids;
+    auto end_tokenizer_time = std::chrono::steady_clock::now();
+    OPENVINO_ASSERT(metrics.raw_metrics.tokenization_durations.size() > 0);
+    metrics.raw_metrics.tokenization_durations[metrics.raw_metrics.tokenization_durations.size() - 1] += ov::genai::MicroSeconds(PerfMetrics::get_microsec(end_tokenizer_time - start_tokenizer_time));
+    int64_t image_pad_token_id = encoded_image_pad_token.data<int64_t>()[encoded_image_pad_token.get_size() - 1];
+    return merge_text_and_image_embeddings_glm(input_ids, text_embeds, image_embeds, image_pad_token_id);
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/glm_edge_v/classes.hpp
+++ b/src/cpp/src/visual_language/glm_edge_v/classes.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+/// @brief Vision encoder for GLM-Edge-V (model_type "glm" with a nested
+/// SigLIP vision_config). Preprocessing mirrors the HF MllamaImageProcessor
+/// with max_image_tiles == 1: aspect-ratio-preserving resize to fit within a
+/// single size.height x size.width canvas, followed by bottom/right padding.
+class VisionEncoderGLMEdgeV : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+/// @brief Inputs embedder for GLM-Edge-V. The image placeholder token is
+/// <|begin_of_image|> (boi_token_id). The prompt is expanded so that each image
+/// contributes N copies of that token (N == number of vision embedding rows),
+/// and vision features are scattered into those positions like InternVL.
+class InputsEmbedderGLMEdgeV : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderGLMEdgeV(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings = true, const std::vector<size_t>& image_sequence = {}) override;
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
+
+    NormalizedPrompt normalize_prompt(
+        const std::string& prompt,
+        size_t base_id,
+        const std::vector<EncodedImage>& images
+    ) const override;
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -26,6 +26,8 @@
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 
+#include "visual_language/glm_edge_v/classes.hpp"
+
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
 
@@ -377,6 +379,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, model_dir, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -425,6 +429,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config); 
+    } else if (vlm_config.model_type == VLMModelType::GLM_EDGE_V) {
+        m_impl = std::make_shared<InputsEmbedderGLMEdgeV>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -391,6 +391,7 @@ private:
     friend class InputsEmbedderGemma3n;
     friend class InputsEmbedderGemma4;
     friend class InputsEmbedderVideoChatFlashQwen;
+    friend class InputsEmbedderGLMEdgeV;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -26,6 +26,8 @@
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 
+#include "visual_language/glm_edge_v/classes.hpp"
+
 namespace ov::genai {
 
 VisionEncoder::VisionEncoder(const std::filesystem::path& model_dir, const std::string& device, const ov::AnyMap properties) {
@@ -146,6 +148,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderGemma4>(model_dir, device, properties);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -193,6 +197,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderGemma4>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::GLM_EDGE_V) {
+        return std::make_shared<VisionEncoderGLMEdgeV>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -34,6 +34,10 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"videochat_flash_qwen", VLMModelType::VIDEOCHAT_FLASH_QWEN},
         {"qwen3_omni", VLMModelType::QWEN3_OMNI},
         {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
+        // GLM-Edge-V reports model_type "glm" (shared with the text-only GLM
+        // decoder) but carries a nested SigLIP vision_config. It only reaches
+        // the VLM config path when used as a VLM, so mapping "glm" here is safe.
+        {"glm", VLMModelType::GLM_EDGE_V},
     };
 
     auto it = model_types_map.find(value);
@@ -122,6 +126,11 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
                 speaker_ids[key] = val.get<int64_t>();
             }
         }
+    }
+    // GLM-Edge-V: the image placeholder token is <|begin_of_image|>
+    // (config.json boi_token_id). Reuse image_pad_token for the merge step.
+    if (model_type == VLMModelType::GLM_EDGE_V) {
+        image_pad_token = "<|begin_of_image|>";
     }
 }
 

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -32,6 +32,7 @@ enum class VLMModelType {
     GEMMA4_UNIFIED,
     VIDEOCHAT_FLASH_QWEN,
     QWEN3_OMNI,
+    GLM_EDGE_V,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -163,6 +163,10 @@ else:
 MODEL_GEMMA = "optimum-intel-internal-testing/tiny-random-gemma3"
 MODEL_GEMMA3N = "optimum-intel-internal-testing/tiny-random-gemma3n"
 
+# GLM-Edge-V (config.model_type == "glm" with a nested SigLIP vision_config,
+# GlmForCausalLM remote code). Uploaded by the optimum-intel testing infra.
+GLM_EDGE_V_MODEL_ID = "optimum-intel-internal-testing/tiny-random-glm-edge-v"
+
 MODEL_IDS: list[str] = []
 if is_transformers_version("<", "5.0"):
     # minicpmv, internvl_chat architectures are deprecating support for transformers >= v5 by optimum-intel
@@ -176,6 +180,7 @@ if is_transformers_version("<", "5.0"):
         "optimum-intel-internal-testing/tiny-random-gemma3",
         MODEL_GEMMA3N,
         "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+        GLM_EDGE_V_MODEL_ID,
         *VIDEO_MODEL_IDS,
     ]
 else:
@@ -216,6 +221,7 @@ IMAGE_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
     "optimum-intel-internal-testing/tiny-random-gemma4-unified-it": lambda idx: "<|image|>",
     "optimum-intel-internal-testing/tiny-random-gemma4-31B": lambda idx: "<|image|>",
     "qnguyen3/nanoLLaVA": lambda idx: "<image>\n",
+    GLM_EDGE_V_MODEL_ID: lambda idx: "<image>",
     VIDEOCHAT_FLASH_QWEN_MODEL_ID: lambda idx: f"<|image_{idx + 1}|>\n",
 }
 
@@ -336,6 +342,20 @@ def _maybe_skip_unsupported_model_export(model_id: str) -> None:
     if _is_videochat_flash_qwen_model(model_id) and not is_optimum_intel_version_for_videochat_flash_qwen():
         pytest.skip("ValueError: The current version of optimum-intel does not support videochat_flash_qwen")
 
+    if model_id == GLM_EDGE_V_MODEL_ID:
+        # GLM-Edge-V export support was added to optimum-intel; the tiny-random
+        # test model is published separately by the optimum-intel testing infra.
+        # Skip cleanly until the referenced model id is available on the Hub.
+        from huggingface_hub import model_info
+        from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
+        try:
+            model_info(model_id)
+        except (RepositoryNotFoundError, HfHubHTTPError):
+            pytest.skip(
+                f"{model_id} is not available on the Hub yet. GLM-Edge-V GenAI "
+                "support is validated locally against a tiny GLM-Edge-V model."
+            )
+
 
 def _get_vlm_eagle3_model_paths() -> tuple[Path, Path]:
     _maybe_skip_unsupported_model_export(VLM_EAGLE3_MAIN_MODEL_ID)
@@ -422,12 +442,21 @@ def _get_ov_model(model_id: str) -> str:
                     "optimum-intel-internal-testing/tiny-random-phi-4-multimodal",
                     "qnguyen3/nanoLLaVA",
                     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+                    GLM_EDGE_V_MODEL_ID,
                     VIDEOCHAT_FLASH_QWEN_MODEL_ID,
                 },
             )
         )
         if model.config.model_type == "llava-qwen2" or _is_videochat_flash_qwen_model(model_id):
             tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
+        # GLM-Edge-V (model_type "glm" + vision_config) ships a text tokenizer as
+        # its AutoProcessor and a separate MllamaImageProcessor for images.
+        elif model_id == GLM_EDGE_V_MODEL_ID or (
+            getattr(model.config, "model_type", None) == "glm"
+            and getattr(model.config, "vision_config", None) is not None
+        ):
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
+            processor = transformers.AutoImageProcessor.from_pretrained(model_cached, trust_remote_code=True)
         # For tiny-random-internvl2 processor is actually tokenizer
         elif isinstance(processor, transformers.Qwen2TokenizerFast):
             tokenizer = processor

--- a/tools/who_what_benchmark/tests/test_glm_visual_text.py
+++ b/tools/who_what_benchmark/tests/test_glm_visual_text.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused unit tests for GLM-Edge-V (config.model_type == "glm") visual-text
+support in WhoWhatBenchmark.
+
+These tests cover the reusable integration behaviour that was missing:
+
+  * the "glm" visual-text inputs preprocessor is registered, and
+  * ``load_visual_text_model`` forces ``trust_remote_code`` for a config that
+    declares custom multimodal remote code (``auto_map`` + ``vision_config``),
+    so the vision-capable custom class is loaded instead of the built-in
+    text-only GLM class.
+
+They intentionally avoid downloading weights: the loader behaviour is checked
+by patching ``AutoConfig`` / model factories with lightweight fakes.
+"""
+
+import types
+
+import pytest
+
+
+def test_glm_registered_in_inputs_preprocessors():
+    from whowhatbench.inputs_preprocessors import MODEL_TYPE_TO_CLS_MAPPING
+    from whowhatbench.inputs_preprocessors.glm import GlmEdgeVInputsPreprocessor
+
+    assert "glm" in MODEL_TYPE_TO_CLS_MAPPING
+    assert MODEL_TYPE_TO_CLS_MAPPING["glm"] is GlmEdgeVInputsPreprocessor
+
+
+class _FakeVisionConfig:
+    patch_size = 14
+    image_size = 672
+
+
+class _FakeGlmVLMConfig:
+    """Mimics a GLM-Edge-V config: model_type "glm" with a vision_config and an
+    auto_map pointing at custom remote modeling code."""
+
+    model_type = "glm"
+    vision_config = _FakeVisionConfig()
+    auto_map = {
+        "AutoConfig": "configuration_glm.GlmConfig",
+        "AutoModel": "modeling_glm.GlmModel",
+        "AutoModelForCausalLM": "modeling_glm.GlmForCausalLM",
+    }
+
+
+def test_loader_forces_remote_code_for_glm_vlm(monkeypatch):
+    """A glm config with vision_config + auto_map must be loaded with
+    trust_remote_code=True, otherwise the built-in text-only GLM class is used
+    and pixel_values / the vision tower are silently dropped."""
+    from whowhatbench import model_loaders
+
+    fake_config = _FakeGlmVLMConfig()
+
+    def fake_autoconfig_from_pretrained(model_id, trust_remote_code=False, **kwargs):
+        # Built-in "glm" config resolves even without remote code.
+        return fake_config
+
+    captured = {}
+
+    class _FakeModel:
+        def __init__(self, config):
+            self.config = config
+
+        def eval(self):
+            return self
+
+    def make_from_pretrained(name):
+        def _from_pretrained(model_id, device_map=None, **kwargs):
+            # AutoModelForImageTextToText / AutoModelForVision2Seq do not know
+            # about "glm" -> mimic transformers raising ValueError so the loader
+            # falls through to the AutoModelForCausalLM branch.
+            if name in ("AutoModelForImageTextToText", "AutoModelForVision2Seq"):
+                raise ValueError("Unrecognized configuration class for glm")
+            captured["cls"] = name
+            captured["trust_remote_code"] = kwargs.get("trust_remote_code")
+            return _FakeModel(fake_config)
+
+        return _from_pretrained
+
+    monkeypatch.setattr(
+        model_loaders.AutoConfig, "from_pretrained", fake_autoconfig_from_pretrained
+    )
+    monkeypatch.setattr(
+        model_loaders.AutoModel,
+        "from_pretrained",
+        make_from_pretrained("AutoModel"),
+    )
+    monkeypatch.setattr(
+        model_loaders.AutoModelForCausalLM,
+        "from_pretrained",
+        make_from_pretrained("AutoModelForCausalLM"),
+    )
+
+    import transformers
+
+    monkeypatch.setattr(
+        transformers.AutoModelForImageTextToText,
+        "from_pretrained",
+        make_from_pretrained("AutoModelForImageTextToText"),
+        raising=False,
+    )
+    if hasattr(transformers, "AutoModelForVision2Seq"):
+        monkeypatch.setattr(
+            transformers.AutoModelForVision2Seq,
+            "from_pretrained",
+            make_from_pretrained("AutoModelForVision2Seq"),
+            raising=False,
+        )
+
+    model = model_loaders.load_visual_text_model(
+        "some/glm-edge-v", device="CPU", use_hf=True, model_type="visual-text"
+    )
+
+    assert model is not None
+    # The generation-capable class must be selected via AutoModelForCausalLM ...
+    assert captured["cls"] == "AutoModelForCausalLM"
+    # ... and remote code must be trusted so the custom VLM class is used.
+    assert captured["trust_remote_code"] is True
+
+
+def test_glm_preprocessor_builds_pixel_values(monkeypatch):
+    """The glm preprocessor must place image placeholders via the chat template
+    and attach pixel_values from a separately-loaded image processor."""
+    import numpy as np
+    import torch
+
+    from whowhatbench.inputs_preprocessors.glm import GlmEdgeVInputsPreprocessor
+
+    class _FakeTokenizer:
+        chat_template = "dummy"
+
+        def apply_chat_template(
+            self, messages, add_generation_prompt=True, return_dict=True,
+            tokenize=True, return_tensors="pt",
+        ):
+            # one image => must contain image content entries
+            has_image = any(
+                c.get("type") == "image"
+                for m in messages
+                for c in m["content"]
+            )
+            assert has_image
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.tensor([[1, 1, 1]]),
+            }
+
+    class _FakeImageProcessor:
+        image_mean = [0.5, 0.5, 0.5]
+
+        def __call__(self, images):
+            return types.SimpleNamespace(
+                pixel_values=np.zeros((1, 1, 1, 3, 4, 4), dtype="float32")
+            )
+
+    class _FakeImage:
+        pass
+
+    config = _FakeGlmVLMConfig()
+    config._name_or_path = "some/glm-edge-v"
+
+    pp = GlmEdgeVInputsPreprocessor()
+    # Inject the fake image processor so no download is attempted.
+    pp._image_processor = _FakeImageProcessor()
+
+    inputs = pp.preprocess_inputs(
+        "What is shown?",
+        image=_FakeImage(),
+        processor=_FakeTokenizer(),
+        tokenizer=_FakeTokenizer(),
+        config=config,
+        video=None,
+    )
+
+    assert "input_ids" in inputs
+    assert "attention_mask" in inputs
+    assert "pixel_values" in inputs
+    assert inputs["pixel_values"].shape[-3:] == (3, 4, 4)
+
+
+def test_glm_preprocessor_rejects_video():
+    from whowhatbench.inputs_preprocessors.glm import GlmEdgeVInputsPreprocessor
+
+    pp = GlmEdgeVInputsPreprocessor()
+
+    class _FakeTokenizer:
+        chat_template = "dummy"
+
+    with pytest.raises(ValueError):
+        pp.preprocess_inputs(
+            "text",
+            image=None,
+            processor=_FakeTokenizer(),
+            tokenizer=_FakeTokenizer(),
+            config=_FakeGlmVLMConfig(),
+            video=object(),
+        )

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -8,6 +8,7 @@ from .qwen2 import Qwen2VLInputsPreprocessor
 from .qwen3 import Qwen3VLInputsPreprocessor, Qwen3_5VLInputsPreprocessor
 from .gemma3 import Gemma3InputsPreprocessor
 from .gemma4 import Gemma4InputsPreprocessor, Gemma4UnifiedInputsPreprocessor
+from .glm import GlmEdgeVInputsPreprocessor
 from .vlm_inputs_preprocessor import VLMInputsPreprocessor
 
 MODEL_TYPE_TO_CLS_MAPPING = {
@@ -30,6 +31,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "llava_next": LLAVAInputsPreprocessor,
     "llava-qwen2": NanoLlavaInputsPreprocessor,
     "internvl_chat": InternVLInputsPreprocessor,
+    "glm": GlmEdgeVInputsPreprocessor,
 }
 
 __all__ = ["MODEL_TYPE_TO_CLS_MAPPING", "VLMInputsPreprocessor"]

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
@@ -1,0 +1,114 @@
+import numpy as np
+import torch
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+)
+from typing import TYPE_CHECKING, Optional, Union, Any
+
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+class GlmEdgeVInputsPreprocessor(VLMInputsPreprocessor):
+    """Inputs preprocessor for the GLM-Edge-V family (config.model_type == "glm"
+    with a ``vision_config``).
+
+    Unlike most VLMs, GLM-Edge-V does not ship a combined ``AutoProcessor``:
+    ``AutoProcessor.from_pretrained`` resolves to the text tokenizer only, and
+    the image side is a separate ``AutoImageProcessor`` (an ``MllamaImageProcessor``).
+    So both ``processor`` and ``tokenizer`` passed here are the text tokenizer;
+    the image processor is loaded here from ``config._name_or_path``.
+
+    The documented inference contract is:
+      * tokenizer.apply_chat_template(messages, add_generation_prompt=True,
+        return_dict=True, tokenize=True, return_tensors="pt") produces
+        ``input_ids``/``attention_mask`` with ``config.vision_config`` worth of
+        ``<|begin_of_image|>`` (``boi_token_id``) placeholder tokens per image;
+      * ``AutoImageProcessor(image).pixel_values`` produces a
+        ``[batch, num_media, num_tiles, 3, H, W]`` tensor;
+      * ``model.generate(input_ids=..., attention_mask=..., pixel_values=...)``.
+    """
+
+    def __init__(self, chat_mode: bool = False, model: Optional[Any] = None):
+        super().__init__(chat_mode)
+        self._image_processor = None
+        if model is not None:
+            self.def_image_token_id = getattr(model.config, "boi_token_id", None)
+        else:
+            self.def_image_token_id = None
+
+    def update_chat_history_with_answer(self, answer):
+        self.chat_history.append(
+            {"role": "assistant", "content": [{"type": "text", "text": answer}]}
+        )
+
+    def _get_image_processor(self, processor, config):
+        # If the object handed to us already behaves like an image processor
+        # (i.e. exposes pixel_values), reuse it directly.
+        if processor is not None and hasattr(processor, "image_mean"):
+            return processor
+        if self._image_processor is None:
+            if config is None or getattr(config, "_name_or_path", None) is None:
+                raise ValueError(
+                    "Cannot resolve the GLM-Edge-V image processor: config with "
+                    "'_name_or_path' is required."
+                )
+            self._image_processor = AutoImageProcessor.from_pretrained(
+                config._name_or_path, trust_remote_code=True
+            )
+        return self._image_processor
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+        if tokenizer.chat_template is None:
+            raise ValueError("Chat template is not set for the GLM-Edge-V tokenizer.")
+
+        if image is not None and not isinstance(image, list):
+            image = [image]
+        self.update_images(image)
+
+        content = []
+        if image is not None:
+            content.extend([{"type": "image"}] * len(image))
+        content.append({"type": "text", "text": text})
+
+        if self.chat_mode:
+            self.chat_history.append({"role": "user", "content": content})
+            messages = self.chat_history
+        else:
+            messages = [{"role": "user", "content": content}]
+
+        inputs = tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            return_dict=True,
+            tokenize=True,
+            return_tensors="pt",
+        )
+        inputs = dict(inputs)
+
+        if self.images:
+            image_processor = self._get_image_processor(processor, config)
+            pixel_values = image_processor(self.images).pixel_values
+            inputs["pixel_values"] = torch.as_tensor(pixel_values)
+
+        return inputs

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -424,6 +424,24 @@ def load_visual_text_model(
             config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
             trust_remote_code = True
 
+        # Some visual-language models reuse a config.model_type that also has a
+        # built-in *text-only* implementation in transformers (e.g. GLM-Edge-V
+        # ships config.model_type == "glm" with a vision_config and custom
+        # remote modeling code). In that case AutoConfig(trust_remote_code=False)
+        # succeeds and would silently load the text-only class, dropping the
+        # vision tower and rejecting pixel_values. Detect the custom multimodal
+        # remote code via auto_map + vision_config and force remote code loading.
+        if (
+            not trust_remote_code
+            and getattr(config, "vision_config", None) is not None
+            and isinstance(getattr(config, "auto_map", None), dict)
+            and any(
+                key in config.auto_map
+                for key in ("AutoModelForCausalLM", "AutoModelForImageTextToText", "AutoModelForVision2Seq")
+            )
+        ):
+            trust_remote_code = True
+
         # force downloading to .cache image_processing file, as it is not happened by default
         if config.model_type.lower() in ["minicpmo"]:
             from transformers import AutoImageProcessor
@@ -460,7 +478,11 @@ def load_visual_text_model(
                     from transformers import AutoModelForImageTextToText
 
                     model_cls = AutoModelForImageTextToText
-                elif config.model_type in ["gemma3", "gemma3n"]:
+                elif config.model_type in ["gemma3", "gemma3n", "glm"]:
+                    # These VLMs expose the generation-capable class through
+                    # AutoModelForCausalLM (their auto_map maps AutoModel to the
+                    # base model without a generate() method). GLM-Edge-V uses
+                    # config.model_type == "glm" with a vision_config.
                     model_cls = AutoModelForCausalLM
 
                 model = model_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)

--- a/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
@@ -124,7 +124,18 @@ class VisualTextEvaluator(TextEvaluator):
             pruning_ratio,
             relevance_weight,
         ):
-            if model.config.model_type in MODEL_TYPE_TO_CLS_MAPPING and "transformers" in str(type(model)):
+            use_wwb_preprocessor = model.config.model_type in MODEL_TYPE_TO_CLS_MAPPING and (
+                "transformers" in str(type(model))
+                # GLM-Edge-V (config.model_type == "glm" with a vision_config)
+                # does not ship a combined AutoProcessor, so Optimum's
+                # preprocess_inputs (which expects an image processor in
+                # `processor`) fails when WWB passes the text tokenizer. The
+                # WWB preprocessor resolves the image processor itself and works
+                # for both the HF Transformers and Optimum/OpenVINO GenAI
+                # backends.
+                or model.config.model_type == "glm"
+            )
+            if use_wwb_preprocessor:
                 inputs_processor = MODEL_TYPE_TO_CLS_MAPPING[model.config.model_type]()
                 preprocess_inputs = inputs_processor.preprocess_inputs
             else:


### PR DESCRIPTION
## Description

Enabled GLM-Edge-V (model_type 'glm' + SigLIP vision_config) in the GenAI VLM pipeline. Added VLMModelType::GLM_EDGE_V, glm_edge_v/classes.{hpp,cpp} (Mllama-style vision preprocessing + boi_token image-embedding merge), factory registration, and image_pad_token config. Rebuilt local GenAI; text-only and image-text outputs match optimum-intel exactly; WWB similarity 1.0 for both optimum and genai. Added tiny-random GLM-Edge-V coverage to test_vlm_pipeline.py (66 local passes) and a WWB evaluator fix so GLM uses the WWB preprocessor on the Optimum path. Updated supported-models docs.

## Reproduce generation

```python
import numpy as np, requests, PIL.Image, openvino as ov, openvino_genai as ov_genai
MODEL_DIR = "ov_model_glm"
pipe = ov_genai.VLMPipeline(MODEL_DIR, "CPU")
cfg = ov_genai.GenerationConfig(); cfg.max_new_tokens = 50; cfg.do_sample = False
url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = ov.Tensor(np.array(PIL.Image.open(requests.get(url, stream=True).raw).convert("RGB")))
out = pipe.generate("What is shown in this image?", images=[image], generation_config=cfg)
print(out)
```

## Validation

- WWB Optimum similarity: **1.0**
- WWB GenAI similarity: **1.0**
- First-token latency: **Not run**
- Throughput: **Not run**

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1876

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.

## Changed files

- `src/cpp/src/visual_language/vlm_config.hpp`
- `src/cpp/src/visual_language/vlm_config.cpp`
- `src/cpp/src/visual_language/glm_edge_v/classes.hpp`
- `src/cpp/src/visual_language/glm_edge_v/classes.cpp`
- `src/cpp/src/visual_language/vision_encoder.cpp`
- `src/cpp/src/visual_language/inputs_embedder.hpp`
- `src/cpp/src/visual_language/inputs_embedder.cpp`
- `tests/python_tests/test_vlm_pipeline.py`
- `tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py`
- `site/docs/supported-models/_components/vlm-models-table/models.ts`
- `ite/docs/supported-models/_components/vlm-models-table/models.ts`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py`
- `tools/who_what_benchmark/whowhatbench/model_loaders.py`
- `.model_analysis/`
- `src/cpp/src/visual_language/glm_edge_v/`
- `tools/who_what_benchmark/tests/test_glm_visual_text.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py`
