### PR TITLE
Fix double video frames sampling for Qwen3-VL and Qwen3-Omni

### DIFF
--- a/src/cpp/src/visual_language/qwen3_omni/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.cpp
@@ -112,27 +112,14 @@ EncodedVideo VisionEncoderQwen3Omni::encode_frames(const std::vector<ov::Tensor>
     EncodedVideo encoded_video;
     const auto& config = m_video_processor_config;
 
-    fill_video_metadata(encoded_video, frames.size(), config);
-
-    std::vector<ov::Tensor> sampled_frames;
-    if (!config.do_sample_frames) {
-        sampled_frames = frames;
-    } else {
-        sampled_frames.reserve(encoded_video.metadata.frames_indices.size());
-        for (size_t idx : encoded_video.metadata.frames_indices) {
-            OPENVINO_ASSERT(idx < frames.size(), "Frame index ", idx, " out of range for ", frames.size(), " frames.");
-            sampled_frames.push_back(frames.at(idx));
-        }
-    }
-
-    const auto frames_size = sampled_frames.size();
+    const auto frames_size = frames.size();
     encoded_video.frame_num = (frames_size + config.temporal_patch_size - 1) / config.temporal_patch_size;
 
     size_t frame_id = 0;
     size_t i = 0;
     for (; i + config.temporal_patch_size <= frames_size; i += config.temporal_patch_size) {
-        preprocess_to_patches(std::vector<ov::Tensor>(sampled_frames.begin() + i,
-                                                      sampled_frames.begin() + i + config.temporal_patch_size),
+        preprocess_to_patches(std::vector<ov::Tensor>(frames.begin() + i,
+                                                      frames.begin() + i + config.temporal_patch_size),
                               config,
                               encoded_video.video_features,
                               encoded_video.resized_source_size,
@@ -141,7 +128,7 @@ EncodedVideo VisionEncoderQwen3Omni::encode_frames(const std::vector<ov::Tensor>
         frame_id++;
     }
     for (; i < frames_size; i++) {
-        preprocess_to_patches({sampled_frames[i]},
+        preprocess_to_patches({frames[i]},
                               config,
                               encoded_video.video_features,
                               encoded_video.resized_source_size,

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -333,21 +333,7 @@ std::shared_ptr<ov::Model> patch_weighted_sum_into_pos_model(
 
 EncodedVideo VisionEncoderQwen3VL::encode_frames(const std::vector<ov::Tensor>& frames) {
     EncodedVideo encoded_video;
-
-    fill_video_metadata(encoded_video, frames.size(), m_video_processor_config);
-
-    std::vector<ov::Tensor> sampled_frames;
-    if (!m_video_processor_config.do_sample_frames) {
-        sampled_frames = frames;
-    } else {
-        sampled_frames.reserve(encoded_video.metadata.frames_indices.size());
-        for (size_t idx : encoded_video.metadata.frames_indices) {
-            OPENVINO_ASSERT(idx < frames.size(), "Frame index ", idx, " out of range for ", frames.size(), " frames.");
-            sampled_frames.push_back(frames.at(idx));
-        }
-    }
-
-    VisionEncoderQwen2VL::encode_frames_with_config(encoded_video, sampled_frames, m_video_processor_config);
+    VisionEncoderQwen2VL::encode_frames_with_config(encoded_video, frames, m_video_processor_config);
     return encoded_video;
 }
 


### PR DESCRIPTION
## Description
This PR fixes double video frames sampling for Qwen3-VL and Qwen3-Omni models. The issue was introduced in Qwen3-Omni PR https://github.com/openvinotoolkit/openvino.genai/pull/4102/changes#diff-cd070593e3b32072adb5842fa5074658badebe635278c3d7fd6d33830c6f9f3aL329-R350.

CVS-191298

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation - **N/A**.
