### PR TITLE
Align llm_bench dependencies with Gemma4 Transformers 5.5

### DIFF
--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -4,6 +4,8 @@
 
 #include "llm/pipeline_stateful.hpp"
 
+#include <algorithm>
+
 #include "lora/helper.hpp"
 #include "lm_encoding.hpp"
 #include "openvino/genai/text_streamer.hpp"
@@ -412,11 +414,15 @@ EncodedResults StatefulLLMPipeline::generate(
         (config.is_greedy_decoding() || config.is_multinomial()),
         "Currently streaming is possible only with batch size=1 and only for greedy or multinomial decoding");
 
-    auto num_inputs = m_model_runner.get_compiled_model().inputs().size();
-    OPENVINO_ASSERT(num_inputs == 4 || num_inputs == 3, "Model should have 3 or 4 inputs: "
-                    "either (input_ids, attention_mask, beam_idx) or "
-                    "(input_ids, attention_mask, position_ids, beam_idx) "
-                    "but you have '" + std::to_string(num_inputs) + "' inputs");
+    const auto compiled_inputs = m_model_runner.get_compiled_model().inputs();
+    // NPUW block-based KV-cache models expose additional KV block parameters. Those
+    // parameters are bound and maintained by the NPUW infer request; the GenAI
+    // pipeline only owns the standard language-model inputs below.
+    const auto has_named_input = [&](const std::string& name) {
+        return std::any_of(compiled_inputs.begin(), compiled_inputs.end(), [&](const auto& input) {
+            return input.get_any_name() == name || input.get_names().count(name) != 0;
+        });
+    };
 
     if (is_chat_conversation) {
         if (m_use_full_chat_history)
@@ -450,7 +456,7 @@ EncodedResults StatefulLLMPipeline::generate(
 
     size_t prev_attn_mask_size = concatenated_attention_mask.get_shape()[1];
 
-    bool position_ids_available = (num_inputs == 4);
+    const bool position_ids_available = has_named_input("position_ids");
     std::optional<ov::Tensor> position_ids = std::nullopt;
     if (position_ids_available) {
         position_ids = ov::Tensor{ov::element::i64, input_ids.get_shape()};

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -414,15 +414,11 @@ EncodedResults StatefulLLMPipeline::generate(
         (config.is_greedy_decoding() || config.is_multinomial()),
         "Currently streaming is possible only with batch size=1 and only for greedy or multinomial decoding");
 
-    const auto compiled_inputs = m_model_runner.get_compiled_model().inputs();
-    // NPUW block-based KV-cache models expose additional KV block parameters. Those
-    // parameters are bound and maintained by the NPUW infer request; the GenAI
-    // pipeline only owns the standard language-model inputs below.
-    const auto has_named_input = [&](const std::string& name) {
-        return std::any_of(compiled_inputs.begin(), compiled_inputs.end(), [&](const auto& input) {
-            return input.get_any_name() == name || input.get_names().count(name) != 0;
-        });
-    };
+    auto num_inputs = m_model_runner.get_compiled_model().inputs().size();
+    OPENVINO_ASSERT(num_inputs == 4 || num_inputs == 3, "Model should have 3 or 4 inputs: "
+                    "either (input_ids, attention_mask, beam_idx) or "
+                    "(input_ids, attention_mask, position_ids, beam_idx) "
+                    "but you have '" + std::to_string(num_inputs) + "' inputs");
 
     if (is_chat_conversation) {
         if (m_use_full_chat_history)
@@ -456,7 +452,7 @@ EncodedResults StatefulLLMPipeline::generate(
 
     size_t prev_attn_mask_size = concatenated_attention_mask.get_shape()[1];
 
-    const bool position_ids_available = has_named_input("position_ids");
+    bool position_ids_available = (num_inputs == 4);
     std::optional<ov::Tensor> position_ids = std::nullopt;
     if (position_ids_available) {
         position_ids = ov::Tensor{ov::element::i64, input_ids.get_shape()};

--- a/src/cpp/src/llm/pipeline_stateful.cpp
+++ b/src/cpp/src/llm/pipeline_stateful.cpp
@@ -4,8 +4,6 @@
 
 #include "llm/pipeline_stateful.hpp"
 
-#include <algorithm>
-
 #include "lora/helper.hpp"
 #include "lm_encoding.hpp"
 #include "openvino/genai/text_streamer.hpp"

--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -7,11 +7,11 @@ openvino_genai
 # Image processing for VLMs
 pillow==12.3.0
 torch>=2.1.0,<=2.12
-transformers[sentencepiece]>=4.40.0,<5.4.0
+# Gemma4 support is available in Transformers 5.5.0.
+transformers[sentencepiece]==5.5.0
 diffusers>=0.22.0,<=0.39.0
-# optimum is in dependency list of optimum-intel
-# last supported commit f50a0b326df82d4b05c461a9184a97f616bfa63a
-optimum-intel[nncf]>=1.25.0
+# Optimum Intel 2.1 supports Transformers 5.x.
+optimum-intel[nncf]==2.1.0
 packaging>=20.0,<=26.2
 psutil
 timm<=1.0.28


### PR DESCRIPTION
## Description

Align the `llm_bench` Python dependencies with the Gemma4 VLM conversion and restore the Stateful pipeline implementation to the state before the experimental multi-input change.

The benchmark requirements now use:

- `transformers[sentencepiece]==5.5.0`
- `optimum-intel[nncf]==2.1.0`

The Stateful pipeline input-count relaxation is removed because the Gemma4 model's five inputs are `inputs_embeds`, `per_layer_inputs`, `attention_mask`, `position_ids`, and `beam_idx`, rather than additional `input_ids`-compatible inputs. Gemma4 should be routed through the VLM pipeline, which owns the text and per-layer embedding models.

EISW-229048

## Checklist:
- [x] This PR follows the GenAI Contributing guidelines.
- [ ] Tests have been updated or added to cover the new code. Dependency installation and the Gemma4 benchmark still require validation in the target environment.
- [ ] This PR fully addresses the ticket. The pipeline-routing/runtime fix requires follow-up work; this PR records the compatible benchmark dependency set and restores the pre-PR Stateful behavior.
- [x] No documentation changes are required for this dependency-only update.