### PR TITLE
Tune VLM EAGLE3 accept rate

### DIFF
--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -26,6 +26,12 @@ std::unordered_map<std::string, ov::Tensor> deep_copy_tensors_map(
 
 namespace ov::genai {
 
+std::unordered_map<std::string, ov::Tensor>
+ContinuousBatchingPipeline::IContinuousBatchingPipeline::prepare_lm_extra_inputs(
+    const std::unordered_map<std::string, ov::Tensor>& lm_extra_inputs) const {
+    return deep_copy_tensors_map(lm_extra_inputs);
+}
+
 GenerationConfig ContinuousBatchingPipeline::IContinuousBatchingPipeline::get_config() const {
     return m_generation_config;
 }
@@ -423,7 +429,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[0].get_shape()[1], 0));
 
-        lm_extra_inputs_list.push_back(m_inputs_embedder->get_lm_extra_inputs());
+        lm_extra_inputs_list.push_back(prepare_lm_extra_inputs(m_inputs_embedder->get_lm_extra_inputs()));
 
         auto end_get_inputs_embeds = std::chrono::steady_clock::now();
         vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
@@ -481,7 +487,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
             position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[i].get_shape()[1], 0));
 
-            lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
+            lm_extra_inputs_list.push_back(prepare_lm_extra_inputs(m_inputs_embedder->get_lm_extra_inputs()));
 
             auto end_get_inputs_embeds = std::chrono::steady_clock::now();
             vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
@@ -712,7 +718,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         position_ids_list.push_back(m_inputs_embedder->get_position_ids(input_embeds_list[i].get_shape()[1], 0));
 
-        lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
+        lm_extra_inputs_list.push_back(prepare_lm_extra_inputs(m_inputs_embedder->get_lm_extra_inputs()));
 
         auto end_get_inputs_embeds = std::chrono::steady_clock::now();
         vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
@@ -806,7 +812,7 @@ GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_re
                              sampling_params,
                              token_type_ids,
                              prompt_ids,
-                             m_inputs_embedder->get_lm_extra_inputs());
+                             prepare_lm_extra_inputs(m_inputs_embedder->get_lm_extra_inputs()));
         handle->m_generation_stream->set_vlm_perf_metrics(std::move(metrics));
     }
     return handle;
@@ -857,7 +863,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
                              sampling_params,
                              token_type_ids,
                              prompt_ids,
-                             m_inputs_embedder->get_lm_extra_inputs());
+                             prepare_lm_extra_inputs(m_inputs_embedder->get_lm_extra_inputs()));
         handle->m_generation_stream->set_vlm_perf_metrics(std::move(metrics));
     }
     return handle;

--- a/src/cpp/src/continuous_batching/pipeline_base.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.hpp
@@ -78,6 +78,8 @@ protected:
     std::shared_ptr<VisionRegistry> m_vision_registry;
 
     void stream_tokens(const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr, const GenerationHandle& handle);
+    virtual std::unordered_map<std::string, ov::Tensor> prepare_lm_extra_inputs(
+        const std::unordered_map<std::string, ov::Tensor>& lm_extra_inputs) const;
 public:
     GenerationConfig get_config() const;
     void set_config(const GenerationConfig& config);

--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
@@ -3,11 +3,33 @@
 
 #include <algorithm>
 
+#include "continuous_batching/pipeline_base.hpp"
 #include "eagle3_strategy.hpp"
 #include "openvino/pass/pa_kv_reorder_fusion.hpp"
 #include "speculative_decoding/eagle3_model_transforms.hpp"
 
 namespace ov::genai {
+namespace {
+
+constexpr char kDraftEmbeddingsExtraInputName[] = "__ov_genai_internal_draft_embeddings";
+
+ov::Tensor take_request_draft_embeddings(std::optional<std::unordered_map<std::string, ov::Tensor>>& lm_extra_inputs) {
+    if (!lm_extra_inputs.has_value()) {
+        return {};
+    }
+
+    auto it = lm_extra_inputs->find(kDraftEmbeddingsExtraInputName);
+    if (it == lm_extra_inputs->end()) {
+        return {};
+    }
+
+    ov::Tensor draft_embeddings = it->second;
+    lm_extra_inputs->erase(it);
+    return draft_embeddings;
+}
+
+}  // namespace
+
 KVUpdateWrapper::KVUpdateWrapper(const ov::genai::ModelDesc& kv_model_desc) {
     m_compiled_model =
             utils::singleton_core().compile_model(kv_model_desc.model, kv_model_desc.device, kv_model_desc.properties);
@@ -224,6 +246,21 @@ void ContinuousBatchingPipeline::Eagle3DecodingImpl::update_eagle_pipeline_param
     m_draft_eagle_pipeline->set_d2t_for_draft_decoding(d2t_tensor);
 }
 
+std::unordered_map<std::string, ov::Tensor>
+ContinuousBatchingPipeline::Eagle3DecodingImpl::prepare_lm_extra_inputs(
+    const std::unordered_map<std::string, ov::Tensor>& lm_extra_inputs) const {
+    auto prepared_inputs = IContinuousBatchingPipeline::prepare_lm_extra_inputs(lm_extra_inputs);
+    if (m_inputs_embedder) {
+        // For embeddings input mode, pass precomputed draft embeddings via extra inputs
+        // so add_request() can consume them for draft-path first-token trimming.
+        const ov::Tensor draft_inputs_embeds = m_inputs_embedder->get_draft_inputs_embeds();
+        if (draft_inputs_embeds && draft_inputs_embeds.get_size() > 0) {
+            prepared_inputs[kDraftEmbeddingsExtraInputName] = draft_inputs_embeds;
+        }
+    }
+    return prepared_inputs;
+}
+
 GenerationHandle
 ContinuousBatchingPipeline::Eagle3DecodingImpl::add_request(uint64_t request_id,
                                                                  const ov::Tensor& input_ids,
@@ -235,9 +272,14 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::add_request(uint64_t request_id,
     auto draft_sampling_params = sampling_params;
     draft_sampling_params.ignore_eos = true;
     draft_sampling_params.stop_strings = {};
+
+    // Extract draft-only embeddings that were staged in lm_extra_inputs and remove
+    // them so the main pipeline receives only its regular auxiliary inputs.
+    ov::Tensor request_draft_embeddings = take_request_draft_embeddings(lm_extra_inputs);
     // remove first token from input_ids to create the draft model input
     // refer to: https://github.com/SafeAILab/EAGLE/blob/main/eagle/model/cnets.py#L617
-    ov::Tensor draft_input = create_draft_input(input_ids);
+    ov::Tensor draft_input = create_draft_input(
+        request_draft_embeddings && request_draft_embeddings.get_size() > 0 ? request_draft_embeddings : input_ids);
     std::optional<ov::Tensor> draft_token_type_ids = token_type_ids;
     std::optional<ov::Tensor> draft_prompt_ids = prompt_ids;
     ov::Tensor main_position_ids;
@@ -308,19 +350,13 @@ std::vector<EncodedGenerationResult> ContinuousBatchingPipeline::Eagle3DecodingI
     strategy.prepare_request = [this](size_t,
                                       const ov::Tensor& in_ids,
                                       GenerationConfig& main_cfg,
-                                      GenerationConfig& draft_cfg,
-                                      ov::Tensor& main_in,
-                                      ov::Tensor& draft_in) {
+                                      ov::Tensor& main_in) {
         OPENVINO_ASSERT(main_cfg.assistant_confidence_threshold == 0.f,
                         "Eagle3 only supports num_assistant_tokens (assistant_confidence_threshold must be 0.f)");
         if (main_cfg.num_assistant_tokens == 0) {
             main_cfg.num_assistant_tokens = m_main_pipeline->default_num_assistant_tokens;
-            draft_cfg.num_assistant_tokens = main_cfg.num_assistant_tokens;
         }
-        draft_cfg.ignore_eos = true;
-        draft_cfg.stop_strings = {};
         main_in = in_ids;
-        draft_in = create_draft_input(in_ids);
     };
 
     strategy.check_streaming = [](const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr,

--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.hpp
@@ -81,6 +81,8 @@ public:
 protected:
     void align_request_pair_processed_prefix(uint64_t request_id) override;
     void update_eagle_pipeline_params(const std::shared_ptr<ov::op::v0::Constant>& d2t_tensor);
+    std::unordered_map<std::string, ov::Tensor> prepare_lm_extra_inputs(
+        const std::unordered_map<std::string, ov::Tensor>& lm_extra_inputs) const override;
     ov::Tensor create_draft_input(const ov::Tensor& original_input);
     // Creates draft model input by removing the first token from the original input sequence.
     ov::Tensor create_draft_input_ids(const ov::Tensor& original_input_ids);

--- a/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.cpp
@@ -284,18 +284,13 @@ ContinuousBatchingPipeline::SpeculativeDecodingImpl::generate(const std::vector<
     strategy.prepare_request = [this](size_t,
                                   const ov::Tensor& in_ids,
                                   GenerationConfig& main_cfg,
-                                  GenerationConfig& draft_cfg,
-                                  ov::Tensor& main_in,
-                                  ov::Tensor& draft_in) {
+                                  ov::Tensor& main_in) {
         if (main_cfg.assistant_confidence_threshold == 0.f) {
             if (main_cfg.num_assistant_tokens == 0) {
                 main_cfg.num_assistant_tokens = m_main_pipeline->default_num_assistant_tokens;
             }
         }
-        draft_cfg.ignore_eos = true;
-        draft_cfg.stop_strings = {};
         main_in = in_ids;
-        draft_in = in_ids;
     };
     strategy.check_streaming = [](const std::shared_ptr<ThreadedStreamerWrapper>& streamer_ptr,
                                   const std::vector<ov::Tensor>& input_ids,

--- a/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/fast_draft_strategy.hpp
@@ -17,9 +17,7 @@ struct GenerateStrategy {
     std::function<void(size_t,
                        const ov::Tensor& in_ids,
                        GenerationConfig& main_cfg,
-                       GenerationConfig& draft_cfg,
-                       ov::Tensor& main_in,
-                       ov::Tensor& draft_in)> prepare_request;
+                       ov::Tensor& main_in)> prepare_request;
     std::function<void(const std::shared_ptr<ThreadedStreamerWrapper>&,
                        const std::vector<ov::Tensor>&,
                        const std::vector<GenerationConfig>&)> check_streaming;
@@ -68,11 +66,8 @@ std::vector<EncodedGenerationResult> generate_common(
     std::vector<GenerationHandle> main_generations;
     for (size_t rid = 0; rid < input_ids.size(); ++rid) {
         GenerationConfig main_cfg = sampling_params[rid];
-        GenerationConfig draft_cfg = main_cfg;
-        ov::Tensor main_in, draft_in;
-        strategy.prepare_request(rid, input_ids[rid],
-                                main_cfg, draft_cfg,
-                                main_in, draft_in);
+        ov::Tensor main_in;
+        strategy.prepare_request(rid, input_ids[rid], main_cfg, main_in);
 
         const bool has_valid_token_type_ids = token_type_ids.has_value() && rid < token_type_ids->size();
         const bool has_valid_prompt_ids = prompt_ids.has_value() && rid < prompt_ids->size();

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -54,6 +54,7 @@ std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::IInputsEmbedder::g
 
 void InputsEmbedder::IInputsEmbedder::start_chat(const std::string& system_message) {
     m_is_chat_conversation = true;
+    m_draft_inputs_embeds = ov::Tensor();
     if (!m_cache_state.get_state().empty()) {
         m_cache_state.reset_state();
     }
@@ -80,6 +81,7 @@ void InputsEmbedder::IInputsEmbedder::update_chat_history(const std::string& dec
 
 void InputsEmbedder::IInputsEmbedder::finish_chat() {
     m_is_chat_conversation = false;
+    m_draft_inputs_embeds = ov::Tensor();
     m_cache_state.reset_state();
 }
 
@@ -529,6 +531,10 @@ void InputsEmbedder::set_position_ids(const ov::Tensor& position_ids) {
 
 void InputsEmbedder::set_rope_delta(int64_t rope_delta) {
     m_impl->set_rope_delta(rope_delta);
+}
+
+ov::Tensor InputsEmbedder::get_draft_inputs_embeds() const {
+    return m_impl->get_draft_inputs_embeds();
 }
 
 std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::get_generation_phase_position_ids(const size_t inputs_embeds_size, const size_t history_size, int64_t rope_delta) {

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -74,6 +74,11 @@ public:
         const std::vector<size_t>& videos_sequence = {},
         const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count = {});
 
+    // returns the draft-specific input embeddings prepared for speculative (eagle3) decoding,
+    // or an empty tensor when the embedder does not provide a dedicated draft embedding.
+    // aligned with VLLM implementation
+    ov::Tensor get_draft_inputs_embeds() const;
+
     bool has_token_type_ids() const;
 
     const std::unordered_map<std::string, ov::Tensor>& get_lm_extra_inputs() const;
@@ -180,6 +185,8 @@ private:
         // position ids
         ov::Tensor m_position_ids;
         int64_t m_rope_delta = 0;
+        // Cached text-only embeddings for speculative (eagle3) draft path.
+        ov::Tensor m_draft_inputs_embeds;
         virtual ~IInputsEmbedder() = default;
 
     public:
@@ -295,6 +302,16 @@ private:
             size_t base_video_id,
             const std::vector<EncodedImage>& images,
             const std::vector<EncodedVideo>& videos) const;
+
+        virtual ov::Tensor get_draft_inputs_embeds() const {
+            return m_draft_inputs_embeds;
+        }
+
+        void cache_draft_inputs_embeds(const ov::Tensor& text_embeds) {
+            OPENVINO_ASSERT(static_cast<bool>(text_embeds), "Cannot cache an empty draft embeddings tensor");
+            m_draft_inputs_embeds = ov::Tensor(text_embeds.get_element_type(), text_embeds.get_shape());
+            text_embeds.copy_to(m_draft_inputs_embeds);
+        }
 
     protected:
         IInputsEmbedder(

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -634,12 +634,16 @@ NormalizedPrompt InputsEmbedderMiniCPM::normalize_prompt(const std::string& prom
 
 ov::Tensor InputsEmbedderMiniCPM::get_inputs_embeds(const std::string& unified_prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
     std::string unk64;
+    // MiniCPM tokenizer always adds special tokens (leading BOS) in pytorch,
+    // regardless of whether the chat template was applied.
+    set_add_special_tokens(true);
     ov::Tensor encoded_input = get_encoded_input_ids(unified_prompt, metrics);
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
     ov::Tensor inputs_embeds = m_embedding->infer(req, encoded_input);
-
+    // make a copy of inputs_embeds to avoid data corruption when the infer request is used by another thread
+    cache_draft_inputs_embeds(inputs_embeds);
     OPENVINO_ASSERT(
         m_vlm_config.hidden_size == inputs_embeds.get_shape().at(2),
         "Unexpected embedding size"

--- a/src/cpp/src/visual_language/minicpm/classes.hpp
+++ b/src/cpp/src/visual_language/minicpm/classes.hpp
@@ -67,7 +67,6 @@ public:
         size_t base_id,
         const std::vector<EncodedImage>& images
     ) const override;
-
 };
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -750,6 +750,9 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
             m_lm_extra_inputs["deepstack_visual_embeds"] = std::move(deepstack_visual_embeds);
         }
 
+        // Cache draft embeddings as text-only inputs for Eagle3 draft model.
+        cache_draft_inputs_embeds(text_embeds);
+
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
         std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
         return inputs_embeds;
@@ -805,6 +808,10 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
     if (has_lm_extra_input("visual_pos_masks")) {
         m_lm_extra_inputs["visual_pos_masks"] = create_visual_pos_masks(input_ids, image_pad_token_id, video_pad_token_id);
     }
+
+    // Cache draft embeddings after pruning updates, but before vision/text merge,
+    // so Eagle3 draft path receives sequence-aligned text-only embeddings.
+    cache_draft_inputs_embeds(text_embeds);
 
     return qwen2_vl_utils::merge_text_and_video_image_embeddings(input_ids,
                                                                  text_embeds,

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -182,6 +182,7 @@ if is_transformers_version("<", "5.0"):
         MODEL_GEMMA3N,
         "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
         *VIDEO_MODEL_IDS,
+        "optimum-intel-internal-testing/tiny-random-minicpm-v-4",
     ]
 else:
     MODEL_IDS = [
@@ -432,6 +433,7 @@ def _get_ov_model(model_id: str) -> str:
                     "qnguyen3/nanoLLaVA",
                     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
                     VIDEOCHAT_FLASH_QWEN_MODEL_ID,
+                    "optimum-intel-internal-testing/tiny-random-minicpm-v-4",
                 },
             )
         )
@@ -2247,6 +2249,9 @@ def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):
         optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True).strip()
     elif optimum_model.config.model_type == "videochat_flash_qwen":
         assert tokenizer is not None, "Tokenizer should be set for videochat_flash_qwen models."
+        optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+    elif optimum_model.config.model_type == "minicpmv":
+        assert tokenizer is not None, "Tokenizer should be set for minicpmv models."
         optimum_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
     else:
         optimum_output = processor.batch_decode(


### PR DESCRIPTION
## Description

Carries the implementation changes from #4096 for tuning the VLM EAGLE3 accept rate.

Jira ticket: CVS-189495

Additionally, uses `optimum-intel-internal-testing/tiny-random-minicpm-v-4` instead of `xf2022/tiny-random-minicpm-v-4` in the VLM tests.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. Updated `tests/python_tests/test_vlm_pipeline.py`.
- [x] This PR fully addresses the requested changes.
- [x] N/A: No documentation changes are required for this test/model-reference update.

## Verification

- `git diff HEAD^ HEAD --check`: passed.
- Python syntax check for `tests/python_tests/test_vlm_pipeline.py`: passed.
- Focused model-reference verification: passed.
- Full CMake build is blocked locally because the OpenVINO 2026.4 development package is unavailable.
