### PR TITLE
flux2_klein_pipeline.hpp: Set default NPUW compilation flags for NPU

### DIFF
--- a/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
@@ -91,73 +91,12 @@ inline ov::Tensor flux2_prepare_image_ids(const size_t batch_size, const std::ve
     return image_ids;
 }
 
-// Sets a key/value pair in config only if the key is not already present,
-// preserving any user-supplied override.
-inline void flux2_npu_set_default(ov::AnyMap& config, const std::string& key, ov::Any value) {
-    if (config.count(key) == 0) {
-        config.emplace(key, std::move(value));
-    }
-}
-
-inline bool flux2_npu_use_npuw_disabled(const ov::AnyMap& config) {
-    auto it = config.find("NPU_USE_NPUW");
-    if (it == config.end()) {
-        return false;
-    }
-    if (it->second.is<std::string>()) {
-        return it->second.as<std::string>() == "NO";
-    }
-    if (it->second.is<bool>()) {
-        return it->second.as<bool>() == false;
-    }
-    return false;
-}
-
-inline void flux2_apply_npu_defaults_text_encoder(ov::AnyMap& config) {
-    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
-    if (flux2_npu_use_npuw_disabled(config)) {
+inline void flux2_apply_npuw_defaults(ov::AnyMap& config) {
+    ov::genai::utils::set_config_default(config, "NPU_USE_NPUW", std::string("YES"));
+    if (!ov::genai::utils::is_npuw_enabled(config)) {
         return;
     }
-    flux2_npu_set_default(config, "NPUW_DEVICES",    std::string("NPU"));
-    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",  std::string(""));
-    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE", std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_DQ",          std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_F16IC",       std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_DQ_FULL",     std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_FOLD",        std::string("YES"));
-    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS", std::string("NO"));
-}
-
-inline void flux2_apply_npu_defaults_transformer(ov::AnyMap& config) {
-    flux2_npu_set_default(config, "NPU_COMPILATION_MODE_PARAMS",
-                         std::string("compute-layers-with-higher-precision=MVN"));
-    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
-    if (flux2_npu_use_npuw_disabled(config)) {
-        return;
-    }
-    flux2_npu_set_default(config, "NPUW_DEVICES",    std::string("NPU"));
-    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",  std::string(""));
-    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE", std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_DQ",          std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_F16IC",       std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_DQ_FULL",     std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_FOLD",        std::string("YES"));
-    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS", std::string("NO"));
-}
-
-inline void flux2_apply_npu_defaults_vae(ov::AnyMap& config) {
-    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
-    if (flux2_npu_use_npuw_disabled(config)) {
-        return;
-    }
-    flux2_npu_set_default(config, "NPUW_DEVICES",       std::string("NPU"));
-    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",     std::string(""));
-    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE",    std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_ONLINE_PIPELINE", std::string("NONE"));
-    flux2_npu_set_default(config, "NPUW_F16IC",          std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_DQ_FULL",        std::string("NO"));
-    flux2_npu_set_default(config, "NPUW_FOLD",           std::string("YES"));
-    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS",   std::string("NO"));
+    ov::genai::utils::set_config_default(config, "NPUW_FLUX2", std::string("YES"));
 }
 
 }  // anonymous namespace
@@ -321,23 +260,25 @@ public:
         update_adapters_from_properties(properties, m_generation_config.adapters);
         auto updated_properties = update_adapters_in_properties(properties, &Flux2KleinPipeline::derived_adapters);
 
-        ov::AnyMap text_encoder_props = *updated_properties;
-        if (text_encode_device == "NPU") {
-            flux2_apply_npu_defaults_text_encoder(text_encoder_props);
-        }
-        m_text_encoder->compile(text_encode_device, text_encoder_props);
+        const ov::AnyMap& base_props = *updated_properties;
+        std::optional<ov::AnyMap> npu_props;
 
-        ov::AnyMap vae_props = *updated_properties;
-        if (vae_device == "NPU") {
-            flux2_apply_npu_defaults_vae(vae_props);
-        }
-        m_vae->compile(vae_device, vae_props);
+        const auto get_compile_props = [&](const std::string& device) -> const ov::AnyMap& {
+            if (device != "NPU") {
+                return base_props;
+            }
 
-        ov::AnyMap transformer_props = *updated_properties;
-        if (denoise_device == "NPU") {
-            flux2_apply_npu_defaults_transformer(transformer_props);
-        }
-        m_transformer->compile(denoise_device, transformer_props);
+            if (!npu_props.has_value()) {
+                npu_props = base_props;
+                flux2_apply_npuw_defaults(*npu_props);
+            }
+
+            return *npu_props;
+        };
+
+        m_text_encoder->compile(text_encode_device, get_compile_props(text_encode_device));
+        m_vae->compile(vae_device, get_compile_props(vae_device));
+        m_transformer->compile(denoise_device, get_compile_props(denoise_device));
     }
 
     std::shared_ptr<DiffusionPipeline> clone() override {

--- a/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
@@ -101,7 +101,16 @@ inline void flux2_npu_set_default(ov::AnyMap& config, const std::string& key, ov
 
 inline bool flux2_npu_use_npuw_disabled(const ov::AnyMap& config) {
     auto it = config.find("NPU_USE_NPUW");
-    return it != config.end() && it->second.as<std::string>() == "NO";
+    if (it == config.end()) {
+        return false;
+    }
+    if (it->second.is<std::string>()) {
+        return it->second.as<std::string>() == "NO";
+    }
+    if (it->second.is<bool>()) {
+        return it->second.as<bool>() == false;
+    }
+    return false;
 }
 
 inline void flux2_apply_npu_defaults_text_encoder(ov::AnyMap& config) {

--- a/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
+++ b/src/cpp/src/image_generation/flux2_klein_pipeline.hpp
@@ -91,6 +91,66 @@ inline ov::Tensor flux2_prepare_image_ids(const size_t batch_size, const std::ve
     return image_ids;
 }
 
+// Sets a key/value pair in config only if the key is not already present,
+// preserving any user-supplied override.
+inline void flux2_npu_set_default(ov::AnyMap& config, const std::string& key, ov::Any value) {
+    if (config.count(key) == 0) {
+        config.emplace(key, std::move(value));
+    }
+}
+
+inline bool flux2_npu_use_npuw_disabled(const ov::AnyMap& config) {
+    auto it = config.find("NPU_USE_NPUW");
+    return it != config.end() && it->second.as<std::string>() == "NO";
+}
+
+inline void flux2_apply_npu_defaults_text_encoder(ov::AnyMap& config) {
+    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
+    if (flux2_npu_use_npuw_disabled(config)) {
+        return;
+    }
+    flux2_npu_set_default(config, "NPUW_DEVICES",    std::string("NPU"));
+    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",  std::string(""));
+    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE", std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_DQ",          std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_F16IC",       std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_DQ_FULL",     std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_FOLD",        std::string("YES"));
+    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS", std::string("NO"));
+}
+
+inline void flux2_apply_npu_defaults_transformer(ov::AnyMap& config) {
+    flux2_npu_set_default(config, "NPU_COMPILATION_MODE_PARAMS",
+                         std::string("compute-layers-with-higher-precision=MVN"));
+    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
+    if (flux2_npu_use_npuw_disabled(config)) {
+        return;
+    }
+    flux2_npu_set_default(config, "NPUW_DEVICES",    std::string("NPU"));
+    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",  std::string(""));
+    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE", std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_DQ",          std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_F16IC",       std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_DQ_FULL",     std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_FOLD",        std::string("YES"));
+    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS", std::string("NO"));
+}
+
+inline void flux2_apply_npu_defaults_vae(ov::AnyMap& config) {
+    flux2_npu_set_default(config, "NPU_USE_NPUW", std::string("YES"));
+    if (flux2_npu_use_npuw_disabled(config)) {
+        return;
+    }
+    flux2_npu_set_default(config, "NPUW_DEVICES",       std::string("NPU"));
+    flux2_npu_set_default(config, "NPUW_DCOFF_TYPE",     std::string(""));
+    flux2_npu_set_default(config, "NPUW_DCOFF_SCALE",    std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_ONLINE_PIPELINE", std::string("NONE"));
+    flux2_npu_set_default(config, "NPUW_F16IC",          std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_DQ_FULL",        std::string("NO"));
+    flux2_npu_set_default(config, "NPUW_FOLD",           std::string("YES"));
+    flux2_npu_set_default(config, "NPUW_UNFOLD_IREQS",   std::string("NO"));
+}
+
 }  // anonymous namespace
 
 namespace ov {
@@ -251,9 +311,24 @@ public:
                  const ov::AnyMap& properties) override {
         update_adapters_from_properties(properties, m_generation_config.adapters);
         auto updated_properties = update_adapters_in_properties(properties, &Flux2KleinPipeline::derived_adapters);
-        m_text_encoder->compile(text_encode_device, *updated_properties);
-        m_vae->compile(vae_device, *updated_properties);
-        m_transformer->compile(denoise_device, *updated_properties);
+
+        ov::AnyMap text_encoder_props = *updated_properties;
+        if (text_encode_device == "NPU") {
+            flux2_apply_npu_defaults_text_encoder(text_encoder_props);
+        }
+        m_text_encoder->compile(text_encode_device, text_encoder_props);
+
+        ov::AnyMap vae_props = *updated_properties;
+        if (vae_device == "NPU") {
+            flux2_apply_npu_defaults_vae(vae_props);
+        }
+        m_vae->compile(vae_device, vae_props);
+
+        ov::AnyMap transformer_props = *updated_properties;
+        if (denoise_device == "NPU") {
+            flux2_apply_npu_defaults_transformer(transformer_props);
+        }
+        m_transformer->compile(denoise_device, transformer_props);
     }
 
     std::shared_ptr<DiffusionPipeline> clone() override {

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -35,9 +35,7 @@ const std::string SDPA_BACKEND = "SDPA";
 namespace {
 
 void update_config(ov::AnyMap& config, const std::pair<std::string, ov::Any>& pair) {
-    if (config.count(pair.first) == 0) {
-        config.insert(pair);
-    }
+    ov::genai::utils::set_config_default(config, pair.first, pair.second);
 }
 
 void rename_key(ov::AnyMap& config, const std::string& old_key, const std::string& new_key) {
@@ -253,6 +251,42 @@ bool is_npu_requested(const std::string& device, const ov::AnyMap& properties) {
     }
 
     return false;
+}
+
+void set_config_default(ov::AnyMap& config, const std::string& key, ov::Any value) {
+    if (config.count(key) == 0) {
+        config.emplace(key, std::move(value));
+    }
+}
+
+bool is_npuw_enabled(const ov::AnyMap& config) {
+    constexpr const char* npu_use_npuw = "NPU_USE_NPUW";
+    constexpr const char* yes = "YES";
+    constexpr const char* no = "NO";
+
+    auto it = config.find(npu_use_npuw);
+    if (it == config.end()) {
+        return false;
+    }
+
+    const ov::Any& value = it->second;
+    if (value.is<bool>()) {
+        return value.as<bool>();
+    }
+
+    if (value.is<std::string>()) {
+        const std::string str_value = value.as<std::string>();
+        if (str_value == yes) {
+            return true;
+        }
+        if (str_value == no) {
+            return false;
+        }
+
+        OPENVINO_THROW("'", npu_use_npuw, "' must be '", yes, "' or '", no, "', got '", str_value, "'");
+    }
+
+    OPENVINO_THROW("'", npu_use_npuw, "' must be bool or string, got type: ", value.type_info().name());
 }
 
 ov::genai::TokenizedInputs subtract_chat_tokenized_inputs(const ov::genai::TokenizedInputs& minuend, const ov::genai::TokenizedInputs& subtrahend) {

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -120,6 +120,12 @@ ov::genai::OptionalGenerationConfig get_config_from_map(const ov::AnyMap& config
 
 bool is_npu_requested(const std::string& device, const ov::AnyMap& properties);
 
+// Sets a key/value pair in config only if the key is not already present.
+void set_config_default(ov::AnyMap& config, const std::string& key, ov::Any value);
+
+// Returns true when NPUW is enabled via NPU_USE_NPUW.
+bool is_npuw_enabled(const ov::AnyMap& config);
+
 ov::genai::TokenizedInputs subtract_chat_tokenized_inputs(const ov::genai::TokenizedInputs& minuend, const ov::genai::TokenizedInputs& subtrahend);
 
 void apply_slice_before_matmul_transformation(std::shared_ptr<ov::Model> model);


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
This PR primarily adds NPU support for FLIX.2 Klein image generation pipeline.

In order to support reasonable compilation times when running FLUX.2 Klein models on NPU, the pipeline components (Text Encoder, Transformer, VAE encoder/decoder) are compiled using NPUW features by default -- although these configs can be overridden by application.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-192135

## Checklist:
- [X] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [N/A] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [X] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
