### PR TITLE
[llm-bench] Text generation result metric fix for multi-batch

### DIFF
--- a/tools/llm_bench/task/text_generation.py
+++ b/tools/llm_bench/task/text_generation.py
@@ -396,7 +396,10 @@ def run_text_generation_genai(
     else:
         log.warning("No generated tokens")
     first_token_time = (perf_metrics.get_ttft().mean)
-    second_tokens_durations = (np.array(perf_metrics.raw_metrics.m_durations) / 1000).tolist()
+    second_tokens_durations = (
+        np.array(perf_metrics.raw_metrics.m_new_token_times[1:])
+        - np.array(perf_metrics.raw_metrics.m_new_token_times[:-1])
+    ).tolist()
     tm_list = (np.array([first_token_time] + second_tokens_durations) / 1000).tolist()
     inference_durations = (np.array(perf_metrics.raw_metrics.token_infer_durations) / 1000 / 1000).tolist()
     log.debug('latency of all tokens:')


### PR DESCRIPTION

## Description
For bs=2, it shows wront latency result like below:
```
[ INFO ] [1][P0] First token latency: 37.52 ms, other tokens latency: 11.94 ms/2tokens, len of input tokens: 14 * 2
[ INFO ] [1][P0] First infer latency: 37.43 ms, other infers latency: 23.88 ms/infer, inference count: 16
```

The 11.94 ms/2tokens is a wrong result. Latency should not be divided by number of tokens.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [N/A] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [N/A] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
