### PR TITLE
Fix DeepStack visual_pos_masks layout mismatch in PagedAttention

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -89,6 +89,7 @@ void prepare_model_for_paged_attention(const std::shared_ptr<ov::Model>& model,
         .run_on_model(model);
     model->validate_nodes_and_infer_types();
     utils::apply_gather_before_matmul_transformation(model);
+    utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
 }
 
 ContinuousBatchingPipeline::ContinuousBatchingImpl::ContinuousBatchingImpl(

--- a/src/cpp/src/speculative_decoding/continuous_batching/dflash_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/dflash_strategy.cpp
@@ -284,6 +284,7 @@ ContinuousBatchingPipeline::DFlashDecodingImpl::DFlashDecodingImpl(
                                    allow_qq_bias)
         .run_on_model(main_model);
     utils::apply_gather_before_matmul_transformation(main_model);
+    utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(main_model);
     validate_target_has_no_unmanaged_state(main_model);
     utils::dflash::expose_target_hidden_states(
         main_model,

--- a/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.cpp
@@ -56,6 +56,8 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::init_speculative_models(con
 
     utils::apply_gather_before_matmul_transformation(main_model);
     utils::apply_gather_before_matmul_transformation(draft_model);
+    utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(main_model);
+    utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(draft_model);
 
     bool is_draft_scheduler_undefined = draft_model_desc.scheduler_config == SchedulerConfig();
 

--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -11,15 +11,19 @@
 
 #include "openvino/runtime/properties.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/divide.hpp"
 #include "openvino/op/gather.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/non_zero.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/tanh.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/genai/text_streamer.hpp"
 #include "gguf_utils/gguf_modeling.hpp"
+#include "logger.hpp"
 
 
 #include "sampling/sampler.hpp"
@@ -343,6 +347,61 @@ void apply_gather_before_matmul_transformation(std::shared_ptr<ov::Model> model)
         matmul->input(0).replace_source_output(gather);
         model->add_parameters({indices});
     }
+}
+
+void fix_deepstack_visual_pos_masks_layout_for_paged_attention(std::shared_ptr<ov::Model> model) {
+    const std::string mask_name = "visual_pos_masks";
+
+    // The runtime feeds this input by tensor name (see ModelRunner::forward()), while some
+    // transformations look it up by friendly name - accept either, like the DFlash transforms do.
+    std::shared_ptr<ov::op::v0::Parameter> visual_pos_masks_param;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name() == mask_name || param->output(0).get_names().count(mask_name) != 0) {
+            visual_pos_masks_param = param;
+            break;
+        }
+    }
+    if (!visual_pos_masks_param) {
+        // Most models (including non-DeepStack VLMs) don't have this input at all.
+        return;
+    }
+
+    // Everything below is a conservative skip rather than a hard error: the worst case is that the
+    // model keeps the pre-existing (broken) layout, which is still better than refusing to compile a
+    // model whose structure we simply don't recognize. Warn loudly though - a silent skip here shows
+    // up much later as an out-of-bounds assert inside ScatterNDUpdate.
+    const auto& mask_shape = visual_pos_masks_param->get_partial_shape();
+    if (mask_shape.rank().is_dynamic() || mask_shape.rank().get_length() != 2) {
+        GENAI_WARN("'%s' is expected to be a 2D [batch, seq_len] input, but has shape %s. "
+                   "Skipping the PagedAttention layout fix for DeepStack feature injection.",
+                   mask_name.c_str(),
+                   mask_shape.to_string().c_str());
+        return;
+    }
+
+    auto target_inputs = visual_pos_masks_param->output(0).get_target_inputs();
+    if (target_inputs.empty()) {
+        return;
+    }
+    for (const auto& target : target_inputs) {
+        if (!ov::is_type<ov::op::v3::NonZero>(target.get_node())) {
+            GENAI_WARN("'%s' is consumed by '%s' instead of the expected NonZero. "
+                       "Skipping the PagedAttention layout fix for DeepStack feature injection.",
+                       mask_name.c_str(),
+                       target.get_node()->get_type_name());
+            return;
+        }
+    }
+
+    auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, std::vector<int64_t>{1, 0});
+    auto transpose = std::make_shared<ov::op::v1::Transpose>(visual_pos_masks_param->output(0), order);
+    transpose->set_friendly_name(visual_pos_masks_param->get_friendly_name() + "_transposed_for_paged_attention");
+    for (const auto& target : target_inputs) {
+        target.replace_source_output(transpose->output(0));
+    }
+    // replace_source_output() only invalidates the affected tensors, it doesn't re-run shape
+    // inference, so leave the model in a validated state for whoever runs next.
+    model->validate_nodes_and_infer_types();
 }
 
 ov::Core& singleton_core() {

--- a/src/cpp/src/utils.hpp
+++ b/src/cpp/src/utils.hpp
@@ -126,6 +126,18 @@ void apply_slice_before_matmul_transformation(std::shared_ptr<ov::Model> model);
 
 void apply_gather_before_matmul_transformation(std::shared_ptr<ov::Model> model);
 
+// SDPAToPagedAttention moves the token dimension of hidden_states from the original
+// [batch, seq, hidden] layout to [total_tokens, 1, hidden] (see find_llm_matmul() below),
+// but it has no knowledge of the "visual_pos_masks" input that Qwen3-VL's DeepStack feature
+// injection relies on: NonZero(visual_pos_masks) still produces (batch_idx, seq_idx) index
+// tuples matching the old layout, no longer the new one. This inserts a Transpose right
+// after the "visual_pos_masks" parameter (if present) so that its consumers see indices
+// aligned with the post-PA hidden_states layout. Must only be called on a model that has already
+// been through SDPAToPagedAttention. Silently a no-op if the model has no such parameter (the
+// common case); if the parameter is there but doesn't match the expected pattern, the model is left
+// untouched and a warning is logged.
+void fix_deepstack_visual_pos_masks_layout_for_paged_attention(std::shared_ptr<ov::Model> model);
+
 std::tuple<std::shared_ptr<ov::Node>, int64_t> find_llm_matmul(const std::shared_ptr<ov::Model>& model);
 
 ov::Core& singleton_core();

--- a/tests/cpp/test_deepstack_visual_pos_masks_layout.cpp
+++ b/tests/cpp/test_deepstack_visual_pos_masks_layout.cpp
@@ -1,0 +1,172 @@
+// Copyright (C) 2024-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/non_zero.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/transpose.hpp"
+#include "utils.hpp"
+
+namespace {
+
+template <typename T>
+size_t count_ops(const std::shared_ptr<ov::Model>& model) {
+    size_t count = 0;
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::as_type_ptr<T>(op))
+            count++;
+    }
+    return count;
+}
+
+std::shared_ptr<ov::op::v0::Parameter> find_parameter(const std::shared_ptr<ov::Model>& model,
+                                                      const std::string& name) {
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name() == name || param->output(0).get_names().count(name) != 0)
+            return param;
+    }
+    return nullptr;
+}
+
+// Build: Parameter("visual_pos_masks")[mask_shape] -> NonZero -> Result
+std::shared_ptr<ov::Model> make_mask_nonzero_model(const ov::PartialShape& mask_shape,
+                                                   const std::string& friendly_name = "visual_pos_masks") {
+    auto mask = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, mask_shape);
+    mask->set_friendly_name(friendly_name);
+    mask->output(0).set_names({friendly_name});
+    auto non_zero = std::make_shared<ov::op::v3::NonZero>(mask);
+    auto result = std::make_shared<ov::op::v0::Result>(non_zero);
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{mask});
+}
+
+}  // namespace
+
+// ===================== fix_deepstack_visual_pos_masks_layout_for_paged_attention =====================
+
+// Happy path: visual_pos_masks -> NonZero, matching the expected pattern exactly.
+TEST(DeepstackVisualPosMasksLayout, InsertsTransposeWhenPatternMatches) {
+    auto model = make_mask_nonzero_model(ov::PartialShape{1, -1});
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 1u);
+    auto mask = find_parameter(model, "visual_pos_masks");
+    ASSERT_NE(mask, nullptr);
+
+    // The Parameter's only consumer must now be the inserted Transpose ...
+    auto targets = mask->output(0).get_target_inputs();
+    ASSERT_EQ(targets.size(), 1u);
+    auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(targets.begin()->get_node()->shared_from_this());
+    ASSERT_NE(transpose, nullptr);
+
+    // ... and the original NonZero must now consume the Transpose's output, not the Parameter directly.
+    auto non_zero = ov::as_type_ptr<ov::op::v3::NonZero>(
+        transpose->output(0).get_target_inputs().begin()->get_node()->shared_from_this());
+    ASSERT_NE(non_zero, nullptr);
+    ASSERT_EQ(non_zero->input_value(0).get_node_shared_ptr(), transpose);
+}
+
+// Matched by tensor name even when the friendly name has been mangled/renamed by other passes.
+TEST(DeepstackVisualPosMasksLayout, MatchesByTensorNameWhenFriendlyNameDiffers) {
+    auto mask = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, ov::PartialShape{1, -1});
+    mask->set_friendly_name("Parameter_123");
+    mask->output(0).set_names({"visual_pos_masks"});
+    auto non_zero = std::make_shared<ov::op::v3::NonZero>(mask);
+    auto result = std::make_shared<ov::op::v0::Result>(non_zero);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{mask});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 1u);
+}
+
+// Multiple NonZero consumers of the same mask (e.g. one feeding GatherND, another feeding
+// ScatterNDUpdate) must all be redirected to the same inserted Transpose.
+TEST(DeepstackVisualPosMasksLayout, RedirectsAllNonZeroConsumers) {
+    auto mask = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, ov::PartialShape{1, -1});
+    mask->set_friendly_name("visual_pos_masks");
+    mask->output(0).set_names({"visual_pos_masks"});
+    auto non_zero_1 = std::make_shared<ov::op::v3::NonZero>(mask);
+    auto non_zero_2 = std::make_shared<ov::op::v3::NonZero>(mask);
+    auto result_1 = std::make_shared<ov::op::v0::Result>(non_zero_1);
+    auto result_2 = std::make_shared<ov::op::v0::Result>(non_zero_2);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result_1, result_2}, ov::ParameterVector{mask});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    // Exactly one Transpose must be shared by both NonZero consumers, not one per consumer.
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 1u);
+    ASSERT_EQ(non_zero_1->input_value(0).get_node_shared_ptr(), non_zero_2->input_value(0).get_node_shared_ptr());
+    ASSERT_TRUE(ov::is_type<ov::op::v1::Transpose>(non_zero_1->input_value(0).get_node_shared_ptr()));
+}
+
+// No "visual_pos_masks" input at all - the common case for every non-DeepStack model - must be a no-op.
+TEST(DeepstackVisualPosMasksLayout, NoOpWhenParameterMissing) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, -1, 16});
+    input->set_friendly_name("hidden_states");
+    auto result = std::make_shared<ov::op::v0::Result>(input);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+}
+
+// visual_pos_masks present but not consumed by NonZero at all - conservative skip, not a crash.
+TEST(DeepstackVisualPosMasksLayout, NoOpWhenConsumerIsNotNonZero) {
+    auto mask = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, -1});
+    mask->set_friendly_name("visual_pos_masks");
+    mask->output(0).set_names({"visual_pos_masks"});
+    auto bias = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, 0.0f);
+    auto add = std::make_shared<ov::op::v1::Add>(mask, bias);
+    auto result = std::make_shared<ov::op::v0::Result>(add);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{mask});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+    ASSERT_EQ(add->input_value(0).get_node_shared_ptr(), mask);
+}
+
+// visual_pos_masks present with a mix of NonZero and non-NonZero consumers - conservative skip
+// of the whole parameter, since we can't safely retarget only some of its consumers.
+TEST(DeepstackVisualPosMasksLayout, NoOpWhenOnlySomeConsumersAreNonZero) {
+    auto mask = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, -1});
+    mask->set_friendly_name("visual_pos_masks");
+    mask->output(0).set_names({"visual_pos_masks"});
+    auto non_zero = std::make_shared<ov::op::v3::NonZero>(mask);
+    auto bias = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, 0.0f);
+    auto add = std::make_shared<ov::op::v1::Add>(mask, bias);
+    auto result_1 = std::make_shared<ov::op::v0::Result>(non_zero);
+    auto result_2 = std::make_shared<ov::op::v0::Result>(add);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result_1, result_2}, ov::ParameterVector{mask});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+    ASSERT_EQ(non_zero->input_value(0).get_node_shared_ptr(), mask);
+    ASSERT_EQ(add->input_value(0).get_node_shared_ptr(), mask);
+}
+
+// visual_pos_masks with an unexpected (non-2D) rank - conservative skip.
+TEST(DeepstackVisualPosMasksLayout, NoOpWhenMaskRankIsNot2D) {
+    auto model = make_mask_nonzero_model(ov::PartialShape{-1});
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+}
+
+// visual_pos_masks with a dynamic rank - conservative skip.
+TEST(DeepstackVisualPosMasksLayout, NoOpWhenMaskRankIsDynamic) {
+    auto model = make_mask_nonzero_model(ov::PartialShape::dynamic());
+
+    ov::genai::utils::fix_deepstack_visual_pos_masks_layout_for_paged_attention(model);
+
+    ASSERT_EQ(count_ops<ov::op::v1::Transpose>(model), 0u);
+}


### PR DESCRIPTION

## Description
Fixes PagedAttention backend crash (ScatterNDUpdate out-of-bounds assertion) when running Qwen3-VL with 
`ATTENTION_BACKEND="PA"` by correcting the axis order mismatch introduced when `SDPAToPagedAttention` 
reshapes `hidden_states` but leaves `visual_pos_masks`-derived index tuples un-updated.

The fix inserts a single `Transpose(perm=[1,0])` between the `visual_pos_masks` Parameter and its 
`NonZero` consumers, converting mask shape from `[1, total_tokens]` to `[total_tokens, 1]` so that 
index tuple order matches the post-PA layout. Activation is conservative: only applies when the 
Parameter is found, its rank is statically 2, and all direct consumers are `NonZero` ops; 
otherwise silently no-ops with optional warnings.

CVS-192302
