### PR TITLE
Use single tokenizer for VLM CB backend. Gemma4-12b-it template fix

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline.cpp
+++ b/src/cpp/src/continuous_batching/pipeline.cpp
@@ -70,7 +70,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline( const std::filesystem::p
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
         auto non_adapter_properties = extract_adapters_from_properties(properties_without_draft_model);
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, non_adapter_properties.fork());
+        embedder = std::make_shared<InputsEmbedder>(models_path, tokenizer, device, non_adapter_properties.fork());
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -128,7 +128,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(const std::shared_ptr<ov:
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
         auto non_adapter_properties = extract_adapters_from_properties(properties_without_draft_model);
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, non_adapter_properties.fork());
+        embedder = std::make_shared<InputsEmbedder>(models_path, tokenizer, device, non_adapter_properties.fork());
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -184,7 +184,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(
     auto generation_config = utils::from_config_json_if_exists(models_path);
     std::shared_ptr<InputsEmbedder> embedder;
     if (std::filesystem::exists(models_path / "openvino_text_embeddings_model.xml")) {
-        embedder = std::make_shared<InputsEmbedder>(models_path, device, properties_without_draft_model_without_gguf);
+        embedder = std::make_shared<InputsEmbedder>(models_path, tokenizer, device, properties_without_draft_model_without_gguf);
     }
 
     utils::print_scheduler_config_info(scheduler_config);
@@ -278,7 +278,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(
         std::string weights_path = rt_info.at("__weights_path").as<std::string>();
         directory = std::filesystem::path(weights_path).parent_path();
         if (std::filesystem::exists(directory / "openvino_text_embeddings_model.xml")) {
-            embedder = std::make_shared<InputsEmbedder>(directory, device, properties_without_draft_model);
+            embedder = std::make_shared<InputsEmbedder>(directory, tokenizer, device, properties_without_draft_model);
         }
     }
 
@@ -341,7 +341,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(
         std::string weights_path = rt_info.at("__weights_path").as<std::string>();
         directory = std::filesystem::path(weights_path).parent_path();
         if (std::filesystem::exists(directory / "openvino_text_embeddings_model.xml")) {
-            embedder = std::make_shared<InputsEmbedder>(directory, device, properties_without_draft_model);
+            embedder = std::make_shared<InputsEmbedder>(directory, tokenizer, device, properties_without_draft_model);
         }
     }
 
@@ -394,7 +394,7 @@ ContinuousBatchingPipeline::ContinuousBatchingPipeline(
         std::string weights_path = rt_info.at("__weights_path").as<std::string>();
         directory = std::filesystem::path(weights_path).parent_path();
         if (std::filesystem::exists(directory / "openvino_text_embeddings_model.xml")) {
-            embedder = std::make_shared<InputsEmbedder>(directory, device, properties_without_draft_model);
+            embedder = std::make_shared<InputsEmbedder>(directory, tokenizer, device, properties_without_draft_model);
         }
     }
 

--- a/src/cpp/src/visual_language/gemma3/classes.cpp
+++ b/src/cpp/src/visual_language/gemma3/classes.cpp
@@ -54,9 +54,10 @@ EncodedImage VisionEncoderGemma3::encode(const ov::Tensor& image, const ov::AnyM
 InputsEmbedderGemma3::InputsEmbedderGemma3(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) {
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {
         patch_chat_template();
     }
 

--- a/src/cpp/src/visual_language/gemma3/classes.hpp
+++ b/src/cpp/src/visual_language/gemma3/classes.hpp
@@ -24,6 +24,7 @@ public:
     InputsEmbedderGemma3(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/gemma3n/classes.cpp
+++ b/src/cpp/src/visual_language/gemma3n/classes.cpp
@@ -49,9 +49,10 @@ EncodedImage VisionEncoderGemma3n::encode(const ov::Tensor& image, const ov::Any
 
 InputsEmbedderGemma3n::InputsEmbedderGemma3n(const VLMConfig& vlm_config,
                                              const std::filesystem::path& model_dir,
+                                             const Tokenizer& tokenizer,
                                              const std::string& device,
                                              const ov::AnyMap device_config)
-    : IInputsEmbedder(vlm_config, model_dir, device, device_config) {
+    : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {
     auto per_layer_model_path = model_dir / "openvino_text_embeddings_per_layer_model.xml";
     auto core = utils::singleton_core();
     auto model = core.read_model(per_layer_model_path);

--- a/src/cpp/src/visual_language/gemma3n/classes.hpp
+++ b/src/cpp/src/visual_language/gemma3n/classes.hpp
@@ -24,6 +24,7 @@ class InputsEmbedderGemma3n : public InputsEmbedder::IInputsEmbedder {
 public:
     InputsEmbedderGemma3n(const VLMConfig& vlm_config,
                           const std::filesystem::path& model_dir,
+                          const Tokenizer& tokenizer,
                           const std::string& device,
                           const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -6,9 +6,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <sstream>
 #include <iomanip>
 #include <numeric>
+#include <sstream>
 
 #include "logger.hpp"
 #include "utils.hpp"
@@ -148,14 +148,12 @@ size_t get_num_valid_soft_tokens(const PatchExtractionConfig& patch_config,
 /**
  * @brief Populates video metadata and computes frame sampling indices.
  */
-void fill_video_metadata(
-    ov::genai::VideoMetadata& video_metadata,
-    size_t total_num_frames,
-    const ov::genai::VideoProcessorConfig& video_config
-) {
+void fill_video_metadata(ov::genai::VideoMetadata& video_metadata,
+                         size_t total_num_frames,
+                         const ov::genai::VideoProcessorConfig& video_config) {
     if (video_metadata.fps == 0.0f) {
         GENAI_WARN("Gemma4 requires frame timestamps to construct prompts, but fps is not set. "
-               "Defaulting to 24 fps. Please provide VideoMetadata with fps for more accurate results.");
+                   "Defaulting to 24 fps. Please provide VideoMetadata with fps for more accurate results.");
         video_metadata.fps = DEFAULT_METADATA_FPS;
     }
 
@@ -173,7 +171,8 @@ void fill_video_metadata(
     size_t num_frames = video_config.num_frames;
 
     if (num_frames == 0) {
-        num_frames = std::min(total_num_frames, video_config.max_frames > 0 ? video_config.max_frames : total_num_frames);
+        num_frames =
+            std::min(total_num_frames, video_config.max_frames > 0 ? video_config.max_frames : total_num_frames);
     }
 
     num_frames = std::min(num_frames, total_num_frames);
@@ -378,10 +377,9 @@ std::vector<ov::genai::EncodedImage> InputsEmbedderGemma4::encode_images(const s
 
 std::vector<ov::genai::EncodedVideo> InputsEmbedderGemma4::encode_videos(
     const std::vector<ov::Tensor>& videos,
-    const std::vector<VideoMetadata>& videos_metadata
-) {
+    const std::vector<VideoMetadata>& videos_metadata) {
     OPENVINO_ASSERT(videos.size() == videos_metadata.size() || videos_metadata.empty(),
-        "Number of videos and videos metadata must match if metadata provided.");
+                    "Number of videos and videos metadata must match if metadata provided.");
 
     std::vector<EncodedVideo> encoded_videos;
     encoded_videos.reserve(videos.size());
@@ -400,28 +398,25 @@ std::vector<ov::genai::EncodedVideo> InputsEmbedderGemma4::encode_videos(
     return encoded_videos;
 }
 
-NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(
-    const std::string& prompt,
-    size_t base_id,
-    const std::vector<EncodedImage>& images
-) const {
+NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(const std::string& prompt,
+                                                        size_t base_id,
+                                                        const std::vector<EncodedImage>& images) const {
     return normalize_prompt(prompt, base_id, 0, images, {});
 }
 
-NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(
-    const std::string& prompt,
-    size_t base_image_id,
-    size_t base_video_id,
-    const std::vector<EncodedImage>& images,
-    const std::vector<EncodedVideo>& videos
-) const {
+NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(const std::string& prompt,
+                                                        size_t base_image_id,
+                                                        size_t base_video_id,
+                                                        const std::vector<EncodedImage>& images,
+                                                        const std::vector<EncodedVideo>& videos) const {
     const auto& boi = m_vlm_config.boi_token;
     const auto& eoi = m_vlm_config.eoi_token;
     const auto& image_token = m_vlm_config.image_token;
     const auto& video_token = m_vlm_config.video_token;
 
     // Images
-    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_image_id, images.size(), VisionType::IMAGE);
+    auto [unified_prompt, images_sequence] =
+        normalize(prompt, image_token, image_token, base_image_id, images.size(), VisionType::IMAGE);
 
     size_t search_offset = 0;
     for (size_t new_image_id : images_sequence) {
@@ -444,18 +439,16 @@ NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(
     std::vector<size_t> videos_sequence;
     std::tie(unified_prompt, videos_sequence) =
         normalize(unified_prompt, video_token, video_token, base_video_id, videos.size(), VisionType::VIDEO);
-    
+
     expand_video_tags_in_prompt(unified_prompt, videos, videos_sequence, base_video_id);
 
     return {std::move(unified_prompt), std::move(images_sequence), std::move(videos_sequence)};
 }
 
-void InputsEmbedderGemma4::expand_video_tags_in_prompt(
-    std::string& unified_prompt,
-    const std::vector<EncodedVideo>& encoded_videos,
-    const std::vector<size_t>& videos_sequence,
-    size_t video_base_id
-) const {
+void InputsEmbedderGemma4::expand_video_tags_in_prompt(std::string& unified_prompt,
+                                                       const std::vector<EncodedVideo>& encoded_videos,
+                                                       const std::vector<size_t>& videos_sequence,
+                                                       size_t video_base_id) const {
     const auto& boi = m_vlm_config.boi_token;
     const auto& eoi = m_vlm_config.eoi_token;
     const auto& video_token = m_vlm_config.video_token;
@@ -465,29 +458,37 @@ void InputsEmbedderGemma4::expand_video_tags_in_prompt(
         const auto& encoded_video = encoded_videos.at(video_id - video_base_id);
         OPENVINO_ASSERT(encoded_video.frame_num > 0, "Video must contain at least one frame.");
         OPENVINO_ASSERT(encoded_video.metadata.frames_indices.size() >= encoded_video.frame_num,
-            "Video metadata frames_indices size (", encoded_video.metadata.frames_indices.size(),
-            ") must be >= frame_num (", encoded_video.frame_num, ")");
+                        "Video metadata frames_indices size (",
+                        encoded_video.metadata.frames_indices.size(),
+                        ") must be >= frame_num (",
+                        encoded_video.frame_num,
+                        ")");
         OPENVINO_ASSERT(encoded_video.num_video_tokens % encoded_video.frame_num == 0,
-            "num_video_tokens (", encoded_video.num_video_tokens,
-            ") must be divisible by frame_num (", encoded_video.frame_num, ")");
+                        "num_video_tokens (",
+                        encoded_video.num_video_tokens,
+                        ") must be divisible by frame_num (",
+                        encoded_video.frame_num,
+                        ")");
         OPENVINO_ASSERT(encoded_video.metadata.fps > 0.0f,
-            "Video metadata fps must be positive for timestamp calculation");
+                        "Video metadata fps must be positive for timestamp calculation");
 
         const size_t tokens_per_frame = encoded_video.num_video_tokens / encoded_video.frame_num;
 
         // Build expanded tag: "MM:SS <boi><video_token>*N<eoi> MM:SS <boi><video_token>×N<eoi> ..."
         std::string expanded;
         // MM:SS (5) + whitespace (1) + <boi> + <video_token>*N + <eoi> + whitespace (1)
-        const size_t per_frame_expanded_size =  5 + 1 + boi.size() + video_token.size() * tokens_per_frame + eoi.size() + 1;
+        const size_t per_frame_expanded_size =
+            5 + 1 + boi.size() + video_token.size() * tokens_per_frame + eoi.size() + 1;
         expanded.reserve(encoded_video.frame_num * per_frame_expanded_size);
         for (size_t i = 0; i < encoded_video.frame_num; ++i) {
-            const float seconds = static_cast<float>(encoded_video.metadata.frames_indices[i]) / encoded_video.metadata.fps;
+            const float seconds =
+                static_cast<float>(encoded_video.metadata.frames_indices[i]) / encoded_video.metadata.fps;
             const int mins = static_cast<int>(seconds) / 60;
             const int secs = static_cast<int>(seconds) % 60;
 
             std::ostringstream timestamp_ss;
-            timestamp_ss << std::setfill('0') << std::setw(2) << mins
-                << ":" << std::setfill('0') << std::setw(2) << secs;
+            timestamp_ss << std::setfill('0') << std::setw(2) << mins << ":" << std::setfill('0') << std::setw(2)
+                         << secs;
 
             expanded += timestamp_ss.str();
             expanded += " ";
@@ -528,8 +529,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::compute_inputs_embeds(
     const std::vector<EncodedVideo>& videos,
     VLMPerfMetrics& metrics,
     const std::vector<size_t>& images_sequence,
-    const std::vector<size_t>& videos_sequence
-) {
+    const std::vector<size_t>& videos_sequence) {
     std::vector<ov::Tensor> image_embeds;
     image_embeds.reserve(images_sequence.size());
     for (size_t new_image_id : images_sequence) {
@@ -575,16 +575,18 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::compute_inputs_embeds(
 
     // Merge image embeddings at image_token_id positions
     if (!image_embeds.empty()) {
-        inputs_embeds = utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, m_image_token_id);
+        inputs_embeds =
+            utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, m_image_token_id);
     } else {
         inputs_embeds = std::move(text_embeds);
     }
 
     // Merge video embeddings at video_token_id positions
     if (!video_embeds.empty()) {
-        inputs_embeds = utils::merge_text_and_image_embeddings_llava(input_ids, inputs_embeds, video_embeds, m_video_token_id);
+        inputs_embeds =
+            utils::merge_text_and_image_embeddings_llava(input_ids, inputs_embeds, video_embeds, m_video_token_id);
     }
-    
+
     return {std::move(inputs_embeds), std::move(input_ids)};
 }
 
@@ -604,8 +606,7 @@ ov::Tensor InputsEmbedderGemma4::get_inputs_embeds(
     bool recalculate_merged_embeddings,
     const std::vector<size_t>& images_sequence,
     const std::vector<size_t>& videos_sequence,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
-) {
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
     return compute_inputs_embeds(prompt, images, videos, metrics, images_sequence, videos_sequence).first;
 }
 
@@ -628,9 +629,9 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::get_inputs_embeds_with_t
     bool recalculate_merged_embeddings,
     const std::vector<size_t>& images_sequence,
     const std::vector<size_t>& videos_sequence,
-    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
-) {
-    auto [inputs_embeds, input_ids] = compute_inputs_embeds(prompt, images, videos, metrics, images_sequence, videos_sequence);
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
+    auto [inputs_embeds, input_ids] =
+        compute_inputs_embeds(prompt, images, videos, metrics, images_sequence, videos_sequence);
     ov::Tensor token_type_ids = get_token_type_ids(input_ids);
     return {std::move(inputs_embeds), std::move(token_type_ids)};
 }
@@ -655,7 +656,9 @@ ov::Tensor InputsEmbedderGemma4::get_token_type_ids(const ov::Tensor& input_ids)
 void InputsEmbedderGemma4::encode_vision_token_ids() {
     std::call_once(m_vision_token_ids_once_flag, [this]() {
         const auto encoded_vision_tokens =
-            m_tokenizer.encode(m_vlm_config.image_token + m_vlm_config.video_token, ov::genai::add_special_tokens(false)).input_ids;
+            m_tokenizer
+                .encode(m_vlm_config.image_token + m_vlm_config.video_token, ov::genai::add_special_tokens(false))
+                .input_ids;
         OPENVINO_ASSERT(encoded_vision_tokens.get_size() == 2, "Encoded vision tokens must contain two tokens");
         m_image_token_id = encoded_vision_tokens.data<int64_t>()[0];
         m_video_token_id = encoded_vision_tokens.data<int64_t>()[1];

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -676,6 +676,10 @@ const std::unordered_map<std::string, ov::Tensor>& InputsEmbedderGemma4::get_lm_
 }
 
 void InputsEmbedderGemma4::patch_chat_template() {
+    if (m_vlm_config.model_type != VLMModelType::GEMMA4_UNIFIED) {
+        return;
+    }
+
     std::string patched_chat_template = m_tokenizer.get_chat_template();
     // minja does not support Python-style implicit concatenation of adjacent multiline string literals:
     //     "first "

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <iomanip>
 #include <numeric>
+#include <regex>
 #include <sstream>
 
 #include "logger.hpp"
@@ -311,9 +312,12 @@ EncodedVideo VisionEncoderGemma4::encode_frames(const std::vector<ov::Tensor>& f
 
 InputsEmbedderGemma4::InputsEmbedderGemma4(const VLMConfig& vlm_config,
                                            const std::filesystem::path& model_dir,
+                                           const Tokenizer& tokenizer,
                                            const std::string& device,
                                            const ov::AnyMap device_config)
-    : IInputsEmbedder(vlm_config, model_dir, device, device_config) {
+    : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {
+    patch_chat_template();
+
     // per-layer embeddings model is optional, large MOE models don't have it
     if (!has_per_layer_embeddings()) {
         return;
@@ -339,6 +343,8 @@ InputsEmbedderGemma4::InputsEmbedderGemma4(const VLMConfig& vlm_config,
                                            const std::string& device,
                                            const ov::AnyMap device_config)
     : IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {
+    patch_chat_template();
+
     // per-layer embeddings model is optional, large MOE models don't have it
     if (!has_per_layer_embeddings()) {
         return;
@@ -667,6 +673,18 @@ void InputsEmbedderGemma4::encode_vision_token_ids() {
 
 const std::unordered_map<std::string, ov::Tensor>& InputsEmbedderGemma4::get_lm_extra_inputs() const {
     return m_lm_extra_inputs;
+}
+
+void InputsEmbedderGemma4::patch_chat_template() {
+    std::string patched_chat_template = m_tokenizer.get_chat_template();
+    // minja does not support Python-style implicit concatenation of adjacent multiline string literals:
+    //     "first "
+    //     "second"
+    // Normalize the pair to "first second" before parsing.
+    const std::regex multiline_string_concatenation{R"("[ \t]*\r?\n[ \t]*")"};
+    patched_chat_template = std::regex_replace(patched_chat_template, multiline_string_concatenation, "");
+
+    m_tokenizer.set_chat_template(patched_chat_template);
 }
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -676,10 +676,6 @@ const std::unordered_map<std::string, ov::Tensor>& InputsEmbedderGemma4::get_lm_
 }
 
 void InputsEmbedderGemma4::patch_chat_template() {
-    if (m_vlm_config.model_type != VLMModelType::GEMMA4_UNIFIED) {
-        return;
-    }
-
     std::string patched_chat_template = m_tokenizer.get_chat_template();
     // minja does not support Python-style implicit concatenation of adjacent multiline string literals:
     //     "first "

--- a/src/cpp/src/visual_language/gemma4/classes.hpp
+++ b/src/cpp/src/visual_language/gemma4/classes.hpp
@@ -47,14 +47,15 @@ public:
                                  bool recalculate_merged_embeddings = true,
                                  const std::vector<size_t>& image_sequence = {}) override;
 
-    ov::Tensor get_inputs_embeds(const std::string& prompt,
-                                 const std::vector<ov::genai::EncodedImage>& images,
-                                 const std::vector<ov::genai::EncodedVideo>& videos,
-                                 ov::genai::VLMPerfMetrics& metrics,
-                                 bool recalculate_merged_embeddings = true,
-                                 const std::vector<size_t>& image_sequence = {},
-                                 const std::vector<size_t>& videos_sequence = {},
-                                 const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count = {}) override;
+    ov::Tensor get_inputs_embeds(
+        const std::string& prompt,
+        const std::vector<ov::genai::EncodedImage>& images,
+        const std::vector<ov::genai::EncodedVideo>& videos,
+        ov::genai::VLMPerfMetrics& metrics,
+        bool recalculate_merged_embeddings = true,
+        const std::vector<size_t>& image_sequence = {},
+        const std::vector<size_t>& videos_sequence = {},
+        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count = {}) override;
 
     std::pair<ov::Tensor, ov::Tensor> get_inputs_embeds_with_token_type_ids(
         const std::string& prompt,
@@ -77,23 +78,18 @@ public:
 
     std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
 
-    std::vector<ov::genai::EncodedVideo> encode_videos(
-        const std::vector<ov::Tensor>& videos,
-        const std::vector<VideoMetadata>& videos_metadata = {}) override;
+    std::vector<ov::genai::EncodedVideo> encode_videos(const std::vector<ov::Tensor>& videos,
+                                                       const std::vector<VideoMetadata>& videos_metadata = {}) override;
 
-    NormalizedPrompt normalize_prompt(
-        const std::string& prompt,
-        size_t base_id,
-        const std::vector<EncodedImage>& images
-    ) const override;
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t base_id,
+                                      const std::vector<EncodedImage>& images) const override;
 
-    NormalizedPrompt normalize_prompt(
-        const std::string& prompt,
-        size_t base_image_id,
-        size_t base_video_id,
-        const std::vector<EncodedImage>& images,
-        const std::vector<EncodedVideo>& videos
-    ) const override;
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t base_image_id,
+                                      size_t base_video_id,
+                                      const std::vector<EncodedImage>& images,
+                                      const std::vector<EncodedVideo>& videos) const override;
 
     const std::unordered_map<std::string, ov::Tensor>& get_lm_extra_inputs() const override;
 
@@ -114,12 +110,10 @@ private:
     // Extra inputs to pass to the language model
     std::unordered_map<std::string, ov::Tensor> m_lm_extra_inputs;
 
-    void expand_video_tags_in_prompt(
-        std::string& unified_prompt,
-        const std::vector<EncodedVideo>& encoded_videos,
-        const std::vector<size_t>& videos_sequence,
-        size_t video_base_id
-    ) const;
+    void expand_video_tags_in_prompt(std::string& unified_prompt,
+                                     const std::vector<EncodedVideo>& encoded_videos,
+                                     const std::vector<size_t>& videos_sequence,
+                                     size_t video_base_id) const;
 
     ov::Tensor get_per_layer_embeddings(const ov::Tensor& input_ids);
 
@@ -130,14 +124,12 @@ private:
     /// @brief Compute merged text+image embeddings together with the encoded input_ids.
     /// Shared implementation behind get_inputs_embeds() and get_inputs_embeds_with_token_type_ids().
     /// @return A pair of (inputs_embeds, input_ids).
-    std::pair<ov::Tensor, ov::Tensor> compute_inputs_embeds(
-        const std::string& prompt,
-        const std::vector<EncodedImage>& images,
-        const std::vector<EncodedVideo>& videos,
-        VLMPerfMetrics& metrics,
-        const std::vector<size_t>& images_sequence,
-        const std::vector<size_t>& videos_sequence
-    );
+    std::pair<ov::Tensor, ov::Tensor> compute_inputs_embeds(const std::string& prompt,
+                                                            const std::vector<EncodedImage>& images,
+                                                            const std::vector<EncodedVideo>& videos,
+                                                            VLMPerfMetrics& metrics,
+                                                            const std::vector<size_t>& images_sequence,
+                                                            const std::vector<size_t>& videos_sequence);
 
     ov::Tensor get_token_type_ids(const ov::Tensor& input_ids);
 

--- a/src/cpp/src/visual_language/gemma4/classes.hpp
+++ b/src/cpp/src/visual_language/gemma4/classes.hpp
@@ -31,6 +31,7 @@ class InputsEmbedderGemma4 : public InputsEmbedder::IInputsEmbedder {
 public:
     InputsEmbedderGemma4(const VLMConfig& vlm_config,
                          const std::filesystem::path& model_dir,
+                         const Tokenizer& tokenizer,
                          const std::string& device,
                          const ov::AnyMap device_config);
 
@@ -138,6 +139,8 @@ private:
     std::once_flag m_vision_token_ids_once_flag;
 
     void encode_vision_token_ids();
+
+    void patch_chat_template();
 };
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -86,12 +86,13 @@ void InputsEmbedder::IInputsEmbedder::finish_chat() {
 InputsEmbedder::IInputsEmbedder::IInputsEmbedder(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config) :
     m_vlm_config{vlm_config},
     m_vision_encoder(VisionEncoder::create(model_dir, m_vlm_config.model_type, device, device_config)),
     m_embedding(EmbeddingsModel::create(model_dir, m_vlm_config.scale_emb, device, device_config)),
-    m_tokenizer{model_dir, device_config},
+    m_tokenizer{tokenizer},
     m_pruning_processor(std::make_shared<VisionTokenPruningProcessor>(device)) { }
 
 InputsEmbedder::IInputsEmbedder::IInputsEmbedder(
@@ -338,45 +339,51 @@ const std::unordered_map<std::string, ov::Tensor>& InputsEmbedder::IInputsEmbedd
 
 InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
                                const std::string& device,
+                               const ov::AnyMap device_config) :
+    InputsEmbedder(model_dir, Tokenizer(model_dir, device_config), device, device_config) {}
+
+InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
+                               const Tokenizer& tokenizer,
+                               const std::string& device,
                                const ov::AnyMap device_config) {
     auto vlm_config = utils::from_config_json_if_exists<VLMConfig>(model_dir, "config.json");
 
     if (vlm_config.model_type == VLMModelType::MINICPM) {
-        m_impl = std::make_shared<InputsEmbedderMiniCPM>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderMiniCPM>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::LLAVA) {
-        m_impl = std::make_shared<InputsEmbedderLLaVA>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderLLaVA>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::NANOLLAVA) {
-        m_impl = std::make_shared<InputsEmbedderNanoLLaVA>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderNanoLLaVA>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::LLAVA_NEXT) {
-        m_impl = std::make_shared<InputsEmbedderLLaVANext>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderLLaVANext>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::LLAVA_NEXT_VIDEO) {
-        m_impl = std::make_shared<InputsEmbedderLLaVANextVideo>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderLLaVANextVideo>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::INTERNVL_CHAT) {
-        m_impl = std::make_shared<InputsEmbedderInternVLChat>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderInternVLChat>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::PHI3_V) {
-        m_impl = std::make_shared<InputsEmbedderPhi3V>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderPhi3V>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::PHI4MM) {
-        m_impl = std::make_shared<InputsEmbedderPhi4MM>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderPhi4MM>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN2_VL) {
-        m_impl = std::make_shared<InputsEmbedderQwen2VL>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderQwen2VL>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN2_5_VL) {
-        m_impl = std::make_shared<InputsEmbedderQwen2_5_VL>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderQwen2_5_VL>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN3_VL) {
-        m_impl = std::make_shared<InputsEmbedderQwen3VL>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderQwen3VL>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN3_5 || vlm_config.model_type == VLMModelType::QWEN3_5_MOE) {
-        m_impl = std::make_shared<InputsEmbedderQwen3_5>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderQwen3_5>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::QWEN3_OMNI) {
-        m_impl = std::make_shared<InputsEmbedderQwen3Omni>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderQwen3Omni>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3) {
-        m_impl = std::make_shared<InputsEmbedderGemma3>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderGemma3>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA3N) {
-        m_impl = std::make_shared<InputsEmbedderGemma3n>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderGemma3n>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA4) {
-        m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::GEMMA4_UNIFIED) {
-        m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
-        m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, device, device_config);
+        m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, tokenizer, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -424,7 +431,7 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
     } else if (vlm_config.model_type == VLMModelType::GEMMA4_UNIFIED) {
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
-        m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config); 
+        m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -35,6 +35,11 @@ struct NormalizedPrompt {
 class InputsEmbedder {
 public:
     InputsEmbedder(const std::filesystem::path& model_dir,
+                   const Tokenizer& tokenizer,
+                   const std::string& device,
+                   const ov::AnyMap device_config);
+
+    InputsEmbedder(const std::filesystem::path& model_dir,
                    const std::string& device,
                    const ov::AnyMap device_config);
 
@@ -295,6 +300,7 @@ private:
         IInputsEmbedder(
             const VLMConfig& vlm_config,
             const std::filesystem::path& model_dir,
+            const Tokenizer& tokenizer,
             const std::string& device,
             const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/internvl_chat/classes.cpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.cpp
@@ -213,9 +213,10 @@ ov::Tensor merge_text_and_image_embeddings_internvl(
 InputsEmbedderInternVLChat::InputsEmbedderInternVLChat(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) { }
 
 InputsEmbedderInternVLChat::InputsEmbedderInternVLChat(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/internvl_chat/classes.hpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.hpp
@@ -24,6 +24,7 @@ public:
     InputsEmbedderInternVLChat(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/llava/classes.cpp
+++ b/src/cpp/src/visual_language/llava/classes.cpp
@@ -64,9 +64,10 @@ EncodedImage VisionEncoderLLaVA::encode( const ov::Tensor& image, const ov::AnyM
 InputsEmbedderLLaVA::InputsEmbedderLLaVA(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) { }
 
 InputsEmbedderLLaVA::InputsEmbedderLLaVA(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/llava/classes.hpp
+++ b/src/cpp/src/visual_language/llava/classes.hpp
@@ -24,6 +24,7 @@ public:
     InputsEmbedderLLaVA(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/llava_next_video/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next_video/classes.cpp
@@ -440,9 +440,10 @@ NormalizedPrompt InputsEmbedderLLaVANextVideo::normalize_prompt(const std::strin
 InputsEmbedderLLaVANextVideo::InputsEmbedderLLaVANextVideo(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    InputsEmbedderLLaVANext(vlm_config, model_dir, device, device_config) { }
+    InputsEmbedderLLaVANext(vlm_config, model_dir, tokenizer, device, device_config) { }
 
 InputsEmbedderLLaVANextVideo::InputsEmbedderLLaVANextVideo(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/llava_next_video/classes.hpp
+++ b/src/cpp/src/visual_language/llava_next_video/classes.hpp
@@ -56,6 +56,7 @@ public:
     InputsEmbedderLLaVANextVideo(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -790,9 +790,10 @@ VisionEncoderMiniCPM::VisionEncoderMiniCPM(
 InputsEmbedderMiniCPM::InputsEmbedderMiniCPM(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) {}
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 InputsEmbedderMiniCPM::InputsEmbedderMiniCPM(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/minicpm/classes.hpp
+++ b/src/cpp/src/visual_language/minicpm/classes.hpp
@@ -48,6 +48,7 @@ public:
     InputsEmbedderMiniCPM(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
     

--- a/src/cpp/src/visual_language/nanollava/classes.cpp
+++ b/src/cpp/src/visual_language/nanollava/classes.cpp
@@ -114,9 +114,10 @@ EncodedImage VisionEncoderNanoLLaVA::encode(const ov::Tensor& image, const ov::A
 InputsEmbedderNanoLLaVA::InputsEmbedderNanoLLaVA(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) { }
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) { }
 
 InputsEmbedderNanoLLaVA::InputsEmbedderNanoLLaVA(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/nanollava/classes.hpp
+++ b/src/cpp/src/visual_language/nanollava/classes.hpp
@@ -24,6 +24,7 @@ public:
     InputsEmbedderNanoLLaVA(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -890,9 +890,10 @@ VisionEncoderPhi3V::VisionEncoderPhi3V(const ModelsMap& models_map,
 InputsEmbedderPhi3V::InputsEmbedderPhi3V(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : IInputsEmbedder(vlm_config, model_dir, device, device_config) {}
+) : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 
 InputsEmbedderPhi3V::InputsEmbedderPhi3V(

--- a/src/cpp/src/visual_language/phi3_vision/classes.hpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.hpp
@@ -48,6 +48,7 @@ public:
     InputsEmbedderPhi3V(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config
     );

--- a/src/cpp/src/visual_language/phi4mm/classes.cpp
+++ b/src/cpp/src/visual_language/phi4mm/classes.cpp
@@ -770,9 +770,10 @@ EncodedImage VisionEncoderPhi4MM::encode(const ov::Tensor& image, const ov::AnyM
 InputsEmbedderPhi4MM::InputsEmbedderPhi4MM(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : IInputsEmbedder(vlm_config, model_dir, device, device_config) {}
+) : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 
 InputsEmbedderPhi4MM::InputsEmbedderPhi4MM(

--- a/src/cpp/src/visual_language/phi4mm/classes.hpp
+++ b/src/cpp/src/visual_language/phi4mm/classes.hpp
@@ -46,6 +46,7 @@ public:
     InputsEmbedderPhi4MM(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config
     );

--- a/src/cpp/src/visual_language/qwen2_5_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2_5_vl/classes.cpp
@@ -94,9 +94,10 @@ ov::Tensor get_cu_window_seqlens(const std::vector<int32_t>& cu_window_seqlens) 
 InputsEmbedderQwen2_5_VL::InputsEmbedderQwen2_5_VL(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config) {}
+    InputsEmbedderQwen2VL(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 InputsEmbedderQwen2_5_VL::InputsEmbedderQwen2_5_VL(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/qwen2_5_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2_5_vl/classes.hpp
@@ -23,6 +23,7 @@ public:
     InputsEmbedderQwen2_5_VL(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -938,9 +938,10 @@ void VisionEncoderQwen2VL::encode_frames_with_config(
 InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config) :
-    IInputsEmbedder(vlm_config, model_dir, device, device_config) {
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {
     auto merger_path = model_dir / "openvino_vision_embeddings_merger_model.xml";
     if (std::filesystem::exists(merger_path)) {
         auto model = utils::singleton_core().read_model(merger_path);

--- a/src/cpp/src/visual_language/qwen2vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.hpp
@@ -63,6 +63,7 @@ public:
     InputsEmbedderQwen2VL(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/qwen3_5/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_5/classes.cpp
@@ -9,9 +9,10 @@ namespace ov::genai {
 InputsEmbedderQwen3_5::InputsEmbedderQwen3_5(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen3VL(vlm_config, model_dir, device, device_config) {}
+) : InputsEmbedderQwen3VL(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 InputsEmbedderQwen3_5::InputsEmbedderQwen3_5(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/qwen3_5/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_5/classes.hpp
@@ -22,6 +22,7 @@ public:
     InputsEmbedderQwen3_5(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/qwen3_omni/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.cpp
@@ -156,9 +156,10 @@ EncodedVideo VisionEncoderQwen3Omni::encode_frames(const std::vector<ov::Tensor>
 
 InputsEmbedderQwen3Omni::InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
                                                  const std::filesystem::path& model_dir,
+                                                 const Tokenizer& tokenizer,
                                                  const std::string& device,
                                                  const ov::AnyMap device_config)
-    : InputsEmbedderQwen3VL(vlm_config, model_dir, device, device_config),
+    : InputsEmbedderQwen3VL(vlm_config, model_dir, tokenizer, device, device_config),
       m_audio_token_id(vlm_config.audio_token_id) {
     // Audio encoder is optional — check is_available() / has_audio_encoder() before encoding
     m_audio_encoder = std::make_unique<AudioEncoderQwen3Omni>(model_dir, vlm_config, device, device_config);
@@ -646,14 +647,12 @@ std::pair<ov::Tensor, int64_t> InputsEmbedderQwen3Omni::create_position_ids(
         }
     }
 
-    // Calculate rope delta from maximum position value 
+    // Calculate rope delta from maximum position value
     // (exclude text dimension which tracks sequence position but isn't consumed by RoPE)
     const size_t num_position_dims = position_ids.get_shape().at(0);
     const size_t num_spatial_dims = num_position_dims - 1;
-    const int64_t position_ids_max_element = *std::max_element(
-        position_ids.data<int64_t>(),
-        position_ids.data<int64_t>() + num_spatial_dims * seq_len
-    );
+    const int64_t position_ids_max_element =
+        *std::max_element(position_ids.data<int64_t>(), position_ids.data<int64_t>() + num_spatial_dims * seq_len);
     const int64_t rope_delta = position_ids_max_element + 1 - static_cast<int64_t>(seq_len);
 
     return {position_ids, rope_delta};

--- a/src/cpp/src/visual_language/qwen3_omni/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.hpp
@@ -41,6 +41,7 @@ class InputsEmbedderQwen3Omni : public InputsEmbedderQwen3VL {
 public:
     InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
                             const std::filesystem::path& model_dir,
+                            const Tokenizer& tokenizer,
                             const std::string& device,
                             const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -354,9 +354,10 @@ EncodedVideo VisionEncoderQwen3VL::encode_frames(const std::vector<ov::Tensor>& 
 InputsEmbedderQwen3VL::InputsEmbedderQwen3VL(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen2VL(vlm_config, model_dir, device, device_config),
+) : InputsEmbedderQwen2VL(vlm_config, model_dir, tokenizer, device, device_config),
     m_use_patched_pos_model(!is_cpp_pos_embeds_fallback_requested()) {
     auto pos_model = utils::singleton_core().read_model(
         model_dir / "openvino_vision_embeddings_pos_model.xml");

--- a/src/cpp/src/visual_language/qwen3_vl/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.hpp
@@ -23,6 +23,7 @@ class InputsEmbedderQwen3VL : public InputsEmbedderQwen2VL {
 public:
     InputsEmbedderQwen3VL(const VLMConfig& vlm_config,
                           const std::filesystem::path& model_dir,
+                          const Tokenizer& tokenizer,
                           const std::string& device,
                           const ov::AnyMap device_config);
 

--- a/src/cpp/src/visual_language/videochat_flash/classes.cpp
+++ b/src/cpp/src/visual_language/videochat_flash/classes.cpp
@@ -1077,9 +1077,10 @@ std::vector<ov::genai::EncodedVideo> InputsEmbedderVideoChatFlashQwen::encode_vi
 InputsEmbedderVideoChatFlashQwen::InputsEmbedderVideoChatFlashQwen(
     const VLMConfig& vlm_config,
     const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : IInputsEmbedder(vlm_config, model_dir, device, device_config) {}
+) : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
 
 InputsEmbedderVideoChatFlashQwen::InputsEmbedderVideoChatFlashQwen(
     const VLMConfig& vlm_config,

--- a/src/cpp/src/visual_language/videochat_flash/classes.hpp
+++ b/src/cpp/src/visual_language/videochat_flash/classes.hpp
@@ -91,6 +91,7 @@ public:
     InputsEmbedderVideoChatFlashQwen(
         const VLMConfig& vlm_config,
         const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
         const std::string& device,
         const ov::AnyMap device_config
     );


### PR DESCRIPTION
## Description

Fix Gemma 4 chat templates containing Python-style implicit multiline string concatenation, which minja does not support.

The Gemma 4 inputs embedder now normalizes adjacent string literals before parsing. Continuous Batching also passes its existing tokenizer to the VLM inputs embedder, ensuring that the patched template is shared and avoiding duplicate tokenizer loading.

### Performance

Local Debug build, Gemma 4 12B, CPU, five runs after warmup:

| Revision | Mean load time | Median |
|---|---:|---:|
| `master` | 1575.2 ms | 1574 ms |
| This PR | 1504.6 ms | 1499 ms |

Loading time improved by **70.6 ms (4.48%)** on average.

Validated by building and running `benchmark_vlm` with the Gemma 4 Continuous Batching pipeline. No documentation changes are required because the public API is unchanged.

CVS-191107

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [NA] Tests have been updated or added to cover the new code. - tested with current scope
- [x] This PR fully addresses the ticket.
- [NA] I have made corresponding changes to the documentation.
