### PR TITLE
[llm_bench] Restore Python < 3.11 compatibility for av

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -42,6 +42,7 @@ torchcodec<=0.11.1; sys_platform == "linux"
 torchvision>=0.16,<=0.27.0
 soundfile==0.14.0
 # For OpenGVLab/VideoChat-Flash-Qwen2_5-7B_InternVideo2-1B
-av==18.0.0
+av==17.1.0; python_version < "3.11"
+av==18.0.0; python_version >= "3.11"
 imageio==2.37.3
 decord==0.6.0; platform_system != "Darwin"


### PR DESCRIPTION
This is port of https://github.com/openvinotoolkit/openvino.genai/pull/4129

[CVS-190670](https://jira.devtools.intel.com/browse/CVS-190670)

The dependency set was resolving av 18.0.0, and av 18 no longer supports Python 3.10.
Failing convert jobs in this path still run on Python 3.10, so installation failed at av first, which left the environment partially installed and caused downstream runtime errors later in the pipeline.
Pinning av 17.1.0 for Python 3.10 restores successful dependency installation and makes those jobs deterministic again.
For newer runtimes, Python 3.11+ can still use av 18.0.0, so this is backward-compatible and does not block forward upgrades.