### PR TITLE
[OMNI] Preserve ChatHistory multimodal input for speech

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -636,12 +636,15 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     std::vector<ov::Tensor> input_embeds_list;
     std::vector<ov::Tensor> token_type_ids_list;
     std::vector<std::pair<ov::Tensor, std::optional<int64_t>>> position_ids_list;
-    // FIXME original_prompt_ids_list is not populated for VLM prompt lookup with ChatHistory API
     std::vector<ov::Tensor> original_prompt_ids_list;
     std::vector<std::unordered_map<std::string, ov::Tensor>> lm_extra_inputs_list;
 
     std::vector<VLMPerfMetrics> vlm_perf_metrics(histories.size());
     bool recalculate_merged_embeddings = images_vector.size() > 0 || videos_vector.size() > 0;
+    const bool capture_prompt_ids = std::any_of(sampling_params.begin(), sampling_params.end(),
+                                                [](const GenerationConfig& params) {
+                                                    return params.return_omni_outputs;
+                                                });
 
     std::vector<VLMChatContext> chat_contexts;
     chat_contexts.reserve(histories.size());
@@ -683,6 +686,12 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         m_inputs_embedder->set_apply_chat_template_status(false);
 
+        // Capture the exact multimodal prompt-token slice consumed by the Thinker. Omni Talker
+        // needs these IDs, but collecting them must not force ChatHistory through the string path.
+        const size_t cache_size_before = capture_prompt_ids
+                             ? m_inputs_embedder->get_cache_state().get_state().size()
+                             : 0;
+
         if (m_inputs_embedder->has_token_type_ids()) {
             auto [embeds, tt_ids] =
                 m_inputs_embedder->get_inputs_embeds_with_token_type_ids(templated_history,
@@ -705,6 +714,16 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                                                                                 processed_chat_data.video_sequence,
                                                                                 processed_chat_data.vision_counts));
         }
+
+                                            if (capture_prompt_ids) {
+                                                const auto& cache_ids = m_inputs_embedder->get_cache_state().get_state();
+                                                OPENVINO_ASSERT(cache_ids.size() >= cache_size_before,
+                                                                "Inputs embedder token cache unexpectedly shrank while processing ChatHistory");
+                                                const size_t new_tokens = cache_ids.size() - cache_size_before;
+                                                ov::Tensor prompt_ids_tensor(ov::element::i64, {1, new_tokens});
+                                                std::copy(cache_ids.begin() + cache_size_before, cache_ids.end(), prompt_ids_tensor.data<int64_t>());
+                                                original_prompt_ids_list.push_back(std::move(prompt_ids_tensor));
+                                            }
 
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[i].get_shape()[1], 0));
 
@@ -750,6 +769,11 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         gen_result.perf_metrics.m_evaluated = false;
         gen_result.perf_metrics.evaluate_statistics(generate_start_time);
+
+        if (!result.m_intermediate_hidden_states.empty()) {
+            gen_result.intermediate_hidden_states = std::move(result.m_intermediate_hidden_states);
+            gen_result.full_token_ids = std::move(result.m_full_token_ids);
+        }
 
         results.emplace_back(gen_result);
 

--- a/src/cpp/src/omni/pipeline_impl.cpp
+++ b/src/cpp/src/omni/pipeline_impl.cpp
@@ -103,17 +103,13 @@ OmniDecodedResults OmniPipeline::OmniPipelineImpl::generate(const ChatHistory& h
                     ") must match videos size (", videos.size(), ") or be empty");
 
     if (talker_speech_config.return_audio) {
-        // Speech output requires the prompts overload's per-prompt loop, which captures the
-        // prompt-id slice into VLMDecodedResults::prompt_ids. The histories overload doesn't
-        // yet wire that capture (CB pipeline_base.cpp leaves original_prompt_ids_list empty
-        // for the ChatHistory path — see the FIXME there). Apply the chat template here and
-        // route through the prompts path so speech generation has its prompt_ids.
-        const std::string templated_prompt = m_vlm->get_tokenizer().apply_chat_template(history, true);
         GenerationConfig text_cfg = text_config;
-        text_cfg.apply_chat_template = false;
         text_cfg.return_omni_outputs = true;
+        // Keep multimodal normalization inside the ChatHistory path. Applying the chat template
+        // first and routing the resulting string through the prompt overload would place image
+        // and audio tags outside the user message and can change Thinker output.
         VLMDecodedResults vlm_result =
-            m_vlm->generate(templated_prompt, images, videos, audios, videos_metadata, text_cfg, streamer);
+            m_vlm->generate(history, images, videos, audios, videos_metadata, text_cfg, streamer);
         TalkerResults talker_result = m_talker->generate(vlm_result, talker_speech_config, speech_streamer);
         OmniDecodedResults omni_result;
         static_cast<VLMDecodedResults&>(omni_result) = std::move(vlm_result);


### PR DESCRIPTION
Issue
When return_audio was enabled for an OmniPipeline request using ChatHistory, the pipeline applied the chat template first and then routed the resulting string through the regular prompt overload.

For Qwen3-Omni, multimodal normalization inserts image and audio tokens into the user message. Routing an already-templated string through the prompt overload could therefore place multimodal tokens outside the intended user-message structure.

As a result, enabling speech could change the Thinker input and generated text, even though return_audio should only enable additional speech generation.

Root Cause
The speech path used the string-prompt overload as a workaround because the continuous-batching ChatHistory path did not provide the prompt token IDs and hidden-state outputs required by the Talker.

This caused the text-only and speech-enabled paths to construct the multimodal prompt differently:

Text-only: normalize each ChatHistory message, then apply the chat template.
Speech-enabled: apply the chat template first, then normalize the resulting string.
Solution
This change keeps speech-enabled requests on the native ChatHistory path and adds the missing Omni outputs directly to that path:

Preserve the normal ChatHistory multimodal normalization order.
Capture the exact prompt-token slice consumed by the Thinker.
Propagate intermediate hidden states and full token IDs to the Talker.
Limit prompt-ID capture to requests with return_omni_outputs=true, leaving regular VLM and text-only requests unchanged.


<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-180271


## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
