### PR TITLE
cmake: make GenAI install destinations configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,12 @@ if(EXISTS "${OpenVINOGenAI_SOURCE_DIR}/tests/cpp" AND ENABLE_TESTS)
     add_subdirectory(tests/cpp)
 endif()
 
-install(FILES LICENSE DESTINATION docs/licensing COMPONENT licensing_genai RENAME LICENSE-GENAI)
-install(FILES third-party-programs.txt DESTINATION docs/licensing COMPONENT licensing_genai RENAME third-party-programs-genai.txt)
+set(OPENVINO_GENAI_INSTALL_LICENSEDIR "docs/licensing" CACHE PATH
+    "Directory used to install OpenVINO GenAI license files")
+install(FILES LICENSE DESTINATION ${OPENVINO_GENAI_INSTALL_LICENSEDIR}
+        COMPONENT licensing_genai RENAME LICENSE-GENAI)
+install(FILES third-party-programs.txt DESTINATION ${OPENVINO_GENAI_INSTALL_LICENSEDIR}
+        COMPONENT licensing_genai RENAME third-party-programs-genai.txt)
 if(NOT DEFINED CPACK_ARCHIVE_COMPONENT_INSTALL)
     set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,9 +56,20 @@ if(CPACK_GENERATOR STREQUAL "NPM")
         list(APPEND rpaths "@loader_path/../node_modules/openvino-node/bin")
     endif()
 else()
-    set(LIBRARY_DESTINATION runtime/lib/${ARCH_DIR})
-    set(ARCHIVE_DESTINATION runtime/lib/${ARCH_DIR})
-    set(RUNTIME_DESTINATION runtime/bin/${ARCH_DIR})
+    set(OPENVINO_GENAI_INSTALL_LIBDIR "runtime/lib/${ARCH_DIR}" CACHE PATH
+        "Directory used to install OpenVINO GenAI libraries")
+    set(OPENVINO_GENAI_INSTALL_BINDIR "runtime/bin/${ARCH_DIR}" CACHE PATH
+        "Directory used to install OpenVINO GenAI executables")
+    set(OPENVINO_GENAI_INSTALL_INCLUDEDIR "runtime/include" CACHE PATH
+        "Directory used to install OpenVINO GenAI headers")
+    set(OPENVINO_GENAI_INSTALL_CMAKEDIR "runtime/cmake" CACHE PATH
+        "Directory used to install OpenVINO GenAI CMake files")
+    set(OPENVINO_GENAI_INSTALL_PYTHONDIR "python" CACHE PATH
+        "Directory used to install the OpenVINO GenAI Python package")
+
+    set(LIBRARY_DESTINATION ${OPENVINO_GENAI_INSTALL_LIBDIR})
+    set(ARCHIVE_DESTINATION ${OPENVINO_GENAI_INSTALL_LIBDIR})
+    set(RUNTIME_DESTINATION ${OPENVINO_GENAI_INSTALL_BINDIR})
 endif()
 
 #

--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -14,7 +14,7 @@ if(WIN32)
   add_vs_version_resource(${TARGET_NAME})
 endif()
 
-target_include_directories(${TARGET_NAME} PUBLIC "$<INSTALL_INTERFACE:runtime/include>"
+target_include_directories(${TARGET_NAME} PUBLIC "$<INSTALL_INTERFACE:${OPENVINO_GENAI_INSTALL_INCLUDEDIR}>"
                                                  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                  $<BUILD_INTERFACE:$<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>>)
 
@@ -41,7 +41,7 @@ install(TARGETS ${TARGET_NAME} EXPORT OpenVINOGenAITargets
             NAMELINK_COMPONENT core_c_genai_dev
         ARCHIVE DESTINATION ${ARCHIVE_DESTINATION} COMPONENT core_c_genai_dev
         RUNTIME DESTINATION ${RUNTIME_DESTINATION} COMPONENT core_c_genai
-        INCLUDES DESTINATION runtime/include)
+        INCLUDES DESTINATION ${OPENVINO_GENAI_INSTALL_INCLUDEDIR})
 if(OpenVINODeveloperPackage_FOUND AND COMMAND ov_install_pdb)
     ov_install_pdb(${TARGET_NAME})
 endif()

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -271,7 +271,7 @@ if(WIN32)
   add_vs_version_resource(${TARGET_NAME})
 endif()
 
-target_include_directories(${TARGET_NAME} INTERFACE "$<INSTALL_INTERFACE:runtime/include>"
+target_include_directories(${TARGET_NAME} INTERFACE "$<INSTALL_INTERFACE:${OPENVINO_GENAI_INSTALL_INCLUDEDIR}>"
                                                     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
@@ -350,7 +350,7 @@ install(TARGETS ${TARGET_NAME} EXPORT OpenVINOGenAITargets
             NAMELINK_COMPONENT core_genai_dev
         ARCHIVE DESTINATION ${ARCHIVE_DESTINATION} COMPONENT core_genai_dev
         RUNTIME DESTINATION ${RUNTIME_DESTINATION} COMPONENT core_genai
-        INCLUDES DESTINATION runtime/include)
+        INCLUDES DESTINATION ${OPENVINO_GENAI_INSTALL_INCLUDEDIR})
 if(OpenVINODeveloperPackage_FOUND AND COMMAND ov_install_pdb)
     ov_install_pdb(${TARGET_NAME})
 endif()
@@ -362,19 +362,20 @@ endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
                   ${OpenVINOGenAI_SOURCE_DIR}/src/c/include/
-        DESTINATION runtime/include COMPONENT core_genai_dev)
+        DESTINATION ${OPENVINO_GENAI_INSTALL_INCLUDEDIR} COMPONENT core_genai_dev)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openvino/genai/version.hpp
-        DESTINATION runtime/include/openvino/genai COMPONENT core_genai_dev)
+        DESTINATION ${OPENVINO_GENAI_INSTALL_INCLUDEDIR}/openvino/genai COMPONENT core_genai_dev)
 
 install(EXPORT OpenVINOGenAITargets FILE OpenVINOGenAITargets.cmake
-        NAMESPACE openvino:: DESTINATION runtime/cmake
+        NAMESPACE openvino:: DESTINATION ${OPENVINO_GENAI_INSTALL_CMAKEDIR}
         COMPONENT core_genai_dev)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file("${OpenVINOGenAI_SOURCE_DIR}/cmake/templates/OpenVINOGenAIConfig.cmake.in"
-                              "${CMAKE_BINARY_DIR}/OpenVINOGenAIConfig.cmake" INSTALL_DESTINATION runtime/cmake)
+                              "${CMAKE_BINARY_DIR}/OpenVINOGenAIConfig.cmake"
+                              INSTALL_DESTINATION ${OPENVINO_GENAI_INSTALL_CMAKEDIR})
 write_basic_package_version_file("${CMAKE_BINARY_DIR}/OpenVINOGenAIConfigVersion.cmake"
                                  VERSION ${OpenVINOGenAI_VERSION} COMPATIBILITY AnyNewerVersion)
 install(FILES "${CMAKE_BINARY_DIR}/OpenVINOGenAIConfig.cmake" "${CMAKE_BINARY_DIR}/OpenVINOGenAIConfigVersion.cmake"
-        DESTINATION runtime/cmake COMPONENT core_genai_dev)
+        DESTINATION ${OPENVINO_GENAI_INSTALL_CMAKEDIR} COMPONENT core_genai_dev)
 export(EXPORT OpenVINOGenAITargets FILE "${CMAKE_BINARY_DIR}/OpenVINOGenAITargets.cmake" NAMESPACE openvino::)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -69,10 +69,10 @@ endif()
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/openvino_genai/__init__.py"
               "${CMAKE_CURRENT_SOURCE_DIR}/openvino_genai/__init__.pyi"
               "${CMAKE_CURRENT_SOURCE_DIR}/openvino_genai/py_openvino_genai.pyi"
-        DESTINATION python/openvino_genai
+        DESTINATION ${OPENVINO_GENAI_INSTALL_PYTHONDIR}/openvino_genai
         COMPONENT pygenai_${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR})
 install(TARGETS ${TARGET_NAME}
-        LIBRARY DESTINATION python/openvino_genai
+        LIBRARY DESTINATION ${OPENVINO_GENAI_INSTALL_PYTHONDIR}/openvino_genai
         COMPONENT pygenai_${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR})
 
 install(FILES "${OpenVINOGenAI_SOURCE_DIR}/LICENSE"


### PR DESCRIPTION
OpenVINO GenAI hard-codes an archive-oriented runtime directory hierarchy for libraries, headers, executables, CMake metadata, Python modules, and license files. This forces system packagers to relocate files after installation and can leave exported target paths inconsistent with the final layout.

Expose cache variables for each install destination while preserving the current paths as defaults. Use the same values in install rules, exported targets, and package configuration so an alternate GNU-style layout remains a valid CMake package.

Example use:
cmake -S . -B build \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DOPENVINO_GENAI_INSTALL_LIBDIR=/usr/lib64 \
    -DOPENVINO_GENAI_INSTALL_BINDIR=/usr/bin \
    -DOPENVINO_GENAI_INSTALL_INCLUDEDIR=/usr/include \
    -DOPENVINO_GENAI_INSTALL_CMAKEDIR=/usr/lib64/cmake/OpenVINOGenAI \
    -DOPENVINO_GENAI_INSTALL_PYTHONDIR=/usr/lib64/python3.14/site-packages \
    -DOPENVINO_GENAI_INSTALL_LICENSEDIR=/usr/share/licenses/openvino-genai

Then check it by:
cmake -N -LA build | grep '^OPENVINO_GENAI_INSTALL_'
