### PR TITLE
[Speculative decoding] Fix Eagle3 KV cache reorder model precision mismatch

### DIFF
--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
@@ -6,7 +6,6 @@
 #include "eagle3_strategy.hpp"
 #include "openvino/pass/pa_kv_reorder_fusion.hpp"
 #include "speculative_decoding/eagle3_model_transforms.hpp"
-#include "logger.hpp"
 
 namespace ov::genai {
 KVUpdateWrapper::KVUpdateWrapper(const ov::genai::ModelDesc& kv_model_desc) {
@@ -92,15 +91,12 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::Eagle3DecodingImpl(const ov::gen
     ov::genai::ModelDesc kv_model_desc;
     kv_model_desc.model = kv_model;
     kv_model_desc.device = std::move(main_device);
-    // only kv cache information is needed for kv update model
-    if (main_model_desc.properties.count(ov::hint::kv_cache_precision.name()) > 0) {
-        kv_model_desc.properties[ov::hint::kv_cache_precision.name()] = main_model_desc.properties.at(ov::hint::kv_cache_precision.name());
-    } else {
-        GENAI_INFO("kv cache precision not specified in main model properties. leave to plugin for default precision.");
-    }
 
-    auto kv_cache_precision =
-        m_main_pipeline->get_model_property(ov::hint::kv_cache_precision.name()).as<ov::element::Type>();
+    // Read the KV cache precision from the compiled main model's key_cache input port rather than
+    // the ov::hint::kv_cache_precision property: plugins may resolve the actual cache precision
+    // (e.g. CPU promoting to bf16 based on inference precision) independently of that hint, and the
+    // reorder model must match the precision of the tensors actually bound by the scheduler.
+    auto kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
     // transformation for kv update model: u4 KV cache is stored as u8 internally,
     // so the reorder pass operates on u8 while the original precision is preserved in rt_info.
     kv_model->set_rt_info(kv_cache_precision, "auxiliary_kv_cache_precision");
@@ -108,7 +104,13 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::Eagle3DecodingImpl(const ov::gen
         kv_cache_precision = ov::element::u8;
     }
     ov::pass::PaKVReorderFusion(kv_cache_precision).run_on_model(kv_model);
-    // add rt_info for real kv precision into kv_model
+    // Pass the resolved (post u4->u8) precision explicitly instead of forwarding the raw
+    // ov::hint::kv_cache_precision value from main_model_desc.properties: for u4 caches that raw
+    // value would still say "u4" while PaKVReorderFusion above already rewrote the key_cache./
+    // value_cache. parameters to u8, and some plugins (e.g. GPU) give an explicitly user-set
+    // kv_cache_precision property priority over the auxiliary_kv_cache_precision rt_info, which
+    // would reintroduce a precision mismatch between the property and the actual parameter type.
+    kv_model_desc.properties[ov::hint::kv_cache_precision.name()] = kv_cache_precision;
     m_kv_update_wrapper = std::make_shared<KVUpdateWrapper>(kv_model_desc);
 
     m_perf_metrics = ov::genai::SDPerModelsPerfMetrics();

--- a/src/cpp/src/speculative_decoding/continuous_batching/pipeline_impl.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/pipeline_impl.hpp
@@ -9,6 +9,7 @@
 #include "continuous_batching/pipeline_impl.hpp"
 #include "openvino/genai/continuous_batching_pipeline.hpp"
 #include "update_request_structs.hpp"
+#include "utils.hpp"
 
 namespace ov::genai {
 class ContinuousBatchingPipeline::ContinuousBatchingForSpeculativeDecodingImpl : public ContinuousBatchingPipeline::ContinuousBatchingImpl {
@@ -71,6 +72,16 @@ public:
                         name,
                         "'");
         return compiled_model.get_property(name);
+    }
+
+    // Returns the actual runtime element type of the compiled model's KV cache inputs.
+    // Plugins may select a KV cache precision that differs from the ov::hint::kv_cache_precision
+    // property value (for example, CPU promotes the cache to bf16 based on the resolved inference
+    // precision regardless of the configured hint), so the precision must be read from the
+    // compiled model's key_cache input port to match the tensors actually bound by the scheduler.
+    ov::element::Type get_kv_cache_element_type() {
+        OPENVINO_ASSERT(m_model_runner, "get_kv_cache_element_type() called before model runner is initialized");
+        return utils::get_compiled_kv_cache_precision(m_model_runner->get_infer_request().get_compiled_model());
     }
 
 protected:

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -803,6 +803,31 @@ size_t get_npu_kv_cache_capacity(const ov::CompiledModel& compiled_model) {
     return max_prompt_len + min_response_len - max_generation_token_len;
 }
 
+ov::element::Type get_compiled_kv_cache_precision(const ov::CompiledModel& compiled_model) {
+    std::optional<ov::element::Type> kv_cache_precision;
+    for (const auto& input : compiled_model.inputs()) {
+        for (const auto& name : input.get_names()) {
+            if (name.find("key_cache.") == 0 || name.find("value_cache.") == 0) {
+                const ov::element::Type precision = input.get_element_type();
+                OPENVINO_ASSERT(!kv_cache_precision || *kv_cache_precision == precision,
+                                "Non-uniform KV cache precision across cache inputs is not supported: got ",
+                                *kv_cache_precision,
+                                " and ",
+                                precision,
+                                " for input '",
+                                name,
+                                "'");
+                kv_cache_precision = precision;
+                break;
+            }
+        }
+    }
+    OPENVINO_ASSERT(
+        kv_cache_precision,
+        "Compiled model does not expose key_cache/value_cache inputs required to determine KV cache precision");
+    return *kv_cache_precision;
+}
+
 std::optional<ov::Any> pop_option(ov::AnyMap& config, const std::string& option_name) {
     if (auto it = config.find(option_name); it != config.end()) {
         std::optional<ov::Any> found = std::make_optional(it->second);

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -257,6 +257,14 @@ std::pair<ov::CompiledModel, KVDesc> compile_decoder_for_npu_text_embedding(cons
 
 size_t get_npu_kv_cache_capacity(const ov::CompiledModel& compiled_model);
 
+/// @brief Reads the runtime KV cache element type from a compiled model's key_cache.* / value_cache.* inputs.
+/// Plugins may resolve the actual cache precision (e.g. CPU promoting to bf16 based on the resolved inference
+/// precision) independently of the ov::hint::kv_cache_precision property, so the precision must be read from the
+/// compiled model's cache input ports to match the tensors actually allocated and bound by the cache manager.
+/// Throws if no cache inputs are present or if the cache inputs use non-uniform precision, since downstream
+/// consumers (e.g. the Eagle3 KV cache reorder model) assume a single precision shared by all key/value inputs.
+ov::element::Type get_compiled_kv_cache_precision(const ov::CompiledModel& compiled_model);
+
 /// @brief SharedOptional is a wrapper around a reference to an existing object and an optional shared alternative value.
 /// The difference from std::optional is that the default state is not empty and contains a reference to an existing object outside the class.
 /// Another difference is that the alternative value is shared between all instances of SharedOptional like std::shared_ptr.


### PR DESCRIPTION

## Description
Fixes a `ParameterMismatch` crash in Eagle3 speculative decoding where the
KV cache reorder helper model expected FP16 tensors while the main model's
compiled KV cache was actually BF16. The reorder model's precision is now
derived from the main model's compiled `key_cache.*` port instead of the
`kv_cache_precision` hint, and propagated consistently everywhere it's used
so plugins don't fall back to a stale/mismatched value. Verified locally
with Qwen3-8B target + Eagle3 draft on CPU, which now generates successfully.

CVS-191392


