### PR TITLE
[wwb] Seed RNG for speech-generation

### DIFF
--- a/tools/who_what_benchmark/tests/test_unit_speechgen.py
+++ b/tools/who_what_benchmark/tests/test_unit_speechgen.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+class _Speech:
+    def __init__(self, data):
+        self.data = data
+
+
+class _SpeechResult:
+    def __init__(self, data, sample_rate=16000):
+        self.speeches = [_Speech(data)]
+        self.output_sample_rate = sample_rate
+
+
+class _RngModel:
+    """Fake TTS model whose output depends on the global torch RNG."""
+
+    def get_speaker_embedding_shape(self):
+        return (1, 512)
+
+    def generate(self, prompt, speaker_embedding=None, **kwargs):
+        import torch
+
+        audio = torch.randn(16).cpu().numpy().astype(np.float32)
+        return _SpeechResult(audio)
+
+
+def _make_evaluator(tmp_path, seed, prompts):
+    """Build a SpeechGenerationEvaluator from ground-truth CSV (no model load)."""
+    import pandas as pd
+
+    from whowhatbench.speech_generation_evaluator import SpeechGenerationEvaluator
+
+    gt_file = tmp_path / "gt.csv"
+    pd.DataFrame({"prompts": prompts, "audio": ["x.wav"] * len(prompts)}).to_csv(gt_file, index=False)
+
+    return SpeechGenerationEvaluator(
+        gt_data=str(gt_file),
+        test_data={"prompts": prompts},
+        num_samples=len(prompts),
+        seed=seed,
+    )
+
+
+def test_generate_data_seeds_before_each_prompt(tmp_path, monkeypatch):
+    """torch.manual_seed(seed) is called once per prompt, before each generation."""
+    torch = pytest.importorskip("torch")
+
+    prompts = ["one", "two", "three"]
+    evaluator = _make_evaluator(tmp_path, seed=123, prompts=prompts)
+
+    seed_calls = []
+    monkeypatch.setattr(torch, "manual_seed", lambda value: seed_calls.append(value))
+
+    evaluator._generate_data(_RngModel(), audio_dir=str(tmp_path / "out"))
+
+    assert seed_calls == [123, 123, 123]
+
+
+def test_generate_data_deterministic_across_runs(tmp_path):
+    """A seeded evaluator produces identical audio across two independent runs."""
+    pytest.importorskip("torch")
+
+    prompts = ["hello", "world"]
+
+    def collect():
+        evaluator = _make_evaluator(tmp_path, seed=7, prompts=prompts)
+        frame = evaluator._generate_data(_RngModel(), audio_dir=str(tmp_path / "run"))
+        import soundfile as sf
+
+        return [sf.read(path)[0] for path in frame["audio"].values]
+
+    first = collect()
+    second = collect()
+
+    for a, b in zip(first, second):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_generate_data_no_seed_leaves_rng_untouched(tmp_path, monkeypatch):
+    """With seed=None the evaluator must not touch the global torch RNG."""
+    torch = pytest.importorskip("torch")
+
+    prompts = ["only"]
+    evaluator = _make_evaluator(tmp_path, seed=None, prompts=prompts)
+
+    seed_calls = []
+    monkeypatch.setattr(torch, "manual_seed", lambda value: seed_calls.append(value))
+
+    evaluator._generate_data(_RngModel(), audio_dir=str(tmp_path / "out"))
+
+    assert seed_calls == []

--- a/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
@@ -266,12 +266,14 @@ class SpeechGenerationEvaluator(BaseEvaluator):
         vocoder_path: str = None,
         speech_language: str = "",
         speech_voice: str = "",
+        seed: int = None,
     ) -> None:
         if base_model is None and gt_data is None:
             raise ValueError("Speech generation pipeline for evaluation or ground truth data must be defined")
 
         self.test_data = test_data
         self.num_samples = num_samples
+        self.seed = seed
         self.generation_fn = gen_speech_fn
         self.whisper_model = whisper_model
         self.vocoder_path = vocoder_path
@@ -464,6 +466,11 @@ class SpeechGenerationEvaluator(BaseEvaluator):
                 speaker_embedding = self._load_speaker_embedding(speaker_embedding_file_path, expected_shape)
             else:
                 speaker_embedding = self.speaker_embedding
+
+            if self.seed is not None:
+                import torch
+
+                torch.manual_seed(self.seed)
 
             generated_audio, generated_sr = generation_fn(
                 model,

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -279,7 +279,7 @@ def parse_args():
         "--seed",
         type=int,
         default=42,
-        help="Text-to-image specific parameter that defines the seed value.",
+        help="Seed value for text-to-image/video generation and for pinning the RNG in text-to-speech generation.",
     )
     parser.add_argument(
         "--taylorseer-config",
@@ -1065,6 +1065,7 @@ def create_evaluator(base_model, args):
                 vocoder_path=args.vocoder_path,
                 speech_language=args.speech_language,
                 speech_voice=args.speech_voice,
+                seed=args.seed,
             )
         elif task == "visual-text" or task == "visual-video-text":
             processor, config = load_processor(args)


### PR DESCRIPTION
## Description

WWB generates the speech-generation reference and target audio in separate passes. On the HF path the models sample from the global torch RNG, and nothing pinned it between passes. The two passes drew different noise as a result, so comparing an identical model against itself scored well below 1.000: Speaker 0.857, Acoustic 0.839, Overall 0.834 on Qwen3-Omni. Calling `torch.manual_seed` by hand before generation brought it back to 1.000.

WWB already has a `--seed` argument (default 42), but it was only wired to text-to-image and text-to-video. This PR passes it into the speech-generation evaluator and pins the RNG once per prompt, right before each generation, so both passes draw the same noise. GenAI and Optimum don't use the global torch RNG, so for those backends this only adds determinism and leaves the output unchanged. The `--seed` help text now mentions speech generation.

CVS-190714

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. Added `tools/who_what_benchmark/tests/test_unit_speechgen.py` with three unit tests: `manual_seed` is called once per prompt before each generation, a seeded evaluator yields identical audio across two runs, and `seed=None` leaves the global RNG untouched.
- [x] This PR fully addresses the ticket. The Qwen3-Omni HF path from the ticket lives in PR #4015; because that path also generates through the shared `SpeechGenerationEvaluator`, it inherits the seeding once merged.
- [ ] N/A I have made corresponding changes to the documentation.
