### PR TITLE
Add SDXL image-to-image and inpainting support blob export

### DIFF
--- a/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
@@ -145,6 +145,8 @@ public:
 
     ImageGenerationPerfMetrics get_performance_metrics();
 
+    void export_model(const std::filesystem::path& export_path);
+
 private:
     std::shared_ptr<DiffusionPipeline> m_impl;
 

--- a/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/image2image_pipeline.hpp
@@ -145,6 +145,12 @@ public:
 
     ImageGenerationPerfMetrics get_performance_metrics();
 
+    /**
+      * @brief Exports compiled models to a specified directory.
+      * @param export_path A path to a directory to export compiled models to
+      *
+      * See @ref ov::genai::blob_path property to load previously exported models and for more details.
+      */
     void export_model(const std::filesystem::path& export_path);
 
 private:

--- a/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
@@ -170,6 +170,12 @@ public:
 
     ImageGenerationPerfMetrics get_performance_metrics();
 
+    /**
+      * @brief Exports compiled models to a specified directory.
+      * @param export_path A path to a directory to export compiled models to
+      *
+      * See @ref ov::genai::blob_path property to load previously exported models and for more details.
+      */
     void export_model(const std::filesystem::path& export_path);
 
 private:

--- a/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
+++ b/src/cpp/include/openvino/genai/image_generation/inpainting_pipeline.hpp
@@ -170,6 +170,8 @@ public:
 
     ImageGenerationPerfMetrics get_performance_metrics();
 
+    void export_model(const std::filesystem::path& export_path);
+
 private:
     std::shared_ptr<DiffusionPipeline> m_impl;
 

--- a/src/cpp/src/image_generation/image2image_pipeline.cpp
+++ b/src/cpp/src/image_generation/image2image_pipeline.cpp
@@ -211,9 +211,8 @@ ImageGenerationPerfMetrics Image2ImagePipeline::get_performance_metrics() {
 }
 
 void Image2ImagePipeline::export_model(const std::filesystem::path& export_path) {
-    if (std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl) == nullptr) {
-        OPENVINO_THROW("Blob export is supported only for Stable Diffusion XL pipelines");
-    }
+    OPENVINO_ASSERT(std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl),
+                     "Blob export is supported only for Stable Diffusion XL pipelines");
     m_impl->export_model(export_path);
 }
 

--- a/src/cpp/src/image_generation/image2image_pipeline.cpp
+++ b/src/cpp/src/image_generation/image2image_pipeline.cpp
@@ -210,6 +210,13 @@ ImageGenerationPerfMetrics Image2ImagePipeline::get_performance_metrics() {
     return m_impl->get_performance_metrics();
 }
 
+void Image2ImagePipeline::export_model(const std::filesystem::path& export_path) {
+    if (std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl) == nullptr) {
+        OPENVINO_THROW("Blob export is supported only for Stable Diffusion XL pipelines");
+    }
+    m_impl->export_model(export_path);
+}
+
 Image2ImagePipeline Image2ImagePipeline::clone() {
     Image2ImagePipeline pipe(m_impl->clone());
     return pipe;

--- a/src/cpp/src/image_generation/inpainting_pipeline.cpp
+++ b/src/cpp/src/image_generation/inpainting_pipeline.cpp
@@ -226,5 +226,12 @@ ImageGenerationPerfMetrics InpaintingPipeline::get_performance_metrics() {
     return m_impl->get_performance_metrics();
 }
 
+void InpaintingPipeline::export_model(const std::filesystem::path& export_path) {
+    if (std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl) == nullptr) {
+        OPENVINO_THROW("Blob export is supported only for Stable Diffusion XL pipelines");
+    }
+    m_impl->export_model(export_path);
+}
+
 }  // namespace genai
 }  // namespace ov

--- a/src/cpp/src/image_generation/inpainting_pipeline.cpp
+++ b/src/cpp/src/image_generation/inpainting_pipeline.cpp
@@ -227,9 +227,8 @@ ImageGenerationPerfMetrics InpaintingPipeline::get_performance_metrics() {
 }
 
 void InpaintingPipeline::export_model(const std::filesystem::path& export_path) {
-    if (std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl) == nullptr) {
-        OPENVINO_THROW("Blob export is supported only for Stable Diffusion XL pipelines");
-    }
+    OPENVINO_ASSERT(std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl),
+                     "Blob export is supported only for Stable Diffusion XL pipelines");
     m_impl->export_model(export_path);
 }
 

--- a/src/cpp/src/image_generation/models/autoencoder_kl.cpp
+++ b/src/cpp/src/image_generation/models/autoencoder_kl.cpp
@@ -153,8 +153,18 @@ AutoencoderKL::AutoencoderKL(const std::filesystem::path& vae_encoder_path,
                              const std::filesystem::path& vae_decoder_path,
                              const std::string& device,
                              const ov::AnyMap& properties)
-    : AutoencoderKL(vae_encoder_path, vae_decoder_path) {
-    compile(device, *extract_adapters_from_properties(properties));
+    : m_config(vae_decoder_path / "config.json") {
+    const auto [properties_without_blob, blob_path] = utils::extract_export_properties(properties);
+
+    if (blob_path.has_value()) {
+        import_model(*blob_path, device, properties_without_blob);
+        return;
+    }
+
+    m_decoder_model = utils::singleton_core().read_model(vae_decoder_path / "openvino_model.xml");
+    merge_vae_image_post_processing();
+    m_encoder_model = utils::singleton_core().read_model(vae_encoder_path / "openvino_model.xml");
+    compile(device, *extract_adapters_from_properties(properties_without_blob));
 }
 
 AutoencoderKL::AutoencoderKL(const std::string& vae_decoder_model,

--- a/src/cpp/src/image_generation/text2image_pipeline.cpp
+++ b/src/cpp/src/image_generation/text2image_pipeline.cpp
@@ -242,6 +242,8 @@ Text2ImagePipeline Text2ImagePipeline::clone() {
 }
 
 void Text2ImagePipeline::export_model(const std::filesystem::path& export_dir) {
+    OPENVINO_ASSERT(std::dynamic_pointer_cast<StableDiffusionXLPipeline>(m_impl),
+                     "Blob export is supported only for Stable Diffusion XL pipelines");
     m_impl->export_model(export_dir);
 }
 

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2119,6 +2119,8 @@ class Image2ImagePipeline:
         """
     def decode(self, latent: openvino._pyopenvino.Tensor) -> openvino._pyopenvino.Tensor:
         ...
+    def export_model(self, export_path: os.PathLike | str | bytes) -> None:
+        ...
     def generate(self, prompt: str, image: openvino._pyopenvino.Tensor, **kwargs) -> openvino._pyopenvino.Tensor:
         """
             Generates images for text-to-image models.
@@ -2393,6 +2395,8 @@ class InpaintingPipeline:
                         kwargs: Device properties.
         """
     def decode(self, latent: openvino._pyopenvino.Tensor) -> openvino._pyopenvino.Tensor:
+        ...
+    def export_model(self, export_path: os.PathLike | str | bytes) -> None:
         ...
     def generate(self, prompt: str, image: openvino._pyopenvino.Tensor, mask_image: openvino._pyopenvino.Tensor, **kwargs) -> openvino._pyopenvino.Tensor:
         """

--- a/src/python/py_image_generation_pipelines.cpp
+++ b/src/python/py_image_generation_pipelines.cpp
@@ -634,7 +634,8 @@ void init_image_generation_pipelines(py::module_& m) {
             py::arg("image"), "Initial image",
             (text2image_generate_docstring + std::string(" \n ")).c_str())
         .def("decode", &ov::genai::Image2ImagePipeline::decode, py::arg("latent"))
-        .def("get_performance_metrics", &ov::genai::Image2ImagePipeline::get_performance_metrics);
+        .def("get_performance_metrics", &ov::genai::Image2ImagePipeline::get_performance_metrics)
+        .def("export_model", &ov::genai::Image2ImagePipeline::export_model, py::arg("export_path"));
 
 
     auto inpainting_pipeline = py::class_<ov::genai::InpaintingPipeline>(m, "InpaintingPipeline", "This class is used for generation with inpainting models.")
@@ -741,7 +742,8 @@ void init_image_generation_pipelines(py::module_& m) {
             py::arg("mask_image"), "Mask image",
             (text2image_generate_docstring + std::string(" \n ")).c_str())
         .def("decode", &ov::genai::InpaintingPipeline::decode, py::arg("latent"))
-        .def("get_performance_metrics", &ov::genai::InpaintingPipeline::get_performance_metrics);
+        .def("get_performance_metrics", &ov::genai::InpaintingPipeline::get_performance_metrics)
+        .def("export_model", &ov::genai::InpaintingPipeline::export_model, py::arg("export_path"));
 
     // define constructors to create one pipeline from another
     // NOTE: needs to be defined once all pipelines are created

--- a/tests/python_tests/test_image_generation.py
+++ b/tests/python_tests/test_image_generation.py
@@ -266,8 +266,8 @@ class TestImageGenerationOnNpuByNpuwCpu:
 
 
 class TestImageGenerationWithBlobTensorModels:
-    def _construct_reshaped(self, model_dir):
-        pipe = ov_genai.Text2ImagePipeline(model_dir)
+    def _construct_reshaped(self, model_dir, pipeline_type=ov_genai.Text2ImagePipeline):
+        pipe = pipeline_type(model_dir)
         pipe.reshape(
             num_images_per_prompt=1, height=64, width=64, guidance_scale=pipe.get_generation_config().guidance_scale
         )
@@ -302,11 +302,10 @@ class TestImageGenerationWithBlobTensorModels:
         except Exception as e:
             raise RuntimeError(f"Failed to read tokenizer from {tokenizer_path}: {e}")
 
-    def _load_blob_pipeline(self, model_dir, blob_dir):
+    def _load_blob_pipeline(self, model_dir, blob_dir, pipeline_type=ov_genai.Text2ImagePipeline):
         from pathlib import Path
 
         model_dir = Path(model_dir)
-        # This test case only supports text2image pipelines.
         tokenizer = self._read_tokenizer(model_dir)
         tokenizer_2 = self._read_tokenizer(model_dir, tokenizer_name="tokenizer_2")
         text_encoder_blob_tensor = self._read_blob_tensor(blob_dir, "text_encoder")
@@ -328,11 +327,17 @@ class TestImageGenerationWithBlobTensorModels:
             "CPU",
         )
 
-        vae = ov_genai.AutoencoderKL(
-            vae_decoder_blob_tensor,
-            ov_genai.AutoencoderKL.Config(model_dir / "vae_decoder" / "config.json"),
-            "CPU",
-        )
+        vae_config = ov_genai.AutoencoderKL.Config(model_dir / "vae_decoder" / "config.json")
+        if pipeline_type == ov_genai.Text2ImagePipeline:
+            vae = ov_genai.AutoencoderKL(vae_decoder_blob_tensor, vae_config, "CPU")
+        else:
+            vae_encoder_blob_tensor = self._read_blob_tensor(blob_dir, "vae_encoder")
+            vae = ov_genai.AutoencoderKL(
+                vae_encoder_blob_tensor,
+                vae_decoder_blob_tensor,
+                vae_config,
+                "CPU",
+            )
 
         unet = ov_genai.UNet2DConditionModel(
             unet_blob_tensor,
@@ -341,7 +346,7 @@ class TestImageGenerationWithBlobTensorModels:
             "CPU",
         )
 
-        blob_pipe = ov_genai.Text2ImagePipeline.stable_diffusion_xl(
+        blob_pipe = pipeline_type.stable_diffusion_xl(
             scheduler=ov_genai.Scheduler.from_config(model_dir / "scheduler" / "scheduler_config.json"),
             clip_text_model=text_encoder,
             clip_text_model_with_projection=text_encoder_2,
@@ -365,6 +370,62 @@ class TestImageGenerationWithBlobTensorModels:
 
         assert general_image.data.shape == blob_image.data.shape
         assert (general_image.data == blob_image.data).all()
+
+    @pytest.mark.parametrize("image_generation_model", [SDXL_MODEL_ID], indirect=True)
+    @pytest.mark.parametrize("pipeline_type", [ov_genai.Image2ImagePipeline, ov_genai.InpaintingPipeline])
+    def test_image_conditioned_pipeline_with_blob_path(self, image_generation_model, tmp_path, pipeline_type):
+        blob_dir = tmp_path / "blob_model"
+        generation_args = self._get_generation_args()
+        prompt = generation_args.pop("prompt")
+        input_image = get_random_image()
+        input_images = (
+            [input_image] if pipeline_type == ov_genai.Image2ImagePipeline else [input_image, get_mask_image()]
+        )
+
+        general_pipe = self._construct_reshaped(image_generation_model, pipeline_type)
+        general_image = general_pipe.generate(prompt, *input_images, **generation_args)
+        general_pipe.export_model(blob_dir)
+
+        blob_pipe = pipeline_type(image_generation_model, "CPU", blob_path=blob_dir)
+        blob_image = blob_pipe.generate(prompt, *input_images, **generation_args)
+
+        assert general_image.data.shape == blob_image.data.shape
+        assert (general_image.data == blob_image.data).all()
+
+    @pytest.mark.parametrize("image_generation_model", [SDXL_MODEL_ID], indirect=True)
+    @pytest.mark.parametrize("pipeline_type", [ov_genai.Image2ImagePipeline, ov_genai.InpaintingPipeline])
+    def test_image_conditioned_pipeline_with_blob_tensor_models(self, image_generation_model, tmp_path, pipeline_type):
+        blob_dir = tmp_path / "blob_model"
+        generation_args = self._get_generation_args()
+        prompt = generation_args.pop("prompt")
+        input_image = get_random_image()
+        input_images = (
+            [input_image] if pipeline_type == ov_genai.Image2ImagePipeline else [input_image, get_mask_image()]
+        )
+
+        general_pipe = self._construct_reshaped(image_generation_model, pipeline_type)
+        general_image = general_pipe.generate(prompt, *input_images, **generation_args)
+        general_pipe.export_model(blob_dir)
+
+        blob_pipe = self._load_blob_pipeline(image_generation_model, blob_dir, pipeline_type)
+        blob_image = blob_pipe.generate(prompt, *input_images, **generation_args)
+
+        assert general_image.data.shape == blob_image.data.shape
+        assert (general_image.data == blob_image.data).all()
+
+    @pytest.mark.parametrize("image_generation_model", [FLUX_MODEL_ID], indirect=True)
+    def test_image2image_blob_export_is_sdxl_only(self, image_generation_model, tmp_path):
+        pipe = ov_genai.Image2ImagePipeline(image_generation_model)
+
+        with pytest.raises(RuntimeError, match="Blob export is supported only for Stable Diffusion XL pipelines"):
+            pipe.export_model(tmp_path / "blob_model")
+
+    @pytest.mark.parametrize("image_generation_model", [FLUX_MODEL_ID], indirect=True)
+    def test_inpainting_blob_export_is_sdxl_only(self, image_generation_model, tmp_path):
+        pipe = ov_genai.InpaintingPipeline(image_generation_model)
+
+        with pytest.raises(RuntimeError, match="Blob export is supported only for Stable Diffusion XL pipelines"):
+            pipe.export_model(tmp_path / "blob_model")
 
 
 class TestFlux2KleinImageGeneration:

--- a/tests/python_tests/test_image_generation.py
+++ b/tests/python_tests/test_image_generation.py
@@ -427,6 +427,13 @@ class TestImageGenerationWithBlobTensorModels:
         with pytest.raises(RuntimeError, match="Blob export is supported only for Stable Diffusion XL pipelines"):
             pipe.export_model(tmp_path / "blob_model")
 
+    @pytest.mark.parametrize("image_generation_model", [FLUX_MODEL_ID], indirect=True)
+    def test_text2image_blob_export_is_sdxl_only(self, image_generation_model, tmp_path):
+        pipe = ov_genai.Text2ImagePipeline(image_generation_model)
+
+        with pytest.raises(RuntimeError, match="Blob export is supported only for Stable Diffusion XL pipelines"):
+            pipe.export_model(tmp_path / "blob_model")
+
 
 class TestFlux2KleinImageGeneration:
     @pytest.mark.parametrize("image_generation_model", [FLUX2_KLEIN_MODEL_ID], indirect=True)


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

This is following up PR for #3874 to solve image to image, and inpainting pipeline for SDXL doesn't support export. blob
Notes: Previously, only SDXL text-to-image supports export 

Changes:

- Add `export_model()` for `Image2ImagePipeline` and `InpaintingPipeline`
- Add assert for `Text2ImagePipeline`, `Image2ImagePipeline` and `InpaintingPipeline` when export non-SDXL model

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-186789](https://jira.devtools.intel.com/browse/CVS-186789)


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
