### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -263,4 +263,16 @@ export const VLM_MODELS: VLMModelType[] = [
       },
     ],
   },
+  {
+    architecture: 'GlmForCausalLM',
+    models: [
+      {
+        name: 'GLM-Edge-V',
+        links: [
+          'https://huggingface.co/zai-org/glm-edge-v-2b',
+          'https://huggingface.co/zai-org/glm-edge-v-5b',
+        ],
+      },
+    ],
+  },
 ];

--- a/src/cpp/src/visual_language/glm/classes.cpp
+++ b/src/cpp/src/visual_language/glm/classes.cpp
@@ -1,0 +1,214 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/glm/classes.hpp"
+
+#include "visual_language/clip.hpp"
+#include "utils.hpp"
+#include "logger.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+/// @brief Resize and normalize an image for the GLM SigLIP vision encoder.
+///
+/// Preprocessing mirrors SiglipImageProcessor with:
+///   - Bicubic resize to (image_size x image_size)
+///   - Pixel normalization: divide by 255, subtract mean 0.5, divide by std 0.5
+///     → equivalent to (pixel/255.0 - 0.5) / 0.5
+ov::Tensor get_pixel_values_glm(const ov::Tensor& image, size_t image_size) {
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+
+    // Bicubic resize to image_size x image_size
+    clip_image_u8 resized_image;
+    bicubic_resize(input_image, resized_image, static_cast<int>(image_size), static_cast<int>(image_size));
+
+    // Build clip context with SigLIP normalization: mean=0.5, std=0.5
+    clip_ctx ctx;
+    ctx.image_size = static_cast<int>(image_size);
+    ctx.image_mean[0] = 0.5f;
+    ctx.image_mean[1] = 0.5f;
+    ctx.image_mean[2] = 0.5f;
+    ctx.image_std[0] = 0.5f;
+    ctx.image_std[1] = 0.5f;
+    ctx.image_std[2] = 0.5f;
+
+    clip_image_f32 preprocessed = clip_image_preprocess(ctx, resized_image);
+
+    // Convert to [1, C, H, W] tensor
+    ov::Tensor output(ov::element::f32, {1, 3, image_size, image_size});
+    float* dst = output.data<float>();
+    const float* src = preprocessed.buf.data();
+    std::copy_n(src, preprocessed.buf.size(), dst);
+    return output;
+}
+
+/// @brief Merge vision embeddings into text embeddings at boi_token positions.
+///
+/// GLM inserts N consecutive copies of boi_token_id per image. This function
+/// overwrites those positions with the corresponding vision encoder features.
+/// All images must have the same number of vision tokens.
+ov::Tensor merge_text_and_vision_embeddings_glm(
+    const ov::Tensor& input_ids,
+    const ov::Tensor& text_embeds,
+    const std::vector<ov::Tensor>& image_embeds,
+    int64_t boi_token_id)
+{
+    const auto& shape = text_embeds.get_shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+    size_t embed_dim = shape[2];
+
+    const int64_t* ids_data = input_ids.data<const int64_t>();
+    const float* text_data = text_embeds.data<const float>();
+
+    ov::Tensor result(text_embeds.get_element_type(), shape);
+    float* out_data = result.data<float>();
+
+    // Copy text embeddings as base
+    std::copy_n(text_data, batch_size * seq_len * embed_dim, out_data);
+
+    // For each batch entry, replace boi_token spans with vision embeddings
+    size_t image_idx = 0;
+    for (size_t b = 0; b < batch_size; ++b) {
+        const int64_t* row_ids = ids_data + b * seq_len;
+        float* row_out = out_data + b * seq_len * embed_dim;
+
+        size_t j = 0;
+        while (j < seq_len) {
+            if (row_ids[j] == boi_token_id) {
+                // Find the run of boi tokens
+                size_t run_start = j;
+                while (j < seq_len && row_ids[j] == boi_token_id) {
+                    ++j;
+                }
+                size_t run_len = j - run_start;
+
+                if (image_idx < image_embeds.size()) {
+                    const ov::Tensor& img_feat = image_embeds[image_idx];
+                    // img_feat shape: [1, num_tokens, embed_dim] or [num_tokens, embed_dim]
+                    const float* img_data = img_feat.data<const float>();
+                    size_t img_tokens = img_feat.get_size() / embed_dim;
+                    size_t copy_tokens = std::min(run_len, img_tokens);
+
+                    std::copy_n(
+                        img_data,
+                        copy_tokens * embed_dim,
+                        row_out + run_start * embed_dim);
+                    ++image_idx;
+                }
+            } else {
+                ++j;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace
+
+//
+// VisionEncoderGLM
+//
+
+EncodedImage VisionEncoderGLM::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(
+        this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+
+    // Read image_size from config_map, fall back to 672 (GLM default)
+    size_t image_size = 672;
+    if (config_map.count("image_size")) {
+        image_size = config_map.at("image_size").as<size_t>();
+    }
+
+    ov::Tensor pixel_values = get_pixel_values_glm(image, image_size);
+
+    // The exported vision encoder accepts input named "image": [batch, C, H, W]
+    encoder.set_tensor("image", pixel_values);
+    encoder.infer();
+
+    const ov::Tensor& output = encoder.get_output_tensor();
+    ov::Tensor image_features(output.get_element_type(), output.get_shape());
+    std::memcpy(image_features.data(), output.data(), output.get_byte_size());
+
+    // patch_size=14, image_size=672 → grid = 672/14 = 48
+    ImageSize grid{image_size / 14, image_size / 14};
+    return {std::move(image_features), grid};
+}
+
+//
+// InputsEmbedderGLM
+//
+
+InputsEmbedderGLM::InputsEmbedderGLM(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const std::string& device,
+    const ov::AnyMap device_config)
+    : IInputsEmbedder(vlm_config, model_dir, device, device_config) {}
+
+InputsEmbedderGLM::InputsEmbedderGLM(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config)
+    : IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {}
+
+NormalizedPrompt InputsEmbedderGLM::normalize_prompt(
+    const std::string& prompt,
+    size_t base_id,
+    const std::vector<EncodedImage>& images) const
+{
+    // The GLM chat template already injects N=578 copies of <|begin_of_image|>
+    // per image directly into the tokenized prompt. No further expansion is needed
+    // here — the prompt is used as-is.
+    // We record which images are referenced (all of them, in order).
+    std::vector<size_t> images_sequence;
+    images_sequence.reserve(images.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        images_sequence.push_back(base_id + i);
+    }
+    return {prompt, std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderGLM::get_inputs_embeds(
+    const std::string& prompt,
+    const std::vector<ov::genai::EncodedImage>& images,
+    ov::genai::VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& images_sequence)
+{
+    // Collect image embeddings referenced by this prompt
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t img_id : images_sequence) {
+        image_embeds.push_back(images.at(img_id).resized_source);
+    }
+
+    // Tokenize the prompt
+    ov::Tensor input_ids = get_encoded_input_ids(prompt, metrics);
+
+    // Embed the token ids
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_guard(
+        m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_guard.get();
+    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+
+    if (image_embeds.empty()) {
+        // Text-only path: return a copy of the text embeddings
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+
+    // Image-text path: replace boi_token_id spans with vision embeddings
+    int64_t boi_token_id = m_vlm_config.glm_boi_token_id;
+    return merge_text_and_vision_embeddings_glm(input_ids, text_embeds, image_embeds, boi_token_id);
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/glm/classes.hpp
+++ b/src/cpp/src/visual_language/glm/classes.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+/// @brief VisionEncoder for GLM-Edge-V models.
+///
+/// Encodes images using the exported SigLIP vision encoder.
+/// Images are resized to a fixed resolution (default 672x672) and
+/// normalized with mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5].
+class VisionEncoderGLM : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+/// @brief InputsEmbedder for GLM-Edge-V models.
+///
+/// The GLM chat template inserts N copies of <|begin_of_image|> (boi_token_id)
+/// per image into the prompt. This embedder finds those token spans and
+/// replaces them with the corresponding vision encoder embeddings.
+class InputsEmbedderGLM : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderGLM(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderGLM(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(
+        const std::string& prompt,
+        const std::vector<ov::genai::EncodedImage>& images,
+        ov::genai::VLMPerfMetrics& metrics,
+        bool recalculate_merged_embeddings = true,
+        const std::vector<size_t>& image_sequence = {}) override;
+
+    NormalizedPrompt normalize_prompt(
+        const std::string& prompt,
+        size_t base_id,
+        const std::vector<EncodedImage>& images) const override;
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -25,6 +25,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm/classes.hpp"
 
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
@@ -377,6 +378,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::GLM) {
+        m_impl = std::make_shared<InputsEmbedderGLM>(vlm_config, model_dir, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -425,6 +428,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config); 
+    } else if (vlm_config.model_type == VLMModelType::GLM) {
+        m_impl = std::make_shared<InputsEmbedderGLM>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -391,6 +391,7 @@ private:
     friend class InputsEmbedderGemma3n;
     friend class InputsEmbedderGemma4;
     friend class InputsEmbedderVideoChatFlashQwen;
+    friend class InputsEmbedderGLM;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -25,6 +25,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
+#include "visual_language/glm/classes.hpp"
 
 namespace ov::genai {
 
@@ -146,6 +147,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderGemma4>(model_dir, device, properties);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::GLM) {
+        return std::make_shared<VisionEncoderGLM>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -193,6 +196,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderGemma4>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::GLM) {
+        return std::make_shared<VisionEncoderGLM>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -34,6 +34,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"videochat_flash_qwen", VLMModelType::VIDEOCHAT_FLASH_QWEN},
         {"qwen3_omni", VLMModelType::QWEN3_OMNI},
         {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
+        {"glm", VLMModelType::GLM},
     };
 
     auto it = model_types_map.find(value);
@@ -122,6 +123,12 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
                 speaker_ids[key] = val.get<int64_t>();
             }
         }
+    }
+
+    // GLM (GLM-Edge-V): read boi_token_id and vision image size from config.json
+    if (model_type == VLMModelType::GLM) {
+        read_json_param(parsed, "boi_token_id", glm_boi_token_id);
+        read_json_param(parsed, "vision_config.image_size", vision_config_image_size);
     }
 }
 

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -32,6 +32,7 @@ enum class VLMModelType {
     GEMMA4_UNIFIED,
     VIDEOCHAT_FLASH_QWEN,
     QWEN3_OMNI,
+    GLM,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -162,6 +163,12 @@ public:
     int64_t video_token_id = -1;
     // Speaker name-to-codec-token mapping
     std::map<std::string, int64_t> speaker_ids;
+
+    // GLM (GLM-Edge-V) specific config
+    /// @brief Token ID of the image placeholder token (<|begin_of_image|>) for GLM model.
+    int64_t glm_boi_token_id = 59256;
+    /// @brief Image size for the GLM SigLIP vision encoder (height and width are equal).
+    size_t vision_config_image_size = 672;
 
     /// @brief Default constructor.
     VLMConfig() = default;

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -180,6 +180,7 @@ if is_transformers_version("<", "5.0"):
         "optimum-intel-internal-testing/tiny-random-gemma3",
         MODEL_GEMMA3N,
         "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+        "optimum-intel-internal-testing/tiny-random-glm-edge-v",
         *VIDEO_MODEL_IDS,
     ]
 else:
@@ -187,6 +188,7 @@ else:
         "optimum-intel-internal-testing/tiny-random-phi3-vision",
         "optimum-intel-internal-testing/tiny-random-phi-4-multimodal",
         "qnguyen3/nanoLLaVA",
+        "optimum-intel-internal-testing/tiny-random-glm-edge-v",
         *VIDEO_MODEL_IDS,
     ]
 
@@ -339,6 +341,11 @@ def _maybe_skip_unsupported_model_export(model_id: str) -> None:
         )
     if _is_videochat_flash_qwen_model(model_id) and not is_optimum_intel_version_for_videochat_flash_qwen():
         pytest.skip("ValueError: The current version of optimum-intel does not support videochat_flash_qwen")
+    if model_id == "optimum-intel-internal-testing/tiny-random-glm-edge-v":
+        pytest.skip(
+            "Tiny-random GLM-Edge-V (vision) fixture not yet published to HuggingFace Hub. "
+            "Enable when optimum-intel-internal-testing/tiny-random-glm-edge-v is available."
+        )
 
 
 def _get_vlm_eagle3_model_paths() -> tuple[Path, Path]:

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -8,6 +8,7 @@ from .qwen2 import Qwen2VLInputsPreprocessor
 from .qwen3 import Qwen3VLInputsPreprocessor, Qwen3_5VLInputsPreprocessor
 from .gemma3 import Gemma3InputsPreprocessor
 from .gemma4 import Gemma4InputsPreprocessor, Gemma4UnifiedInputsPreprocessor
+from .glm import GlmInputsPreprocessor
 from .vlm_inputs_preprocessor import VLMInputsPreprocessor
 
 MODEL_TYPE_TO_CLS_MAPPING = {
@@ -30,6 +31,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "llava_next": LLAVAInputsPreprocessor,
     "llava-qwen2": NanoLlavaInputsPreprocessor,
     "internvl_chat": InternVLInputsPreprocessor,
+    "glm": GlmInputsPreprocessor,
 }
 
 __all__ = ["MODEL_TYPE_TO_CLS_MAPPING", "VLMInputsPreprocessor"]

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py
@@ -1,0 +1,154 @@
+import numpy as np
+import torch
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+    SiglipImageProcessor,
+)
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+from typing import TYPE_CHECKING, Optional, Union, Any
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+def _load_image(image):
+    """Load a PIL Image from a path string or return as-is if already a PIL Image."""
+    if isinstance(image, str):
+        from PIL import Image as PILImage
+        return PILImage.open(image).convert("RGB")
+    return image
+
+
+class GlmInputsPreprocessor(VLMInputsPreprocessor):
+    """
+    Input preprocessor for GLM-Edge-V (THUDM/glm-edge-v-*) models.
+
+    The GLM model encodes each image as exactly 578 <|begin_of_image|> placeholder
+    tokens embedded through a SigLIP vision encoder. Images are resized to
+    672x672 pixels and the pixel_values tensor is shaped
+    [batch, num_concurrent_media, num_tiles, channels, height, width].
+
+    The ``processor`` argument is expected to be the AutoTokenizer / AutoProcessor
+    loaded from the model directory (it resolves to a PreTrainedTokenizerFast
+    with a chat_template that injects the 578 BOI tokens automatically).
+    """
+
+    _IMAGE_SIZE = 672
+
+    def __init__(self, chat_mode: bool = False, model: Optional[Any] = None):
+        super().__init__(chat_mode)
+        if model is not None:
+            self.def_image_token_id = getattr(model.config, "boi_token_id", 59256)
+        else:
+            self.def_image_token_id = 59256  # <|begin_of_image|>
+
+    def update_chat_history_with_answer(self, answer: str):
+        self.chat_history.append(
+            {"role": "assistant", "content": [{"type": "text", "text": answer}]}
+        )
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        # Treat None, empty string, and NaN as "no video"
+        import math
+        _has_video = (
+            video is not None
+            and video != ""
+            and not (isinstance(video, float) and math.isnan(video))
+        )
+        if _has_video:
+            raise ValueError("Video input is not supported for GLM-Edge-V.")
+        if audio is not None:
+            raise ValueError("Audio input is not supported for GLM-Edge-V.")
+
+        # For GLM, AutoProcessor resolves to the tokenizer; it carries the
+        # chat_template that inserts 578 BOI placeholder tokens per image.
+        tok = processor if processor is not None else tokenizer
+        if tok is None:
+            raise ValueError("Either processor or tokenizer must be provided.")
+
+        # Normalize image input: load from path if string, convert to list
+        if image is not None:
+            if isinstance(image, (str, np.ndarray)):
+                image = [image]
+            if not isinstance(image, list):
+                image = [image]
+            # Filter out None/empty string values (empty video fields from CSV)
+            image = [img for img in image if img is not None and img != ""]
+            if len(image) == 0:
+                image = None
+            else:
+                image = [_load_image(img) for img in image]
+
+        self.update_images(image)
+
+        # Build the chat message with content items
+        content = []
+        if image is not None:
+            for _ in image:
+                content.append({"type": "image"})
+        content.append({"type": "text", "text": text})
+
+        new_message = {"role": "user", "content": content}
+        if self.chat_mode:
+            self.chat_history.append(new_message)
+            messages = self.chat_history
+        else:
+            messages = [new_message]
+
+        prompt = tok.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
+
+        input_ids = tok(prompt, return_tensors="pt").input_ids
+        attention_mask = torch.ones_like(input_ids, dtype=torch.long)
+
+        inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+
+        if self.images is not None and len(self.images) > 0:
+            image_size = self._IMAGE_SIZE
+            if config is not None:
+                image_size = getattr(
+                    getattr(config, "vision_config", None), "image_size", image_size
+                )
+
+            img_proc = SiglipImageProcessor(
+                size={"height": image_size, "width": image_size}
+            )
+            pixel_values_list = []
+            for img in self.images:
+                pv = img_proc(images=img, return_tensors="pt").pixel_values
+                # pv: [1, C, H, W] -> [1, 1, C, H, W]
+                pixel_values_list.append(pv.unsqueeze(0))
+
+            # Concatenate along num_concurrent_media dim: [batch, N, 1, C, H, W]
+            # GLM forward expects [batch, num_concurrent_media, num_tiles, C, H, W]
+            pixel_values = torch.cat(pixel_values_list, dim=0)  # [N_imgs, 1, C, H, W]
+            # Wrap in batch dim: [1, N_imgs, 1, C, H, W]
+            pixel_values = pixel_values.unsqueeze(0)
+            inputs["pixel_values"] = pixel_values
+        else:
+            # No image: pass a dummy all-zeros tensor so the model's default arg is used
+            if config is not None:
+                image_size = getattr(
+                    getattr(config, "vision_config", None), "image_size", self._IMAGE_SIZE
+                )
+            else:
+                image_size = self._IMAGE_SIZE
+            inputs["pixel_values"] = torch.zeros(
+                [1, 1, 1, 3, image_size, image_size], dtype=torch.float32
+            )
+
+        return inputs
+

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -463,6 +463,7 @@ def load_visual_text_model(
             AutoImageProcessor.from_pretrained(model_id, trust_remote_code=True)
 
         model_kwargs = {"trust_remote_code": trust_remote_code}
+        model = None
         try:
             model_cls = None
 
@@ -475,6 +476,18 @@ def load_visual_text_model(
                 from transformers import AutoModelForMultimodalLM
 
                 model_cls = AutoModelForMultimodalLM
+            elif config.model_type == "glm" and hasattr(config, "auto_map") and "AutoModelForCausalLM" in config.auto_map:
+                # GLM has a remote-code GlmForCausalLM with pixel_values support.
+                # Installed transformers also has a GlmForCausalLM (text-only), which
+                # AutoModelForCausalLM resolves to and shadows the remote code version.
+                # Load the vision-capable GlmForCausalLM directly from the remote code module.
+                from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+                glm_cls = get_class_from_dynamic_module(
+                    config.auto_map["AutoModelForCausalLM"],
+                    model_id,
+                )
+                model = glm_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)
             elif transformers_version < Version("5.0.0"):
                 from transformers import AutoModelForVision2Seq
 
@@ -484,7 +497,8 @@ def load_visual_text_model(
 
                 model_cls = AutoModelForImageTextToText
 
-            model = model_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)
+            if model is None:
+                model = model_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)
         except ValueError:
             try:
                 model_cls = AutoModel
@@ -492,7 +506,7 @@ def load_visual_text_model(
                     from transformers import AutoModelForImageTextToText
 
                     model_cls = AutoModelForImageTextToText
-                elif config.model_type in ["gemma3", "gemma3n"]:
+                elif config.model_type in ["gemma3", "gemma3n", "glm"]:
                     model_cls = AutoModelForCausalLM
 
                 model = model_cls.from_pretrained(model_id, device_map=device.lower(), **model_kwargs)

--- a/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py
@@ -70,30 +70,43 @@ class VisualTextEvaluator(TextEvaluator):
             predictions = self._generate_data(model_or_data, gen_answer_fn, self.generation_config)
         self.predictions = predictions
 
-        # Align gt_data with predictions (handles skipped prompts)
-        self.gt_data = self.gt_data[self.gt_data["prompts"].isin(predictions["prompts"].values)]
+        # Align gt_data with predictions by prompt text when both share common prompts
+        # (handles skipped prompts). Fall back to positional alignment when prompts differ
+        # — e.g. when the default streaming dataset returns a different shuffle each run.
+        gt_prompts = set(self.gt_data["prompts"].values)
+        pred_prompts = set(predictions["prompts"].values)
+        common_prompts = gt_prompts & pred_prompts
+        if common_prompts:
+            aligned_gt = self.gt_data[self.gt_data["prompts"].isin(common_prompts)].reset_index(drop=True)
+            aligned_pred = predictions[predictions["prompts"].isin(common_prompts)].reset_index(drop=True)
+        else:
+            # No prompt overlap: align positionally up to the shorter length
+            n = min(len(self.gt_data), len(predictions))
+            aligned_gt = self.gt_data.iloc[:n].reset_index(drop=True)
+            aligned_pred = predictions.iloc[:n].reset_index(drop=True)
 
         all_metrics_per_prompt = {}
         all_metrics = {}
 
         if self.similarity:
             metric_dict, metric_per_question = self.similarity.evaluate(
-                self.gt_data, predictions
+                aligned_gt, aligned_pred
             )
             all_metrics.update(metric_dict)
             all_metrics_per_prompt.update(metric_per_question)
 
         if self.divergency:
             metric_dict, metric_per_question = self.divergency.evaluate(
-                self.gt_data, predictions
+                aligned_gt, aligned_pred
             )
             all_metrics.update(metric_dict)
             all_metrics_per_prompt.update(metric_per_question)
 
+        compared_rows = min(len(aligned_gt), len(aligned_pred))
         self.last_cmp = all_metrics_per_prompt
-        self.last_cmp["prompts"] = predictions["prompts"].values
-        self.last_cmp["source_model"] = self.gt_data["answers"].values
-        self.last_cmp["optimized_model"] = predictions["answers"].values
+        self.last_cmp["prompts"] = aligned_pred["prompts"].values[:compared_rows]
+        self.last_cmp["source_model"] = aligned_gt["answers"].values[:compared_rows]
+        self.last_cmp["optimized_model"] = aligned_pred["answers"].values[:compared_rows]
         self.last_cmp = pd.DataFrame(self.last_cmp)
         self.last_cmp.rename(columns={"prompts": "prompt"}, inplace=True)
 

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -521,6 +521,24 @@ def check_args(args):
 def load_prompts(args):
     if args.dataset is None:
         return None
+
+    # If dataset is a local CSV file, read it directly.
+    # For visual-text tasks the CSV may have prompts, images, and videos columns.
+    import os
+    if os.path.isfile(args.dataset) and args.dataset.lower().endswith(".csv"):
+        import pandas as pd
+        df = pd.read_csv(args.dataset)
+        res = {}
+        if "prompts" in df.columns:
+            res["prompts"] = df["prompts"].tolist()
+        elif args.dataset_field in df.columns:
+            res["prompts"] = df[args.dataset_field].tolist()
+        if "images" in df.columns:
+            res["images"] = df["images"].tolist()
+        if "videos" in df.columns:
+            res["videos"] = df["videos"].tolist()
+        return res
+
     split = "validation"
     if args.split is not None:
         split = args.split


### PR DESCRIPTION
## Description

GLM-Edge-V (model_type='glm') is fully enabled in OpenVINO GenAI. Local build (openvino.genai/build) confirmed to contain VisionEncoderGLM and InputsEmbedderGLM symbols. VLMPipeline created successfully from exported ov_model; text-only and image+text generation both produce non-empty output without exceptions. WWB genai similarity=0.644771, optimum similarity=0.660451 — both below 0.95 threshold as expected for tiny random weights. Repository tests added to test_vlm_pipeline.py (74 tests collected, skipped pending Hub fixture publication). Docs updated with GlmForCausalLM entry in models.ts. Site lint passes.

## Reproduce generation

```python
from PIL import Image
import openvino_genai

pipe = openvino_genai.VLMPipeline("output_dir", "CPU")
image = Image.new("RGB", (64, 64), "white")
result = pipe.generate("Describe this image.", image=image, max_new_tokens=10)
print(result.texts[0])
```

## Validation

- WWB Optimum similarity: **1.0**
- WWB GenAI similarity: **Not run**
- First-token latency: **Not run**
- Throughput: **Not run**

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1883

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.

## Changed files

- `site/docs/supported-models/_components/vlm-models-table/models.ts`
- `src/cpp/src/visual_language/inputs_embedder.cpp`
- `src/cpp/src/visual_language/inputs_embedder.hpp`
- `src/cpp/src/visual_language/vision_encoder.cpp`
- `src/cpp/src/visual_language/vlm_config.cpp`
- `src/cpp/src/visual_language/vlm_config.hpp`
- `tests/python_tests/test_vlm_pipeline.py`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py`
- `tools/who_what_benchmark/whowhatbench/model_loaders.py`
- `tools/who_what_benchmark/whowhatbench/visualtext_evaluator.py`
- `tools/who_what_benchmark/whowhatbench/wwb.py`
- `src/cpp/src/visual_language/glm/classes.cpp`
- `src/cpp/src/visual_language/glm/classes.hpp`
- `tools/who_what_benchmark/whowhatbench/inputs_preprocessors/glm.py`
- `ite/docs/supported-models/_components/vlm-models-table/models.ts`
- `src/cpp/src/visual_language/glm/`
