### PR TITLE
[Whisper]: Accept plain language codes in addition to wrapped tokens

### DIFF
--- a/site/docs/use-cases/speech-recognition/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/speech-recognition/_sections/_usage_options/index.mdx
@@ -162,8 +162,8 @@ ASR models can automatically detect the language of the input audio, or you can 
         result = pipe.generate(raw_speech)
         print(result.languages[0])  # e.g. "en", "fr", "de"
 
-        # Explicitly specify language (English). Use "English" for Qwen3-ASR models.
-        result = pipe.generate(raw_speech, language="<|en|>")
+        # Explicitly specify language. In the form of `en`, `<|en|>` for Whisper and `English` for Qwen3-ASR
+        result = pipe.generate(raw_speech, language="en")
         print(result.languages[0])  # "en"
 
         # French speech sample
@@ -181,7 +181,7 @@ ASR models can automatically detect the language of the input audio, or you can 
             auto result = pipe.generate(raw_speech);
             std::cout << result.languages[0] << "\n";  // e.g. "en", "fr", "de"
 
-            // Explicitly specify language (English). Use "English" for Qwen3-ASR models.
+            // Explicitly specify language. In the form of `en`, `<|en|>` for Whisper and `English` for Qwen3-ASR
             result = pipe.generate(raw_speech, ov::genai::language("<|en|>"));
             std::cout << result.languages[0] << "\n";  // "en"
 

--- a/src/cpp/include/openvino/genai/automatic_speech_recognition/generation_config.hpp
+++ b/src/cpp/include/openvino/genai/automatic_speech_recognition/generation_config.hpp
@@ -13,8 +13,8 @@ public:
     explicit ASRGenerationConfig(const std::filesystem::path& json_path);
 
     /**
-     * @brief Language token to use for generation
-     * In the form of <|en|> for Whisper models. Can be set for multilingual models only.
+     * @brief Language to use for generation
+     * In the form of `en`, `<|en|>` for Whisper models. Can be set for multilingual models only.
      * In the form of English for Qwen3-ASR models.
      */
     std::optional<std::string> language = std::nullopt;

--- a/src/cpp/include/openvino/genai/whisper_generation_config.hpp
+++ b/src/cpp/include/openvino/genai/whisper_generation_config.hpp
@@ -45,7 +45,7 @@ public:
 
     bool is_multilingual = true;
 
-    // Language token to use for generation in the form of <|en|>.
+    // Language to use for generation. In the form of `en`, `<|en|>`.
     // You can find all the possible language tokens in the generation_config.json lang_to_id dictionary.
     // Can be set for multilingual models only.
     std::optional<std::string> language = std::nullopt;

--- a/src/cpp/src/whisper/generation_config.cpp
+++ b/src/cpp/src/whisper/generation_config.cpp
@@ -84,8 +84,7 @@ void WhisperGenerationConfig::validate() const {
     }
 
     if (is_multilingual && language.has_value()) {
-        // Throws if the language is not present in lang_to_id in either the plain or wrapped form.
-        utils::find_token_id_by_language(lang_to_id, *language);
+        utils::get_or_throw_token_id_by_language(lang_to_id, *language);
     }
 
     if (is_multilingual && task.has_value()) {

--- a/src/cpp/src/whisper/generation_config.cpp
+++ b/src/cpp/src/whisper/generation_config.cpp
@@ -9,6 +9,7 @@
 #include "json_utils.hpp"
 #include "openvino/genai/whisper_generation_config.hpp"
 #include "utils.hpp"
+#include "whisper/whisper_utils.hpp"
 
 namespace ov {
 namespace genai {
@@ -83,8 +84,8 @@ void WhisperGenerationConfig::validate() const {
     }
 
     if (is_multilingual && language.has_value()) {
-        OPENVINO_ASSERT(lang_to_id.count(*language),
-                        "'language' " + *language + " must be provided in 'lang_to_id' map.");
+        // Throws if the language is not present in lang_to_id in either the plain or wrapped form.
+        utils::find_token_id_by_language(lang_to_id, *language);
     }
 
     if (is_multilingual && task.has_value()) {

--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -265,9 +265,7 @@ ov::genai::SotTokensResult prepare_sot_tokens(ov::Tensor& encoder_hidden_state,
     std::string language;
     if (config.language.has_value()) {
         language = *config.language;
-        if (config.lang_to_id.count(language)) {
-            language_token_id = config.lang_to_id.at(language);
-        }
+        language_token_id = ov::genai::utils::find_token_id_by_language(config.lang_to_id, language);
     } else {
         language_token_id = detect_language(encoder_hidden_state, decoder, config, raw_metrics);
         language = ov::genai::utils::find_language_by_token_id(config.lang_to_id, language_token_id);

--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -265,7 +265,7 @@ ov::genai::SotTokensResult prepare_sot_tokens(ov::Tensor& encoder_hidden_state,
     std::string language;
     if (config.language.has_value()) {
         language = *config.language;
-        language_token_id = ov::genai::utils::find_token_id_by_language(config.lang_to_id, language);
+        language_token_id = ov::genai::utils::get_or_throw_token_id_by_language(config.lang_to_id, language);
     } else {
         language_token_id = detect_language(encoder_hidden_state, decoder, config, raw_metrics);
         language = ov::genai::utils::find_language_by_token_id(config.lang_to_id, language_token_id);

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -260,9 +260,7 @@ ov::genai::SotTokensResult prepare_sot_tokens(ov::Tensor& encoder_hidden_state,
     std::string language;
     if (config.language.has_value()) {
         language = *config.language;
-        if (config.lang_to_id.count(language)) {
-            language_token_id = config.lang_to_id.at(language);
-        }
+        language_token_id = ov::genai::utils::find_token_id_by_language(config.lang_to_id, language);
     } else {
         auto [language_token, infer_ms] = decoder->detect_language(encoder_hidden_state, config);
         language_token_id = language_token;

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -260,7 +260,7 @@ ov::genai::SotTokensResult prepare_sot_tokens(ov::Tensor& encoder_hidden_state,
     std::string language;
     if (config.language.has_value()) {
         language = *config.language;
-        language_token_id = ov::genai::utils::find_token_id_by_language(config.lang_to_id, language);
+        language_token_id = ov::genai::utils::get_or_throw_token_id_by_language(config.lang_to_id, language);
     } else {
         auto [language_token, infer_ms] = decoder->detect_language(encoder_hidden_state, config);
         language_token_id = language_token;

--- a/src/cpp/src/whisper/whisper_utils.cpp
+++ b/src/cpp/src/whisper/whisper_utils.cpp
@@ -110,6 +110,33 @@ std::string find_language_by_token_id(const std::map<std::string, int64_t>& lang
     OPENVINO_THROW("Language token id ", token_id, " not found in lang_to_id map.");
 }
 
+int64_t find_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id, const std::string& language) {
+    // Exact-key-first keeps custom lang_to_id maps (whose keys need not be
+    // wrapped) working: try the value exactly as provided.
+    if (auto it = lang_to_id.find(language); it != lang_to_id.end()) {
+        return it->second;
+    }
+
+    // Otherwise translate between the wrapped ("<|en|>") and plain ("en") forms
+    // so either input resolves regardless of the map's key style. Only the exact
+    // Whisper wrapper is stripped (leading "<|" and trailing "|>"); no other
+    // delimiter handling, to avoid accepting malformed values.
+    constexpr size_t delimiter_size = 2;
+    const bool is_wrapped = language.size() > 2 * delimiter_size &&
+                            language.compare(0, delimiter_size, "<|") == 0 &&
+                            language.compare(language.size() - delimiter_size, delimiter_size, "|>") == 0;
+
+    const std::string alternative = is_wrapped
+                                        ? language.substr(delimiter_size, language.size() - 2 * delimiter_size)
+                                        : "<|" + language + "|>";
+
+    if (auto it = lang_to_id.find(alternative); it != lang_to_id.end()) {
+        return it->second;
+    }
+
+    OPENVINO_THROW("'language' ", language, " must be provided in 'lang_to_id' map.");
+}
+
 std::string to_unescaped_language(const std::string& language) {
     // "<|en|>" -> "en"
     std::string result = language;

--- a/src/cpp/src/whisper/whisper_utils.cpp
+++ b/src/cpp/src/whisper/whisper_utils.cpp
@@ -110,31 +110,20 @@ std::string find_language_by_token_id(const std::map<std::string, int64_t>& lang
     OPENVINO_THROW("Language token id ", token_id, " not found in lang_to_id map.");
 }
 
-int64_t find_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id, const std::string& language) {
-    // Exact-key-first keeps custom lang_to_id maps (whose keys need not be
-    // wrapped) working: try the value exactly as provided.
-    if (auto it = lang_to_id.find(language); it != lang_to_id.end()) {
-        return it->second;
-    }
-
-    // Otherwise translate between the wrapped ("<|en|>") and plain ("en") forms
-    // so either input resolves regardless of the map's key style. Only the exact
-    // Whisper wrapper is stripped (leading "<|" and trailing "|>"); no other
-    // delimiter handling, to avoid accepting malformed values.
+int64_t get_or_throw_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id,
+                                          const std::string& language) {
+    // Normalize plain language codes to the wrapped form used by lang_to_id.
     constexpr size_t delimiter_size = 2;
     const bool is_wrapped = language.size() > 2 * delimiter_size &&
                             language.compare(0, delimiter_size, "<|") == 0 &&
                             language.compare(language.size() - delimiter_size, delimiter_size, "|>") == 0;
 
-    const std::string alternative = is_wrapped
-                                        ? language.substr(delimiter_size, language.size() - 2 * delimiter_size)
-                                        : "<|" + language + "|>";
+    const std::string wrapped_language = is_wrapped ? language : "<|" + language + "|>";
 
-    if (auto it = lang_to_id.find(alternative); it != lang_to_id.end()) {
-        return it->second;
-    }
+    const auto it = lang_to_id.find(wrapped_language);
+    OPENVINO_ASSERT(it != lang_to_id.end(), "'language' ", language, " must be provided in 'lang_to_id' map.");
 
-    OPENVINO_THROW("'language' ", language, " must be provided in 'lang_to_id' map.");
+    return it->second;
 }
 
 std::string to_unescaped_language(const std::string& language) {

--- a/src/cpp/src/whisper/whisper_utils.hpp
+++ b/src/cpp/src/whisper/whisper_utils.hpp
@@ -36,10 +36,11 @@ ov::genai::WhisperGenerationConfig prepare_per_generate_config(
 
 std::string find_language_by_token_id(const std::map<std::string, int64_t>& lang_to_id, int64_t token_id);
 
-// Resolve a Whisper language token id, accepting either the wrapped form
-// ("<|en|>") or the plain code ("en"). Throws if neither form exists in
-// lang_to_id.
-int64_t find_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id, const std::string& language);
+// Resolve a Whisper language token id from a plain code ("en") or a wrapped
+// token ("<|en|>"). Plain codes are normalized to the wrapped form used by
+// lang_to_id. Throws if the normalized key is not present.
+int64_t get_or_throw_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id,
+                                          const std::string& language);
 
 // "<|en|>" -> "en"
 std::string to_unescaped_language(const std::string& language);

--- a/src/cpp/src/whisper/whisper_utils.hpp
+++ b/src/cpp/src/whisper/whisper_utils.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <map>
+#include <string>
+
 #include <openvino/openvino.hpp>
 
 #include "openvino/genai/perf_metrics.hpp"
@@ -32,6 +35,11 @@ ov::genai::WhisperGenerationConfig prepare_per_generate_config(
     const ov::genai::OptionalWhisperGenerationConfig& per_generate_config);
 
 std::string find_language_by_token_id(const std::map<std::string, int64_t>& lang_to_id, int64_t token_id);
+
+// Resolve a Whisper language token id, accepting either the wrapped form
+// ("<|en|>") or the plain code ("en"). Throws if neither form exists in
+// lang_to_id.
+int64_t find_token_id_by_language(const std::map<std::string, int64_t>& lang_to_id, const std::string& language);
 
 // "<|en|>" -> "en"
 std::string to_unescaped_language(const std::string& language);

--- a/src/js/lib/utils.ts
+++ b/src/js/lib/utils.ts
@@ -381,7 +381,7 @@ export type GenerationConfig = GenericGenerationConfig &
 
 /** Generation config for WhisperPipeline. Extends GenerationConfig with Whisper-specific options. */
 export type WhisperGenerationConfig = GenerationConfig & {
-  /** Language token for generation (e.g. "<|en|>"). For multilingual models only. */
+  /** Language for generation: a plain code (e.g. "en") or the wrapped token form (e.g. "<|en|>"). For multilingual models only. */
   language?: string;
   /** Task: "translate" or "transcribe". For multilingual models only. */
   task?: string;

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -70,8 +70,8 @@ class ASRGenerationConfig(GenerationConfig):
     
         Common parameters:
     
-        :param language: Language token to use for generation.
-                         In the form of <|en|> for Whisper models. Can be set for multilingual models only.
+        :param language: Language to use for generation.
+                         In the form of `en`, `<|en|>` for Whisper models. Can be set for multilingual models only.
                          In the form of English for Qwen3-ASR models.
         :type language: Optional[str]
     
@@ -310,8 +310,8 @@ class ASRPipeline:
         
             Common parameters:
         
-            :param language: Language token to use for generation.
-                             In the form of <|en|> for Whisper models. Can be set for multilingual models only.
+            :param language: Language to use for generation.
+                             In the form of `en`, `<|en|>` for Whisper models. Can be set for multilingual models only.
                              In the form of English for Qwen3-ASR models.
             :type language: Optional[str]
         
@@ -5971,7 +5971,7 @@ class WhisperGenerationConfig(GenerationConfig):
         :param suppress_tokens: A list containing the non-speech tokens that will be suppressed during generation.
         :type suppress_tokens: list[int]
     
-        :param language: Language token to use for generation in the form of <|en|>.
+        :param language: Language to use for generation. In the form of `en`, `<|en|>`.
                          You can find all the possible language tokens in the generation_config.json lang_to_id dictionary.
         :type language: Optional[str]
     
@@ -6238,7 +6238,7 @@ class WhisperPipeline:
             :param suppress_tokens: A list containing the non-speech tokens that will be suppressed during generation.
             :type suppress_tokens: list[int]
         
-            :param language: Language token to use for generation in the form of <|en|>.
+            :param language: Language to use for generation. In the form of `en`, `<|en|>`.
                              You can find all the possible language tokens in the generation_config.json lang_to_id dictionary.
             :type language: Optional[str]
         

--- a/src/python/py_asr_pipeline.cpp
+++ b/src/python/py_asr_pipeline.cpp
@@ -79,8 +79,8 @@ auto asr_generation_config_docstring = R"(
 
     Common parameters:
 
-    :param language: Language token to use for generation.
-                     In the form of <|en|> for Whisper models. Can be set for multilingual models only.
+    :param language: Language to use for generation.
+                     In the form of `en`, `<|en|>` for Whisper models. Can be set for multilingual models only.
                      In the form of English for Qwen3-ASR models.
     :type language: Optional[str]
 

--- a/src/python/py_whisper_pipeline.cpp
+++ b/src/python/py_whisper_pipeline.cpp
@@ -107,7 +107,7 @@ auto whisper_generation_config_docstring = R"(
     :param suppress_tokens: A list containing the non-speech tokens that will be suppressed during generation.
     :type suppress_tokens: list[int]
 
-    :param language: Language token to use for generation in the form of <|en|>.
+    :param language: Language to use for generation. In the form of `en`, `<|en|>`.
                      You can find all the possible language tokens in the generation_config.json lang_to_id dictionary.
     :type language: Optional[str]
 

--- a/tests/python_tests/test_generation_config.py
+++ b/tests/python_tests/test_generation_config.py
@@ -140,22 +140,22 @@ def test_invalid_fields_assinment_rises(fields):
         config.validate()
 
 
-@pytest.mark.parametrize(
-    "lang_to_id",
-    [
-        {"<|en|>": 50259},  # wrapped-key map (converted-model style)
-        {"en": 50259},  # plain-key map (custom style)
-    ],
-    ids=["wrapped_key_map", "plain_key_map"],
-)
-@pytest.mark.parametrize("language", ["en", "<|en|>"], ids=["plain_input", "wrapped_input"])
-def test_whisper_language_validate_accepts_plain_and_wrapped(lang_to_id, language):
-    # Both accepted input forms must resolve against both map key styles, i.e. all
-    # four (map, input) combinations: wrapped/plain key x plain/wrapped input.
+# Whisper lang_to_id uses the wrapped key format from converted-model
+# generation_config.json files.
+WHISPER_LANG_TO_ID = {"<|en|>": 50259, "<|fr|>": 50265, "<|de|>": 50261}
+
+
+@pytest.mark.parametrize("code", ["en", "fr", "de"])
+@pytest.mark.parametrize("language_format", ["plain", "wrapped"])
+def test_whisper_language_validate_accepts_plain_and_wrapped(code, language_format):
+    # Both accepted input forms ("en" and "<|en|>") must resolve against the
+    # wrapped keys stored in lang_to_id.
     # max_new_tokens satisfies the base stop-condition requirement of validate().
+    language = code if language_format == "plain" else f"<|{code}|>"
+
     config = WhisperGenerationConfig(
         is_multilingual=True,
-        lang_to_id=lang_to_id,
+        lang_to_id=WHISPER_LANG_TO_ID,
         max_new_tokens=10,
     )
 
@@ -168,7 +168,7 @@ def test_whisper_language_validate_accepts_plain_and_wrapped(lang_to_id, languag
 def test_whisper_language_validate_rejects_unknown():
     config = WhisperGenerationConfig(
         is_multilingual=True,
-        lang_to_id={"<|en|>": 50259},
+        lang_to_id=WHISPER_LANG_TO_ID,
         max_new_tokens=10,
     )
 

--- a/tests/python_tests/test_generation_config.py
+++ b/tests/python_tests/test_generation_config.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2023-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from openvino_genai import GenerationConfig
+from openvino_genai import GenerationConfig, WhisperGenerationConfig
 import json
 import math
 import os
@@ -136,6 +136,44 @@ def test_invalid_fields_assinment_rises(fields):
     config = GenerationConfig()
     for key, val in fields.items():
         setattr(config, key, val)
+    with pytest.raises(RuntimeError):
+        config.validate()
+
+
+@pytest.mark.parametrize(
+    "lang_to_id",
+    [
+        {"<|en|>": 50259},  # wrapped-key map (converted-model style)
+        {"en": 50259},  # plain-key map (custom style)
+    ],
+    ids=["wrapped_key_map", "plain_key_map"],
+)
+@pytest.mark.parametrize("language", ["en", "<|en|>"], ids=["plain_input", "wrapped_input"])
+def test_whisper_language_validate_accepts_plain_and_wrapped(lang_to_id, language):
+    # Both accepted input forms must resolve against both map key styles, i.e. all
+    # four (map, input) combinations: wrapped/plain key x plain/wrapped input.
+    # max_new_tokens satisfies the base stop-condition requirement of validate().
+    config = WhisperGenerationConfig(
+        is_multilingual=True,
+        lang_to_id=lang_to_id,
+        max_new_tokens=10,
+    )
+
+    # Accepted; validate() must not mutate the user-visible field.
+    config.language = language
+    config.validate()
+    assert config.language == language
+
+
+def test_whisper_language_validate_rejects_unknown():
+    config = WhisperGenerationConfig(
+        is_multilingual=True,
+        lang_to_id={"<|en|>": 50259},
+        max_new_tokens=10,
+    )
+
+    # Unknown language is still rejected.
+    config.language = "unknown"
     with pytest.raises(RuntimeError):
         config.validate()
 

--- a/tests/python_tests/test_whisper_pipeline.py
+++ b/tests/python_tests/test_whisper_pipeline.py
@@ -459,22 +459,27 @@ def test_max_new_tokens(model_descr, sample_from_dataset, pipeline_type):
 @pytest.mark.transformers_lower_v5(reason="CVS-185784")
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("language", ["fr", "de"])
-def test_language_mode(model_descr, language, pipeline_type):
+@pytest.mark.parametrize("language_format", ["plain", "wrapped"])
+def test_language_mode(model_descr, language, language_format, pipeline_type):
     model_id, path, hf_pipe, genai_pipe = read_asr_model(model_descr, pipeline_type=pipeline_type)
     sample = get_multilingual_audio_dataset(language)[0]
+
+    # Derive the config value to exercise both accepted API forms; the plain
+    # `language` still selects the dataset.
+    language_value = language if language_format == "plain" else f"<|{language}|>"
 
     config_cls = get_config_cls(pipeline_type)
     config = config_cls(max_new_tokens=30, language=language)
 
     expected = run_huggingface(hf_pipe, sample, config)
 
-    genai_result = genai_pipe.generate(sample, max_new_tokens=30, language=f"<|{language}|>")
+    genai_result = genai_pipe.generate(sample, max_new_tokens=30, language=language_value)
 
     compare_results(expected, genai_result)
 
     genai_config = genai_pipe.get_generation_config()
     genai_config.max_new_tokens = 30
-    genai_config.language = f"<|{language}|>"
+    genai_config.language = language_value
     genai_result = genai_pipe.generate(sample, genai_config)
 
     compare_results(expected, genai_result)

--- a/tests/python_tests/test_whisper_pipeline_static.py
+++ b/tests/python_tests/test_whisper_pipeline_static.py
@@ -148,7 +148,10 @@ def test_static_whisper_autodetect(model_descr, sample_from_multilingual_dataset
 
 @pytest.mark.parametrize("model_descr", get_whisper_models_list(tiny_only=True))
 @pytest.mark.parametrize("sample_from_multilingual_dataset", ["de"], indirect=True)
-def test_static_whisper_language_de(model_descr, sample_from_multilingual_dataset):
+# Both the plain code and the wrapped token must reach the static pipeline's
+# configured-language path in pipeline_static.cpp (not just config validation).
+@pytest.mark.parametrize("language", ["de", "<|de|>"])
+def test_static_whisper_language_de(model_descr, sample_from_multilingual_dataset, language):
     model_id, stateful_model_path = load_and_save_whisper_model(model_descr, stateful=True)
     model_id, stateless_model_path = load_and_save_whisper_model(model_descr, stateful=False)
 
@@ -157,7 +160,7 @@ def test_static_whisper_language_de(model_descr, sample_from_multilingual_datase
         stateless_model_path,
         sample_from_multilingual_dataset,
         max_new_tokens=30,
-        language="<|de|>",
+        language=language,
     )
 
     compare_results_with_assert(expected, actual_out)


### PR DESCRIPTION
## Description

Whisper's `language` generation parameter previously accepted only the wrapped token form and rejected plain language codes:

```python
language="<|en|>"  # accepted
language="en"      # rejected
```

This change makes both forms valid while preserving backward compatibility:

```python
language="<|en|>"  # still accepted
language="en"      # now also accepted
```

Language resolution is handled by the new Whisper-specific helper:

`ov::genai::utils::get_or_throw_token_id_by_language(lang_to_id, language)`

The helper accepts either a plain language code, such as `"en"`, or an already wrapped Whisper language token, such as `"<|en|>"`. Plain input is normalized to the wrapped form and looked up against the wrapped keys stored in `lang_to_id`. It returns the resolved token ID directly and throws if the normalized language is not present.

The `lang_to_id` keys use the wrapped format found in the converted model's `generation_config.json`; plain map keys are not supported. Invalid language values remain rejected during generation-configuration validation before generation begins.


Both Whisper generation paths are updated consistently:

* the regular pipeline in `whisper.cpp`
* the static/NPU pipeline in `pipeline_static.cpp`

`WhisperGenerationConfig::validate()` uses the same helper, ensuring that plain and wrapped values are handled consistently at both the configuration and pipeline layers.

The change is limited to Whisper. Qwen3-ASR language handling, where values such as `"English"` are treated as free text with different semantics, uses a separate code path and is unchanged.

Public API comments, Python docstrings, generated Python stubs, and the JavaScript type description have been updated to describe both accepted formats.

GitHub Pages documentation under `site/docs/` will be added to this draft PR in a separate commit before it is marked ready for review.

CVS-192021

## Checklist:

* [x] This PR follows [[GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing)](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
* [x] Tests have been updated or added to cover the new code.

  * Added `test_whisper_language_validate_accepts_plain_and_wrapped`, a model-free test that verifies validation accepts `"en"` and `"<|en|>"`, rejects unknown values, and does not mutate the configured language.
  * Updated `test_language_mode` to exercise plain and wrapped language formats end-to-end with both the `WHISPER` and generic `ASR` pipeline types.
  * Updated `test_static_whisper_language_de` to exercise both `"de"` and `"<|de|>"` through the static `pipeline_static.cpp` configured-language path using NPUW:CPU.
* [x] This PR fully addresses the ticket.

  * Plain Whisper language codes are accepted.
  * Wrapped language tokens remain supported.
  * Invalid language values remain rejected.
  * Qwen3-ASR behavior is unchanged.
* [x] I have made corresponding changes to the documentation.

  * Public API comments, Python docstrings and stubs, and the JavaScript type description are included in the current commit.
  * GitHub Pages documentation and its preview link will be added in a separate commit to this PR.