### PR TITLE
[llm_bench] Fix KeyError: 'chat_idx' for text_embed/text_rerank CSV report

### DIFF
--- a/tools/llm_bench/llm_bench_utils/output_csv.py
+++ b/tools/llm_bench/llm_bench_utils/output_csv.py
@@ -155,10 +155,11 @@ def gen_data_to_csv(
     result[f'max_increase_rss_mem({mem_unit.value})'] = round(rss_mem_increase, 5) if rss_mem_increase != '' else rss_mem_increase
     result[f'max_increase_sys_mem({mem_unit.value})'] = round(sys_mem_increase, 5) if sys_mem_increase != '' else sys_mem_increase
     result['prompt_idx'] = iter_data['prompt_idx']
-    result["chat_idx"] = iter_data["chat_idx"]
+    chat_idx = iter_data.get("chat_idx", "")
+    result["chat_idx"] = chat_idx
     result['tokenization_time'] = round(token_time, 5) if token_time != '' else token_time
     result['detokenization_time'] = round(detoken_time, 5) if detoken_time != '' else detoken_time
-    input_idx = iter_data["chat_idx"] if iter_data["chat_idx"] != "" else iter_data["prompt_idx"]
+    input_idx = chat_idx if chat_idx != "" else iter_data["prompt_idx"]
     result["start"], result["end"] = output_json.get_timestamp(iter_data["iteration"], input_idx, iter_timestamp)
     result = result | output_json.get_pre_gen_memory_data(memory_data_collector, print_unit=mem_unit)
 


### PR DESCRIPTION
### Problem

Running `llm_bench` with `-r` (CSV report) on `--task text_embed` or `--task text_rerank` crashes **after** inference completes:

```
File "tools/llm_bench/llm_bench_utils/output_csv.py", line 158, in gen_data_to_csv
    result["chat_idx"] = iter_data["chat_idx"]
KeyError: 'chat_idx'
```

`gen_data_to_csv` reads `iter_data["chat_idx"]` unconditionally. That key is only populated by the text-generation chat pipeline (`gen_iterate_data(chat_idx="")`); the embedding task (`embed_iterate_data`) and the reranking pipeline build their `iter_data` without it. So embedding/reranking benchmarks run to completion, produce valid results, then fail in the report writer.

The writer is only reached when `-r` is passed, which is why the existing `text_embed`/`text_rerank` sample tests (run without `-r`) don't catch it.

### Fix

Read `chat_idx` defensively via `.get("chat_idx", "")`, matching the `""` default the text-gen path already uses.

### Testing

Reproduced the `KeyError` by driving `embed_iterate_data` → `gen_data_to_csv` directly (no model/device needed); confirmed the row writes cleanly with the fix.
