### PR TITLE
[WWB] Bump torch to 2.13.0

### DIFF
--- a/tools/who_what_benchmark/requirements.txt
+++ b/tools/who_what_benchmark/requirements.txt
@@ -23,7 +23,7 @@ librosa==0.11.0
 vocos==0.1.0
 vector-quantize-pytorch==1.31.0
 torchaudio>=2.1.0,<=2.11.0
-torchvision>=0.16,<=0.27.0
+torchvision>=0.16,<=0.28.0
 # For LoRA adapters
 peft==0.19.1
 # For OpenGVLab/VideoChat-Flash-Qwen2_5-7B_InternVideo2-1B

--- a/tools/who_what_benchmark/setup.py
+++ b/tools/who_what_benchmark/setup.py
@@ -48,9 +48,9 @@ setup(
     package_data={"whowhatbench": ["prompts/*.yaml", "prompts/*.json"]},
     extras_require={
         "minicpm-o-2_6": [
-            "torch==2.10.0",
-            "torchvision==0.25.0",
-            "torchaudio==2.10.0",
+            "torch==2.13.0",
+            "torchvision==0.28.0",
+            "torchaudio==2.11.0",
             "transformers>=4.50,<=4.51.3",
             "optimum-intel==1.27.0",
         ],


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

Fixes https://github.com/advisories/GHSA-rrmf-rvhw-rf47 (https://github.com/openvinotoolkit/openvino.genai/security/dependabot/182).
I've checked changelog for 2.11, 2.12, 2.13 - no breaking changes for WWB were introduced.
Also bumped torchvision and torchaudio, as they both had requirements torch==2.10.0.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->