### PR TITLE
[CMAKE] Prevent BUILD_SHARED_LIBS cache leak from OpenCV configuration

### DIFF
--- a/samples/cpp/fetch_opencv.cmake
+++ b/samples/cpp/fetch_opencv.cmake
@@ -21,7 +21,7 @@ function(ov_genai_link_opencv target_name)
             cmake_policy(SET CMP0135 NEW)
         endif()
 
-        set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+        set(BUILD_SHARED_LIBS OFF)
         set(BUILD_WITH_STATIC_CRT OFF CACHE BOOL "" FORCE)
         set(CMAKE_POSITION_INDEPENDENT_CODE ON)
         set(OPENCV_ENABLE_PLUGINS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Description

Keep `BUILD_SHARED_LIBS` local to `ov_genai_link_opencv()` when configuring the fetched OpenCV dependency.

[PR #4092](https://github.com/openvinotoolkit/openvino.genai/pull/4092) made the fallback OpenCV build static using:

```cmake
set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
```

This writes `OFF` to the shared CMake cache. When GenAI is configured through `OPENVINO_EXTRA_MODULES`, the parent OpenVINO build has already created plugin targets as `MODULE_LIBRARY` targets with `BUILD_SHARED_LIBS=ON`.

The leaked cache value later makes `ov_generate_plugins_hpp()` take the static-plugin path and attempt to link those module targets into another target. CMake then fails with:

```text
Target "openvino_auto_plugin" of type MODULE_LIBRARY may not be linked into
another target.
```

Use a function-scoped normal variable instead:

```cmake
set(BUILD_SHARED_LIBS OFF)
```

OpenCV uses policy `CMP0077=NEW`, so the normal variable is still honored by its `option(BUILD_SHARED_LIBS ...)` calls and OpenCV remains static. The parent OpenVINO cache is no longer modified.

## Regressions

- [Android #31476 — arm64](https://github.com/openvinotoolkit/openvino/actions/runs/31257162423/job/93102634817), [x64](https://github.com/openvinotoolkit/openvino/actions/runs/31257162423/job/93102634823)
- [Android #31477 — arm64](https://github.com/openvinotoolkit/openvino/actions/runs/31258094600/job/93104980922), [x64](https://github.com/openvinotoolkit/openvino/actions/runs/31258094600/job/93104980925)
- [Android #31478 — arm64](https://github.com/openvinotoolkit/openvino/actions/runs/31261069001/job/93112343452), [x64](https://github.com/openvinotoolkit/openvino/actions/runs/31261069001/job/93112343451)