### PR TITLE
[Omni] Enable Python subclassing of VLMPipelineBase/TalkerBase and add DI tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,6 +43,10 @@
 - 'src/cpp/src/lm_encoding.cpp'
 - 'src/python/py_vlm_pipeline.cpp'
 - 'tests/python_tests/test_vlm_pipeline.py'
+- 'src/cpp/include/openvino/genai/omni/**/*'
+- 'src/cpp/src/omni/**/*'
+- 'src/python/py_omni_pipeline.cpp'
+- 'tests/python_tests/test_omni_pipeline.py'
 
 'category: RAG':
 - 'src/cpp/include/openvino/genai/rag/**/*'

--- a/.github/workflows/test_matrices/linux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/linux/wheel_tests.yml
@@ -92,7 +92,6 @@
 - name: Omni
   cmd: |-
     python -m pip install transformers==5.1
-    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
   timeout: 90
   components:

--- a/.github/workflows/test_matrices/linux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/linux/wheel_tests.yml
@@ -89,6 +89,16 @@
   components:
     - visual_language
 
+- name: Omni
+  cmd: |-
+    python -m pip install transformers==5.1
+    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
+    python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
+  timeout: 90
+  components:
+    - visual_language
+    - speech_generation
+
 - name: Video Generation
   cmd: |-
     python -m pytest -v ./tests/python_tests/test_video_generation.py --override-ini cache_dir=/mount/caches/pytest/

--- a/.github/workflows/test_matrices/mac/wheel_tests.yml
+++ b/.github/workflows/test_matrices/mac/wheel_tests.yml
@@ -36,6 +36,14 @@
 #   components:
 #     - continuous_batching
 
+- name: Omni (API)
+  cmd: |-
+    python -m pytest -v ./tests/python_tests/test_omni_pipeline.py -k "not TestOmniPipelineRealModel"
+  timeout: 40
+  components:
+    - visual_language
+    - speech_generation
+
 - name: GGUF Reader tests
   cmd: |-
     python -m pytest -v ./tests/python_tests/test_gguf_reader.py

--- a/.github/workflows/test_matrices/manylinux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/manylinux/wheel_tests.yml
@@ -92,6 +92,8 @@
 
 - name: Omni
   cmd: |-
+    python -m pip install transformers==5.1
+    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
   timeout: 90
   components:

--- a/.github/workflows/test_matrices/manylinux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/manylinux/wheel_tests.yml
@@ -93,7 +93,6 @@
 - name: Omni
   cmd: |-
     python -m pip install transformers==5.1
-    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
   timeout: 90
   components:

--- a/.github/workflows/test_matrices/manylinux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/manylinux/wheel_tests.yml
@@ -93,7 +93,7 @@
 - name: Omni
   cmd: |-
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
-  timeout: 60
+  timeout: 90
   components:
     - visual_language
     - speech_generation

--- a/.github/workflows/test_matrices/manylinux/wheel_tests.yml
+++ b/.github/workflows/test_matrices/manylinux/wheel_tests.yml
@@ -90,6 +90,14 @@
   components:
     - visual_language
 
+- name: Omni
+  cmd: |-
+    python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
+  timeout: 60
+  components:
+    - visual_language
+    - speech_generation
+
 - name: Video Generation
   cmd: |-
     python -m pytest -v ./tests/python_tests/test_video_generation.py --override-ini cache_dir=/mount/caches/pytest/

--- a/.github/workflows/test_matrices/windows/wheel_tests.yml
+++ b/.github/workflows/test_matrices/windows/wheel_tests.yml
@@ -101,7 +101,6 @@
 - name: Omni
   cmd: |-
     python -m pip install transformers==5.1
-    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
   timeout: 90
   components:

--- a/.github/workflows/test_matrices/windows/wheel_tests.yml
+++ b/.github/workflows/test_matrices/windows/wheel_tests.yml
@@ -100,6 +100,8 @@
 
 - name: Omni
   cmd: |-
+    python -m pip install transformers==5.1
+    python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@6898d97242498b7dc4367a12555e4f7e52b01d16
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
   timeout: 90
   components:

--- a/.github/workflows/test_matrices/windows/wheel_tests.yml
+++ b/.github/workflows/test_matrices/windows/wheel_tests.yml
@@ -101,7 +101,7 @@
 - name: Omni
   cmd: |-
     python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
-  timeout: 60
+  timeout: 90
   components:
     - visual_language
     - speech_generation

--- a/.github/workflows/test_matrices/windows/wheel_tests.yml
+++ b/.github/workflows/test_matrices/windows/wheel_tests.yml
@@ -98,6 +98,14 @@
   components:
     - visual_language
 
+- name: Omni
+  cmd: |-
+    python -m pytest -v ./tests/python_tests/test_omni_pipeline.py --override-ini cache_dir=/mount/caches/pytest/
+  timeout: 60
+  components:
+    - visual_language
+    - speech_generation
+
 - name: Video Generation
   cmd: |-
     python -m pytest -s -v tests/python_tests/test_video_generation.py --override-ini cache_dir=/mount/caches/pytest/

--- a/src/cpp/src/omni/talker.cpp
+++ b/src/cpp/src/omni/talker.cpp
@@ -4,7 +4,6 @@
 #include "openvino/genai/omni/talker.hpp"
 
 #include "openvino/core/except.hpp"
-#include "openvino/genai/omni/pipeline.hpp"
 #include "omni/talker_speech_config_utils.hpp"
 #include "utils.hpp"
 #include "visual_language/qwen3_omni/speech_pipeline.hpp"
@@ -34,50 +33,6 @@ std::vector<ov::Tensor> split_hidden_states(const std::vector<ov::Tensor>& per_s
         }
     }
     return per_token;
-}
-
-/// @brief Resolve a talker property-bag into a typed config plus optional streamer.
-/// Starts from `base` (the caller's default), overlays recognized `properties`, and rejects
-/// unknown keys so typos surface immediately instead of being silently dropped.
-struct ResolvedTalkerProperties {
-    OmniTalkerSpeechConfig config;
-    OmniSpeechStreamerVariant speech_streamer;
-};
-
-std::string join_recognized_keys() {
-    std::string joined = "speech_streamer, talker_speech_config";
-    for (const auto& key : omni_talker_speech_config_keys()) {
-        joined += ", ";
-        joined += key;
-    }
-    return joined;
-}
-
-ResolvedTalkerProperties resolve_talker_properties(const OmniTalkerSpeechConfig& base, const ov::AnyMap& properties) {
-    ResolvedTalkerProperties out{base, std::monostate{}};
-    ov::AnyMap leftover;
-    for (const auto& [key, value] : properties) {
-        if (key == ov::genai::speech_streamer.name()) {
-            out.speech_streamer = value.as<OmniSpeechStreamerVariant>();
-        } else if (key == ov::genai::talker_speech_config.name()) {
-            out.config = value.as<OmniTalkerSpeechConfig>();
-        } else {
-            OPENVINO_ASSERT(is_omni_talker_speech_config_key(key),
-                            "Talker::generate: unrecognized property '",
-                            key,
-                            "'. Recognized keys: ",
-                            join_recognized_keys(),
-                            ".");
-            leftover.emplace(key, value);
-        }
-    }
-    if (!leftover.empty()) {
-        update_omni_talker_speech_config(out.config, leftover);
-    }
-    // Values supplied via properties bypass set_speech_config(), so this is the only guard
-    // on the AnyMap path.
-    validate_omni_talker_speech_config(out.config);
-    return out;
 }
 
 }  // namespace

--- a/src/cpp/src/omni/talker_speech_config.cpp
+++ b/src/cpp/src/omni/talker_speech_config.cpp
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include "omni/talker_speech_config_utils.hpp"
+#include "openvino/genai/omni/pipeline.hpp"
 #include "utils.hpp"
 
 namespace ov {
@@ -139,6 +140,53 @@ void validate_omni_talker_speech_config(const OmniTalkerSpeechConfig& config) {
                     config.audio_chunk_frames,
                     ". Max allowed: ",
                     kAudioChunkFramesUpperBound);
+}
+
+namespace {
+
+std::string join_recognized_keys() {
+    std::string joined = "speech_streamer, talker_speech_config";
+    for (const auto& key : omni_talker_speech_config_keys()) {
+        joined += ", ";
+        joined += key;
+    }
+    return joined;
+}
+
+}  // namespace
+
+ResolvedTalkerProperties resolve_talker_properties(const OmniTalkerSpeechConfig& base, const ov::AnyMap& properties) {
+    ResolvedTalkerProperties out{base, std::monostate{}};
+    ov::AnyMap leftover;
+    for (const auto& [key, value] : properties) {
+        if (key == ov::genai::speech_streamer.name()) {
+            // Python kwargs arrive already unwrapped to a concrete alternative, C++ callers pass the variant.
+            if (value.is<std::shared_ptr<OmniSpeechStreamerBase>>()) {
+                out.speech_streamer = value.as<std::shared_ptr<OmniSpeechStreamerBase>>();
+            } else if (value.is<std::function<StreamingStatus(const ov::Tensor&)>>()) {
+                out.speech_streamer = value.as<std::function<StreamingStatus(const ov::Tensor&)>>();
+            } else {
+                out.speech_streamer = value.as<OmniSpeechStreamerVariant>();
+            }
+        } else if (key == ov::genai::talker_speech_config.name()) {
+            out.config = value.as<OmniTalkerSpeechConfig>();
+        } else {
+            OPENVINO_ASSERT(is_omni_talker_speech_config_key(key),
+                            "TalkerBase::generate: unrecognized property '",
+                            key,
+                            "'. Recognized keys: ",
+                            join_recognized_keys(),
+                            ".");
+            leftover.emplace(key, value);
+        }
+    }
+    if (!leftover.empty()) {
+        update_omni_talker_speech_config(out.config, leftover);
+    }
+    // Values supplied via properties bypass set_speech_config(), so this is the only guard
+    // on the AnyMap path.
+    validate_omni_talker_speech_config(out.config);
+    return out;
 }
 
 }  // namespace genai

--- a/src/cpp/src/omni/talker_speech_config_utils.hpp
+++ b/src/cpp/src/omni/talker_speech_config_utils.hpp
@@ -7,7 +7,9 @@
 #include <vector>
 
 #include "openvino/core/any.hpp"
+#include "openvino/genai/omni/speech_streamer_base.hpp"
 #include "openvino/genai/omni/talker_speech_config.hpp"
+#include "openvino/genai/visibility.hpp"
 
 namespace ov {
 namespace genai {
@@ -35,6 +37,17 @@ bool is_omni_talker_speech_config_key(const std::string& key);
 /// checked here — the caller (OmniPipelineImpl) handles those separately.
 /// @throws ov::Exception if config is invalid.
 void validate_omni_talker_speech_config(const OmniTalkerSpeechConfig& config);
+
+/// @brief Resolve a talker property-bag into a typed config plus optional streamer.
+/// Starts from `base` (the caller's default), overlays recognized `properties`, and rejects
+/// unknown keys so typos surface immediately instead of being silently dropped.
+struct ResolvedTalkerProperties {
+    OmniTalkerSpeechConfig config;
+    OmniSpeechStreamerVariant speech_streamer;
+};
+
+OPENVINO_GENAI_EXPORTS
+ResolvedTalkerProperties resolve_talker_properties(const OmniTalkerSpeechConfig& base, const ov::AnyMap& properties);
 
 }  // namespace genai
 }  // namespace ov

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -21,6 +21,7 @@
 #include "openvino/genai/generation_config.hpp"
 
 #include "openvino/genai/streamer_base.hpp"
+#include "openvino/genai/visibility.hpp"
 
 namespace ov {
 namespace genai {
@@ -113,10 +114,10 @@ Config from_config_json_if_exists(const std::filesystem::path& models_path, cons
     return std::filesystem::exists(config_file_path) ? Config{config_file_path} : Config{};
 }
 
-ov::genai::StreamerVariant get_streamer_from_map(const ov::AnyMap& config_map);
+OPENVINO_GENAI_EXPORTS ov::genai::StreamerVariant get_streamer_from_map(const ov::AnyMap& config_map);
 ov::genai::OmniSpeechStreamerVariant get_audio_streamer_from_map(const ov::AnyMap& config_map);
 
-ov::genai::OptionalGenerationConfig get_config_from_map(const ov::AnyMap& config_map);
+OPENVINO_GENAI_EXPORTS ov::genai::OptionalGenerationConfig get_config_from_map(const ov::AnyMap& config_map);
 
 bool is_npu_requested(const std::string& device, const ov::AnyMap& properties);
 

--- a/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/speech_pipeline.cpp
@@ -839,12 +839,17 @@ TalkerResults Qwen3OmniSpeechPipeline::generate_speech(const std::vector<int64_t
     auto [talker_input, trailing_text_hidden] =
         build_talker_input(full_token_ids, all_intermediate_hidden_states, speaker_embed_to_use);
 
-    if (talker_input.get_shape()[1] == 0) {
-        GENAI_WARN("Speech: build_talker_input returned empty, cannot generate speech");
-        if (streaming)
-            end_speech_streamer(audio_streamer);
-        return build_result(ov::Tensor{});
+    // Close the streamer before the assert below so a streaming consumer is not left waiting.
+    if (talker_input.get_shape()[1] == 0 && streaming) {
+        end_speech_streamer(audio_streamer);
     }
+    OPENVINO_ASSERT(talker_input.get_shape()[1] != 0,
+                    "Speech generation produced no talker input: none of the ",
+                    full_token_ids.size(),
+                    " thinker tokens matched im_start_token_id=",
+                    m_config.im_start_token_id,
+                    ", so the conversation could not be segmented. The role token ids in the model's "
+                    "config.json must be the ids its tokenizer actually emits.");
 
     GENAI_DEBUG("Speech: talker_input=[1, %zu, %zu], trailing=[1, %zu, ...], streaming=%s, chunk_frames=%zu",
                 talker_input.get_shape()[1],

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -4499,6 +4499,12 @@ class TalkerBase:
             is Talker. Subclasses must override generate(), list_speakers(), and
             get_speaker_embedding().
     """
+    def __init__(self) -> None:
+        ...
+    def generate(self, vlm_result: VLMDecodedResults, talker_speech_config: OmniTalkerSpeechConfig, speech_streamer: collections.abc.Callable[[openvino._pyopenvino.Tensor], StreamingStatus] | openvino_genai.py_openvino_genai.OmniSpeechStreamerBase | None = None) -> TalkerResults:
+        """
+        Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.
+        """
     def get_speaker_embedding(self, name: str) -> openvino._pyopenvino.Tensor:
         ...
     def list_speakers(self) -> list[str]:
@@ -5762,7 +5768,30 @@ class VLMPipeline(VLMPipelineBase):
 class VLMPipelineBase:
     """
     Abstract base of VLM-style pipelines.
+    
+            Subclass to plug a custom thinker into OmniPipeline via its dependency-injection
+            constructor. A subclass must override generate(), get_tokenizer(), get_generation_config(),
+            set_generation_config(), set_chat_template(), and the Qwen3-Omni capability queries
+            supports_hidden_states_collection() and is_audio_output_enabled().
     """
+    def __init__(self) -> None:
+        ...
+    def generate(self, prompt: str | openvino_genai.py_openvino_genai.ChatHistory, images: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], audios: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos_metadata: collections.abc.Sequence[VideoMetadata] = [], generation_config: GenerationConfig = ..., streamer: collections.abc.Callable[[str], int | None] | openvino_genai.py_openvino_genai.StreamerBase | None = None) -> VLMDecodedResults:
+        """
+        Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.
+        """
+    def get_generation_config(self) -> GenerationConfig:
+        ...
+    def get_tokenizer(self) -> Tokenizer:
+        ...
+    def is_audio_output_enabled(self) -> bool:
+        ...
+    def set_chat_template(self, chat_template: str) -> None:
+        ...
+    def set_generation_config(self, config: GenerationConfig) -> None:
+        ...
+    def supports_hidden_states_collection(self) -> bool:
+        ...
 class VLMRawPerfMetrics:
     """
     

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -4679,9 +4679,23 @@ class TalkerBase:
     """
     def __init__(self) -> None:
         ...
+    @typing.overload
     def generate(self, vlm_result: VLMDecodedResults, talker_speech_config: OmniTalkerSpeechConfig, speech_streamer: collections.abc.Callable[[openvino._pyopenvino.Tensor], StreamingStatus] | openvino_genai.py_openvino_genai.OmniSpeechStreamerBase | None = None) -> TalkerResults:
         """
         Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.
+        """
+    @typing.overload
+    def generate(self, vlm_result: VLMDecodedResults, **kwargs) -> TalkerResults:
+        """
+                                Run speech generation against a VLM result, configured by keyword arguments.
+        
+                                Property-bag form of generate(). Recognized kwargs are the OmniTalkerSpeechConfig
+                                fields (return_audio, speaker, speaker_embedding, audio_chunk_frames,
+                                max_new_tokens, rng_seed, talker_temperature, talker_top_k,
+                                talker_repetition_penalty, cp_temperature, cp_top_k), plus speech_streamer.
+                                Unrecognized keys raise. Fields not given fall back to get_speech_config().
+        
+                                :return: TalkerResults
         """
     def get_speaker_embedding(self, name: str) -> openvino._pyopenvino.Tensor:
         ...
@@ -5987,9 +6001,15 @@ class VLMPipelineBase:
     """
     def __init__(self) -> None:
         ...
+    @typing.overload
     def generate(self, prompt: str | openvino_genai.py_openvino_genai.ChatHistory, images: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], audios: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos_metadata: collections.abc.Sequence[VideoMetadata] = [], generation_config: GenerationConfig = ..., streamer: collections.abc.Callable[[str], int | None] | openvino_genai.py_openvino_genai.StreamerBase | None = None) -> VLMDecodedResults:
         """
         Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.
+        """
+    @typing.overload
+    def generate(self, prompt: str | openvino_genai.py_openvino_genai.ChatHistory, **kwargs) -> VLMDecodedResults:
+        """
+        Generate a VLM response from a property bag: images, videos, audios, videos_metadata, generation_config, streamer, or any GenerationConfig field as a keyword argument. Reduces to the typed generate() the subclass overrides.
         """
     def get_generation_config(self) -> GenerationConfig:
         ...

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -4677,6 +4677,12 @@ class TalkerBase:
             generate(), get_speech_config(), set_speech_config(), list_speakers(), and
             get_speaker_embedding().
     """
+    def __init__(self) -> None:
+        ...
+    def generate(self, vlm_result: VLMDecodedResults, talker_speech_config: OmniTalkerSpeechConfig, speech_streamer: collections.abc.Callable[[openvino._pyopenvino.Tensor], StreamingStatus] | openvino_genai.py_openvino_genai.OmniSpeechStreamerBase | None = None) -> TalkerResults:
+        """
+        Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.
+        """
     def get_speaker_embedding(self, name: str) -> openvino._pyopenvino.Tensor:
         ...
     def get_speech_config(self) -> OmniTalkerSpeechConfig:
@@ -5973,7 +5979,30 @@ class VLMPipeline(VLMPipelineBase):
 class VLMPipelineBase:
     """
     Abstract base of VLM-style pipelines.
+    
+            Subclass to plug a custom thinker into OmniPipeline via its dependency-injection
+            constructor. A subclass must override generate(), get_tokenizer(), get_generation_config(),
+            set_generation_config(), set_chat_template(), and the Qwen3-Omni capability queries
+            supports_hidden_states_collection() and is_audio_output_enabled().
     """
+    def __init__(self) -> None:
+        ...
+    def generate(self, prompt: str | openvino_genai.py_openvino_genai.ChatHistory, images: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], audios: collections.abc.Sequence[openvino._pyopenvino.Tensor] = [], videos_metadata: collections.abc.Sequence[VideoMetadata] = [], generation_config: GenerationConfig = ..., streamer: collections.abc.Callable[[str], int | None] | openvino_genai.py_openvino_genai.StreamerBase | None = None) -> VLMDecodedResults:
+        """
+        Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.
+        """
+    def get_generation_config(self) -> GenerationConfig:
+        ...
+    def get_tokenizer(self) -> Tokenizer:
+        ...
+    def is_audio_output_enabled(self) -> bool:
+        ...
+    def set_chat_template(self, chat_template: str) -> None:
+        ...
+    def set_generation_config(self, config: GenerationConfig) -> None:
+        ...
+    def supports_hidden_states_collection(self) -> bool:
+        ...
 class VLMRawPerfMetrics:
     """
     

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -173,12 +173,11 @@ public:
                                speech_streamer);
     }
 
-    // OmniPipeline only ever calls the typed overload above, and the property-bag form would need
-    // the internal config-parsing helpers that these bindings deliberately don't include.
-    ov::genai::TalkerResults generate(const VLMDecodedResults&, const ov::AnyMap&) override {
-        OPENVINO_THROW(
-            "Python TalkerBase subclasses implement generate(vlm_result, talker_speech_config, speech_streamer). "
-            "The property-bag generate(vlm_result, properties) overload is not available from Python.");
+    // Reduce the property bag the same way Talker does, then dispatch through the typed
+    // override, so a Python backend answers both C++ overloads with one Python method.
+    ov::genai::TalkerResults generate(const VLMDecodedResults& vlm_result, const ov::AnyMap& properties) override {
+        auto resolved = ov::genai::resolve_talker_properties(get_speech_config(), properties);
+        return generate(vlm_result, resolved.config, resolved.speech_streamer);
     }
 
     OmniTalkerSpeechConfig get_speech_config() const override {
@@ -433,6 +432,29 @@ void init_omni_pipeline(py::module_& m) {
                     py::arg("talker_speech_config"),
                     py::arg("speech_streamer") = std::monostate{},
                     "Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.");
+
+    talker_base.def("generate",
+                    [](TalkerBase& self, const VLMDecodedResults& vlm_result, const py::kwargs& kwargs) {
+                        const ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
+                        ov::genai::TalkerResults res;
+                        {
+                            py::gil_scoped_release rel;
+                            res = self.generate(vlm_result, properties);
+                        }
+                        return res;
+                    },
+                    py::arg("vlm_result"),
+                    R"(
+                        Run speech generation against a VLM result, configured by keyword arguments.
+
+                        Property-bag form of generate(). Recognized kwargs are the OmniTalkerSpeechConfig
+                        fields (return_audio, speaker, speaker_embedding, audio_chunk_frames,
+                        max_new_tokens, rng_seed, talker_temperature, talker_top_k,
+                        talker_repetition_penalty, cp_temperature, cp_top_k), plus speech_streamer.
+                        Unrecognized keys raise. Fields not given fall back to get_speech_config().
+
+                        :return: TalkerResults
+                    )");
 
     py::class_<OmniDecodedResults, VLMDecodedResults>(m, "OmniDecodedResults",
         R"(Omni-specific decoded results including speech outputs.

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -152,6 +152,34 @@ auto omni_generate_history_docstring = R"(
     :type videos_metadata: list[VideoMetadata]
 )";
 
+// Trampoline enabling Python subclasses of TalkerBase (injected via the OmniPipeline DI ctor).
+class PyTalkerBase : public TalkerBase {
+public:
+    using TalkerBase::TalkerBase;
+
+    ov::genai::TalkerResults generate(const VLMDecodedResults& vlm_result,
+                                      const OmniTalkerSpeechConfig& talker_speech_config,
+                                      const ov::genai::OmniSpeechStreamerVariant& speech_streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::TalkerResults,
+                               TalkerBase,
+                               generate,
+                               vlm_result,
+                               talker_speech_config,
+                               speech_streamer);
+    }
+
+    std::vector<std::string> list_speakers() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(std::vector<std::string>, TalkerBase, list_speakers);
+    }
+
+    ov::Tensor get_speaker_embedding(const std::string& name) const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::Tensor, TalkerBase, get_speaker_embedding, name);
+    }
+};
+
 py::object call_omni_generate(OmniPipeline& pipe,
                               const std::string& prompt,
                               const std::vector<ov::Tensor>& images,
@@ -211,12 +239,16 @@ py::object call_omni_generate_history(OmniPipeline& pipe,
 }  // namespace
 
 void init_omni_pipeline(py::module_& m) {
-    py::class_<TalkerBase, std::shared_ptr<TalkerBase>>(m, "TalkerBase",
+    // Register the base and the Talker subclass first (Talker needs its base registered), but defer
+    // the generate() binding until OmniTalkerSpeechConfig and TalkerResults are registered below —
+    // pybind resolves argument/return types at .def() time and would otherwise emit raw C++ names.
+    auto talker_base = py::class_<TalkerBase, PyTalkerBase, std::shared_ptr<TalkerBase>>(m, "TalkerBase",
         R"(Abstract speech-output backend for OmniPipeline.
 
         Subclass to plug a custom talker into OmniPipeline. The default implementation
         is Talker. Subclasses must override generate(), list_speakers(), and
         get_speaker_embedding().)")
+        .def(py::init<>())
         .def("list_speakers", &TalkerBase::list_speakers)
         .def("get_speaker_embedding", &TalkerBase::get_speaker_embedding, py::arg("name"));
 
@@ -320,6 +352,14 @@ void init_omni_pipeline(py::module_& m) {
         .def(py::init<>())
         .def_readonly("waveforms", &ov::genai::TalkerResults::waveforms)
         .def_readonly("perf_metrics", &ov::genai::TalkerResults::perf_metrics);
+
+    // Deferred from the TalkerBase registration so OmniTalkerSpeechConfig and TalkerResults render
+    // as Python types in the signature rather than raw C++ names.
+    talker_base.def("generate", &TalkerBase::generate,
+                    py::arg("vlm_result"),
+                    py::arg("talker_speech_config"),
+                    py::arg("speech_streamer") = std::monostate{},
+                    "Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.");
 
     py::class_<OmniDecodedResults, VLMDecodedResults>(m, "OmniDecodedResults",
         R"(Omni-specific decoded results including speech outputs.

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -417,7 +417,18 @@ void init_omni_pipeline(py::module_& m) {
 
     // Deferred from the TalkerBase registration so OmniTalkerSpeechConfig and TalkerResults render
     // as Python types in the signature rather than raw C++ names.
-    talker_base.def("generate", &TalkerBase::generate,
+    talker_base.def("generate",
+                    [](TalkerBase& self,
+                       const VLMDecodedResults& vlm_result,
+                       const OmniTalkerSpeechConfig& talker_speech_config,
+                       const ov::genai::OmniSpeechStreamerVariant& speech_streamer) {
+                        ov::genai::TalkerResults res;
+                        {
+                            py::gil_scoped_release rel;
+                            res = self.generate(vlm_result, talker_speech_config, speech_streamer);
+                        }
+                        return res;
+                    },
                     py::arg("vlm_result"),
                     py::arg("talker_speech_config"),
                     py::arg("speech_streamer") = std::monostate{},

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -156,6 +156,52 @@ auto omni_generate_history_docstring = R"(
     :type videos_metadata: list[VideoMetadata]
 )";
 
+// Trampoline enabling Python subclasses of TalkerBase (injected via the OmniPipeline DI ctor).
+class PyTalkerBase : public TalkerBase {
+public:
+    using TalkerBase::TalkerBase;
+
+    ov::genai::TalkerResults generate(const VLMDecodedResults& vlm_result,
+                                      const OmniTalkerSpeechConfig& talker_speech_config,
+                                      const ov::genai::OmniSpeechStreamerVariant& speech_streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::TalkerResults,
+                               TalkerBase,
+                               generate,
+                               vlm_result,
+                               talker_speech_config,
+                               speech_streamer);
+    }
+
+    // OmniPipeline only ever calls the typed overload above, and the property-bag form would need
+    // the internal config-parsing helpers that these bindings deliberately don't include.
+    ov::genai::TalkerResults generate(const VLMDecodedResults&, const ov::AnyMap&) override {
+        OPENVINO_THROW(
+            "Python TalkerBase subclasses implement generate(vlm_result, talker_speech_config, speech_streamer). "
+            "The property-bag generate(vlm_result, properties) overload is not available from Python.");
+    }
+
+    OmniTalkerSpeechConfig get_speech_config() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(OmniTalkerSpeechConfig, TalkerBase, get_speech_config);
+    }
+
+    void set_speech_config(const OmniTalkerSpeechConfig& config) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, TalkerBase, set_speech_config, config);
+    }
+
+    std::vector<std::string> list_speakers() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(std::vector<std::string>, TalkerBase, list_speakers);
+    }
+
+    ov::Tensor get_speaker_embedding(const std::string& name) const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::Tensor, TalkerBase, get_speaker_embedding, name);
+    }
+};
+
 py::object call_omni_generate(OmniPipeline& pipe,
                               const std::string& prompt,
                               const std::vector<ov::Tensor>& images,
@@ -270,13 +316,17 @@ void init_omni_pipeline(py::module_& m) {
         .def_readwrite("cp_temperature", &OmniTalkerSpeechConfig::cp_temperature)
         .def_readwrite("cp_top_k", &OmniTalkerSpeechConfig::cp_top_k);
 
-    py::class_<TalkerBase, std::shared_ptr<TalkerBase>>(m, "TalkerBase",
+    // PyTalkerBase is the trampoline that lets a Python subclass satisfy the pure virtuals.
+    // generate() is bound further down, once TalkerResults is registered, so its signature
+    // renders as a Python type rather than a raw C++ name.
+    auto talker_base = py::class_<TalkerBase, PyTalkerBase, std::shared_ptr<TalkerBase>>(m, "TalkerBase",
         R"(Abstract speech-output backend for OmniPipeline.
 
         Pure interface with no storage of its own. Subclass to plug a custom talker into
         OmniPipeline; the default implementation is Talker. Subclasses must override
         generate(), get_speech_config(), set_speech_config(), list_speakers(), and
         get_speaker_embedding().)")
+        .def(py::init<>())
         .def("list_speakers", &TalkerBase::list_speakers)
         .def("get_speaker_embedding", &TalkerBase::get_speaker_embedding, py::arg("name"))
         .def("get_speech_config",
@@ -364,6 +414,14 @@ void init_omni_pipeline(py::module_& m) {
         .def(py::init<>())
         .def_readonly("waveforms", &ov::genai::TalkerResults::waveforms)
         .def_readonly("perf_metrics", &ov::genai::TalkerResults::perf_metrics);
+
+    // Deferred from the TalkerBase registration so OmniTalkerSpeechConfig and TalkerResults render
+    // as Python types in the signature rather than raw C++ names.
+    talker_base.def("generate", &TalkerBase::generate,
+                    py::arg("vlm_result"),
+                    py::arg("talker_speech_config"),
+                    py::arg("speech_streamer") = std::monostate{},
+                    "Run speech generation against a VLM result. Override in a subclass. Returns TalkerResults.");
 
     py::class_<OmniDecodedResults, VLMDecodedResults>(m, "OmniDecodedResults",
         R"(Omni-specific decoded results including speech outputs.

--- a/src/python/py_utils.cpp
+++ b/src/python/py_utils.cpp
@@ -499,7 +499,7 @@ ov::Any py_object_to_any(const py::object& py_obj, std::string property_name) {
         auto streamer = py::cast<ov::genai::pybind::utils::PyBindStreamerVariant>(py_obj);
         return ov::genai::streamer(pystreamer_to_streamer(streamer)).second;
     } else if ((py::isinstance<py::function>(py_obj) || py::isinstance<ov::genai::OmniSpeechStreamerBase>(py_obj)) &&
-               property_name == "audio_streamer") {
+               (property_name == "audio_streamer" || property_name == "speech_streamer")) {
         auto audio_streamer = py::cast<ov::genai::pybind::utils::PyBindOmniSpeechStreamerVariant>(py_obj);
         auto converted = py_speech_streamer_to_streamer(audio_streamer);
         // Store the unwrapped concrete type so get_audio_streamer_from_map can .is<T>() it

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/stl/filesystem.h>
 #include <pybind11/functional.h>
 
+#include "openvino/core/except.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
 #include "openvino/genai/visual_language/perf_metrics.hpp"
 #include "openvino/genai/visual_language/video_metadata.hpp"
@@ -20,6 +21,130 @@
 namespace py = pybind11;
 namespace pyutils = ov::genai::pybind::utils;
 namespace common_utils = ov::genai::common_bindings::utils;
+
+namespace {
+
+// Trampoline enabling Python subclasses of VLMPipelineBase (injected via the OmniPipeline DI ctor).
+// C++ has many generate overloads but Python has one name: the videos_metadata-aware overloads map
+// to the Python "generate", the narrower ones forward to them, and the AnyMap overloads throw.
+class PyVLMPipelineBase : public ov::genai::VLMPipelineBase {
+public:
+    using ov::genai::VLMPipelineBase::VLMPipelineBase;
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const std::vector<ov::Tensor>& audios,
+                                          const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::VLMDecodedResults,
+                               ov::genai::VLMPipelineBase,
+                               generate,
+                               prompt,
+                               images,
+                               videos,
+                               audios,
+                               videos_metadata,
+                               generation_config,
+                               streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const std::vector<ov::Tensor>& audios,
+                                          const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::VLMDecodedResults,
+                               ov::genai::VLMPipelineBase,
+                               generate,
+                               history,
+                               images,
+                               videos,
+                               audios,
+                               videos_metadata,
+                               generation_config,
+                               streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(prompt, images, {}, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(prompt, images, videos, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(history, images, {}, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(history, images, videos, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string&, const ov::AnyMap&) override {
+        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(prompt, config_map) overload is not supported "
+                       "for Python-defined subclasses. Override the "
+                       "generate(prompt, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory&, const ov::AnyMap&) override {
+        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(history, config_map) overload is not supported "
+                       "for Python-defined subclasses. Override the "
+                       "generate(history, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    }
+
+    ov::genai::Tokenizer get_tokenizer() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::Tokenizer, ov::genai::VLMPipelineBase, get_tokenizer);
+    }
+
+    void set_chat_template(const std::string& new_template) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, ov::genai::VLMPipelineBase, set_chat_template, new_template);
+    }
+
+    ov::genai::GenerationConfig get_generation_config() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::GenerationConfig, ov::genai::VLMPipelineBase, get_generation_config);
+    }
+
+    void set_generation_config(const ov::genai::GenerationConfig& new_config) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, ov::genai::VLMPipelineBase, set_generation_config, new_config);
+    }
+
+    bool supports_hidden_states_collection() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(bool, ov::genai::VLMPipelineBase, supports_hidden_states_collection);
+    }
+
+    bool is_audio_output_enabled() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(bool, ov::genai::VLMPipelineBase, is_audio_output_enabled);
+    }
+};
+
+}  // namespace
 
 auto vlm_generate_description = R"(
     Generates sequences for VLMs.
@@ -287,10 +412,46 @@ An input image without explicit slicing metadata counts as one slice.)")
             return res;
         });
 
-    // Abstract public base. Registered (without a constructor) so that a VLMPipeline can be
-    // passed to OmniPipeline's DI constructor as a shared_ptr<VLMPipelineBase>.
-    py::class_<ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipelineBase>>(
-        m, "VLMPipelineBase", "Abstract base of VLM-style pipelines.");
+    py::class_<ov::genai::VLMPipelineBase, PyVLMPipelineBase, std::shared_ptr<ov::genai::VLMPipelineBase>>(
+        m, "VLMPipelineBase",
+        R"(Abstract base of VLM-style pipelines.
+
+        Subclass to plug a custom thinker into OmniPipeline via its dependency-injection
+        constructor. A subclass must override generate(), get_tokenizer(), get_generation_config(),
+        set_generation_config(), set_chat_template(), and the Qwen3-Omni capability queries
+        supports_hidden_states_collection() and is_audio_output_enabled().)")
+        .def(py::init<>())
+        .def("generate",
+             [](ov::genai::VLMPipelineBase& self,
+                const std::variant<std::string, ov::genai::ChatHistory>& prompt,
+                const std::vector<ov::Tensor>& images,
+                const std::vector<ov::Tensor>& videos,
+                const std::vector<ov::Tensor>& audios,
+                const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                const ov::genai::GenerationConfig& generation_config,
+                const pyutils::PyBindStreamerVariant& streamer) -> ov::genai::VLMDecodedResults {
+                 auto native_streamer = pyutils::pystreamer_to_streamer(streamer);
+                 if (const auto* prompt_str = std::get_if<std::string>(&prompt)) {
+                     return self.generate(*prompt_str, images, videos, audios, videos_metadata,
+                                          generation_config, native_streamer);
+                 }
+                 return self.generate(std::get<ov::genai::ChatHistory>(prompt), images, videos, audios,
+                                      videos_metadata, generation_config, native_streamer);
+             },
+             py::arg("prompt"),
+             py::arg("images") = std::vector<ov::Tensor>{},
+             py::arg("videos") = std::vector<ov::Tensor>{},
+             py::arg("audios") = std::vector<ov::Tensor>{},
+             py::arg("videos_metadata") = std::vector<ov::genai::VideoMetadata>{},
+             py::arg("generation_config") = ov::genai::GenerationConfig{},
+             py::arg("streamer") = std::monostate{},
+             "Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.")
+        .def("get_tokenizer", &ov::genai::VLMPipelineBase::get_tokenizer)
+        .def("set_chat_template", &ov::genai::VLMPipelineBase::set_chat_template, py::arg("chat_template"))
+        .def("get_generation_config", &ov::genai::VLMPipelineBase::get_generation_config)
+        .def("set_generation_config", &ov::genai::VLMPipelineBase::set_generation_config, py::arg("config"))
+        .def("supports_hidden_states_collection", &ov::genai::VLMPipelineBase::supports_hidden_states_collection)
+        .def("is_audio_output_enabled", &ov::genai::VLMPipelineBase::is_audio_output_enabled);
 
     py::class_<ov::genai::VLMPipeline, ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipeline>>(m, "VLMPipeline", "This class is used for generation with VLMs")
         .def(py::init([](

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -468,12 +468,18 @@ An input image without explicit slicing metadata counts as one slice.)")
                 const ov::genai::GenerationConfig& generation_config,
                 const pyutils::PyBindStreamerVariant& streamer) -> ov::genai::VLMDecodedResults {
                  auto native_streamer = pyutils::pystreamer_to_streamer(streamer);
-                 if (const auto* prompt_str = std::get_if<std::string>(&prompt)) {
-                     return self.generate(*prompt_str, images, videos, audios, videos_metadata,
-                                          generation_config, native_streamer);
+                 ov::genai::VLMDecodedResults res;
+                 {
+                     py::gil_scoped_release rel;
+                     if (const auto* prompt_str = std::get_if<std::string>(&prompt)) {
+                         res = self.generate(*prompt_str, images, videos, audios, videos_metadata,
+                                             generation_config, native_streamer);
+                     } else {
+                         res = self.generate(std::get<ov::genai::ChatHistory>(prompt), images, videos, audios,
+                                             videos_metadata, generation_config, native_streamer);
+                     }
                  }
-                 return self.generate(std::get<ov::genai::ChatHistory>(prompt), images, videos, audios,
-                                      videos_metadata, generation_config, native_streamer);
+                 return res;
              },
              py::arg("prompt"),
              py::arg("images") = std::vector<ov::Tensor>{},

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -15,6 +15,8 @@
 #include "openvino/genai/visual_language/perf_metrics.hpp"
 #include "openvino/genai/visual_language/video_metadata.hpp"
 #include "tokenizer/tokenizers_path.hpp"
+#include "utils.hpp"
+#include "visual_language/multimodal_inputs.hpp"
 #include "py_utils.hpp"
 #include "bindings_utils.hpp"
 
@@ -26,7 +28,7 @@ namespace {
 
 // Trampoline enabling Python subclasses of VLMPipelineBase (injected via the OmniPipeline DI ctor).
 // C++ has many generate overloads but Python has one name: the videos_metadata-aware overloads map
-// to the Python "generate", the narrower ones forward to them, and the AnyMap overloads throw.
+// to the Python "generate" and every other overload — narrow, or property-bag — reduces to them.
 class PyVLMPipelineBase : public ov::genai::VLMPipelineBase {
 public:
     using ov::genai::VLMPipelineBase::VLMPipelineBase;
@@ -101,16 +103,27 @@ public:
         return generate(history, images, videos, {}, {}, generation_config, streamer);
     }
 
-    ov::genai::VLMDecodedResults generate(const std::string&, const ov::AnyMap&) override {
-        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(prompt, config_map) overload is not supported "
-                       "for Python-defined subclasses. Override the "
-                       "generate(prompt, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    ov::genai::VLMDecodedResults generate(const std::string& prompt, const ov::AnyMap& config_map) override {
+        const auto inputs = unpack_config_map(config_map);
+        return generate(prompt,
+                        inputs.images.value_or(std::vector<ov::Tensor>{}),
+                        inputs.videos.value_or(std::vector<ov::Tensor>{}),
+                        inputs.audios.value_or(std::vector<ov::Tensor>{}),
+                        inputs.videos_metadata.value_or(std::vector<ov::genai::VideoMetadata>{}),
+                        resolve_generation_config(config_map),
+                        ov::genai::utils::get_streamer_from_map(config_map));
     }
 
-    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory&, const ov::AnyMap&) override {
-        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(history, config_map) overload is not supported "
-                       "for Python-defined subclasses. Override the "
-                       "generate(history, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const ov::AnyMap& config_map) override {
+        const auto inputs = unpack_config_map(config_map);
+        return generate(history,
+                        inputs.images.value_or(std::vector<ov::Tensor>{}),
+                        inputs.videos.value_or(std::vector<ov::Tensor>{}),
+                        inputs.audios.value_or(std::vector<ov::Tensor>{}),
+                        inputs.videos_metadata.value_or(std::vector<ov::genai::VideoMetadata>{}),
+                        resolve_generation_config(config_map),
+                        ov::genai::utils::get_streamer_from_map(config_map));
     }
 
     ov::genai::Tokenizer get_tokenizer() const override {
@@ -141,6 +154,23 @@ public:
     bool is_audio_output_enabled() const override {
         py::gil_scoped_acquire acquire;
         PYBIND11_OVERRIDE_PURE(bool, ov::genai::VLMPipelineBase, is_audio_output_enabled);
+    }
+
+private:
+    static ov::genai::MultimodalInputs unpack_config_map(const ov::AnyMap& config_map) {
+        OPENVINO_ASSERT(config_map.find(ov::genai::utils::AUDIO_STREAMER_ARG_NAME) == config_map.end(),
+                        "VLMPipelineBase: '",
+                        ov::genai::utils::AUDIO_STREAMER_ARG_NAME,
+                        "' is only consumed by the built-in Qwen3-Omni speech path and cannot be forwarded to a "
+                        "Python-defined subclass.");
+        return ov::genai::extract_multimodal_inputs(config_map);
+    }
+
+    ov::genai::GenerationConfig resolve_generation_config(const ov::AnyMap& config_map) {
+        const auto provided = ov::genai::utils::get_config_from_map(config_map);
+        auto config = provided.has_value() ? *provided : get_generation_config();
+        config.update_generation_config(config_map);
+        return config;
     }
 };
 
@@ -489,6 +519,26 @@ An input image without explicit slicing metadata counts as one slice.)")
              py::arg("generation_config") = ov::genai::GenerationConfig{},
              py::arg("streamer") = std::monostate{},
              "Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.")
+        .def("generate",
+             [](ov::genai::VLMPipelineBase& self,
+                const std::variant<std::string, ov::genai::ChatHistory>& prompt,
+                const py::kwargs& kwargs) -> ov::genai::VLMDecodedResults {
+                 const ov::AnyMap config_map = pyutils::kwargs_to_any_map(kwargs);
+                 ov::genai::VLMDecodedResults res;
+                 {
+                     py::gil_scoped_release rel;
+                     if (const auto* prompt_str = std::get_if<std::string>(&prompt)) {
+                         res = self.generate(*prompt_str, config_map);
+                     } else {
+                         res = self.generate(std::get<ov::genai::ChatHistory>(prompt), config_map);
+                     }
+                 }
+                 return res;
+             },
+             py::arg("prompt"),
+             "Generate a VLM response from a property bag: images, videos, audios, videos_metadata, "
+             "generation_config, streamer, or any GenerationConfig field as a keyword argument. "
+             "Reduces to the typed generate() the subclass overrides.")
         .def("get_tokenizer", &ov::genai::VLMPipelineBase::get_tokenizer)
         .def("set_chat_template", &ov::genai::VLMPipelineBase::set_chat_template, py::arg("chat_template"))
         .def("get_generation_config", &ov::genai::VLMPipelineBase::get_generation_config)

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/stl/filesystem.h>
 #include <pybind11/functional.h>
 
+#include "openvino/core/except.hpp"
 #include "openvino/genai/visual_language/pipeline.hpp"
 #include "openvino/genai/visual_language/perf_metrics.hpp"
 #include "openvino/genai/visual_language/video_metadata.hpp"
@@ -20,6 +21,130 @@
 namespace py = pybind11;
 namespace pyutils = ov::genai::pybind::utils;
 namespace common_utils = ov::genai::common_bindings::utils;
+
+namespace {
+
+// Trampoline enabling Python subclasses of VLMPipelineBase (injected via the OmniPipeline DI ctor).
+// C++ has many generate overloads but Python has one name: the videos_metadata-aware overloads map
+// to the Python "generate", the narrower ones forward to them, and the AnyMap overloads throw.
+class PyVLMPipelineBase : public ov::genai::VLMPipelineBase {
+public:
+    using ov::genai::VLMPipelineBase::VLMPipelineBase;
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const std::vector<ov::Tensor>& audios,
+                                          const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::VLMDecodedResults,
+                               ov::genai::VLMPipelineBase,
+                               generate,
+                               prompt,
+                               images,
+                               videos,
+                               audios,
+                               videos_metadata,
+                               generation_config,
+                               streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const std::vector<ov::Tensor>& audios,
+                                          const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::VLMDecodedResults,
+                               ov::genai::VLMPipelineBase,
+                               generate,
+                               history,
+                               images,
+                               videos,
+                               audios,
+                               videos_metadata,
+                               generation_config,
+                               streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(prompt, images, {}, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string& prompt,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(prompt, images, videos, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(history, images, {}, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory& history,
+                                          const std::vector<ov::Tensor>& images,
+                                          const std::vector<ov::Tensor>& videos,
+                                          const ov::genai::GenerationConfig& generation_config,
+                                          const ov::genai::StreamerVariant& streamer) override {
+        return generate(history, images, videos, {}, {}, generation_config, streamer);
+    }
+
+    ov::genai::VLMDecodedResults generate(const std::string&, const ov::AnyMap&) override {
+        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(prompt, config_map) overload is not supported "
+                       "for Python-defined subclasses. Override the "
+                       "generate(prompt, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    }
+
+    ov::genai::VLMDecodedResults generate(const ov::genai::ChatHistory&, const ov::AnyMap&) override {
+        OPENVINO_THROW("VLMPipelineBase: the property-bag generate(history, config_map) overload is not supported "
+                       "for Python-defined subclasses. Override the "
+                       "generate(history, images, videos, audios, videos_metadata, generation_config, streamer) method.");
+    }
+
+    ov::genai::Tokenizer get_tokenizer() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::Tokenizer, ov::genai::VLMPipelineBase, get_tokenizer);
+    }
+
+    void set_chat_template(const std::string& new_template) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, ov::genai::VLMPipelineBase, set_chat_template, new_template);
+    }
+
+    ov::genai::GenerationConfig get_generation_config() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(ov::genai::GenerationConfig, ov::genai::VLMPipelineBase, get_generation_config);
+    }
+
+    void set_generation_config(const ov::genai::GenerationConfig& new_config) override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(void, ov::genai::VLMPipelineBase, set_generation_config, new_config);
+    }
+
+    bool supports_hidden_states_collection() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(bool, ov::genai::VLMPipelineBase, supports_hidden_states_collection);
+    }
+
+    bool is_audio_output_enabled() const override {
+        py::gil_scoped_acquire acquire;
+        PYBIND11_OVERRIDE_PURE(bool, ov::genai::VLMPipelineBase, is_audio_output_enabled);
+    }
+};
+
+}  // namespace
 
 auto vlm_generate_description = R"(
     Generates sequences for VLMs.
@@ -324,10 +449,46 @@ An input image without explicit slicing metadata counts as one slice.)")
             return res;
         });
 
-    // Abstract public base. Registered (without a constructor) so that a VLMPipeline can be
-    // passed to OmniPipeline's DI constructor as a shared_ptr<VLMPipelineBase>.
-    py::class_<ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipelineBase>>(
-        m, "VLMPipelineBase", "Abstract base of VLM-style pipelines.");
+    py::class_<ov::genai::VLMPipelineBase, PyVLMPipelineBase, std::shared_ptr<ov::genai::VLMPipelineBase>>(
+        m, "VLMPipelineBase",
+        R"(Abstract base of VLM-style pipelines.
+
+        Subclass to plug a custom thinker into OmniPipeline via its dependency-injection
+        constructor. A subclass must override generate(), get_tokenizer(), get_generation_config(),
+        set_generation_config(), set_chat_template(), and the Qwen3-Omni capability queries
+        supports_hidden_states_collection() and is_audio_output_enabled().)")
+        .def(py::init<>())
+        .def("generate",
+             [](ov::genai::VLMPipelineBase& self,
+                const std::variant<std::string, ov::genai::ChatHistory>& prompt,
+                const std::vector<ov::Tensor>& images,
+                const std::vector<ov::Tensor>& videos,
+                const std::vector<ov::Tensor>& audios,
+                const std::vector<ov::genai::VideoMetadata>& videos_metadata,
+                const ov::genai::GenerationConfig& generation_config,
+                const pyutils::PyBindStreamerVariant& streamer) -> ov::genai::VLMDecodedResults {
+                 auto native_streamer = pyutils::pystreamer_to_streamer(streamer);
+                 if (const auto* prompt_str = std::get_if<std::string>(&prompt)) {
+                     return self.generate(*prompt_str, images, videos, audios, videos_metadata,
+                                          generation_config, native_streamer);
+                 }
+                 return self.generate(std::get<ov::genai::ChatHistory>(prompt), images, videos, audios,
+                                      videos_metadata, generation_config, native_streamer);
+             },
+             py::arg("prompt"),
+             py::arg("images") = std::vector<ov::Tensor>{},
+             py::arg("videos") = std::vector<ov::Tensor>{},
+             py::arg("audios") = std::vector<ov::Tensor>{},
+             py::arg("videos_metadata") = std::vector<ov::genai::VideoMetadata>{},
+             py::arg("generation_config") = ov::genai::GenerationConfig{},
+             py::arg("streamer") = std::monostate{},
+             "Generate a VLM response. prompt may be a str or a ChatHistory. Override in a subclass.")
+        .def("get_tokenizer", &ov::genai::VLMPipelineBase::get_tokenizer)
+        .def("set_chat_template", &ov::genai::VLMPipelineBase::set_chat_template, py::arg("chat_template"))
+        .def("get_generation_config", &ov::genai::VLMPipelineBase::get_generation_config)
+        .def("set_generation_config", &ov::genai::VLMPipelineBase::set_generation_config, py::arg("config"))
+        .def("supports_hidden_states_collection", &ov::genai::VLMPipelineBase::supports_hidden_states_collection)
+        .def("is_audio_output_enabled", &ov::genai::VLMPipelineBase::is_audio_output_enabled);
 
     py::class_<ov::genai::VLMPipeline, ov::genai::VLMPipelineBase, std::shared_ptr<ov::genai::VLMPipeline>>(m, "VLMPipeline", "This class is used for generation with VLMs")
         .def(py::init([](

--- a/tests/python_tests/pytest.ini
+++ b/tests/python_tests/pytest.ini
@@ -13,6 +13,7 @@ markers =
     ; rag         - Tests related to the RAG components.
     ; speech_generation - Tests related to text-to-speech generation
     ; video_generation - Tests related to video generation
+    ; omni        - Tests related to the Qwen3-Omni text + speech pipeline.
     real_models
     nightly
     samples
@@ -25,6 +26,7 @@ markers =
     rag
     speech_generation
     video_generation
+    omni
     transformers_lower_v5
     transformers_dependent
     transformers_higher_v5_1

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -24,9 +24,14 @@ Two tiers, following the other pipeline suites:
 
 2. Real-model tests against `optimum-intel-internal-testing/tiny-random-qwen3-omni`,
    covering the path-based constructor, text-only and speech generation, the
-   ChatHistory overload, and the speaker APIs.
+   ChatHistory overload, generation-config sensitivity, ModelsMap/path equivalence,
+   multimodal inputs, and the speaker APIs.
 
-The real-model tier needs newer dependencies than tests/python_tests/requirements.txt
+3. Full-model tests marked `real_models`, pointed at a complete Qwen3-Omni export by
+   OMNI_REAL_MODEL_PATH. The tiny checkpoint cannot synthesize speech at all, so the
+   tests that need a real waveform live here and are deselected by default.
+
+The tiny-checkpoint tier needs newer dependencies than tests/python_tests/requirements.txt
 pins, so the CI matrix entries install them per job: transformers 5.0.0 reads an unset
 `use_sliding_window` in `Qwen3OmniMoeTalkerCodePredictorConfig.__init__` and the export
 dies with an `AttributeError` (fixed in 5.1.0), and optimum-intel only grew the
@@ -38,6 +43,7 @@ suite against the repo-wide pins degrades to the model-free tier instead of fail
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -62,6 +68,9 @@ pytestmark = pytest.mark.omni
 
 OMNI_MODEL_ID = "optimum-intel-internal-testing/tiny-random-qwen3-omni"
 
+# Points at a full Qwen3-Omni OpenVINO export for the speech tests the tiny checkpoint cannot host.
+OMNI_REAL_MODEL_ENV = "OMNI_REAL_MODEL_PATH"
+
 # Written by the Talker export; without them OmniPipeline's path ctor cannot build the speech stage.
 TALKER_ARTIFACTS = (
     "openvino_talker_model.xml",
@@ -83,10 +92,11 @@ SPEAKER_EMBEDDING_SCALE = -8.0
 
 NO_WAVEFORM_XFAIL_REASON = (
     "tiny-random-qwen3-omni's talker role token ids are outside its tokenizer's range (im_start 151644, "
-    "user 872, assistant 77091, against a max id of 769), so build_talker_input finds no segments, "
-    "returns empty, and generate() yields zero waveforms without ever reaching code2wav. Same "
-    "checkpoint limitation test_tools_llm_benchmark.py xfails its omni text_to_speech cases on, for "
-    "both --optimum and --genai."
+    "user 872, assistant 77091, against a max id of 769), so build_talker_input finds no segments and "
+    "speech generation raises before reaching code2wav — see "
+    "test_speech_generation_rejects_unmatched_role_tokens, which locks that error in. Same checkpoint "
+    "limitation test_tools_llm_benchmark.py xfails its omni text_to_speech cases on, for both "
+    "--optimum and --genai."
 )
 
 VIDEO_INPUT_XFAIL_REASON = (
@@ -719,6 +729,26 @@ def _generate_speech(pipe: ov_genai.OmniPipeline, speaker: str | ov.Tensor) -> n
     return _single_waveform(result)
 
 
+@pytest.fixture(scope="module")
+def real_omni_pipe() -> ov_genai.OmniPipeline:
+    """Pipeline over a full Qwen3-Omni export, for tests the tiny checkpoint cannot host.
+
+    Pointed at by OMNI_REAL_MODEL_PATH rather than a models/ list file: those hold HF ids consumed by
+    the LLM suites' indirect fixture, which cannot express a pre-exported VLM+talker directory. Tests
+    using this are also marked real_models, so pytest.ini's default addopts deselect them; the skip
+    below only matters when somebody opts in without setting the variable.
+    """
+    raw_path = os.environ.get(OMNI_REAL_MODEL_ENV)
+    if not raw_path:
+        pytest.skip(f"set {OMNI_REAL_MODEL_ENV} to a full Qwen3-Omni OpenVINO export to run this")
+
+    model_dir = Path(raw_path)
+    if not (model_dir / "openvino_talker_model.xml").exists():
+        pytest.skip(f"{OMNI_REAL_MODEL_ENV}={model_dir} has no talker export")
+
+    return ov_genai.OmniPipeline(model_dir, "CPU")
+
+
 def _load_models_map(model_dir: Path) -> dict[str, tuple[str, ov.Tensor]]:
     """Read every exported IR in ``model_dir`` into the ModelsMap form the blob ctors accept.
 
@@ -926,6 +956,27 @@ class TestOmniPipelineRealModel:
 
         _single_waveform(result)
 
+    def test_speech_generation_rejects_unmatched_role_tokens(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+        """A checkpoint whose role token ids never appear in its token stream must raise, not go quiet.
+
+        Speech used to warn and hand back an empty waveform list here, so a misconfigured checkpoint
+        looked like a model that simply had nothing to say. The caller asked for audio; failing to
+        segment the conversation is a configuration error and has to surface as one.
+
+        This is the inverse of test_generate_with_speech: that one asserts the audio a healthy
+        checkpoint owes us and xfails here, this one pins the diagnosis we give for a broken one.
+        """
+        with pytest.raises(RuntimeError, match="im_start_token_id") as excinfo:
+            omni_pipe.generate(
+                "Describe this.",
+                text_config=_text_config(),
+                talker_speech_config=_talker_speech_config(return_audio=True),
+            )
+
+        message = str(excinfo.value)
+        assert "no talker input" in message, f"the error must say what failed, got: {message}"
+        assert "config.json" in message, f"the error must point at the fix, got: {message}"
+
     def test_generate_from_chat_history(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """The ChatHistory overload accepts structured turns and leaves the caller's history intact."""
         history = ov_genai.ChatHistory()
@@ -1006,8 +1057,8 @@ class TestOmniPipelineRealModel:
         embedding = omni_pipe.get_talker().get_speaker_embedding(speakers[0])
         assert embedding.get_size() > 0, f"speaker {speakers[0]!r} must resolve to a non-empty embedding"
 
-    @pytest.mark.skip(reason=NO_WAVEFORM_XFAIL_REASON)
-    def test_altering_speaker_embedding_changes_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+    @pytest.mark.real_models
+    def test_altering_speaker_embedding_changes_speech(self, real_omni_pipe: ov_genai.OmniPipeline) -> None:
         """A modified speaker embedding yields different speech; an unmodified one reproduces it exactly.
 
         OmniTalkerSpeechConfig.speaker is a variant of name-or-tensor, and the tensor branch bypasses
@@ -1015,7 +1066,11 @@ class TestOmniPipelineRealModel:
         greedy path, so all three runs pin the same rng_seed. The control run proves the pipeline is
         reproducible under that seed, which is what lets the third run attribute its difference to the
         embedding rather than to sampling noise.
+
+        Needs a full checkpoint: the tiny one cannot synthesize at all, so there is no waveform to
+        compare. See NO_WAVEFORM_XFAIL_REASON.
         """
+        omni_pipe = real_omni_pipe
         talker = omni_pipe.get_talker()
         speakers = talker.list_speakers()
         assert speakers, "the checkpoint declares speakers, so list_speakers() must not be empty"
@@ -1037,12 +1092,16 @@ class TestOmniPipelineRealModel:
             f"({perturbed.size} samples), so the embedding is not reaching the talker"
         )
 
-    @pytest.mark.skip(reason=NO_WAVEFORM_XFAIL_REASON)
-    def test_distinct_speakers_produce_distinct_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
-        """Two different named speakers must not render the same audio for the same text and seed."""
+    @pytest.mark.real_models
+    def test_distinct_speakers_produce_distinct_speech(self, real_omni_pipe: ov_genai.OmniPipeline) -> None:
+        """Two different named speakers must not render the same audio for the same text and seed.
+
+        Needs a full checkpoint, for the same reason as the embedding test above.
+        """
+        omni_pipe = real_omni_pipe
         speakers = omni_pipe.get_talker().list_speakers()
         if len(speakers) < 2:
-            pytest.skip(f"{OMNI_MODEL_ID} declares a single speaker ({speakers}); nothing to compare")
+            pytest.skip(f"the checkpoint declares a single speaker ({speakers}); nothing to compare")
 
         first = _generate_speech(omni_pipe, speaker=speakers[0])
         second = _generate_speech(omni_pipe, speaker=speakers[1])

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -26,16 +26,13 @@ Two tiers, following the other pipeline suites:
    covering the path-based constructor, text-only and speech generation, the
    ChatHistory overload, and the speaker APIs.
 
-The real-model tier currently skips: the tiny checkpoint is a full omni model
-(talker_config, code2wav_config, enable_audio_output), but exporting it needs
-support that the pinned dependencies do not have yet. With transformers==5.0.0 the
-export raises `AttributeError: 'Qwen3OmniMoeTalkerCodePredictorConfig' object has no
-attribute 'use_sliding_window'` — the same failure `test_vlm_pipeline.py`'s
-`test_qwen3_omni_vision_preprocess_modes_equivalence` xfails on. Beyond that, the
-pinned optimum-intel exports no talker/code2wav submodels at all, so `Talker` has
-nothing to load. `omni_model_path` detects both cases — plus transformers older than
-4.57, which cannot export Qwen3-Omni at all — and skips with the reason; the tests
-activate on their own once either dependency catches up.
+The real-model tier needs newer dependencies than tests/python_tests/requirements.txt
+pins, so the CI matrix entries install them per job: transformers 5.0.0 reads an unset
+`use_sliding_window` in `Qwen3OmniMoeTalkerCodePredictorConfig.__init__` and the export
+dies with an `AttributeError` (fixed in 5.1.0), and optimum-intel only grew the
+talker/code2wav export in huggingface/optimum-intel#1700, after the pinned revision.
+`omni_model_path` still detects both gaps and skips with the reason, so running the
+suite against the repo-wide pins degrades to the model-free tier instead of failing.
 """
 
 from __future__ import annotations
@@ -47,10 +44,17 @@ from pathlib import Path
 
 import numpy as np
 import openvino as ov
+import openvino_tokenizers
 import pytest
+import transformers
+from huggingface_hub import snapshot_download
+from optimum.intel import OVModelForVisualCausalLM
+from optimum.utils.import_utils import is_transformers_version
 
 import openvino_genai as ov_genai
+from utils.atomic_download import AtomicDownloadManager
 from utils.constants import get_ov_cache_converted_models_dir
+from utils.network import retry_request
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +67,42 @@ TALKER_ARTIFACTS = (
     "openvino_talker_model.xml",
     "openvino_code_predictor_model.xml",
     "openvino_code2wav_model.xml",
+)
+
+MEDIA_EDGE = 64
+VIDEO_FRAMES = 4
+AUDIO_SAMPLE_RATE = 16000
+AUDIO_SAMPLES = AUDIO_SAMPLE_RATE
+
+SPEECH_PROMPT = "Say hello."
+
+TALKER_RNG_SEED = 1234
+TALKER_MAX_NEW_TOKENS = 8
+
+SPEAKER_EMBEDDING_SCALE = -8.0
+
+NO_WAVEFORM_XFAIL_REASON = (
+    "tiny-random-qwen3-omni's talker role token ids are outside its tokenizer's range (im_start 151644, "
+    "user 872, assistant 77091, against a max id of 769), so build_talker_input finds no segments, "
+    "returns empty, and generate() yields zero waveforms without ever reaching code2wav. Same "
+    "checkpoint limitation test_tools_llm_benchmark.py xfails its omni text_to_speech cases on, for "
+    "both --optimum and --genai."
+)
+
+VIDEO_INPUT_XFAIL_REASON = (
+    "tiny-random-qwen3-omni's processor_config.json declares video_processor.patch_size=14 (a stale "
+    "Qwen2VL default) while image_processor and thinker_config.vision_config both say 16, so the video "
+    "patch dim is 2*3*14*14=1176 against an encoder built for 1536 and the infer request fails "
+    "shape.compatible(). Setting that one value to 16 makes video work on this checkpoint, and real "
+    "Qwen3-Omni models already ship 16 — the encoder and the video path itself are fine."
+)
+
+AUDIO_INPUT_XFAIL_REASON = (
+    "tiny-random-qwen3-omni is internally inconsistent for audio: thinker_config.audio_token_id is 9, "
+    "while its tokenizer maps <|AUDIO|> to 267 and has no <|audio_pad|> token at all. GenAI injects "
+    "<|audio_start|><|audio_pad|>...<|audio_end|> and merges audio features at audio_token_id positions, "
+    "so nothing matches and merge_audio_embeddings() throws 'Audio token count mismatch: placed 0 "
+    "embeddings'. Same root cause as the omni speech_to_text xfail in test_tools_llm_benchmark.py."
 )
 
 
@@ -208,6 +248,7 @@ class RecordingTalker(ov_genai.TalkerBase):
         super().__init__()
         self.generate_calls = 0
         self.last_return_audio: bool | None = None
+        self.last_speech_streamer: object | None = None
         self._speakers = speakers if speakers is not None else ["default_voice"]
         self._speech_config = ov_genai.OmniTalkerSpeechConfig()
 
@@ -219,6 +260,7 @@ class RecordingTalker(ov_genai.TalkerBase):
     ) -> ov_genai.TalkerResults:
         self.generate_calls += 1
         self.last_return_audio = talker_speech_config.return_audio
+        self.last_speech_streamer = speech_streamer
         return ov_genai.TalkerResults()
 
     # TalkerBase declares these pure virtual, so a Python backend has to store the config itself.
@@ -248,6 +290,7 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
         self.last_videos: list[ov.Tensor] = []
         self.last_audios: list[ov.Tensor] = []
         self.last_videos_metadata: list[ov_genai.VideoMetadata] = []
+        self.last_max_new_tokens: int | None = None
         self._audio_output = audio_output
         self._hidden_states = hidden_states
 
@@ -267,6 +310,7 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
         self.last_videos = list(videos or [])
         self.last_audios = list(audios or [])
         self.last_videos_metadata = list(videos_metadata or [])
+        self.last_max_new_tokens = generation_config.max_new_tokens if generation_config else None
         return ov_genai.VLMDecodedResults()
 
     def get_tokenizer(self) -> ov_genai.Tokenizer:
@@ -303,6 +347,55 @@ class TestCustomTalkerSubclass:
         embedding = talker.get_speaker_embedding("alice")
         assert embedding.shape == [1, 1, 4]
 
+    def test_property_bag_generate_reduces_to_typed_override(self) -> None:
+        """The kwargs generate() resolves the property bag and dispatches to the typed Python override.
+
+        Called through TalkerBase rather than the instance on purpose: a Python subclass's own
+        `generate` shadows the binding, so only the base entry point exercises the C++ AnyMap
+        overload and the trampoline reduction behind it.
+        """
+        talker = RecordingTalker()
+
+        ov_genai.TalkerBase.generate(talker, ov_genai.VLMDecodedResults(), return_audio=False)
+
+        assert talker.generate_calls == 1, "the property-bag overload must reach the typed Python override"
+        assert talker.last_return_audio is False, "return_audio must survive the AnyMap round-trip"
+
+    def test_property_bag_generate_falls_back_to_stored_config(self) -> None:
+        """Fields omitted from the kwargs come from get_speech_config(), not from a default-constructed one."""
+        talker = RecordingTalker()
+        stored = ov_genai.OmniTalkerSpeechConfig()
+        stored.return_audio = False
+        talker.set_speech_config(stored)
+
+        ov_genai.TalkerBase.generate(talker, ov_genai.VLMDecodedResults(), rng_seed=5)
+
+        assert talker.last_return_audio is False, "an omitted field must fall back to the backend's stored config"
+
+    def test_property_bag_generate_accepts_speech_streamer(self) -> None:
+        """A speech_streamer callable passed as a kwarg reaches the typed override.
+
+        The C++ AnyMap overload accepts a speech_streamer property, so the kwargs form has to as
+        well or the two APIs diverge on the one argument that is specific to the talker.
+        """
+        talker = RecordingTalker()
+
+        ov_genai.TalkerBase.generate(
+            talker, ov_genai.VLMDecodedResults(), return_audio=False, speech_streamer=lambda chunk: None
+        )
+
+        assert talker.generate_calls == 1, "a speech_streamer kwarg must not block the property-bag overload"
+        assert talker.last_speech_streamer is not None, "the streamer must survive the AnyMap round-trip"
+
+    def test_property_bag_generate_rejects_unknown_keys(self) -> None:
+        """A typo in a kwarg must raise rather than being silently dropped."""
+        talker = RecordingTalker()
+
+        with pytest.raises(RuntimeError, match="is_omni_talker_speech_config_key"):
+            ov_genai.TalkerBase.generate(talker, ov_genai.VLMDecodedResults(), bogus_key=1)
+
+        assert talker.generate_calls == 0, "an invalid property bag must not reach the backend"
+
 
 class TestCustomVLMSubclass:
     """Users can define a VLMPipelineBase child in Python and have its methods dispatched from C++."""
@@ -315,6 +408,54 @@ class TestCustomVLMSubclass:
         vlm = RecordingVLM(audio_output=False, hidden_states=False)
         assert vlm.is_audio_output_enabled() is False
         assert vlm.supports_hidden_states_collection() is False
+
+    def test_property_bag_generate_reduces_to_typed_override(self) -> None:
+        """The kwargs generate() unpacks media and GenerationConfig fields into the typed override.
+
+        Called through VLMPipelineBase for the same reason as the talker case: the subclass's own
+        `generate` would otherwise shadow the binding under test.
+        """
+        vlm = RecordingVLM()
+        media = ov.Tensor(np.zeros((1, 4, 4, 3), dtype=np.uint8))
+
+        ov_genai.VLMPipelineBase.generate(vlm, "describe", images=[media], max_new_tokens=7)
+
+        assert vlm.generate_calls == 1, "the property-bag overload must reach the typed Python override"
+        assert vlm.last_prompt == "describe"
+        assert len(vlm.last_images) == 1, "images must survive the AnyMap round-trip"
+        assert vlm.last_max_new_tokens == 7, "a bare GenerationConfig field must be folded into the config"
+
+    def test_property_bag_generate_accepts_chat_history(self) -> None:
+        """The ChatHistory property-bag overload reduces the same way the prompt one does.
+
+        max_new_tokens is what forces the AnyMap path: every media argument is also a named
+        parameter of the typed binding, so a call passing only those resolves to the typed
+        overload and never exercises generate(history, AnyMap) at all.
+        """
+        vlm = RecordingVLM()
+        history = ov_genai.ChatHistory()
+        history.append({"role": "user", "content": "describe"})
+
+        ov_genai.VLMPipelineBase.generate(
+            vlm, history, videos=[ov.Tensor(np.zeros((2, 4, 4, 3), dtype=np.uint8))], max_new_tokens=3
+        )
+
+        assert vlm.generate_calls == 1
+        assert len(vlm.last_videos) == 1, "videos must survive the AnyMap round-trip"
+        assert vlm.last_max_new_tokens == 3, "the ChatHistory AnyMap overload must fold in config fields"
+
+    def test_property_bag_generate_rejects_audio_streamer(self) -> None:
+        """audio_streamer has no typed generate() parameter to land in, so it must be rejected loudly.
+
+        It is plumbing for the built-in Qwen3-Omni speech path; forwarding it to a Python subclass
+        would silently drop the caller's streamer.
+        """
+        vlm = RecordingVLM()
+
+        with pytest.raises(RuntimeError, match="audio_streamer"):
+            ov_genai.VLMPipelineBase.generate(vlm, "describe", audio_streamer=lambda chunk: None)
+
+        assert vlm.generate_calls == 0, "an unforwardable property must not reach the backend"
 
 
 @dataclass(frozen=True)
@@ -333,9 +474,22 @@ def injected_omni() -> InjectedOmni:
     return InjectedOmni(ov_genai.OmniPipeline(vlm, talker), vlm, talker)
 
 
-def _talker_speech_config(return_audio: bool) -> ov_genai.OmniTalkerSpeechConfig:
+def _talker_speech_config(
+    return_audio: bool,
+    *,
+    speaker: str | ov.Tensor | None = None,
+    rng_seed: int | None = None,
+    max_new_tokens: int | None = None,
+) -> ov_genai.OmniTalkerSpeechConfig:
+    """Keyword-only extras default to unset, so existing call sites keep the C++ defaults verbatim."""
     config = ov_genai.OmniTalkerSpeechConfig()
     config.return_audio = return_audio
+    if speaker is not None:
+        config.speaker = speaker
+    if rng_seed is not None:
+        config.rng_seed = rng_seed
+    if max_new_tokens is not None:
+        config.max_new_tokens = max_new_tokens
     return config
 
 
@@ -412,13 +566,6 @@ class TestOmniPipelineDependencyInjection:
 
 def _export_tiny_omni_model(target_dir: Path) -> None:
     """Export the tiny Qwen3-Omni checkpoint to OpenVINO IR under ``target_dir``."""
-    import openvino
-    import openvino_tokenizers
-    import transformers
-    from huggingface_hub import snapshot_download
-    from optimum.intel import OVModelForVisualCausalLM
-    from utils.network import retry_request
-
     model_cached = snapshot_download(OMNI_MODEL_ID)  # required to avoid HF rate limits
     align_with_optimum_cli = {"padding_side": "left", "truncation_side": "left"}
     processor = retry_request(
@@ -428,8 +575,6 @@ def _export_tiny_omni_model(target_dir: Path) -> None:
             **align_with_optimum_cli,
         )
     )
-    # No trust_remote_code here: test_vlm_pipeline.py grants it per model, and Qwen3-Omni is not on
-    # that list — the architecture is native to transformers >= 4.57, so the export needs no custom code.
     model = retry_request(
         lambda: OVModelForVisualCausalLM.from_pretrained(
             model_cached, compile=False, device="CPU", export=True, load_in_8bit=False
@@ -437,12 +582,10 @@ def _export_tiny_omni_model(target_dir: Path) -> None:
     )
 
     tokenizer = processor.tokenizer
-    if tokenizer.chat_template is None:
-        tokenizer.chat_template = processor.chat_template
     tokenizer.save_pretrained(target_dir)
     ov_tokenizer, ov_detokenizer = openvino_tokenizers.convert_tokenizer(tokenizer, with_detokenizer=True)
-    openvino.save_model(ov_tokenizer, target_dir / "openvino_tokenizer.xml")
-    openvino.save_model(ov_detokenizer, target_dir / "openvino_detokenizer.xml")
+    ov.save_model(ov_tokenizer, target_dir / "openvino_tokenizer.xml")
+    ov.save_model(ov_detokenizer, target_dir / "openvino_detokenizer.xml")
 
     processor.save_pretrained(target_dir)
     model.save_pretrained(target_dir)
@@ -452,23 +595,11 @@ def _export_tiny_omni_model(target_dir: Path) -> None:
 def omni_model_path() -> Path:
     """Path to an exported tiny Qwen3-Omni model, or skip when the pinned deps cannot produce one.
 
-    Three distinct gaps are reported separately so a future failure points at the right dependency:
-    a transformers version that cannot export Qwen3-Omni at all (checked before any download), the
+    Two distinct gaps are reported separately so a future failure points at the right dependency: the
     export itself raising, and the export succeeding without any talker submodels. Only the known
     transformers 5.0.x config bug is turned into a skip — any other export failure propagates so a
     real regression cannot hide behind a skipped test.
     """
-    from optimum.utils.import_utils import is_transformers_version
-    from utils.atomic_download import AtomicDownloadManager
-
-    # Same gate as test_vlm_pipeline.py's _maybe_skip_unsupported_model_export, applied before the
-    # snapshot download so an unsupported environment costs nothing.
-    if is_transformers_version("<", "4.57.0"):
-        pytest.skip(
-            "ValueError: The current version of Transformers does not allow for the export of Qwen3-Omni. "
-            "Minimum required is 4.57.0."
-        )
-
     model_dir = get_ov_cache_converted_models_dir() / OMNI_MODEL_ID.replace("/", "_")
     manager = AtomicDownloadManager(model_dir)
 
@@ -476,9 +607,7 @@ def omni_model_path() -> Path:
         try:
             manager.execute(_export_tiny_omni_model)
         except AttributeError as error:
-            # Transformers 5.0 generated this config with an uninitialized use_sliding_window
-            # reference, and the optimum-intel revision pinned by CI predates its workaround.
-            # Same failure test_vlm_pipeline.py's Qwen3-Omni preprocessing test xfails on.
+            # Transformers 5.0 reads an uninitialized use_sliding_window in this config; 5.1 fixed it.
             message = str(error)
             if not (
                 is_transformers_version(">=", "5.0")
@@ -494,7 +623,8 @@ def omni_model_path() -> Path:
     if missing:
         pytest.skip(
             f"{OMNI_MODEL_ID} exported without the talker stage (missing {', '.join(missing)}); "
-            "the pinned optimum-intel has no Qwen3-Omni talker/code2wav export support."
+            "requirements.txt pins an optimum-intel predating huggingface/optimum-intel#1700, which added "
+            "the talker/code2wav export. The CI matrix entries install a revision that has it."
         )
 
     return model_dir
@@ -508,7 +638,7 @@ def omni_pipe(omni_model_path: Path) -> ov_genai.OmniPipeline:
     share: none of these tests enters chat mode or mutates the stored configs, so no state carries
     between them.
     """
-    return ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+    return ov_genai.OmniPipeline(omni_model_path, "CPU")
 
 
 def _text_config(max_new_tokens: int = 10) -> ov_genai.GenerationConfig:
@@ -516,6 +646,123 @@ def _text_config(max_new_tokens: int = 10) -> ov_genai.GenerationConfig:
     config.max_new_tokens = max_new_tokens
     config.do_sample = False
     return config
+
+
+def _sampling_text_config(rng_seed: int, max_new_tokens: int = 20) -> ov_genai.GenerationConfig:
+    """Multinomial counterpart of _text_config, seeded so one run reproduces itself.
+
+    The high temperature and ignore_eos come from test_llm_pipeline.py's rng_seed pair: they keep
+    different seeds apart instead of collapsing them onto the same near-greedy sequence.
+    """
+    config = ov_genai.GenerationConfig()
+    config.max_new_tokens = max_new_tokens
+    config.do_sample = True
+    config.temperature = 1.3
+    config.ignore_eos = True
+    config.rng_seed = rng_seed
+    return config
+
+
+@pytest.fixture(scope="module")
+def omni_image() -> ov.Tensor:
+    """Deterministic RGB image as [H, W, 3] uint8 — the layout the image preprocessor expects."""
+    ramp = np.linspace(0, 255, MEDIA_EDGE, dtype=np.uint8)
+    frame = np.empty((MEDIA_EDGE, MEDIA_EDGE, 3), dtype=np.uint8)
+    frame[..., 0] = ramp[None, :]
+    frame[..., 1] = ramp[::-1][:, None]
+    frame[..., 2] = 128
+    return ov.Tensor(frame)
+
+
+@pytest.fixture(scope="module")
+def omni_video() -> ov.Tensor:
+    """Deterministic video as [N, H, W, 3] uint8, one horizontal shift per frame so frames differ."""
+    base = np.tile(np.linspace(0, 255, MEDIA_EDGE, dtype=np.uint8), (MEDIA_EDGE, 1))
+    frames = [np.repeat(np.roll(base, 8 * index, axis=1)[..., None], 3, axis=2) for index in range(VIDEO_FRAMES)]
+    return ov.Tensor(np.stack(frames))
+
+
+@pytest.fixture(scope="module")
+def omni_audio() -> ov.Tensor:
+    """Deterministic mono PCM as a 1-D float32 tensor at 16 kHz — what the audio encoder validates."""
+    seconds = np.arange(AUDIO_SAMPLES, dtype=np.float32) / AUDIO_SAMPLE_RATE
+    return ov.Tensor(np.sin(2.0 * np.pi * 440.0 * seconds).astype(np.float32))
+
+
+def _single_waveform(result: ov_genai.OmniDecodedResults) -> np.ndarray:
+    """Flatten the one waveform a speech-enabled result must carry, rejecting empty/non-finite audio."""
+    waveforms = result.speech_result.waveforms
+    assert len(waveforms) == 1, f"return_audio=True must produce exactly one waveform, got {len(waveforms)}"
+    waveform = np.array(waveforms[0].data, dtype=np.float32).reshape(-1)
+    assert waveform.size > 0, "waveform must not be empty"
+    assert np.isfinite(waveform).all(), "waveform must contain no NaN or Inf"
+    return waveform
+
+
+def _waveforms_differ(left: np.ndarray, right: np.ndarray) -> bool:
+    """Whether two waveforms are different audio, by length or by samples."""
+    return left.shape != right.shape or not np.allclose(left, right)
+
+
+def _generate_speech(pipe: ov_genai.OmniPipeline, speaker: str | ov.Tensor) -> np.ndarray:
+    """Generate speech for the fixed prompt/seed/token budget and return the waveform."""
+    result = pipe.generate(
+        SPEECH_PROMPT,
+        text_config=_text_config(),
+        talker_speech_config=_talker_speech_config(
+            return_audio=True,
+            speaker=speaker,
+            rng_seed=TALKER_RNG_SEED,
+            max_new_tokens=TALKER_MAX_NEW_TOKENS,
+        ),
+    )
+    return _single_waveform(result)
+
+
+def _load_models_map(model_dir: Path) -> dict[str, tuple[str, ov.Tensor]]:
+    """Read every exported IR in ``model_dir`` into the ModelsMap form the blob ctors accept.
+
+    Key convention is the one samples/python/visual_language_chat/encrypted_model_vlm.py uses:
+    ``openvino_<name>_model.xml`` -> ``<name>``. A single glob covers both stages — the VLM picks
+    up language/text_embeddings/vision_embeddings*, the talker picks up
+    talker*/code_predictor/code2wav, and each ignores the keys it does not know.
+    """
+    models_map: dict[str, tuple[str, ov.Tensor]] = {}
+    for xml_path in sorted(model_dir.glob("*.xml")):
+        weights_path = xml_path.with_suffix(".bin")
+        if "tokenizer" in xml_path.name or not weights_path.exists():
+            continue
+        name = xml_path.stem.removeprefix("openvino_").removesuffix("_model")
+        models_map[name] = (
+            xml_path.read_text(encoding="utf-8"),
+            ov.Tensor(np.fromfile(weights_path, dtype=np.uint8)),
+        )
+    return models_map
+
+
+@pytest.fixture(scope="module")
+def omni_pipe_from_models_map(omni_model_path: Path) -> ov_genai.OmniPipeline:
+    """The same checkpoint as omni_pipe, but with both stages built from in-memory IRs and injected.
+
+    Module-scoped for the same reason as omni_pipe: this is a second full model load. The tokenizer
+    is loaded separately rather than taken from omni_pipe.get_vlm(): get_tokenizer() hands back a
+    new wrapper around the *same* C++ impl, so sharing it would couple the two pipelines that this
+    test is supposed to compare independently. ATTENTION_BACKEND is requested explicitly because the
+    path ctor reaches the continuous-batching backend by default — naming it here turns a failure to
+    get it into a raise instead of a silent SDPA fallback that OmniPipeline would then reject with
+    an unrelated-looking "speech output requires the continuous-batching backend".
+    """
+    models_map = _load_models_map(omni_model_path)
+    vlm = ov_genai.VLMPipeline(
+        models_map,
+        ov_genai.Tokenizer(omni_model_path),
+        omni_model_path,
+        "CPU",
+        ATTENTION_BACKEND="PA",
+    )
+    all_on_cpu: dict[str, str] = {}
+    talker = ov_genai.Talker(models_map, ov_genai.OmniTalkerSpeechConfig(), omni_model_path, all_on_cpu)
+    return ov_genai.OmniPipeline(vlm, talker)
 
 
 class TestOmniPipelineRealModel:
@@ -530,6 +777,73 @@ class TestOmniPipelineRealModel:
         assert omni_pipe.get_vlm() is not None, "path ctor must build a VLM stage"
         assert omni_pipe.get_talker() is not None, "path ctor must build a talker stage"
 
+    def test_models_map_ctor_matches_path_ctor_text(
+        self, omni_pipe: ov_genai.OmniPipeline, omni_pipe_from_models_map: ov_genai.OmniPipeline
+    ) -> None:
+        """Building both stages from in-memory IRs decodes the same text as building from a path.
+
+        Greedy decode keeps the two comparable token for token: handing the IRs over as strings and
+        weight tensors changes where they are read from, never the graph that gets compiled.
+        """
+        text_config = _text_config()
+        text_only = _talker_speech_config(return_audio=False)
+
+        from_path = omni_pipe.generate("Describe this.", text_config=text_config, talker_speech_config=text_only)
+        from_map = omni_pipe_from_models_map.generate(
+            "Describe this.", text_config=text_config, talker_speech_config=text_only
+        )
+
+        assert from_map.texts == from_path.texts, (
+            f"ModelsMap-built pipeline decoded {from_map.texts!r}, path-built decoded {from_path.texts!r}"
+        )
+
+        # This checkpoint decodes to '' whatever it is fed, so comparing texts alone cannot fail.
+        # Seeded sampling gives a cumulative score that does discriminate between graphs.
+        seeded = _sampling_text_config(rng_seed=42)
+        path_scores = omni_pipe.generate("Describe this.", text_config=seeded, talker_speech_config=text_only).scores
+        map_scores = omni_pipe_from_models_map.generate(
+            "Describe this.", text_config=seeded, talker_speech_config=text_only
+        ).scores
+
+        assert map_scores == pytest.approx(path_scores), (
+            f"seeded sampling diverged: ModelsMap-built scored {map_scores}, path-built scored {path_scores}, "
+            "so the two constructions did not compile the same graph"
+        )
+
+    @pytest.mark.xfail(reason=NO_WAVEFORM_XFAIL_REASON, strict=True)
+    def test_models_map_ctor_matches_path_ctor_speech(
+        self, omni_pipe: ov_genai.OmniPipeline, omni_pipe_from_models_map: ov_genai.OmniPipeline
+    ) -> None:
+        """The ModelsMap-built talker synthesizes the same waveform as the path-built one.
+
+        The talker samples with top-k, but it re-seeds its RNG from talker_speech_config.rng_seed on
+        every call (default 0 on both sides here), so identical thinker hidden states yield an
+        identical codec token stream and therefore an identical sample count. The samples themselves
+        are compared with a tolerance rather than bit-exactly: the two stacks are independently
+        compiled copies of the same IRs, so only the last float bits may drift.
+        """
+        text_config = _text_config()
+        speech_on = _talker_speech_config(return_audio=True)
+
+        from_path = omni_pipe.generate("Describe this.", text_config=text_config, talker_speech_config=speech_on)
+        from_map = omni_pipe_from_models_map.generate(
+            "Describe this.", text_config=text_config, talker_speech_config=speech_on
+        )
+
+        assert from_map.texts == from_path.texts, "the thinker stages must agree before waveforms can be compared"
+
+        path_waveform = _single_waveform(from_path)
+        map_waveform = _single_waveform(from_map)
+
+        assert map_waveform.shape == path_waveform.shape, (
+            f"waveform lengths diverged ({map_waveform.size} vs {path_waveform.size} samples), so the two talkers "
+            "sampled different codec tokens"
+        )
+        assert np.allclose(map_waveform, path_waveform, rtol=0.0, atol=1e-4), (
+            f"waveforms differ by up to {np.abs(map_waveform - path_waveform).max():.3g}, which is beyond "
+            "independent-compilation float noise"
+        )
+
     def test_generate_text_only(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """With return_audio=False the pipeline decodes text and emits no waveform."""
         result = omni_pipe.generate(
@@ -542,6 +856,66 @@ class TestOmniPipelineRealModel:
         assert len(result.texts) == 1, "greedy decode must produce exactly one sequence"
         assert result.speech_result.waveforms == [], "return_audio=False must not produce waveforms"
 
+    def test_max_new_tokens_changes_generated_length(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+        """Raising max_new_tokens makes the thinker emit strictly more tokens.
+
+        ignore_eos is belt-and-braces: this checkpoint never emits EOS within 24 tokens, so the
+        counts are the same without it, but a checkpoint that did would make both caps stop early
+        at the same length and the comparison would say nothing.
+        """
+        short_config = _text_config(max_new_tokens=4)
+        short_config.ignore_eos = True
+        long_config = _text_config(max_new_tokens=24)
+        long_config.ignore_eos = True
+        text_only = _talker_speech_config(return_audio=False)
+
+        short_result = omni_pipe.generate("Describe this.", text_config=short_config, talker_speech_config=text_only)
+        long_result = omni_pipe.generate("Describe this.", text_config=long_config, talker_speech_config=text_only)
+
+        short_tokens = short_result.perf_metrics.get_num_generated_tokens()
+        long_tokens = long_result.perf_metrics.get_num_generated_tokens()
+
+        assert 0 < short_tokens <= 4, f"max_new_tokens=4 must cap the decode, got {short_tokens} tokens"
+        assert 0 < long_tokens <= 24, f"max_new_tokens=24 must cap the decode, got {long_tokens} tokens"
+        assert short_tokens < long_tokens, (
+            f"raising max_new_tokens from 4 to 24 must lengthen the decode, got {short_tokens} then {long_tokens}"
+        )
+
+    def test_rng_seed_steers_sampling(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+        """One rng_seed reproduces its own result, and the seeds do not all produce the same one.
+
+        Asserted on scores, not texts: this checkpoint decodes to '' for every seed, so a text
+        comparison cannot fail. The cumulative score does discriminate, which is what makes this
+        the test that rng_seed actually reaches the sampler.
+
+        The divergence check spans four seeds and only requires that they are not all identical,
+        mirroring test_llm_pipeline.py's rng_seed pair — any single pair of seeds can collide.
+        """
+        text_only = _talker_speech_config(return_audio=False)
+        seeded = _sampling_text_config(rng_seed=42)
+
+        first = omni_pipe.generate("Describe this.", text_config=seeded, talker_speech_config=text_only)
+        second = omni_pipe.generate("Describe this.", text_config=seeded, talker_speech_config=text_only)
+        assert first.scores == pytest.approx(second.scores), (
+            f"rng_seed=42 must reproduce its own scores, got {first.scores} then {second.scores}"
+        )
+
+        rng_seeds = (42, 123, 777, 2024)
+        sampled = {
+            tuple(
+                omni_pipe.generate(
+                    "Describe this.",
+                    text_config=_sampling_text_config(rng_seed=seed),
+                    talker_speech_config=text_only,
+                ).scores
+            )
+            for seed in rng_seeds
+        }
+        assert len(sampled) > 1, (
+            f"sampling with different rng_seeds {rng_seeds} produced the same scores for every seed"
+        )
+
+    @pytest.mark.xfail(reason=NO_WAVEFORM_XFAIL_REASON, strict=True)
     def test_generate_with_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """With return_audio=True the talker produces a finite, non-empty waveform."""
         result = omni_pipe.generate(
@@ -550,10 +924,7 @@ class TestOmniPipelineRealModel:
             talker_speech_config=_talker_speech_config(return_audio=True),
         )
 
-        assert len(result.speech_result.waveforms) == 1, "return_audio=True must produce one waveform"
-        waveform = np.array(result.speech_result.waveforms[0].data, dtype=np.float32).reshape(-1)
-        assert waveform.size > 0, "waveform must not be empty"
-        assert np.isfinite(waveform).all(), "waveform must contain no NaN or Inf"
+        _single_waveform(result)
 
     def test_generate_from_chat_history(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """The ChatHistory overload accepts structured turns and leaves the caller's history intact."""
@@ -570,6 +941,63 @@ class TestOmniPipelineRealModel:
         assert len(result.texts) == 1
         assert history.get_messages() == messages_before, "ChatHistory messages should not be mutated after generate."
 
+    @pytest.mark.parametrize(
+        "modality",
+        [
+            pytest.param("image", id="image"),
+            pytest.param("video", id="video", marks=pytest.mark.xfail(reason=VIDEO_INPUT_XFAIL_REASON, strict=True)),
+            pytest.param("audio", id="audio", marks=pytest.mark.xfail(reason=AUDIO_INPUT_XFAIL_REASON, strict=True)),
+        ],
+    )
+    def test_generate_from_chat_history_all_modalities(
+        self,
+        omni_pipe: ov_genai.OmniPipeline,
+        omni_image: ov.Tensor,
+        omni_video: ov.Tensor,
+        omni_audio: ov.Tensor,
+        modality: str,
+    ) -> None:
+        """Media attached to a ChatHistory turn reach the thinker instead of being silently dropped.
+
+        Each modality expands the prompt with its own placeholder tokens, so the input token count
+        must grow once media are attached — a modality that never reached preprocessing would leave
+        it untouched. The count is the whole assertion for the vision modalities:
+        vision_encoding_durations is appended unconditionally, so it is non-empty even for a
+        text-only call and proves nothing. audio_encoding_durations is only populated when audio
+        is actually encoded, so it is worth asserting on that branch.
+
+        One modality per case so a failure names the modality that broke rather than the whole set.
+        """
+
+        def fresh_history() -> ov_genai.ChatHistory:
+            # Reusing a ChatHistory whose first call had no media makes a later media call drop it.
+            history = ov_genai.ChatHistory()
+            history.append({"role": "user", "content": "Describe the attached media."})
+            return history
+
+        text_config = _text_config()
+        talker_config = _talker_speech_config(return_audio=False)
+        media: dict[str, list[ov.Tensor]] = {
+            "images": [omni_image] if modality == "image" else [],
+            "videos": [omni_video] if modality == "video" else [],
+            "audios": [omni_audio] if modality == "audio" else [],
+        }
+
+        text_only = omni_pipe.generate(fresh_history(), text_config=text_config, talker_speech_config=talker_config)
+        multimodal = omni_pipe.generate(
+            fresh_history(), **media, text_config=text_config, talker_speech_config=talker_config
+        )
+
+        assert len(multimodal.texts) == 1, "greedy decode must produce exactly one sequence"
+        assert multimodal.perf_metrics.get_num_input_tokens() > text_only.perf_metrics.get_num_input_tokens(), (
+            f"{modality} placeholders must expand the prompt; an unchanged input token count means "
+            "the media never reached preprocessing"
+        )
+        if modality == "audio":
+            assert multimodal.perf_metrics.vlm_raw_metrics.audio_encoding_durations, (
+                "the audio encoder must run when audios are passed"
+            )
+
     def test_speaker_apis(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """list_speakers() reports the checkpoint's voices and each resolves to an embedding."""
         speakers = omni_pipe.get_talker().list_speakers()
@@ -577,3 +1005,49 @@ class TestOmniPipelineRealModel:
         assert speakers, "the checkpoint declares speakers, so list_speakers() must not be empty"
         embedding = omni_pipe.get_talker().get_speaker_embedding(speakers[0])
         assert embedding.get_size() > 0, f"speaker {speakers[0]!r} must resolve to a non-empty embedding"
+
+    @pytest.mark.skip(reason=NO_WAVEFORM_XFAIL_REASON)
+    def test_altering_speaker_embedding_changes_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+        """A modified speaker embedding yields different speech; an unmodified one reproduces it exactly.
+
+        OmniTalkerSpeechConfig.speaker is a variant of name-or-tensor, and the tensor branch bypasses
+        the name lookup and feeds the embedding straight into the talker prefix. The talker has no
+        greedy path, so all three runs pin the same rng_seed. The control run proves the pipeline is
+        reproducible under that seed, which is what lets the third run attribute its difference to the
+        embedding rather than to sampling noise.
+        """
+        talker = omni_pipe.get_talker()
+        speakers = talker.list_speakers()
+        assert speakers, "the checkpoint declares speakers, so list_speakers() must not be empty"
+
+        embedding = talker.get_speaker_embedding(speakers[0])
+        altered_data = (np.array(embedding.data, dtype=np.float32) * SPEAKER_EMBEDDING_SCALE).astype(np.float32)
+        altered = ov.Tensor(altered_data)
+
+        baseline = _generate_speech(omni_pipe, speaker=embedding)
+        control = _generate_speech(omni_pipe, speaker=embedding)
+        perturbed = _generate_speech(omni_pipe, speaker=altered)
+
+        assert np.array_equal(baseline, control), (
+            "the same speaker embedding and rng_seed must reproduce the waveform sample for sample; "
+            "without that the comparison below cannot attribute a difference to the embedding"
+        )
+        assert _waveforms_differ(perturbed, baseline), (
+            f"scaling the speaker embedding by {SPEAKER_EMBEDDING_SCALE} left the waveform unchanged "
+            f"({perturbed.size} samples), so the embedding is not reaching the talker"
+        )
+
+    @pytest.mark.skip(reason=NO_WAVEFORM_XFAIL_REASON)
+    def test_distinct_speakers_produce_distinct_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
+        """Two different named speakers must not render the same audio for the same text and seed."""
+        speakers = omni_pipe.get_talker().list_speakers()
+        if len(speakers) < 2:
+            pytest.skip(f"{OMNI_MODEL_ID} declares a single speaker ({speakers}); nothing to compare")
+
+        first = _generate_speech(omni_pipe, speaker=speakers[0])
+        second = _generate_speech(omni_pipe, speaker=speakers[1])
+
+        assert _waveforms_differ(first, second), (
+            f"speakers {speakers[0]!r} and {speakers[1]!r} rendered identical audio ({first.size} samples); "
+            "the speaker selection is not reaching the talker"
+        )

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -14,16 +14,22 @@ The pybind variant alias OmniSpeechStreamerVariant is intentionally not in
 the smoke import — variant aliases are not re-exported in __init__.py per the
 existing AudioStreamerVariant convention.
 
-This file covers only the parts of the surface that can be exercised without
-loading a multi-GB Qwen3-Omni checkpoint: imports, config defaults, AnyMap
-update, and validate() invariants. Cross-config validation that requires a
-loaded pipeline (return_audio incompatible with beam search etc.) lives in
-the nightly real-model suites — here we only assert that the standalone
-config validate() and the field round-trip behave.
+This file covers the parts of the surface that can be exercised without loading
+a multi-GB Qwen3-Omni checkpoint: imports, config defaults, field round-trips,
+and dependency injection of user-defined VLMPipelineBase / TalkerBase children.
+The DI tests drive the real C++ OmniPipeline composition path against Python-
+defined mocks — no model weights required — so they exercise virtual dispatch,
+the text vs speech branching, and the constructor capability guards end to end.
+
+Cross-config validation that requires a real loaded pipeline (actual audio
+decode, speaker embeddings from a checkpoint, etc.) lives in the nightly
+real-model suites.
 """
 
 from __future__ import annotations
 
+import numpy as np
+import openvino as ov
 import pytest
 
 import openvino_genai as ov_genai
@@ -125,8 +131,8 @@ class TestOmniPipelineAccessors:
     """OmniPipeline getter/setter surface — methods must exist with the right signatures.
 
     No model is loaded here, so we only assert presence and signatures via the unbound
-    method handle. End-to-end behavior (get/set round-trip on a live pipeline) lives in
-    the temp/ scripts that load the MoE checkpoint.
+    method handle. End-to-end get/set behavior against injected pipelines is covered by
+    TestOmniPipelineDependencyInjection.
     """
 
     def test_methods_exist(self) -> None:
@@ -160,3 +166,157 @@ class TestOmniPipelineAccessors:
             ov_genai.Talker(empty_models_map, ov_genai.OmniTalkerSpeechConfig(), ".", empty_device_mapping)
         # Must not be a signature-resolution failure — the overload has to exist.
         assert not isinstance(exc_info.value, TypeError), f"blob ctor overload did not resolve: {exc_info.value}"
+
+
+class RecordingTalker(ov_genai.TalkerBase):
+    """User-defined talker that counts invocations. Result fields are read-only from Python, so
+    dispatch is proven by the call count rather than by round-tripping audio.
+    """
+
+    def __init__(self, speakers: list[str] | None = None) -> None:
+        super().__init__()
+        self.generate_calls = 0
+        self._speakers = speakers if speakers is not None else ["default_voice"]
+        self._speech_config = ov_genai.OmniTalkerSpeechConfig()
+
+    def generate(self, vlm_result, talker_speech_config, speech_streamer=None) -> ov_genai.TalkerResults:  # noqa: ANN001
+        self.generate_calls += 1
+        self.last_return_audio = talker_speech_config.return_audio
+        return ov_genai.TalkerResults()
+
+    # TalkerBase declares these pure virtual, so a Python backend has to store the config itself.
+    def get_speech_config(self) -> ov_genai.OmniTalkerSpeechConfig:
+        return self._speech_config
+
+    def set_speech_config(self, config: ov_genai.OmniTalkerSpeechConfig) -> None:
+        self._speech_config = config
+
+    def list_speakers(self) -> list[str]:
+        return self._speakers
+
+    def get_speaker_embedding(self, name: str) -> ov.Tensor:
+        return ov.Tensor(np.zeros((1, 1, 4), dtype=np.float32))
+
+
+class RecordingVLM(ov_genai.VLMPipelineBase):
+    """User-defined VLM (thinker) that counts generate() calls. Capability queries default to True
+    so the ctor accepts the mock; tests flip them to exercise its guard assertions.
+    """
+
+    def __init__(self, audio_output: bool = True, hidden_states: bool = True) -> None:
+        super().__init__()
+        self.generate_calls = 0
+        self.last_prompt: str | None = None
+        self._audio_output = audio_output
+        self._hidden_states = hidden_states
+
+    def generate(  # noqa: ANN001, PLR0913
+        self,
+        prompt,
+        images=[],  # noqa: B006
+        videos=[],  # noqa: B006
+        audios=[],  # noqa: B006
+        videos_metadata=[],  # noqa: B006
+        generation_config=None,
+        streamer=None,
+    ) -> ov_genai.VLMDecodedResults:
+        self.generate_calls += 1
+        self.last_prompt = prompt
+        return ov_genai.VLMDecodedResults()
+
+    def get_tokenizer(self):  # noqa: ANN201
+        raise RuntimeError("RecordingVLM.get_tokenizer() is not needed for the prompt-based path")
+
+    def set_chat_template(self, chat_template: str) -> None:
+        pass
+
+    def get_generation_config(self) -> ov_genai.GenerationConfig:
+        return ov_genai.GenerationConfig()
+
+    def set_generation_config(self, config: ov_genai.GenerationConfig) -> None:
+        pass
+
+    def supports_hidden_states_collection(self) -> bool:
+        return self._hidden_states
+
+    def is_audio_output_enabled(self) -> bool:
+        return self._audio_output
+
+
+class TestCustomTalkerSubclass:
+    """Users can define a TalkerBase child in Python and have its methods dispatched from C++."""
+
+    def test_subclass_is_instantiable(self) -> None:
+        """TalkerBase must expose a constructor so Python subclasses can be instantiated."""
+        talker = RecordingTalker()
+        assert isinstance(talker, ov_genai.TalkerBase)
+
+    def test_overrides_are_dispatched(self) -> None:
+        """Overridden list_speakers / get_speaker_embedding must call back into Python."""
+        talker = RecordingTalker(speakers=["alice", "bob"])
+        assert talker.list_speakers() == ["alice", "bob"]
+        embedding = talker.get_speaker_embedding("alice")
+        assert embedding.shape == [1, 1, 4]
+
+
+class TestCustomVLMSubclass:
+    """Users can define a VLMPipelineBase child in Python and have its methods dispatched from C++."""
+
+    def test_subclass_is_instantiable(self) -> None:
+        vlm = RecordingVLM()
+        assert isinstance(vlm, ov_genai.VLMPipelineBase)
+
+    def test_capability_overrides_are_dispatched(self) -> None:
+        vlm = RecordingVLM(audio_output=False, hidden_states=False)
+        assert vlm.is_audio_output_enabled() is False
+        assert vlm.supports_hidden_states_collection() is False
+
+
+class TestOmniPipelineDependencyInjection:
+    """OmniPipeline(vlm, talker) accepts user-defined children and orchestrates them via C++."""
+
+    def test_construct_from_python_children(self) -> None:
+        """The DI constructor accepts a Python-defined VLM and Talker and hands them back verbatim."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+        assert pipe.get_vlm() is vlm, "get_vlm() must return the exact injected instance"
+        assert pipe.get_talker() is talker, "get_talker() must return the exact injected instance"
+
+    def test_speech_path_invokes_both_stages(self) -> None:
+        """With return_audio=True, generate() drives the VLM then the talker via virtual dispatch."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+
+        talker_config = ov_genai.OmniTalkerSpeechConfig()
+        talker_config.return_audio = True
+        result = pipe.generate("describe this", talker_speech_config=talker_config)
+
+        assert isinstance(result, ov_genai.OmniDecodedResults)
+        assert vlm.generate_calls == 1, "the injected VLM must be driven exactly once"
+        assert talker.generate_calls == 1, "the injected talker must be driven exactly once"
+        assert vlm.last_prompt == "describe this", "the prompt must reach the Python VLM unchanged"
+        assert talker.last_return_audio is True
+
+    def test_text_only_path_skips_talker(self) -> None:
+        """With return_audio=False, the talker must not be invoked at all."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+
+        talker_config = ov_genai.OmniTalkerSpeechConfig()
+        talker_config.return_audio = False
+        pipe.generate("just text", talker_speech_config=talker_config)
+
+        assert vlm.generate_calls == 1
+        assert talker.generate_calls == 0, "text-only generation must short-circuit the talker"
+
+    def test_rejects_model_without_audio_output(self) -> None:
+        """The constructor must reject a VLM whose is_audio_output_enabled() reports False."""
+        vlm = RecordingVLM(audio_output=False)
+        with pytest.raises(RuntimeError, match="is_audio_output_enabled"):
+            ov_genai.OmniPipeline(vlm, RecordingTalker())
+
+    def test_rejects_backend_without_hidden_states(self) -> None:
+        """The constructor must reject a VLM that cannot collect hidden states the talker needs."""
+        vlm = RecordingVLM(hidden_states=False)
+        with pytest.raises(RuntimeError, match="supports_hidden_states_collection"):
+            ov_genai.OmniPipeline(vlm, RecordingTalker())

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -14,25 +14,53 @@ The pybind variant alias OmniSpeechStreamerVariant is intentionally not in
 the smoke import — variant aliases are not re-exported in __init__.py per the
 existing AudioStreamerVariant convention.
 
-This file covers the parts of the surface that can be exercised without loading
-a multi-GB Qwen3-Omni checkpoint: imports, config defaults, field round-trips,
-and dependency injection of user-defined VLMPipelineBase / TalkerBase children.
-The DI tests drive the real C++ OmniPipeline composition path against Python-
-defined mocks — no model weights required — so they exercise virtual dispatch,
-the text vs speech branching, and the constructor capability guards end to end.
+Two tiers, following the other pipeline suites:
 
-Cross-config validation that requires a real loaded pipeline (actual audio
-decode, speaker embeddings from a checkpoint, etc.) lives in the nightly
-real-model suites.
+1. Model-free tests — imports, config defaults, field round-trips, and dependency
+   injection of user-defined VLMPipelineBase / TalkerBase children. The DI tests
+   drive the real C++ OmniPipeline composition path against Python-defined mocks,
+   exercising virtual dispatch, the text vs speech branching, and the constructor
+   capability guards end to end.
+
+2. Real-model tests against `optimum-intel-internal-testing/tiny-random-qwen3-omni`,
+   covering the path-based constructor, text-only and speech generation, the
+   ChatHistory overload, and the speaker APIs.
+
+The real-model tier currently skips: the tiny checkpoint is a full omni model
+(talker_config, code2wav_config, enable_audio_output), but exporting it needs
+support that the pinned dependencies do not have yet. With transformers==5.0.0 the
+export raises `AttributeError: 'Qwen3OmniMoeTalkerCodePredictorConfig' object has no
+attribute 'use_sliding_window'` — the same failure `test_vlm_pipeline.py`'s
+`test_qwen3_omni_vision_preprocess_modes_equivalence` xfails on. Beyond that, the
+pinned optimum-intel exports no talker/code2wav submodels at all, so `Talker` has
+nothing to load. `omni_model_path` detects both cases and skips with the reason;
+the tests activate on their own once either dependency catches up.
 """
 
 from __future__ import annotations
+
+import logging
+from pathlib import Path
 
 import numpy as np
 import openvino as ov
 import pytest
 
 import openvino_genai as ov_genai
+from utils.constants import get_ov_cache_converted_models_dir
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.omni
+
+OMNI_MODEL_ID = "optimum-intel-internal-testing/tiny-random-qwen3-omni"
+
+# Written by the Talker export; without them OmniPipeline's path ctor cannot build the speech stage.
+TALKER_ARTIFACTS = (
+    "openvino_talker_model.xml",
+    "openvino_code_predictor_model.xml",
+    "openvino_code2wav_model.xml",
+)
 
 
 class TestOmniPipelineImports:
@@ -207,21 +235,29 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
         super().__init__()
         self.generate_calls = 0
         self.last_prompt: str | None = None
+        self.last_images: list[ov.Tensor] = []
+        self.last_videos: list[ov.Tensor] = []
+        self.last_audios: list[ov.Tensor] = []
+        self.last_videos_metadata: list[ov_genai.VideoMetadata] = []
         self._audio_output = audio_output
         self._hidden_states = hidden_states
 
     def generate(  # noqa: ANN001, PLR0913
         self,
         prompt,
-        images=[],  # noqa: B006
-        videos=[],  # noqa: B006
-        audios=[],  # noqa: B006
-        videos_metadata=[],  # noqa: B006
+        images=None,
+        videos=None,
+        audios=None,
+        videos_metadata=None,
         generation_config=None,
         streamer=None,
     ) -> ov_genai.VLMDecodedResults:
         self.generate_calls += 1
         self.last_prompt = prompt
+        self.last_images = list(images or [])
+        self.last_videos = list(videos or [])
+        self.last_audios = list(audios or [])
+        self.last_videos_metadata = list(videos_metadata or [])
         return ov_genai.VLMDecodedResults()
 
     def get_tokenizer(self):  # noqa: ANN201
@@ -270,6 +306,18 @@ class TestCustomVLMSubclass:
         vlm = RecordingVLM(audio_output=False, hidden_states=False)
         assert vlm.is_audio_output_enabled() is False
         assert vlm.supports_hidden_states_collection() is False
+
+    def test_generate_receives_isolated_arguments_per_call(self) -> None:
+        """A caller mutating the sequences one call received must not affect the next call."""
+        vlm = RecordingVLM()
+        vlm.generate("first")
+        vlm.last_images.append(ov.Tensor(np.zeros((1, 1, 4), dtype=np.float32)))
+
+        vlm.generate("second")
+
+        assert list(vlm.last_images) == [], (
+            "generate() leaked argument state between calls — a shared mutable default was reused."
+        )
 
 
 class TestOmniPipelineDependencyInjection:
@@ -320,3 +368,155 @@ class TestOmniPipelineDependencyInjection:
         vlm = RecordingVLM(hidden_states=False)
         with pytest.raises(RuntimeError, match="supports_hidden_states_collection"):
             ov_genai.OmniPipeline(vlm, RecordingTalker())
+
+
+def _export_tiny_omni_model(target_dir: Path) -> None:
+    """Export the tiny Qwen3-Omni checkpoint to OpenVINO IR under ``target_dir``."""
+    import openvino
+    import openvino_tokenizers
+    import transformers
+    from huggingface_hub import snapshot_download
+    from optimum.intel import OVModelForVisualCausalLM
+    from utils.network import retry_request
+
+    model_cached = snapshot_download(OMNI_MODEL_ID)  # required to avoid HF rate limits
+    align_with_optimum_cli = {"padding_side": "left", "truncation_side": "left"}
+    processor = retry_request(
+        lambda: transformers.AutoProcessor.from_pretrained(model_cached, **align_with_optimum_cli)
+    )
+    model = retry_request(
+        lambda: OVModelForVisualCausalLM.from_pretrained(model_cached, compile=False, device="CPU", export=True)
+    )
+
+    tokenizer = processor.tokenizer
+    if tokenizer.chat_template is None:
+        tokenizer.chat_template = processor.chat_template
+    tokenizer.save_pretrained(target_dir)
+    ov_tokenizer, ov_detokenizer = openvino_tokenizers.convert_tokenizer(tokenizer, with_detokenizer=True)
+    openvino.save_model(ov_tokenizer, target_dir / "openvino_tokenizer.xml")
+    openvino.save_model(ov_detokenizer, target_dir / "openvino_detokenizer.xml")
+
+    processor.save_pretrained(target_dir)
+    model.save_pretrained(target_dir)
+
+
+@pytest.fixture(scope="module")
+def omni_model_path() -> Path:
+    """Path to an exported tiny Qwen3-Omni model, or skip when the pinned deps cannot produce one.
+
+    Two distinct gaps are reported separately so a future failure points at the right dependency:
+    the export itself raising, and the export succeeding without any talker submodels. Only the
+    known transformers 5.0.x config bug is turned into a skip — any other export failure propagates
+    so a real regression cannot hide behind a skipped test.
+    """
+    from optimum.utils.import_utils import is_transformers_version
+    from utils.atomic_download import AtomicDownloadManager
+
+    model_dir = get_ov_cache_converted_models_dir() / OMNI_MODEL_ID.replace("/", "_")
+    manager = AtomicDownloadManager(model_dir)
+
+    if not manager.is_complete() and not (model_dir / "openvino_language_model.xml").exists():
+        try:
+            manager.execute(_export_tiny_omni_model)
+        except AttributeError as error:
+            # Transformers 5.0 generated this config with an uninitialized use_sliding_window
+            # reference, and the optimum-intel revision pinned by CI predates its workaround.
+            # Same failure test_vlm_pipeline.py's Qwen3-Omni preprocessing test xfails on.
+            message = str(error)
+            if not (
+                is_transformers_version(">=", "5.0")
+                and is_transformers_version("<", "5.1")
+                and "Qwen3OmniMoeTalkerCodePredictorConfig" in message
+                and "use_sliding_window" in message
+            ):
+                raise
+            logger.info("Tiny Qwen3-Omni export hit the known transformers 5.0.x config bug: %s", message)
+            pytest.skip(f"Cannot export {OMNI_MODEL_ID} with the pinned dependencies: AttributeError: {message}")
+
+    missing = [name for name in TALKER_ARTIFACTS if not (model_dir / name).exists()]
+    if missing:
+        pytest.skip(
+            f"{OMNI_MODEL_ID} exported without the talker stage (missing {', '.join(missing)}); "
+            "the pinned optimum-intel has no Qwen3-Omni talker/code2wav export support."
+        )
+
+    return model_dir
+
+
+class TestOmniPipelineRealModel:
+    """OmniPipeline driven by an exported tiny Qwen3-Omni checkpoint.
+
+    Covers what the mock-based DI tests cannot: the path-based constructor, the real
+    thinker/talker composition, and the speaker APIs backed by actual model data.
+    """
+
+    @staticmethod
+    def _text_config(max_new_tokens: int = 10) -> ov_genai.GenerationConfig:
+        config = ov_genai.GenerationConfig()
+        config.max_new_tokens = max_new_tokens
+        config.do_sample = False
+        return config
+
+    @staticmethod
+    def _talker_config(return_audio: bool) -> ov_genai.OmniTalkerSpeechConfig:
+        config = ov_genai.OmniTalkerSpeechConfig()
+        config.return_audio = return_audio
+        return config
+
+    def test_constructs_from_path(self, omni_model_path: Path) -> None:
+        """The path-based ctor builds both stages from a single model directory."""
+        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+        assert pipe.get_vlm() is not None, "path ctor must build a VLM stage"
+        assert pipe.get_talker() is not None, "path ctor must build a talker stage"
+
+    def test_generate_text_only(self, omni_model_path: Path) -> None:
+        """With return_audio=False the pipeline decodes text and emits no waveform."""
+        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+        result = pipe.generate(
+            "Describe this.",
+            text_config=self._text_config(),
+            talker_speech_config=self._talker_config(return_audio=False),
+        )
+
+        assert isinstance(result, ov_genai.OmniDecodedResults)
+        assert len(result.texts) == 1, "greedy decode must produce exactly one sequence"
+        assert result.speech_result.waveforms == [], "return_audio=False must not produce waveforms"
+
+    def test_generate_with_speech(self, omni_model_path: Path) -> None:
+        """With return_audio=True the talker produces a finite, non-empty waveform."""
+        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+        result = pipe.generate(
+            "Describe this.",
+            text_config=self._text_config(),
+            talker_speech_config=self._talker_config(return_audio=True),
+        )
+
+        assert len(result.speech_result.waveforms) == 1, "return_audio=True must produce one waveform"
+        waveform = np.array(result.speech_result.waveforms[0].data, dtype=np.float32).reshape(-1)
+        assert waveform.size > 0, "waveform must not be empty"
+        assert np.isfinite(waveform).all(), "waveform must contain no NaN or Inf"
+
+    def test_generate_from_chat_history(self, omni_model_path: Path) -> None:
+        """The ChatHistory overload accepts structured turns and leaves the caller's history intact."""
+        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+        history = ov_genai.ChatHistory()
+        history.append({"role": "user", "content": "Describe this."})
+        messages_before = history.get_messages()
+
+        result = pipe.generate(
+            history,
+            text_config=self._text_config(),
+            talker_speech_config=self._talker_config(return_audio=False),
+        )
+
+        assert len(result.texts) == 1
+        assert history.get_messages() == messages_before, "ChatHistory messages should not be mutated after generate."
+
+    def test_speaker_apis(self, omni_model_path: Path) -> None:
+        """list_speakers() reports the checkpoint's voices and each resolves to an embedding."""
+        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+        speakers = pipe.get_talker().list_speakers()
+
+        assert speakers, "the checkpoint declares speakers, so list_speakers() must not be empty"
+        embedding = pipe.get_talker().get_speaker_embedding(speakers[0])
+        assert embedding.get_size() > 0, f"speaker {speakers[0]!r} must resolve to a non-empty embedding"

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -33,13 +33,16 @@ export raises `AttributeError: 'Qwen3OmniMoeTalkerCodePredictorConfig' object ha
 attribute 'use_sliding_window'` — the same failure `test_vlm_pipeline.py`'s
 `test_qwen3_omni_vision_preprocess_modes_equivalence` xfails on. Beyond that, the
 pinned optimum-intel exports no talker/code2wav submodels at all, so `Talker` has
-nothing to load. `omni_model_path` detects both cases and skips with the reason;
-the tests activate on their own once either dependency catches up.
+nothing to load. `omni_model_path` detects both cases — plus transformers older than
+4.57, which cannot export Qwen3-Omni at all — and skips with the reason; the tests
+activate on their own once either dependency catches up.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -204,10 +207,16 @@ class RecordingTalker(ov_genai.TalkerBase):
     def __init__(self, speakers: list[str] | None = None) -> None:
         super().__init__()
         self.generate_calls = 0
+        self.last_return_audio: bool | None = None
         self._speakers = speakers if speakers is not None else ["default_voice"]
         self._speech_config = ov_genai.OmniTalkerSpeechConfig()
 
-    def generate(self, vlm_result, talker_speech_config, speech_streamer=None) -> ov_genai.TalkerResults:  # noqa: ANN001
+    def generate(
+        self,
+        vlm_result: ov_genai.VLMDecodedResults,
+        talker_speech_config: ov_genai.OmniTalkerSpeechConfig,
+        speech_streamer: ov_genai.OmniSpeechStreamerBase | None = None,
+    ) -> ov_genai.TalkerResults:
         self.generate_calls += 1
         self.last_return_audio = talker_speech_config.return_audio
         return ov_genai.TalkerResults()
@@ -234,7 +243,7 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
     def __init__(self, audio_output: bool = True, hidden_states: bool = True) -> None:
         super().__init__()
         self.generate_calls = 0
-        self.last_prompt: str | None = None
+        self.last_prompt: str | ov_genai.ChatHistory | None = None
         self.last_images: list[ov.Tensor] = []
         self.last_videos: list[ov.Tensor] = []
         self.last_audios: list[ov.Tensor] = []
@@ -242,15 +251,15 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
         self._audio_output = audio_output
         self._hidden_states = hidden_states
 
-    def generate(  # noqa: ANN001, PLR0913
+    def generate(  # noqa: PLR0913
         self,
-        prompt,
-        images=None,
-        videos=None,
-        audios=None,
-        videos_metadata=None,
-        generation_config=None,
-        streamer=None,
+        prompt: str | ov_genai.ChatHistory,
+        images: list[ov.Tensor] | None = None,
+        videos: list[ov.Tensor] | None = None,
+        audios: list[ov.Tensor] | None = None,
+        videos_metadata: list[ov_genai.VideoMetadata] | None = None,
+        generation_config: ov_genai.GenerationConfig | None = None,
+        streamer: ov_genai.StreamerBase | Callable[[str], bool] | None = None,
     ) -> ov_genai.VLMDecodedResults:
         self.generate_calls += 1
         self.last_prompt = prompt
@@ -260,7 +269,7 @@ class RecordingVLM(ov_genai.VLMPipelineBase):
         self.last_videos_metadata = list(videos_metadata or [])
         return ov_genai.VLMDecodedResults()
 
-    def get_tokenizer(self):  # noqa: ANN201
+    def get_tokenizer(self) -> ov_genai.Tokenizer:
         raise RuntimeError("RecordingVLM.get_tokenizer() is not needed for the prompt-based path")
 
     def set_chat_template(self, chat_template: str) -> None:
@@ -307,55 +316,86 @@ class TestCustomVLMSubclass:
         assert vlm.is_audio_output_enabled() is False
         assert vlm.supports_hidden_states_collection() is False
 
-    def test_generate_receives_isolated_arguments_per_call(self) -> None:
-        """A caller mutating the sequences one call received must not affect the next call."""
-        vlm = RecordingVLM()
-        vlm.generate("first")
-        vlm.last_images.append(ov.Tensor(np.zeros((1, 1, 4), dtype=np.float32)))
 
-        vlm.generate("second")
+@dataclass(frozen=True)
+class InjectedOmni:
+    """The DI pipeline together with the mocks it was built from, so tests can read the recorded calls."""
 
-        assert list(vlm.last_images) == [], (
-            "generate() leaked argument state between calls — a shared mutable default was reused."
-        )
+    pipeline: ov_genai.OmniPipeline
+    vlm: RecordingVLM
+    talker: RecordingTalker
+
+
+@pytest.fixture
+def injected_omni() -> InjectedOmni:
+    """Function-scoped on purpose: the mocks carry per-test call counters that must start at zero."""
+    vlm, talker = RecordingVLM(), RecordingTalker()
+    return InjectedOmni(ov_genai.OmniPipeline(vlm, talker), vlm, talker)
+
+
+def _talker_speech_config(return_audio: bool) -> ov_genai.OmniTalkerSpeechConfig:
+    config = ov_genai.OmniTalkerSpeechConfig()
+    config.return_audio = return_audio
+    return config
 
 
 class TestOmniPipelineDependencyInjection:
     """OmniPipeline(vlm, talker) accepts user-defined children and orchestrates them via C++."""
 
-    def test_construct_from_python_children(self) -> None:
+    def test_construct_from_python_children(self, injected_omni: InjectedOmni) -> None:
         """The DI constructor accepts a Python-defined VLM and Talker and hands them back verbatim."""
-        vlm, talker = RecordingVLM(), RecordingTalker()
-        pipe = ov_genai.OmniPipeline(vlm, talker)
-        assert pipe.get_vlm() is vlm, "get_vlm() must return the exact injected instance"
-        assert pipe.get_talker() is talker, "get_talker() must return the exact injected instance"
+        assert injected_omni.pipeline.get_vlm() is injected_omni.vlm, (
+            "get_vlm() must return the exact injected instance"
+        )
+        assert injected_omni.pipeline.get_talker() is injected_omni.talker, (
+            "get_talker() must return the exact injected instance"
+        )
 
-    def test_speech_path_invokes_both_stages(self) -> None:
+    def test_speech_path_invokes_both_stages(self, injected_omni: InjectedOmni) -> None:
         """With return_audio=True, generate() drives the VLM then the talker via virtual dispatch."""
-        vlm, talker = RecordingVLM(), RecordingTalker()
-        pipe = ov_genai.OmniPipeline(vlm, talker)
-
-        talker_config = ov_genai.OmniTalkerSpeechConfig()
-        talker_config.return_audio = True
-        result = pipe.generate("describe this", talker_speech_config=talker_config)
+        result = injected_omni.pipeline.generate(
+            "describe this", talker_speech_config=_talker_speech_config(return_audio=True)
+        )
 
         assert isinstance(result, ov_genai.OmniDecodedResults)
-        assert vlm.generate_calls == 1, "the injected VLM must be driven exactly once"
-        assert talker.generate_calls == 1, "the injected talker must be driven exactly once"
-        assert vlm.last_prompt == "describe this", "the prompt must reach the Python VLM unchanged"
-        assert talker.last_return_audio is True
+        assert injected_omni.vlm.generate_calls == 1, "the injected VLM must be driven exactly once"
+        assert injected_omni.talker.generate_calls == 1, "the injected talker must be driven exactly once"
+        assert injected_omni.vlm.last_prompt == "describe this", "the prompt must reach the Python VLM unchanged"
+        assert injected_omni.talker.last_return_audio is True
 
-    def test_text_only_path_skips_talker(self) -> None:
+    def test_text_only_path_skips_talker(self, injected_omni: InjectedOmni) -> None:
         """With return_audio=False, the talker must not be invoked at all."""
-        vlm, talker = RecordingVLM(), RecordingTalker()
-        pipe = ov_genai.OmniPipeline(vlm, talker)
+        injected_omni.pipeline.generate("just text", talker_speech_config=_talker_speech_config(return_audio=False))
 
-        talker_config = ov_genai.OmniTalkerSpeechConfig()
-        talker_config.return_audio = False
-        pipe.generate("just text", talker_speech_config=talker_config)
+        assert injected_omni.vlm.generate_calls == 1
+        assert injected_omni.talker.generate_calls == 0, "text-only generation must short-circuit the talker"
 
-        assert vlm.generate_calls == 1
-        assert talker.generate_calls == 0, "text-only generation must short-circuit the talker"
+    def test_media_arguments_do_not_leak_between_calls(self, injected_omni: InjectedOmni) -> None:
+        """Media passed to one generate() call must not reappear in the next call that omits it.
+
+        The binding declares images/videos/audios/videos_metadata with empty-list defaults, which
+        pybind11 materializes once per overload; a call that omits them must still see an empty
+        sequence rather than whatever the previous call supplied.
+        """
+        media = ov.Tensor(np.zeros((1, 4, 4, 3), dtype=np.uint8))
+        text_only = _talker_speech_config(return_audio=False)
+        injected_omni.pipeline.generate(
+            "with media",
+            images=[media],
+            videos=[media],
+            videos_metadata=[ov_genai.VideoMetadata()],
+            audios=[media],
+            talker_speech_config=text_only,
+        )
+        assert len(injected_omni.vlm.last_images) == 1, "the first call must reach the VLM with its media"
+
+        injected_omni.pipeline.generate("without media", talker_speech_config=text_only)
+
+        assert injected_omni.vlm.generate_calls == 2
+        assert len(injected_omni.vlm.last_images) == 0, "images leaked from the previous generate() call"
+        assert len(injected_omni.vlm.last_videos) == 0, "videos leaked from the previous generate() call"
+        assert len(injected_omni.vlm.last_audios) == 0, "audios leaked from the previous generate() call"
+        assert len(injected_omni.vlm.last_videos_metadata) == 0, "videos_metadata leaked from the previous call"
 
     def test_rejects_model_without_audio_output(self) -> None:
         """The constructor must reject a VLM whose is_audio_output_enabled() reports False."""
@@ -382,10 +422,18 @@ def _export_tiny_omni_model(target_dir: Path) -> None:
     model_cached = snapshot_download(OMNI_MODEL_ID)  # required to avoid HF rate limits
     align_with_optimum_cli = {"padding_side": "left", "truncation_side": "left"}
     processor = retry_request(
-        lambda: transformers.AutoProcessor.from_pretrained(model_cached, **align_with_optimum_cli)
+        lambda: transformers.AutoProcessor.from_pretrained(
+            model_cached,
+            trust_remote_code=True,
+            **align_with_optimum_cli,
+        )
     )
+    # No trust_remote_code here: test_vlm_pipeline.py grants it per model, and Qwen3-Omni is not on
+    # that list — the architecture is native to transformers >= 4.57, so the export needs no custom code.
     model = retry_request(
-        lambda: OVModelForVisualCausalLM.from_pretrained(model_cached, compile=False, device="CPU", export=True)
+        lambda: OVModelForVisualCausalLM.from_pretrained(
+            model_cached, compile=False, device="CPU", export=True, load_in_8bit=False
+        )
     )
 
     tokenizer = processor.tokenizer
@@ -404,13 +452,22 @@ def _export_tiny_omni_model(target_dir: Path) -> None:
 def omni_model_path() -> Path:
     """Path to an exported tiny Qwen3-Omni model, or skip when the pinned deps cannot produce one.
 
-    Two distinct gaps are reported separately so a future failure points at the right dependency:
-    the export itself raising, and the export succeeding without any talker submodels. Only the
-    known transformers 5.0.x config bug is turned into a skip — any other export failure propagates
-    so a real regression cannot hide behind a skipped test.
+    Three distinct gaps are reported separately so a future failure points at the right dependency:
+    a transformers version that cannot export Qwen3-Omni at all (checked before any download), the
+    export itself raising, and the export succeeding without any talker submodels. Only the known
+    transformers 5.0.x config bug is turned into a skip — any other export failure propagates so a
+    real regression cannot hide behind a skipped test.
     """
     from optimum.utils.import_utils import is_transformers_version
     from utils.atomic_download import AtomicDownloadManager
+
+    # Same gate as test_vlm_pipeline.py's _maybe_skip_unsupported_model_export, applied before the
+    # snapshot download so an unsupported environment costs nothing.
+    if is_transformers_version("<", "4.57.0"):
+        pytest.skip(
+            "ValueError: The current version of Transformers does not allow for the export of Qwen3-Omni. "
+            "Minimum required is 4.57.0."
+        )
 
     model_dir = get_ov_cache_converted_models_dir() / OMNI_MODEL_ID.replace("/", "_")
     manager = AtomicDownloadManager(model_dir)
@@ -443,6 +500,24 @@ def omni_model_path() -> Path:
     return model_dir
 
 
+@pytest.fixture(scope="module")
+def omni_pipe(omni_model_path: Path) -> ov_genai.OmniPipeline:
+    """Pipeline built once per module — loading the model per test dominates the suite runtime.
+
+    Reused across the real-model tests the way test_vlm_pipeline.py reuses ov_pipe_model. Safe to
+    share: none of these tests enters chat mode or mutates the stored configs, so no state carries
+    between them.
+    """
+    return ov_genai.OmniPipeline(str(omni_model_path), "CPU")
+
+
+def _text_config(max_new_tokens: int = 10) -> ov_genai.GenerationConfig:
+    config = ov_genai.GenerationConfig()
+    config.max_new_tokens = max_new_tokens
+    config.do_sample = False
+    return config
+
+
 class TestOmniPipelineRealModel:
     """OmniPipeline driven by an exported tiny Qwen3-Omni checkpoint.
 
@@ -450,45 +525,29 @@ class TestOmniPipelineRealModel:
     thinker/talker composition, and the speaker APIs backed by actual model data.
     """
 
-    @staticmethod
-    def _text_config(max_new_tokens: int = 10) -> ov_genai.GenerationConfig:
-        config = ov_genai.GenerationConfig()
-        config.max_new_tokens = max_new_tokens
-        config.do_sample = False
-        return config
-
-    @staticmethod
-    def _talker_config(return_audio: bool) -> ov_genai.OmniTalkerSpeechConfig:
-        config = ov_genai.OmniTalkerSpeechConfig()
-        config.return_audio = return_audio
-        return config
-
-    def test_constructs_from_path(self, omni_model_path: Path) -> None:
+    def test_constructs_from_path(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """The path-based ctor builds both stages from a single model directory."""
-        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
-        assert pipe.get_vlm() is not None, "path ctor must build a VLM stage"
-        assert pipe.get_talker() is not None, "path ctor must build a talker stage"
+        assert omni_pipe.get_vlm() is not None, "path ctor must build a VLM stage"
+        assert omni_pipe.get_talker() is not None, "path ctor must build a talker stage"
 
-    def test_generate_text_only(self, omni_model_path: Path) -> None:
+    def test_generate_text_only(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """With return_audio=False the pipeline decodes text and emits no waveform."""
-        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
-        result = pipe.generate(
+        result = omni_pipe.generate(
             "Describe this.",
-            text_config=self._text_config(),
-            talker_speech_config=self._talker_config(return_audio=False),
+            text_config=_text_config(),
+            talker_speech_config=_talker_speech_config(return_audio=False),
         )
 
         assert isinstance(result, ov_genai.OmniDecodedResults)
         assert len(result.texts) == 1, "greedy decode must produce exactly one sequence"
         assert result.speech_result.waveforms == [], "return_audio=False must not produce waveforms"
 
-    def test_generate_with_speech(self, omni_model_path: Path) -> None:
+    def test_generate_with_speech(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """With return_audio=True the talker produces a finite, non-empty waveform."""
-        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
-        result = pipe.generate(
+        result = omni_pipe.generate(
             "Describe this.",
-            text_config=self._text_config(),
-            talker_speech_config=self._talker_config(return_audio=True),
+            text_config=_text_config(),
+            talker_speech_config=_talker_speech_config(return_audio=True),
         )
 
         assert len(result.speech_result.waveforms) == 1, "return_audio=True must produce one waveform"
@@ -496,27 +555,25 @@ class TestOmniPipelineRealModel:
         assert waveform.size > 0, "waveform must not be empty"
         assert np.isfinite(waveform).all(), "waveform must contain no NaN or Inf"
 
-    def test_generate_from_chat_history(self, omni_model_path: Path) -> None:
+    def test_generate_from_chat_history(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """The ChatHistory overload accepts structured turns and leaves the caller's history intact."""
-        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
         history = ov_genai.ChatHistory()
         history.append({"role": "user", "content": "Describe this."})
         messages_before = history.get_messages()
 
-        result = pipe.generate(
+        result = omni_pipe.generate(
             history,
-            text_config=self._text_config(),
-            talker_speech_config=self._talker_config(return_audio=False),
+            text_config=_text_config(),
+            talker_speech_config=_talker_speech_config(return_audio=False),
         )
 
         assert len(result.texts) == 1
         assert history.get_messages() == messages_before, "ChatHistory messages should not be mutated after generate."
 
-    def test_speaker_apis(self, omni_model_path: Path) -> None:
+    def test_speaker_apis(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """list_speakers() reports the checkpoint's voices and each resolves to an embedding."""
-        pipe = ov_genai.OmniPipeline(str(omni_model_path), "CPU")
-        speakers = pipe.get_talker().list_speakers()
+        speakers = omni_pipe.get_talker().list_speakers()
 
         assert speakers, "the checkpoint declares speakers, so list_speakers() must not be empty"
-        embedding = pipe.get_talker().get_speaker_embedding(speakers[0])
+        embedding = omni_pipe.get_talker().get_speaker_embedding(speakers[0])
         assert embedding.get_size() > 0, f"speaker {speakers[0]!r} must resolve to a non-empty embedding"

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -14,7 +14,7 @@ The pybind variant alias OmniSpeechStreamerVariant is intentionally not in
 the smoke import — variant aliases are not re-exported in __init__.py per the
 existing AudioStreamerVariant convention.
 
-Two tiers, following the other pipeline suites:
+Three tiers, following the other pipeline suites:
 
 1. Model-free tests — imports, config defaults, field round-trips, and dependency
    injection of user-defined VLMPipelineBase / TalkerBase children. The DI tests
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -88,6 +88,8 @@ SPEECH_PROMPT = "Say hello."
 TALKER_RNG_SEED = 1234
 TALKER_MAX_NEW_TOKENS = 8
 
+OPTIMUM_COMPARE_TOKENS = 6
+
 SPEAKER_EMBEDDING_SCALE = -8.0
 
 NO_WAVEFORM_XFAIL_REASON = (
@@ -105,6 +107,15 @@ VIDEO_INPUT_XFAIL_REASON = (
     "patch dim is 2*3*14*14=1176 against an encoder built for 1536 and the infer request fails "
     "shape.compatible(). Setting that one value to 16 makes video work on this checkpoint, and real "
     "Qwen3-Omni models already ship 16 — the encoder and the video path itself are fine."
+)
+
+OPTIMUM_IMAGE_XFAIL_REASON = (
+    "GenAI and optimum agree exactly on generated token ids for a text-only prompt but diverge once an "
+    "image is attached, while still agreeing on the 57-token input length — so they build the same "
+    "sequence and merge different image embeddings into it. Undetermined whether that is a real "
+    "preprocessing difference or this checkpoint's random weights making the greedy argmax flip on "
+    "numerical noise: it cannot be arbitrated locally, because optimum only recognizes model_type "
+    "qwen3_omni_moe and every full Qwen3-Omni export at hand is dense qwen3_omni."
 )
 
 AUDIO_INPUT_XFAIL_REASON = (
@@ -749,6 +760,73 @@ def real_omni_pipe() -> ov_genai.OmniPipeline:
     return ov_genai.OmniPipeline(model_dir, "CPU")
 
 
+class _CapturingStreamer(ov_genai.StreamerBase):
+    """Records the raw token ids GenAI generates.
+
+    Decoded text is useless as a comparison target on this checkpoint: its tokenizer covers ids
+    0-769 while the model head emits the full Qwen vocab, so every generated id falls outside the
+    tokenizer and renders as ''. Ids sidestep the broken tokenizer entirely.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.token_ids: list[int] = []
+
+    def write(self, token: int | Sequence[int]) -> ov_genai.StreamingStatus:
+        if isinstance(token, (list, tuple)):
+            self.token_ids.extend(int(one) for one in token)
+        else:
+            self.token_ids.append(int(token))
+        return ov_genai.StreamingStatus.RUNNING
+
+    def end(self) -> None:
+        pass
+
+
+def _genai_generated_ids(pipe: ov_genai.OmniPipeline, prompt: str, image: np.ndarray | None) -> list[int]:
+    """Token ids the thinker generates, harvested through a streamer."""
+    streamer = _CapturingStreamer()
+    pipe.generate(
+        prompt,
+        images=[ov.Tensor(image)] if image is not None else [],
+        text_config=_text_config(max_new_tokens=OPTIMUM_COMPARE_TOKENS),
+        talker_speech_config=_talker_speech_config(return_audio=False),
+        streamer=streamer,
+    )
+    return streamer.token_ids
+
+
+@dataclass(frozen=True)
+class OptimumReference:
+    """optimum-intel model plus the processor that builds its inputs."""
+
+    model: OVModelForVisualCausalLM
+    processor: transformers.ProcessorMixin
+
+
+def _optimum_generated_ids(reference: OptimumReference, prompt: str, image: np.ndarray | None) -> list[int]:
+    """Token ids optimum-intel generates for the same prompt, sliced off its echoed input."""
+    model = reference.model
+    inputs = model.preprocess_inputs(
+        text=prompt, image=image, processor=reference.processor, tokenizer=None, config=model.config
+    )
+    output_ids = model.generate(**inputs, max_new_tokens=OPTIMUM_COMPARE_TOKENS, do_sample=False)
+    input_ids = inputs["input_ids"] if isinstance(inputs, dict) else inputs.input_ids
+    return [out[len(inp) :].tolist() for inp, out in zip(input_ids, output_ids)][0]
+
+
+@pytest.fixture(scope="module")
+def optimum_reference(omni_model_path: Path) -> OptimumReference:
+    """optimum-intel over the same export, as a reference implementation.
+
+    Module-scoped: this is a second full model load on top of omni_pipe.
+    """
+    return OptimumReference(
+        model=OVModelForVisualCausalLM.from_pretrained(omni_model_path, export=False),
+        processor=transformers.AutoProcessor.from_pretrained(omni_model_path, trust_remote_code=True),
+    )
+
+
 def _load_models_map(model_dir: Path) -> dict[str, tuple[str, ov.Tensor]]:
     """Read every exported IR in ``model_dir`` into the ModelsMap form the blob ctors accept.
 
@@ -955,6 +1033,42 @@ class TestOmniPipelineRealModel:
         )
 
         _single_waveform(result)
+
+    def test_matches_optimum_text(self, omni_pipe: ov_genai.OmniPipeline, optimum_reference: OptimumReference) -> None:
+        """Greedy decode must produce the same token ids as optimum-intel for a text-only prompt.
+
+        Compared on ids rather than decoded text because this checkpoint's tokenizer only covers ids
+        0-769 while the model head emits the full Qwen vocab, so both stacks decode to '' and a text
+        comparison could not fail. Ids are what the two implementations actually disagree about.
+        """
+        prompt = "Describe."
+
+        optimum_ids = _optimum_generated_ids(optimum_reference, prompt, None)
+        genai_ids = _genai_generated_ids(omni_pipe, prompt, None)
+
+        assert genai_ids, "the streamer must observe generated tokens"
+        assert genai_ids == optimum_ids, (
+            f"GenAI generated {genai_ids}, optimum generated {optimum_ids} for the same greedy prompt"
+        )
+
+    @pytest.mark.xfail(reason=OPTIMUM_IMAGE_XFAIL_REASON, strict=True)
+    def test_matches_optimum_image(
+        self, omni_pipe: ov_genai.OmniPipeline, optimum_reference: OptimumReference, omni_image: ov.Tensor
+    ) -> None:
+        """The same comparison with an image attached.
+
+        Both stacks agree on the input length, so any divergence here is in the image embeddings
+        rather than in how the prompt is built.
+        """
+        prompt = "Describe this image."
+        image = np.array(omni_image.data, dtype=np.uint8).reshape(omni_image.shape)
+
+        optimum_ids = _optimum_generated_ids(optimum_reference, prompt, image)
+        genai_ids = _genai_generated_ids(omni_pipe, prompt, image)
+
+        assert genai_ids == optimum_ids, (
+            f"GenAI generated {genai_ids}, optimum generated {optimum_ids} for the same image prompt"
+        )
 
     def test_speech_generation_rejects_unmatched_role_tokens(self, omni_pipe: ov_genai.OmniPipeline) -> None:
         """A checkpoint whose role token ids never appear in its token stream must raise, not go quiet.

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -14,16 +14,22 @@ The pybind variant alias OmniSpeechStreamerVariant is intentionally not in
 the smoke import — variant aliases are not re-exported in __init__.py per the
 existing AudioStreamerVariant convention.
 
-This file covers only the parts of the surface that can be exercised without
-loading a multi-GB Qwen3-Omni checkpoint: imports, config defaults, AnyMap
-update, and validate() invariants. Cross-config validation that requires a
-loaded pipeline (return_audio incompatible with beam search etc.) lives in
-the nightly real-model suites — here we only assert that the standalone
-config validate() and the field round-trip behave.
+This file covers the parts of the surface that can be exercised without loading
+a multi-GB Qwen3-Omni checkpoint: imports, config defaults, field round-trips,
+and dependency injection of user-defined VLMPipelineBase / TalkerBase children.
+The DI tests drive the real C++ OmniPipeline composition path against Python-
+defined mocks — no model weights required — so they exercise virtual dispatch,
+the text vs speech branching, and the constructor capability guards end to end.
+
+Cross-config validation that requires a real loaded pipeline (actual audio
+decode, speaker embeddings from a checkpoint, etc.) lives in the nightly
+real-model suites.
 """
 
 from __future__ import annotations
 
+import numpy as np
+import openvino as ov
 import pytest
 
 import openvino_genai as ov_genai
@@ -126,8 +132,8 @@ class TestOmniPipelineAccessors:
     """OmniPipeline getter/setter surface — methods must exist with the right signatures.
 
     No model is loaded here, so we only assert presence and signatures via the unbound
-    method handle. End-to-end behavior (get/set round-trip on a live pipeline) lives in
-    the temp/ scripts that load the MoE checkpoint.
+    method handle. End-to-end get/set behavior against injected pipelines is covered by
+    TestOmniPipelineDependencyInjection.
     """
 
     def test_methods_exist(self) -> None:
@@ -136,3 +142,149 @@ class TestOmniPipelineAccessors:
         # Speaker APIs live on the Talker, accessed via get_talker()
         for method in ("list_speakers", "get_speaker_embedding"):
             assert hasattr(ov_genai.TalkerBase, method), f"TalkerBase.{method}() missing from public surface"
+
+
+class RecordingTalker(ov_genai.TalkerBase):
+    """User-defined talker that counts invocations. Result fields are read-only from Python, so
+    dispatch is proven by the call count rather than by round-tripping audio.
+    """
+
+    def __init__(self, speakers: list[str] | None = None) -> None:
+        super().__init__()
+        self.generate_calls = 0
+        self._speakers = speakers if speakers is not None else ["default_voice"]
+
+    def generate(self, vlm_result, talker_speech_config, speech_streamer=None) -> ov_genai.TalkerResults:  # noqa: ANN001
+        self.generate_calls += 1
+        self.last_return_audio = talker_speech_config.return_audio
+        return ov_genai.TalkerResults()
+
+    def list_speakers(self) -> list[str]:
+        return self._speakers
+
+    def get_speaker_embedding(self, name: str) -> ov.Tensor:
+        return ov.Tensor(np.zeros((1, 1, 4), dtype=np.float32))
+
+
+class RecordingVLM(ov_genai.VLMPipelineBase):
+    """User-defined VLM (thinker) that counts generate() calls. Capability queries default to True
+    so the ctor accepts the mock; tests flip them to exercise its guard assertions.
+    """
+
+    def __init__(self, audio_output: bool = True, hidden_states: bool = True) -> None:
+        super().__init__()
+        self.generate_calls = 0
+        self.last_prompt: str | None = None
+        self._audio_output = audio_output
+        self._hidden_states = hidden_states
+
+    def generate(  # noqa: ANN001, PLR0913
+        self,
+        prompt,
+        images=[],  # noqa: B006
+        videos=[],  # noqa: B006
+        audios=[],  # noqa: B006
+        videos_metadata=[],  # noqa: B006
+        generation_config=None,
+        streamer=None,
+    ) -> ov_genai.VLMDecodedResults:
+        self.generate_calls += 1
+        self.last_prompt = prompt
+        return ov_genai.VLMDecodedResults()
+
+    def get_tokenizer(self):  # noqa: ANN201
+        raise RuntimeError("RecordingVLM.get_tokenizer() is not needed for the prompt-based path")
+
+    def set_chat_template(self, chat_template: str) -> None:
+        pass
+
+    def get_generation_config(self) -> ov_genai.GenerationConfig:
+        return ov_genai.GenerationConfig()
+
+    def set_generation_config(self, config: ov_genai.GenerationConfig) -> None:
+        pass
+
+    def supports_hidden_states_collection(self) -> bool:
+        return self._hidden_states
+
+    def is_audio_output_enabled(self) -> bool:
+        return self._audio_output
+
+
+class TestCustomTalkerSubclass:
+    """Users can define a TalkerBase child in Python and have its methods dispatched from C++."""
+
+    def test_subclass_is_instantiable(self) -> None:
+        """TalkerBase must expose a constructor so Python subclasses can be instantiated."""
+        talker = RecordingTalker()
+        assert isinstance(talker, ov_genai.TalkerBase)
+
+    def test_overrides_are_dispatched(self) -> None:
+        """Overridden list_speakers / get_speaker_embedding must call back into Python."""
+        talker = RecordingTalker(speakers=["alice", "bob"])
+        assert talker.list_speakers() == ["alice", "bob"]
+        embedding = talker.get_speaker_embedding("alice")
+        assert embedding.shape == [1, 1, 4]
+
+
+class TestCustomVLMSubclass:
+    """Users can define a VLMPipelineBase child in Python and have its methods dispatched from C++."""
+
+    def test_subclass_is_instantiable(self) -> None:
+        vlm = RecordingVLM()
+        assert isinstance(vlm, ov_genai.VLMPipelineBase)
+
+    def test_capability_overrides_are_dispatched(self) -> None:
+        vlm = RecordingVLM(audio_output=False, hidden_states=False)
+        assert vlm.is_audio_output_enabled() is False
+        assert vlm.supports_hidden_states_collection() is False
+
+
+class TestOmniPipelineDependencyInjection:
+    """OmniPipeline(vlm, talker) accepts user-defined children and orchestrates them via C++."""
+
+    def test_construct_from_python_children(self) -> None:
+        """The DI constructor accepts a Python-defined VLM and Talker and hands them back verbatim."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+        assert pipe.get_vlm() is vlm, "get_vlm() must return the exact injected instance"
+        assert pipe.get_talker() is talker, "get_talker() must return the exact injected instance"
+
+    def test_speech_path_invokes_both_stages(self) -> None:
+        """With return_audio=True, generate() drives the VLM then the talker via virtual dispatch."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+
+        talker_config = ov_genai.OmniTalkerSpeechConfig()
+        talker_config.return_audio = True
+        result = pipe.generate("describe this", talker_speech_config=talker_config)
+
+        assert isinstance(result, ov_genai.OmniDecodedResults)
+        assert vlm.generate_calls == 1, "the injected VLM must be driven exactly once"
+        assert talker.generate_calls == 1, "the injected talker must be driven exactly once"
+        assert vlm.last_prompt == "describe this", "the prompt must reach the Python VLM unchanged"
+        assert talker.last_return_audio is True
+
+    def test_text_only_path_skips_talker(self) -> None:
+        """With return_audio=False, the talker must not be invoked at all."""
+        vlm, talker = RecordingVLM(), RecordingTalker()
+        pipe = ov_genai.OmniPipeline(vlm, talker)
+
+        talker_config = ov_genai.OmniTalkerSpeechConfig()
+        talker_config.return_audio = False
+        pipe.generate("just text", talker_speech_config=talker_config)
+
+        assert vlm.generate_calls == 1
+        assert talker.generate_calls == 0, "text-only generation must short-circuit the talker"
+
+    def test_rejects_model_without_audio_output(self) -> None:
+        """The constructor must reject a VLM whose is_audio_output_enabled() reports False."""
+        vlm = RecordingVLM(audio_output=False)
+        with pytest.raises(RuntimeError, match="is_audio_output_enabled"):
+            ov_genai.OmniPipeline(vlm, RecordingTalker())
+
+    def test_rejects_backend_without_hidden_states(self) -> None:
+        """The constructor must reject a VLM that cannot collect hidden states the talker needs."""
+        vlm = RecordingVLM(hidden_states=False)
+        with pytest.raises(RuntimeError, match="supports_hidden_states_collection"):
+            ov_genai.OmniPipeline(vlm, RecordingTalker())

--- a/tests/python_tests/test_omni_pipeline.py
+++ b/tests/python_tests/test_omni_pipeline.py
@@ -31,13 +31,13 @@ Three tiers, following the other pipeline suites:
    OMNI_REAL_MODEL_PATH. The tiny checkpoint cannot synthesize speech at all, so the
    tests that need a real waveform live here and are deselected by default.
 
-The tiny-checkpoint tier needs newer dependencies than tests/python_tests/requirements.txt
-pins, so the CI matrix entries install them per job: transformers 5.0.0 reads an unset
-`use_sliding_window` in `Qwen3OmniMoeTalkerCodePredictorConfig.__init__` and the export
-dies with an `AttributeError` (fixed in 5.1.0), and optimum-intel only grew the
-talker/code2wav export in huggingface/optimum-intel#1700, after the pinned revision.
-`omni_model_path` still detects both gaps and skips with the reason, so running the
-suite against the repo-wide pins degrades to the model-free tier instead of failing.
+The tiny-checkpoint tier needs a newer transformers than tests/python_tests/requirements.txt
+pins, so the CI matrix entries install one per job: transformers 5.0.0 reads an unset
+`use_sliding_window` in `Qwen3OmniMoeTalkerCodePredictorConfig.__init__` and the export dies
+with an `AttributeError`, fixed in 5.1.0. The pinned optimum-intel already carries the
+talker/code2wav export from huggingface/optimum-intel#1700. `omni_model_path` still detects
+both gaps and skips with the reason, so running the suite against the repo-wide pins degrades
+to the model-free tier instead of failing.
 """
 
 from __future__ import annotations
@@ -644,8 +644,8 @@ def omni_model_path() -> Path:
     if missing:
         pytest.skip(
             f"{OMNI_MODEL_ID} exported without the talker stage (missing {', '.join(missing)}); "
-            "requirements.txt pins an optimum-intel predating huggingface/optimum-intel#1700, which added "
-            "the talker/code2wav export. The CI matrix entries install a revision that has it."
+            "the installed optimum-intel exported no talker stage; huggingface/optimum-intel#1700 is what "
+            "added it, so a revision predating that one cannot produce these files."
         )
 
     return model_dir


### PR DESCRIPTION
## Description

`OmniPipeline` takes a `VLMPipelineBase` and a `TalkerBase` through its dependency-injection constructor. The catch is that both base classes were registered in pybind11 without a constructor or a trampoline, so neither could be subclassed from Python. This PR makes both bases subclassable and adds functional tests that inject Python-defined children into `OmniPipeline`.

- Add a `PyTalkerBase` trampoline and expose `TalkerBase.__init__` / `generate` / `list_speakers` / `get_speaker_embedding`. A talker written in Python then dispatches from C++.
- Add a `PyVLMPipelineBase` trampoline and expose `VLMPipelineBase.__init__` plus its `generate`, tokenizer, generation-config, chat-template, and Qwen3-Omni capability-query methods. The many C++ `generate` overloads collapse to a single Python `generate`. The narrower overloads forward to the `videos_metadata`-aware one; the property-bag overloads unpack the bag and forward to it as well, rejecting only `audio_streamer` / `speech_streamer`, which no Python-defined subclass can consume.
- Defer the `TalkerBase.generate` binding until `OmniTalkerSpeechConfig` and `TalkerResults` are registered, so the generated `.pyi` renders those Python types in the signature instead of raw C++ names.
- Extend `tests/python_tests/test_omni_pipeline.py`, following the existing pipeline test patterns. It covers subclass instantiation and dispatch for both bases, plus DI tests that build `OmniPipeline(vlm, talker)` from Python mocks. Those DI tests assert three things: the speech path drives both stages, the text-only path skips the talker, and the constructor rejects a VLM that reports no audio output or no hidden-states collection.

CVS-191233

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. Added `TestCustomTalkerSubclass`, `TestCustomVLMSubclass`, and `TestOmniPipelineDependencyInjection` in `tests/python_tests/test_omni_pipeline.py`.
- [x] This PR fully addresses the ticket.
- [ ] N/A I have made corresponding changes to the documentation.

