### PR TITLE
StatefulLLMPipeline: negotiate NPU chat-history reuse via continuous prefill

### DIFF
--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -23,7 +23,9 @@ StatefulLLMPipeline::StatefulLLMPipeline(
     if (execution_devices[0].find("NPU") != std::string::npos) {
         OPENVINO_ASSERT(execution_devices.size() == 1u);
         m_is_npu = true;
+        m_use_full_chat_history = true;
         m_max_prompt_len = compiled_model.get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>();
+        init_npu_continuous_prefill(compiled_model);
     }
 }
 
@@ -74,6 +76,9 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         utils::KVDesc kv_desc;
         std::tie(compiled_model, kv_desc) = utils::compile_decoder_for_npu(model, *filtered_properties, kv_pos);
         m_max_prompt_len = kv_desc.max_prompt_len;
+        // The capability is only known after compilation, so full chat history stops
+        // being a device rule here and becomes the fallback.
+        init_npu_continuous_prefill(compiled_model);
     } else {
        compiled_model = utils::singleton_core().compile_model(model, device, *filtered_properties);
     }
@@ -156,6 +161,7 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
+    NPUTurnGuard npu_turn_guard(*this);
 
     TokenizedInputs encoded_input;
     auto tokenization_start_time = start_time;
@@ -176,6 +182,8 @@ DecodedResults StatefulLLMPipeline::generate(
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+                if (m_npu_continuous_prefill)
+                    negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
                 encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
             }
         } else if (config.apply_chat_template && !m_tokenizer.get_chat_template().empty()) {
@@ -212,6 +220,8 @@ DecodedResults StatefulLLMPipeline::generate(
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+                if (m_npu_continuous_prefill)
+                    negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
                 encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
             }
             // TODO: Forbid LoRA config change if we are in the chat mode, because it requires regenerating the history with LoRA applied
@@ -240,6 +250,7 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         chat_template_duration_us
     );
+    npu_turn_guard.disarm();
 
     if (is_chat_conversation) {
         if (m_chat_generation_finish_status == ov::genai::GenerationStatus::CANCEL) {
@@ -273,6 +284,8 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
+    // Snapshots the pre-turn history before it is replaced below.
+    NPUTurnGuard npu_turn_guard(*this);
 
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
     OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(), "Chat template must not be empty when using ChatHistory in generate method.");
@@ -307,9 +320,11 @@ DecodedResults StatefulLLMPipeline::generate(
         encoded_input = new_chat_tokens;
     } else {
         ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+        if (m_npu_continuous_prefill)
+            negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
         encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
     }
-    return get_decoded_results(
+    auto decoded_results = get_decoded_results(
         encoded_input,
         config,
         streamer,
@@ -317,6 +332,8 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         PerfMetrics::get_microsec(tokenization_start_time - template_start_time)
     );
+    npu_turn_guard.disarm();
+    return decoded_results;
 }
 
 EncodedResults StatefulLLMPipeline::generate(
@@ -370,6 +387,11 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
+    // Resolved before the alignment block so the negotiation can validate the
+    // response budget, and the turn guard snapshots history before it grows.
+    GenerationConfig config = resolve_generation_config(generation_config);
+    NPUTurnGuard npu_turn_guard(*this);
+
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
 
@@ -382,13 +404,13 @@ EncodedResults StatefulLLMPipeline::generate(
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) {
         ov::Tensor new_chat_tokens = ov::Tensor{ov::element::i64, {1, m_tokenized_chat_history.size()}, m_tokenized_chat_history.data()};
         ov::genai::align_cache_and_history(new_chat_tokens, m_cache_state);
+        if (m_npu_continuous_prefill)
+            negotiate_npu_history_reuse(new_chat_tokens.get_shape().at(1), config);
 
         auto encoded_input = get_chat_encoded_input(new_chat_tokens, m_cache_state);
         input_ids = encoded_input.input_ids;
         attention_mask = encoded_input.attention_mask;
     }
-
-    GenerationConfig config = resolve_generation_config(generation_config);
 
     auto batch_size = input_ids.get_shape().at(0);
 
@@ -416,10 +438,14 @@ EncodedResults StatefulLLMPipeline::generate(
                     "but you have '" + std::to_string(num_inputs) + "' inputs");
 
     if (is_chat_conversation) {
-        if (m_use_full_chat_history)
+        if (m_use_full_chat_history) {
             reset_state();
-        else
+        } else if (!m_npu_continuous_prefill) {
             ov::genai::utils::trim_kv_cache(m_model_runner, m_cache_state, m_adapter_controller);
+        }
+        // With continuous prefill the negotiation already issued the one command for
+        // this turn. The physical trim path stays CPU and GPU only, and no second
+        // state write may happen here.
     }
 
     size_t cache_len = 0;
@@ -494,6 +520,11 @@ EncodedResults StatefulLLMPipeline::generate(
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 
+    // Inference completed, including a cancelled one, which is a successful physically
+    // committed operation and must not go through the failure rollback.
+    npu_turn_guard.disarm();
+    m_forced_full_prefill = false;
+
     if (is_chat_conversation) {
         m_cache_state.num_tokens_to_trim = 0;
 
@@ -528,6 +559,108 @@ void StatefulLLMPipeline::start_chat(const std::string& system_message) {
         return;
 
     m_history.push_back({{"role", "system"}, {"content", system_message}});
+}
+
+void StatefulLLMPipeline::init_npu_continuous_prefill(ov::CompiledModel& compiled_model) {
+    // The capability must come from the read-only property. It must not be probed by
+    // looking for npuw_stored_tokens_state in query_state(), because every existing
+    // plugin build publishes that state and would give a false positive. A plugin
+    // that predates the feature has no such property, which keeps the existing
+    // full-history behaviour automatically.
+    bool supported = false;
+    try {
+        supported = compiled_model.get_property("NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED").as<bool>();
+    } catch (...) {
+        supported = false;
+    }
+    m_npu_continuous_prefill = supported;
+    m_use_full_chat_history = !supported;
+    if (supported) {
+        m_kv_cache_capacity = utils::get_npu_kv_cache_capacity(compiled_model);
+    }
+}
+
+void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config) {
+    OPENVINO_ASSERT(m_npu_continuous_prefill);
+
+    if (m_forced_full_prefill) {
+        // Recovery turn after a failure. The plugin has a pending reset and requires
+        // the complete prompt at cache position zero, and the cache state is already
+        // empty, so no proposal is made.
+        return;
+    }
+
+    // Validate the complete request while the full tokenized history is still in
+    // scope. A failure here must not leave a pending plugin command, so it happens
+    // before the proposal.
+    OPENVINO_ASSERT(full_history_len <= m_max_prompt_len,
+        "Stateful LLM pipeline on NPU may only process prompts or hold chat history up to ",
+        m_max_prompt_len, " tokens. ", full_history_len,
+        " is passed.\n Set the \"MAX_PROMPT_LEN\" config option to increase the limit.");
+    // The final sampled token is returned without being fed through the model and has
+    // no KV entry, hence the minus one on the response budget.
+    const size_t response_budget = std::max<size_t>(config.get_max_new_tokens(full_history_len), 1u);
+    OPENVINO_ASSERT(full_history_len + response_budget - 1 <= m_kv_cache_capacity,
+        "The requested history of ", full_history_len, " tokens plus the response budget of ",
+        response_budget, " tokens does not fit into the NPU KV cache capacity of ",
+        m_kv_cache_capacity, " tokens.");
+
+    auto& state = m_cache_state.get_state();
+    const size_t k_common = state.size();
+    if (k_common == 0) {
+        // Nothing to preserve. A full prompt at position zero is handled by the plugin
+        // whether it is idle or reset pending, and proposing zero while a reset is
+        // already pending would be a protocol error.
+        return;
+    }
+
+    // Propose the common prefix and read the grant back. The write is not idempotent,
+    // the plugin clamps by capacity, chunk alignment and its prefill watermark, so
+    // slicing must happen at the granted value, never at the proposed one.
+    std::optional<ov::VariableState> channel;
+    for (auto& st : m_model_runner.query_state()) {
+        if (st.get_name() == "npuw_stored_tokens_state") {
+            channel = st;
+            break;
+        }
+    }
+    OPENVINO_ASSERT(channel.has_value(), "npuw_stored_tokens_state is missing while continuous prefill is enabled.");
+
+    ov::Tensor proposal(ov::element::i64, {1});
+    proposal.data<int64_t>()[0] = static_cast<int64_t>(k_common);
+    channel->set_state(proposal);
+    const int64_t granted = channel->get_state().data<int64_t>()[0];
+    OPENVINO_ASSERT(granted >= 0 && static_cast<size_t>(granted) <= k_common,
+        "NPU continuous prefill granted an invalid keep of ", granted,
+        " for a proposal of ", k_common, ".");
+
+    // The tokens in [granted, k_common) become part of the delta, since the full
+    // tokenized history is still available to the caller.
+    state.resize(static_cast<size_t>(granted));
+    m_cache_state.num_tokens_to_trim = 0;
+}
+
+void StatefulLLMPipeline::on_npu_turn_failure(ChatHistory history_snapshot,
+                                              std::vector<int64_t> tokenized_history_snapshot) {
+    // One recovery path for every failure point. This deliberately gives up the old
+    // cache even when the plugin rejected during preflight and its cache is intact,
+    // in exchange for a single wire-level recovery sequence. The forced flag comes
+    // first so recovery intent survives even if touching the runner throws again.
+    m_forced_full_prefill = true;
+    m_history = std::move(history_snapshot);
+    m_tokenized_chat_history = std::move(tokenized_history_snapshot);
+    m_cache_state.reset_state();
+    try {
+        for (auto& st : m_model_runner.query_state()) {
+            if (st.get_name() == "npuw_stored_tokens_state") {
+                st.reset();
+                break;
+            }
+        }
+        m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
+    } catch (...) {
+        // Touching the runner must not mask the original failure.
+    }
 }
 
 void StatefulLLMPipeline::reset_state() {

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -23,7 +23,9 @@ StatefulLLMPipeline::StatefulLLMPipeline(
     if (execution_devices[0].find("NPU") != std::string::npos) {
         OPENVINO_ASSERT(execution_devices.size() == 1u);
         m_is_npu = true;
+        m_use_full_chat_history = true;
         m_max_prompt_len = compiled_model.get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>();
+        init_npu_continuous_prefill(compiled_model);
     }
 }
 
@@ -74,6 +76,9 @@ StatefulLLMPipeline::StatefulLLMPipeline(
         utils::KVDesc kv_desc;
         std::tie(compiled_model, kv_desc) = utils::compile_decoder_for_npu(model, *filtered_properties, kv_pos);
         m_max_prompt_len = kv_desc.max_prompt_len;
+        // The capability is only known after compilation, so full chat history stops
+        // being a device rule here and becomes the fallback.
+        init_npu_continuous_prefill(compiled_model);
     } else {
        compiled_model = utils::singleton_core().compile_model(model, device, *filtered_properties);
     }
@@ -156,6 +161,7 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
+    NPUTurnGuard npu_turn_guard(*this);
 
     TokenizedInputs encoded_input;
     auto tokenization_start_time = start_time;
@@ -176,6 +182,8 @@ DecodedResults StatefulLLMPipeline::generate(
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+                if (m_npu_continuous_prefill)
+                    negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
                 encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
             }
         } else if (config.apply_chat_template && !m_tokenizer.get_chat_template().empty()) {
@@ -212,6 +220,8 @@ DecodedResults StatefulLLMPipeline::generate(
                 encoded_input = new_chat_tokens;
             } else {
                 ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+                if (m_npu_continuous_prefill)
+                    negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
                 encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
             }
             // TODO: Forbid LoRA config change if we are in the chat mode, because it requires regenerating the history with LoRA applied
@@ -240,6 +250,7 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         chat_template_duration_us
     );
+    npu_turn_guard.disarm();
 
     if (is_chat_conversation) {
         if (m_chat_generation_finish_status == ov::genai::GenerationStatus::CANCEL) {
@@ -273,6 +284,8 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
+    // Snapshots the pre-turn history before it is replaced below.
+    NPUTurnGuard npu_turn_guard(*this);
 
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
     OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(), "Chat template must not be empty when using ChatHistory in generate method.");
@@ -307,9 +320,11 @@ DecodedResults StatefulLLMPipeline::generate(
         encoded_input = new_chat_tokens;
     } else {
         ov::genai::align_cache_and_history(new_chat_tokens.input_ids, m_cache_state);
+        if (m_npu_continuous_prefill)
+            negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
         encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
     }
-    return get_decoded_results(
+    auto decoded_results = get_decoded_results(
         encoded_input,
         config,
         streamer,
@@ -317,6 +332,8 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         PerfMetrics::get_microsec(tokenization_start_time - template_start_time)
     );
+    npu_turn_guard.disarm();
+    return decoded_results;
 }
 
 EncodedResults StatefulLLMPipeline::generate(
@@ -370,6 +387,11 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
+    // Resolved before the alignment block so the negotiation can validate the
+    // response budget, and the turn guard snapshots history before it grows.
+    GenerationConfig config = resolve_generation_config(generation_config);
+    NPUTurnGuard npu_turn_guard(*this);
+
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
 
@@ -382,13 +404,13 @@ EncodedResults StatefulLLMPipeline::generate(
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS) {
         ov::Tensor new_chat_tokens = ov::Tensor{ov::element::i64, {1, m_tokenized_chat_history.size()}, m_tokenized_chat_history.data()};
         ov::genai::align_cache_and_history(new_chat_tokens, m_cache_state);
+        if (m_npu_continuous_prefill)
+            negotiate_npu_history_reuse(new_chat_tokens.get_shape().at(1), config);
 
         auto encoded_input = get_chat_encoded_input(new_chat_tokens, m_cache_state);
         input_ids = encoded_input.input_ids;
         attention_mask = encoded_input.attention_mask;
     }
-
-    GenerationConfig config = resolve_generation_config(generation_config);
 
     auto batch_size = input_ids.get_shape().at(0);
 
@@ -416,10 +438,14 @@ EncodedResults StatefulLLMPipeline::generate(
                     "but you have '" + std::to_string(num_inputs) + "' inputs");
 
     if (is_chat_conversation) {
-        if (m_use_full_chat_history)
+        if (m_use_full_chat_history) {
             reset_state();
-        else
+        } else if (!m_npu_continuous_prefill) {
             ov::genai::utils::trim_kv_cache(m_model_runner, m_cache_state, m_adapter_controller);
+        }
+        // With continuous prefill the negotiation already issued the one command for
+        // this turn. The physical trim path stays CPU and GPU only, and no second
+        // state write may happen here.
     }
 
     size_t cache_len = 0;
@@ -505,6 +531,11 @@ EncodedResults StatefulLLMPipeline::generate(
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 
+    // Inference completed, including a cancelled one, which is a successful physically
+    // committed operation and must not go through the failure rollback.
+    npu_turn_guard.disarm();
+    m_forced_full_prefill = false;
+
     if (is_chat_conversation) {
         m_cache_state.num_tokens_to_trim = 0;
 
@@ -539,6 +570,108 @@ void StatefulLLMPipeline::start_chat(const std::string& system_message) {
         return;
 
     m_history.push_back({{"role", "system"}, {"content", system_message}});
+}
+
+void StatefulLLMPipeline::init_npu_continuous_prefill(ov::CompiledModel& compiled_model) {
+    // The capability must come from the read-only property. It must not be probed by
+    // looking for npuw_stored_tokens_state in query_state(), because every existing
+    // plugin build publishes that state and would give a false positive. A plugin
+    // that predates the feature has no such property, which keeps the existing
+    // full-history behaviour automatically.
+    bool supported = false;
+    try {
+        supported = compiled_model.get_property("NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED").as<bool>();
+    } catch (...) {
+        supported = false;
+    }
+    m_npu_continuous_prefill = supported;
+    m_use_full_chat_history = !supported;
+    if (supported) {
+        m_kv_cache_capacity = utils::get_npu_kv_cache_capacity(compiled_model);
+    }
+}
+
+void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config) {
+    OPENVINO_ASSERT(m_npu_continuous_prefill);
+
+    if (m_forced_full_prefill) {
+        // Recovery turn after a failure. The plugin has a pending reset and requires
+        // the complete prompt at cache position zero, and the cache state is already
+        // empty, so no proposal is made.
+        return;
+    }
+
+    // Validate the complete request while the full tokenized history is still in
+    // scope. A failure here must not leave a pending plugin command, so it happens
+    // before the proposal.
+    OPENVINO_ASSERT(full_history_len <= m_max_prompt_len,
+        "Stateful LLM pipeline on NPU may only process prompts or hold chat history up to ",
+        m_max_prompt_len, " tokens. ", full_history_len,
+        " is passed.\n Set the \"MAX_PROMPT_LEN\" config option to increase the limit.");
+    // The final sampled token is returned without being fed through the model and has
+    // no KV entry, hence the minus one on the response budget.
+    const size_t response_budget = std::max<size_t>(config.get_max_new_tokens(full_history_len), 1u);
+    OPENVINO_ASSERT(full_history_len + response_budget - 1 <= m_kv_cache_capacity,
+        "The requested history of ", full_history_len, " tokens plus the response budget of ",
+        response_budget, " tokens does not fit into the NPU KV cache capacity of ",
+        m_kv_cache_capacity, " tokens.");
+
+    auto& state = m_cache_state.get_state();
+    const size_t k_common = state.size();
+    if (k_common == 0) {
+        // Nothing to preserve. A full prompt at position zero is handled by the plugin
+        // whether it is idle or reset pending, and proposing zero while a reset is
+        // already pending would be a protocol error.
+        return;
+    }
+
+    // Propose the common prefix and read the grant back. The write is not idempotent,
+    // the plugin clamps by capacity, chunk alignment and its prefill watermark, so
+    // slicing must happen at the granted value, never at the proposed one.
+    std::optional<ov::VariableState> channel;
+    for (auto& st : m_model_runner.query_state()) {
+        if (st.get_name() == "npuw_stored_tokens_state") {
+            channel = st;
+            break;
+        }
+    }
+    OPENVINO_ASSERT(channel.has_value(), "npuw_stored_tokens_state is missing while continuous prefill is enabled.");
+
+    ov::Tensor proposal(ov::element::i64, {1});
+    proposal.data<int64_t>()[0] = static_cast<int64_t>(k_common);
+    channel->set_state(proposal);
+    const int64_t granted = channel->get_state().data<int64_t>()[0];
+    OPENVINO_ASSERT(granted >= 0 && static_cast<size_t>(granted) <= k_common,
+        "NPU continuous prefill granted an invalid keep of ", granted,
+        " for a proposal of ", k_common, ".");
+
+    // The tokens in [granted, k_common) become part of the delta, since the full
+    // tokenized history is still available to the caller.
+    state.resize(static_cast<size_t>(granted));
+    m_cache_state.num_tokens_to_trim = 0;
+}
+
+void StatefulLLMPipeline::on_npu_turn_failure(ChatHistory history_snapshot,
+                                              std::vector<int64_t> tokenized_history_snapshot) {
+    // One recovery path for every failure point. This deliberately gives up the old
+    // cache even when the plugin rejected during preflight and its cache is intact,
+    // in exchange for a single wire-level recovery sequence. The forced flag comes
+    // first so recovery intent survives even if touching the runner throws again.
+    m_forced_full_prefill = true;
+    m_history = std::move(history_snapshot);
+    m_tokenized_chat_history = std::move(tokenized_history_snapshot);
+    m_cache_state.reset_state();
+    try {
+        for (auto& st : m_model_runner.query_state()) {
+            if (st.get_name() == "npuw_stored_tokens_state") {
+                st.reset();
+                break;
+            }
+        }
+        m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
+    } catch (...) {
+        // Touching the runner must not mask the original failure.
+    }
 }
 
 void StatefulLLMPipeline::reset_state() {

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -161,7 +161,6 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
-    NPUTurnGuard npu_turn_guard(*this);
 
     TokenizedInputs encoded_input;
     auto tokenization_start_time = start_time;
@@ -250,7 +249,6 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         chat_template_duration_us
     );
-    npu_turn_guard.disarm();
 
     if (is_chat_conversation) {
         if (m_chat_generation_finish_status == ov::genai::GenerationStatus::CANCEL) {
@@ -284,8 +282,6 @@ DecodedResults StatefulLLMPipeline::generate(
     auto start_time = std::chrono::steady_clock::now();
 
     GenerationConfig config = resolve_generation_config(generation_config);
-    // Snapshots the pre-turn history before it is replaced below.
-    NPUTurnGuard npu_turn_guard(*this);
 
     OPENVINO_ASSERT(config.apply_chat_template, "Chat template must be applied when using ChatHistory in generate method.");
     OPENVINO_ASSERT(!m_tokenizer.get_chat_template().empty(), "Chat template must not be empty when using ChatHistory in generate method.");
@@ -324,7 +320,7 @@ DecodedResults StatefulLLMPipeline::generate(
             negotiate_npu_history_reuse(new_chat_tokens.input_ids.get_shape().at(1), config);
         encoded_input = get_chat_encoded_input(new_chat_tokens.input_ids, m_cache_state);
     }
-    auto decoded_results = get_decoded_results(
+    return get_decoded_results(
         encoded_input,
         config,
         streamer,
@@ -332,8 +328,6 @@ DecodedResults StatefulLLMPipeline::generate(
         tokenization_start_time,
         PerfMetrics::get_microsec(tokenization_start_time - template_start_time)
     );
-    npu_turn_guard.disarm();
-    return decoded_results;
 }
 
 EncodedResults StatefulLLMPipeline::generate(
@@ -387,10 +381,7 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
-    // The turn guard must arm before the alignment block so it snapshots the
-    // history before this turn grows it.
     GenerationConfig config = resolve_generation_config(generation_config);
-    NPUTurnGuard npu_turn_guard(*this);
 
     if (is_chat_conversation && m_chat_input_type == ov::genai::utils::GenerationChatInputsType::ENCODED_INPUTS)
         std::copy(input_ids.data<int64_t>(), input_ids.data<int64_t>() + input_ids.get_size(), std::back_inserter(m_tokenized_chat_history));
@@ -531,11 +522,6 @@ EncodedResults StatefulLLMPipeline::generate(
     ov::genai::EncodedResults& result = finish_info.results;
     m_chat_generation_finish_status = finish_info.streaming_finish_status;
 
-    // Inference completed, including a cancelled one, which is a successful physically
-    // committed operation and must not go through the failure rollback.
-    npu_turn_guard.disarm();
-    m_forced_full_prefill = false;
-
     if (is_chat_conversation) {
         m_cache_state.num_tokens_to_trim = 0;
 
@@ -594,13 +580,6 @@ void StatefulLLMPipeline::init_npu_continuous_prefill(const ov::CompiledModel& c
 void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config) {
     OPENVINO_ASSERT(m_npu_continuous_prefill);
 
-    if (m_forced_full_prefill) {
-        // Recovery turn after a failure. The plugin has a pending reset and requires
-        // the complete prompt at cache position zero, and the cache state is already
-        // empty, so no proposal is made.
-        return;
-    }
-
     // Validate the complete request while the full tokenized history is still in
     // scope. A failure here must not leave a pending plugin command, so it happens
     // before the proposal.
@@ -656,29 +635,6 @@ void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, c
     // tokenized history is still available to the caller.
     state.resize(static_cast<size_t>(granted));
     m_cache_state.num_tokens_to_trim = 0;
-}
-
-void StatefulLLMPipeline::on_npu_turn_failure(ChatHistory history_snapshot,
-                                              std::vector<int64_t> tokenized_history_snapshot) {
-    // One recovery path for every failure point. This deliberately gives up the old
-    // cache even when the plugin rejected during preflight and its cache is intact,
-    // in exchange for a single wire-level recovery sequence. The forced flag comes
-    // first so recovery intent survives even if touching the runner throws again.
-    m_forced_full_prefill = true;
-    m_history = std::move(history_snapshot);
-    m_tokenized_chat_history = std::move(tokenized_history_snapshot);
-    m_cache_state.reset_state();
-    try {
-        for (auto& st : m_model_runner.query_state()) {
-            if (st.get_name() == "npuw_stored_tokens_state") {
-                st.reset();
-                break;
-            }
-        }
-        m_model_runner.get_tensor("attention_mask").set_shape({1, 0});
-    } catch (...) {
-        // Touching the runner must not mask the original failure.
-    }
 }
 
 void StatefulLLMPipeline::reset_state() {

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -561,13 +561,16 @@ void StatefulLLMPipeline::start_chat(const std::string& system_message) {
 void StatefulLLMPipeline::init_npu_continuous_prefill(const ov::CompiledModel& compiled_model) {
     // The capability must come from the read-only property. It must not be probed by
     // looking for npuw_stored_tokens_state in query_state(), because every existing
-    // plugin build publishes that state and would give a false positive. A plugin
-    // that predates the feature has no such property, which keeps the existing
-    // full-history behaviour automatically.
+    // plugin build publishes that state and would give a false positive. The property
+    // is computed on demand and is not listed in supported_properties either, so
+    // asking for it is the only way to probe it. A plugin that predates the feature
+    // answers with an ov::Exception for an unsupported configuration key, which keeps
+    // the existing full-history behaviour automatically and is the only failure
+    // expected here; anything else propagates.
     bool supported = false;
     try {
         supported = compiled_model.get_property("NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED").as<bool>();
-    } catch (...) {
+    } catch (const ov::Exception&) {
         supported = false;
     }
     m_npu_continuous_prefill = supported;
@@ -593,10 +596,14 @@ void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, c
     // decoding loop caps generation against the KV capacity exactly as it does
     // without continuation.
     if (config.max_new_tokens != SIZE_MAX || config.max_length != SIZE_MAX) {
+        const size_t response_budget = config.get_max_new_tokens(full_history_len);
         // The final sampled token is returned without being fed through the model and
-        // has no KV entry, hence the minus one on the response budget.
-        const size_t response_budget = std::max<size_t>(config.get_max_new_tokens(full_history_len), 1u);
-        OPENVINO_ASSERT(full_history_len + response_budget - 1 <= m_kv_cache_capacity,
+        // has no KV entry, hence the minus one on the response budget. The comparison
+        // is written as a subtraction because the budget has no upper bound and the
+        // sum could otherwise wrap around.
+        const size_t kv_entries_needed = response_budget > 0 ? response_budget - 1 : 0;
+        OPENVINO_ASSERT(full_history_len <= m_kv_cache_capacity &&
+                        kv_entries_needed <= m_kv_cache_capacity - full_history_len,
             "The requested history of ", full_history_len, " tokens plus the response budget of ",
             response_budget, " tokens does not fit into the NPU KV cache capacity of ",
             m_kv_cache_capacity, " tokens.");

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -387,8 +387,8 @@ EncodedResults StatefulLLMPipeline::generate(
         data->attention_mask.copy_to(attention_mask);
     }
 
-    // Resolved before the alignment block so the negotiation can validate the
-    // response budget, and the turn guard snapshots history before it grows.
+    // The turn guard must arm before the alignment block so it snapshots the
+    // history before this turn grows it.
     GenerationConfig config = resolve_generation_config(generation_config);
     NPUTurnGuard npu_turn_guard(*this);
 
@@ -572,7 +572,7 @@ void StatefulLLMPipeline::start_chat(const std::string& system_message) {
     m_history.push_back({{"role", "system"}, {"content", system_message}});
 }
 
-void StatefulLLMPipeline::init_npu_continuous_prefill(ov::CompiledModel& compiled_model) {
+void StatefulLLMPipeline::init_npu_continuous_prefill(const ov::CompiledModel& compiled_model) {
     // The capability must come from the read-only property. It must not be probed by
     // looking for npuw_stored_tokens_state in query_state(), because every existing
     // plugin build publishes that state and would give a false positive. A plugin
@@ -608,13 +608,20 @@ void StatefulLLMPipeline::negotiate_npu_history_reuse(size_t full_history_len, c
         "Stateful LLM pipeline on NPU may only process prompts or hold chat history up to ",
         m_max_prompt_len, " tokens. ", full_history_len,
         " is passed.\n Set the \"MAX_PROMPT_LEN\" config option to increase the limit.");
-    // The final sampled token is returned without being fed through the model and has
-    // no KV entry, hence the minus one on the response budget.
-    const size_t response_budget = std::max<size_t>(config.get_max_new_tokens(full_history_len), 1u);
-    OPENVINO_ASSERT(full_history_len + response_budget - 1 <= m_kv_cache_capacity,
-        "The requested history of ", full_history_len, " tokens plus the response budget of ",
-        response_budget, " tokens does not fit into the NPU KV cache capacity of ",
-        m_kv_cache_capacity, " tokens.");
+    // The response budget is validated only when the caller bounded it explicitly.
+    // The default config leaves both max_new_tokens and max_length unbounded, which
+    // means "generate until EOS": there is no requested budget to validate, and the
+    // decoding loop caps generation against the KV capacity exactly as it does
+    // without continuation.
+    if (config.max_new_tokens != SIZE_MAX || config.max_length != SIZE_MAX) {
+        // The final sampled token is returned without being fed through the model and
+        // has no KV entry, hence the minus one on the response budget.
+        const size_t response_budget = std::max<size_t>(config.get_max_new_tokens(full_history_len), 1u);
+        OPENVINO_ASSERT(full_history_len + response_budget - 1 <= m_kv_cache_capacity,
+            "The requested history of ", full_history_len, " tokens plus the response budget of ",
+            response_budget, " tokens does not fit into the NPU KV cache capacity of ",
+            m_kv_cache_capacity, " tokens.");
+    }
 
     auto& state = m_cache_state.get_state();
     const size_t k_common = state.size();

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -31,7 +31,73 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // include reflection of tokens contained in the kv cache and amount of tokens, which are needed to trim from kv cache on the next step of chat
     utils::CacheState m_cache_state;
 
+    // True when the NPU plugin advertises continuous prefill for this compiled model.
+    // Chat turns then negotiate a keep through the npuw_stored_tokens_state variable
+    // state and send only the delta instead of resending the full history.
+    bool m_npu_continuous_prefill = false;
+    // Past KV capacity of the largest generate variant, used to validate the response
+    // budget before proposing.
+    size_t m_kv_cache_capacity = std::numeric_limits<size_t>::max();
+    // Set after a failed turn. The next attempt skips the proposal and sends the full
+    // history, which satisfies the plugin's pending reset.
+    bool m_forced_full_prefill = false;
+    // Guards against nested arming when generate(EncodedInputs) runs inside the
+    // string or ChatHistory entry points.
+    bool m_npu_turn_guard_active = false;
+
     void reset_state();
+
+    // Reads the continuous prefill capability from the compiled model and flips
+    // m_use_full_chat_history accordingly. Called from every construction path.
+    void init_npu_continuous_prefill(ov::CompiledModel& compiled_model);
+    // Proposes the post-alignment common prefix to the plugin, reads the grant back
+    // and resizes the cache state to it, so slicing happens at the granted value.
+    void negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config);
+    // Single recovery path for any failure between proposal and inference. Resets the
+    // plugin channel, restores the pre-turn history and forces a full prefill next.
+    void on_npu_turn_failure(ChatHistory history_snapshot, std::vector<int64_t> tokenized_history_snapshot);
+
+    // Restores conversation state when a turn throws anywhere between the proposal
+    // and the end of inference. Armed only at the outermost generate entry point.
+    class NPUTurnGuard {
+    public:
+        NPUTurnGuard(StatefulLLMPipeline& pipeline) : m_pipeline(pipeline) {
+            if (pipeline.m_npu_continuous_prefill && pipeline.is_chat_conversation &&
+                !pipeline.m_npu_turn_guard_active) {
+                m_armed = true;
+                pipeline.m_npu_turn_guard_active = true;
+                // ChatHistory copies share their JsonContainer storage, so the
+                // snapshot needs explicit deep copies to survive in-place mutation.
+                m_history_snapshot = ChatHistory(pipeline.m_history.get_messages().copy());
+                m_history_snapshot.set_tools(pipeline.m_history.get_tools().copy());
+                m_history_snapshot.set_extra_context(pipeline.m_history.get_extra_context().copy());
+                m_tokenized_history_snapshot = pipeline.m_tokenized_chat_history;
+            }
+        }
+        void disarm() {
+            if (m_armed) {
+                m_pipeline.m_npu_turn_guard_active = false;
+                m_armed = false;
+            }
+        }
+        // Runs during stack unwinding, so the rollback must never throw out of here.
+        ~NPUTurnGuard() {
+            if (m_armed) {
+                m_pipeline.m_npu_turn_guard_active = false;
+                try {
+                    m_pipeline.on_npu_turn_failure(std::move(m_history_snapshot),
+                                                   std::move(m_tokenized_history_snapshot));
+                } catch (...) {
+                }
+            }
+        }
+    private:
+        StatefulLLMPipeline& m_pipeline;
+        bool m_armed = false;
+        ChatHistory m_history_snapshot;
+        std::vector<int64_t> m_tokenized_history_snapshot;
+    };
+    friend class NPUTurnGuard;
 public:
 
     StatefulLLMPipeline(

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -35,8 +35,8 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // Chat turns then negotiate a keep through the npuw_stored_tokens_state variable
     // state and send only the delta instead of resending the full history.
     bool m_npu_continuous_prefill = false;
-    // Past KV capacity of the largest generate variant, used to validate the response
-    // budget before proposing.
+    // Past KV capacity of the largest generate variant, used to validate an explicitly
+    // bounded response budget before proposing.
     size_t m_kv_cache_capacity = std::numeric_limits<size_t>::max();
     // Set after a failed turn. The next attempt skips the proposal and sends the full
     // history, which satisfies the plugin's pending reset.
@@ -49,7 +49,7 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
 
     // Reads the continuous prefill capability from the compiled model and flips
     // m_use_full_chat_history accordingly. Called from every construction path.
-    void init_npu_continuous_prefill(ov::CompiledModel& compiled_model);
+    void init_npu_continuous_prefill(const ov::CompiledModel& compiled_model);
     // Proposes the post-alignment common prefix to the plugin, reads the grant back
     // and resizes the cache state to it, so slicing happens at the granted value.
     void negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config);

--- a/src/cpp/src/llm/pipeline_stateful.hpp
+++ b/src/cpp/src/llm/pipeline_stateful.hpp
@@ -38,12 +38,6 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // Past KV capacity of the largest generate variant, used to validate an explicitly
     // bounded response budget before proposing.
     size_t m_kv_cache_capacity = std::numeric_limits<size_t>::max();
-    // Set after a failed turn. The next attempt skips the proposal and sends the full
-    // history, which satisfies the plugin's pending reset.
-    bool m_forced_full_prefill = false;
-    // Guards against nested arming when generate(EncodedInputs) runs inside the
-    // string or ChatHistory entry points.
-    bool m_npu_turn_guard_active = false;
 
     void reset_state();
 
@@ -53,51 +47,6 @@ class StatefulLLMPipeline final : public LLMPipelineImplBase {
     // Proposes the post-alignment common prefix to the plugin, reads the grant back
     // and resizes the cache state to it, so slicing happens at the granted value.
     void negotiate_npu_history_reuse(size_t full_history_len, const GenerationConfig& config);
-    // Single recovery path for any failure between proposal and inference. Resets the
-    // plugin channel, restores the pre-turn history and forces a full prefill next.
-    void on_npu_turn_failure(ChatHistory history_snapshot, std::vector<int64_t> tokenized_history_snapshot);
-
-    // Restores conversation state when a turn throws anywhere between the proposal
-    // and the end of inference. Armed only at the outermost generate entry point.
-    class NPUTurnGuard {
-    public:
-        NPUTurnGuard(StatefulLLMPipeline& pipeline) : m_pipeline(pipeline) {
-            if (pipeline.m_npu_continuous_prefill && pipeline.is_chat_conversation &&
-                !pipeline.m_npu_turn_guard_active) {
-                m_armed = true;
-                pipeline.m_npu_turn_guard_active = true;
-                // ChatHistory copies share their JsonContainer storage, so the
-                // snapshot needs explicit deep copies to survive in-place mutation.
-                m_history_snapshot = ChatHistory(pipeline.m_history.get_messages().copy());
-                m_history_snapshot.set_tools(pipeline.m_history.get_tools().copy());
-                m_history_snapshot.set_extra_context(pipeline.m_history.get_extra_context().copy());
-                m_tokenized_history_snapshot = pipeline.m_tokenized_chat_history;
-            }
-        }
-        void disarm() {
-            if (m_armed) {
-                m_pipeline.m_npu_turn_guard_active = false;
-                m_armed = false;
-            }
-        }
-        // Runs during stack unwinding, so the rollback must never throw out of here.
-        ~NPUTurnGuard() {
-            if (m_armed) {
-                m_pipeline.m_npu_turn_guard_active = false;
-                try {
-                    m_pipeline.on_npu_turn_failure(std::move(m_history_snapshot),
-                                                   std::move(m_tokenized_history_snapshot));
-                } catch (...) {
-                }
-            }
-        }
-    private:
-        StatefulLLMPipeline& m_pipeline;
-        bool m_armed = false;
-        ChatHistory m_history_snapshot;
-        std::vector<int64_t> m_tokenized_history_snapshot;
-    };
-    friend class NPUTurnGuard;
 public:
 
     StatefulLLMPipeline(

--- a/tests/python_tests/test_llm_pipeline_static.py
+++ b/tests/python_tests/test_llm_pipeline_static.py
@@ -475,6 +475,218 @@ def test_chat_generation(
     )
 
 
+#
+# Continuous prefill
+#
+
+# Continuous prefill reuses the part of the chat history the plugin still holds in its
+# KV cache and sends only the new tokens. It requires chunked prefill, which the plugin
+# enables when the chunk is smaller than the prompt window. The chunk is also the
+# granularity of the granted keep, so a small one keeps it non-zero for short prompts.
+CONTINUOUS_PREFILL_CONFIG: dict = {
+    **DEFAULT_CONFIG,
+    "MAX_PROMPT_LEN": 1024,
+    "MIN_RESPONSE_LEN": 128,
+    "NPUW_LLM_PREFILL_CHUNK_SIZE": 64,
+    "NPUW_LLM_ENABLE_CONTINUOUS_PREFILL": "YES",
+}
+
+# The same pipeline resending the whole history every turn, used as the reference.
+FULL_HISTORY_CONFIG: dict = {
+    key: value for key, value in CONTINUOUS_PREFILL_CONFIG.items() if key != "NPUW_LLM_ENABLE_CONTINUOUS_PREFILL"
+}
+
+# The plugin refuses the capability when the chunk covers the whole prompt window. The
+# option is set here, but the pipeline must still fall back to the full history.
+UNSUPPORTED_CONTINUOUS_PREFILL_CONFIG: dict = {
+    **CONTINUOUS_PREFILL_CONFIG,
+    "NPUW_LLM_PREFILL_CHUNK_SIZE": 1024,
+}
+
+# MAX_PROMPT_LEN + MIN_RESPONSE_LEN - 1, the number of tokens the KV cache holds.
+KV_CACHE_CAPACITY: int = 1024 + 128 - 1
+
+# The questions are long on purpose: the keep is granted in whole chunks, so the
+# history has to grow past a chunk for a turn to be continued rather than prefilled
+# from scratch.
+CHAT_QUESTIONS: list[str] = [
+    "What is OpenVINO, which kinds of hardware is it able to run a model on, and which "
+    "model formats does it read? Please answer with as much detail as you can.",
+    "Repeat the previous answer word by word, then explain what a neural network "
+    "operator is and how several of them are connected into a graph.",
+    "What was my very first question in this conversation, and what did you answer to "
+    "it? Please quote both of them and then add a short comment of your own.",
+    "Summarize everything that was said in this conversation so far, keeping every "
+    "single topic that came up in the order it was brought up.",
+]
+
+CHAT_MAX_NEW_TOKENS: int = 20
+
+
+def chat_with_strings(pipe: LLMPipeline, questions: list[str]) -> list[str]:
+    pipe.start_chat()
+    answers = [pipe.generate(question, max_new_tokens=CHAT_MAX_NEW_TOKENS, do_sample=False) for question in questions]
+    pipe.finish_chat()
+    return answers
+
+
+def chat_with_chat_history(pipe: LLMPipeline, questions: list[str]) -> list[str]:
+    history = ChatHistory()
+    answers = []
+    for question in questions:
+        history.append({"role": "user", "content": question})
+        answer = pipe.generate(history, max_new_tokens=CHAT_MAX_NEW_TOKENS, do_sample=False).texts[0]
+        history.append({"role": "assistant", "content": answer})
+        answers.append(answer)
+    return answers
+
+
+def chat_with_encoded_inputs(pipe: LLMPipeline, tokenizer: Tokenizer, questions: list[str]) -> list[str]:
+    # The pipeline keeps the tokenized history itself, so every turn passes only the
+    # tokens that were added since the previous one.
+    history = ChatHistory()
+    answers = []
+    consumed = 0
+
+    pipe.start_chat()
+    for question in questions:
+        history.append({"role": "user", "content": question})
+        templated = tokenizer.apply_chat_template(history, add_generation_prompt=True)
+        tokenized = tokenizer.encode(templated, add_special_tokens=False)
+        all_tokens = tokenized.input_ids.data[0]
+
+        delta = np.array([all_tokens[consumed:]], dtype=np.int64)
+        inputs = TokenizedInputs(ov.Tensor(delta), ov.Tensor(np.ones_like(delta)))
+        generated = pipe.generate(inputs, max_new_tokens=CHAT_MAX_NEW_TOKENS, do_sample=False).tokens[0]
+
+        answer = tokenizer.decode(generated)
+        history.append({"role": "assistant", "content": answer})
+        answers.append(answer)
+        consumed = len(all_tokens) + len(generated)
+    pipe.finish_chat()
+    return answers
+
+
+class StopAfterNTokens(StreamerBase):
+    def __init__(self, num_tokens: int):
+        StreamerBase.__init__(self)
+        self.num_tokens = num_tokens
+        self.written = 0
+
+    def write(self, token_id) -> StreamingStatus:
+        self.written += 1
+        return StreamingStatus.RUNNING if self.written < self.num_tokens else StreamingStatus.STOP
+
+    def end(self):
+        pass
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+@pytest.mark.parametrize("input_type", ["string", "chat_history", "encoded_inputs"])
+def test_continuous_prefill_matches_full_history(
+    llm_model: OVConvertedModelSchema,
+    tokenizer: Tokenizer,
+    input_type: str,
+):
+    reference_pipe = LLMPipeline(llm_model.models_path, "NPU", **FULL_HISTORY_CONFIG)
+    continued_pipe = LLMPipeline(llm_model.models_path, "NPU", **CONTINUOUS_PREFILL_CONFIG)
+
+    if input_type == "string":
+        reference = chat_with_strings(reference_pipe, CHAT_QUESTIONS)
+        actual = chat_with_strings(continued_pipe, CHAT_QUESTIONS)
+    elif input_type == "chat_history":
+        reference = chat_with_chat_history(reference_pipe, CHAT_QUESTIONS)
+        actual = chat_with_chat_history(continued_pipe, CHAT_QUESTIONS)
+    else:
+        reference = chat_with_encoded_inputs(reference_pipe, tokenizer, CHAT_QUESTIONS)
+        actual = chat_with_encoded_inputs(continued_pipe, tokenizer, CHAT_QUESTIONS)
+
+    assert actual == reference, f"full history:\n{reference}\ncontinuous prefill:\n{actual}"
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+def test_continuous_prefill_unsupported_falls_back_to_full_history(llm_model: OVConvertedModelSchema):
+    reference_pipe = LLMPipeline(llm_model.models_path, "NPU", **FULL_HISTORY_CONFIG)
+    unsupported_pipe = LLMPipeline(llm_model.models_path, "NPU", **UNSUPPORTED_CONTINUOUS_PREFILL_CONFIG)
+
+    reference = chat_with_strings(reference_pipe, CHAT_QUESTIONS)
+    actual = chat_with_strings(unsupported_pipe, CHAT_QUESTIONS)
+
+    assert actual == reference, f"full history:\n{reference}\nfallback:\n{actual}"
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+def test_continuous_prefill_rejects_request_over_kv_capacity(llm_model: OVConvertedModelSchema):
+    continued_pipe = LLMPipeline(llm_model.models_path, "NPU", **CONTINUOUS_PREFILL_CONFIG)
+
+    continued_pipe.start_chat()
+    with pytest.raises(RuntimeError):
+        continued_pipe.generate(CHAT_QUESTIONS[0], max_new_tokens=KV_CACHE_CAPACITY + 1, do_sample=False)
+    continued_pipe.finish_chat()
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+def test_continuous_prefill_accepts_unbounded_response(llm_model: OVConvertedModelSchema):
+    # An unbounded config means "generate until EOS", so there is no requested budget
+    # to check against the KV capacity and the turn must not be rejected.
+    continued_pipe = LLMPipeline(llm_model.models_path, "NPU", **CONTINUOUS_PREFILL_CONFIG)
+
+    continued_pipe.start_chat()
+    continued_pipe.generate(CHAT_QUESTIONS[0], do_sample=False, streamer=StopAfterNTokens(5))
+    continued_pipe.finish_chat()
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+def test_continuous_prefill_failed_turn_does_not_leak_into_next_chat(llm_model: OVConvertedModelSchema):
+    reference_pipe = LLMPipeline(llm_model.models_path, "NPU", **FULL_HISTORY_CONFIG)
+    continued_pipe = LLMPipeline(llm_model.models_path, "NPU", **CONTINUOUS_PREFILL_CONFIG)
+
+    reference = chat_with_strings(reference_pipe, CHAT_QUESTIONS[:1])
+
+    continued_pipe.start_chat()
+    continued_pipe.generate(CHAT_QUESTIONS[0], max_new_tokens=CHAT_MAX_NEW_TOKENS, do_sample=False)
+    with pytest.raises(RuntimeError):
+        continued_pipe.generate(CHAT_QUESTIONS[1], max_new_tokens=KV_CACHE_CAPACITY + 1, do_sample=False)
+    continued_pipe.finish_chat()
+
+    # A failed turn is not rolled back, so the conversation still holds it and
+    # finish_chat() has to drop it, otherwise this answer is produced with a history
+    # behind it.
+    actual = chat_with_strings(continued_pipe, CHAT_QUESTIONS[:1])
+
+    assert actual == reference, f"full history:\n{reference}\nafter a failed turn:\n{actual}"
+
+
+@pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
+def test_continuous_prefill_cancelled_turn_continues_chat(llm_model: OVConvertedModelSchema):
+    # A cancelled turn is physically committed, so the chat goes on from it instead of
+    # being rolled back.
+    def chat_with_cancelled_first_turn(pipe: LLMPipeline) -> list[str]:
+        pipe.start_chat()
+        answers = [
+            pipe.generate(
+                CHAT_QUESTIONS[0],
+                max_new_tokens=CHAT_MAX_NEW_TOKENS,
+                do_sample=False,
+                streamer=StopAfterNTokens(3),
+            )
+        ]
+        answers += [
+            pipe.generate(question, max_new_tokens=CHAT_MAX_NEW_TOKENS, do_sample=False)
+            for question in CHAT_QUESTIONS[1:]
+        ]
+        pipe.finish_chat()
+        return answers
+
+    reference_pipe = LLMPipeline(llm_model.models_path, "NPU", **FULL_HISTORY_CONFIG)
+    continued_pipe = LLMPipeline(llm_model.models_path, "NPU", **CONTINUOUS_PREFILL_CONFIG)
+
+    reference = chat_with_cancelled_first_turn(reference_pipe)
+    actual = chat_with_cancelled_first_turn(continued_pipe)
+
+    assert actual == reference, f"full history:\n{reference}\ncontinuous prefill:\n{actual}"
+
+
 @pytest.mark.parametrize("llm_model", MODELS_LIST, indirect=True)
 @pytest.mark.parametrize("npu_config", PIPELINE_CONFIGS, indirect=True)
 def test_readonly_input_tensor(npu_model: LLMPipeline):


### PR DESCRIPTION
### Details
- On NPU, `m_use_full_chat_history` stops being a device rule: when the compiled model advertises `NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED`, chat turns reuse the existing CPU/GPU cache machinery plus a negotiation step, so every turn re-prefills only the new tokens instead of the entire conversation.
- Per turn: `align_cache_and_history()` computes the common prefix, the pipeline validates the complete request (history within `MAX_PROMPT_LEN`, history + response budget within KV capacity), proposes the prefix through `npuw_stored_tokens_state`, reads the granted keep back, resizes `CacheState` to the grant and slices the input there. The physical `trim_kv_cache` path stays CPU/GPU only.
- Capability is read directly from the property in both NPU construction paths. A `false` value keeps full-history behaviour; property lookup failures propagate. The stored-tokens state is not used for capability discovery.
- Failed turns are not rolled back. A failed pending prefill requires a request reset and full-history prefill for recovery; resetting the chat clears its state. Cancellation stays a committed operation and rolls forward through the next alignment.

Companion plugin PRs (all merged): openvinotoolkit/openvino#37146, openvinotoolkit/openvino#37147, openvinotoolkit/openvino#37148, openvinotoolkit/openvino#37149 (protocol, transaction coordinator, KV strategy continuation, block-based KV continuation).

### Validation
- 3-turn greedy chat on qwen3 via `NPUW_DEVICES=CPU` (chunk 256, prompt window 2048): transcripts token-identical with the feature on and off; NPUW logs confirm delta-only prefills at the granted keep on turns 2 and 3.
- C++ syntax check of the complete modified `pipeline_stateful.cpp` against local OpenVINO headers, plus `git diff --check`. Runtime chat tests were not rerun for the property-read simplification.

### Tickets
- EISW-227938