### PR TITLE
Reorder GenerationHandle notification

### DIFF
--- a/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/decoder.cpp
+++ b/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/decoder.cpp
@@ -109,6 +109,8 @@ EncodedResults Qwen3ASRDecoder::generate(const ov::Tensor& input_ids,
     m_sampler.sample(sequence_groups, logits);
     raw_metrics.m_sampling_durations.emplace_back(
         PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+    for (auto& sg : sequence_groups)
+        sg->notify_handle();
     stream_generated_tokens();
 
     // Track active (not yet finished) sequence groups
@@ -188,6 +190,8 @@ EncodedResults Qwen3ASRDecoder::generate(const ov::Tensor& input_ids,
         m_sampler.sample(active_sequence_groups, logits);
         raw_metrics.m_sampling_durations.emplace_back(
             PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+        for (auto& sg : active_sequence_groups)
+            sg->notify_handle();
         stream_generated_tokens();
         free_finished_requests();
     }

--- a/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/decoder.cpp
+++ b/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/decoder.cpp
@@ -63,6 +63,9 @@ EncodedResults Qwen3ASRDecoder::generate(const ov::Tensor& input_ids,
             return;
         }
         std::unordered_map<uint64_t, GenerationOutput> token = handle->read();
+        if (token.empty()) {
+            return;
+        }
         auto streaming_status = streamer_ptr->write(token.begin()->second.generated_ids);
         if (streaming_status == StreamingStatus::CANCEL) {
             handle->cancel();

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -484,22 +484,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
         free_fork_timer.end();
     }
 
-    {
-        static ManualTimer candidates_timer("generate_candidates_for_prompt_lookup()");
-        candidates_timer.start();
-        generate_candidates_for_prompt_lookup();
-        candidates_timer.end();
-    }
-
-    // Append embeddings for tokens produced in this step.
-    // Validation mode usually skips this because speculative validation reuses/rewinds
-    // candidate tokens instead of committing them here. prompt_lookup is the exception:
-    // it appends validation candidates after sampling and must keep embeddings in sync
-    // before the next scheduling/hash step.
-    if (m_model_input_type == ModelInputType::EMBEDDINGS && sync_embeddings_after_candidates()) {
-        m_model_runner->append_embeddings(m_requests, scheduler_output);
-    }
-
     const auto step_end_time = std::chrono::steady_clock::now();
     for (const auto request_index : scheduler_output.m_scheduled_sequence_groups_ids) {
         const auto& request = m_requests.at(request_index);
@@ -515,7 +499,24 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
                                      step_end_time);
     }
 
+    // notify handles before appending candidates: generated_ids must not include unvalidated draft tokens
     _notify_handles(scheduler_output);
+
+    {
+        static ManualTimer candidates_timer("generate_candidates_for_prompt_lookup()");
+        candidates_timer.start();
+        generate_candidates_for_prompt_lookup();
+        candidates_timer.end();
+    }
+
+    // Append embeddings for tokens produced in this step.
+    // Validation mode usually skips this because speculative validation reuses/rewinds
+    // candidate tokens instead of committing them here. prompt_lookup is the exception:
+    // it appends validation candidates after sampling and must keep embeddings in sync
+    // before the next scheduling/hash step.
+    if (m_model_input_type == ModelInputType::EMBEDDINGS && sync_embeddings_after_candidates()) {
+        m_model_runner->append_embeddings(m_requests, scheduler_output);
+    }
 
     {
         static ManualTimer clean_up_requests_timer("free non running requests");

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -746,7 +746,23 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_free_non_running_reque
     std::vector<SequenceGroup::Ptr>::iterator requests_iterator = m_requests.begin();
     while (requests_iterator != m_requests.end()) {
         const auto& request = *requests_iterator;
-        if (request->has_finished() || request->handle_stopped() || request->handle_cancelled()) {
+        const bool is_finished = request->has_finished();
+        const bool is_stopped = request->handle_stopped();
+        const bool is_cancelled = request->handle_cancelled();
+
+        if (is_finished || is_stopped || is_cancelled) {
+            if (!is_finished && (is_stopped || is_cancelled)) {
+                auto perf_metrics = request->get_perf_metrics();
+                perf_metrics.load_time = m_load_time_ms;
+                request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
+                request->push_empty_outputs();
+            } else if (is_finished) {
+                auto perf_metrics = request->get_perf_metrics();
+                perf_metrics.load_time = m_load_time_ms;
+                request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
+                request->notify_handle_final();
+            }
+
             for (const auto& sequence : request->get_sequences()) {
                 if (m_scheduler->has_block_table(sequence->get_id())) {
                     m_scheduler->free_sequence(sequence->get_id());
@@ -782,7 +798,11 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_notify_handles(const S
     }
     // stopped/cancelled requests may not be among the scheduled ones
     for (auto& request : m_requests) {
-        if (!request->has_finished() && (request->handle_stopped() || request->handle_cancelled())) {
+        const bool is_finished = request->has_finished();
+        const bool is_stopped = request->handle_stopped();
+        const bool is_cancelled = request->handle_cancelled();
+
+        if (!is_finished && (is_stopped || is_cancelled)) {
             auto perf_metrics = request->get_perf_metrics();
             perf_metrics.load_time = m_load_time_ms;
             request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -751,16 +751,15 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_free_non_running_reque
         const bool is_cancelled = request->handle_cancelled();
 
         if (is_finished || is_stopped || is_cancelled) {
-            if (!is_finished && (is_stopped || is_cancelled)) {
+            if (!request->notified_terminal()) {
                 auto perf_metrics = request->get_perf_metrics();
                 perf_metrics.load_time = m_load_time_ms;
                 request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
-                request->push_empty_outputs();
-            } else if (is_finished) {
-                auto perf_metrics = request->get_perf_metrics();
-                perf_metrics.load_time = m_load_time_ms;
-                request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
-                request->notify_handle_final();
+                if (is_finished) {
+                    request->notify_handle_final();
+                } else {
+                    request->notify_handle_stopped_or_cancelled();
+                }
             }
 
             for (const auto& sequence : request->get_sequences()) {
@@ -802,11 +801,11 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_notify_handles(const S
         const bool is_stopped = request->handle_stopped();
         const bool is_cancelled = request->handle_cancelled();
 
-        if (!is_finished && (is_stopped || is_cancelled)) {
+        if (!is_finished && (is_stopped || is_cancelled) && !request->notified_terminal()) {
             auto perf_metrics = request->get_perf_metrics();
             perf_metrics.load_time = m_load_time_ms;
             request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
-            request->push_empty_outputs();
+            request->notify_handle_stopped_or_cancelled();
         }
     }
 }

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -412,6 +412,9 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
         for (size_t i = 0; i < m_requests.size(); ++i) {
             SequenceGroup::Ptr sequence_group = m_requests[i];
             if (!sequence_group->is_waiting()) {
+                auto perf_metrics = sequence_group->get_perf_metrics();
+                perf_metrics.load_time = m_load_time_ms;
+                sequence_group->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
                 sequence_group->set_out_of_memory();
                 sequence_group->notify_handle();
             }
@@ -497,14 +500,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
         m_model_runner->append_embeddings(m_requests, scheduler_output);
     }
 
-    // notify requests dropped by handle
-    {
-        static ManualTimer report_tokens_timer("notify requests dropped by handle");
-        report_tokens_timer.start();
-        _notify_requests_dropped_by_handle();
-        report_tokens_timer.end();
-    }
-
     const auto step_end_time = std::chrono::steady_clock::now();
     for (const auto request_index : scheduler_output.m_scheduled_sequence_groups_ids) {
         const auto& request = m_requests.at(request_index);
@@ -520,7 +515,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
                                      step_end_time);
     }
 
-    // free non running requests for current step
+    _notify_handles(scheduler_output);
 
     {
         static ManualTimer clean_up_requests_timer("free non running requests");
@@ -751,9 +746,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_free_non_running_reque
     while (requests_iterator != m_requests.end()) {
         const auto& request = *requests_iterator;
         if (request->has_finished() || request->handle_stopped() || request->handle_cancelled()) {
-            auto perf_metrics = request->get_perf_metrics();
-            perf_metrics.load_time = m_load_time_ms;
-            request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
             for (const auto& sequence : request->get_sequences()) {
                 if (m_scheduler->has_block_table(sequence->get_id())) {
                     m_scheduler->free_sequence(sequence->get_id());
@@ -767,12 +759,34 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_free_non_running_reque
     }
 }
 
-void ContinuousBatchingPipeline::ContinuousBatchingImpl::_notify_requests_dropped_by_handle() {
-    // Notify the last time by pushing empty output
-    // This causes read() to unblock by adding anything to the queue
-    for (SequenceGroup::Ptr& request : m_requests) {
-        if (request->handle_stopped() || request->handle_cancelled())
+void ContinuousBatchingPipeline::ContinuousBatchingImpl::_notify_handles(const Scheduler::Output& scheduler_output) {
+    for (const auto request_index : scheduler_output.m_scheduled_sequence_groups_ids) {
+        const auto& request = m_requests.at(request_index);
+        const bool is_echo_only = request->get_context_len() <= request->get_prompt_len() &&
+                                  request->get_sampling_parameters().echo &&
+                                  request->get_max_new_tokens() == 0;
+        if (is_echo_only) {
+            auto perf_metrics = request->get_perf_metrics();
+            perf_metrics.load_time = m_load_time_ms;
+            request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
+            request->notify_handle_echo_only();
+        } else if (request->has_finished()) {
+            auto perf_metrics = request->get_perf_metrics();
+            perf_metrics.load_time = m_load_time_ms;
+            request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
+            request->notify_handle_final();
+        } else {
+            request->notify_handle();
+        }
+    }
+    // stopped/cancelled requests may not be among the scheduled ones
+    for (auto& request : m_requests) {
+        if (!request->has_finished() && (request->handle_stopped() || request->handle_cancelled())) {
+            auto perf_metrics = request->get_perf_metrics();
+            perf_metrics.load_time = m_load_time_ms;
+            request->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
             request->push_empty_outputs();
+        }
     }
 }
 
@@ -1026,10 +1040,6 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::_fill_prompt_log_probs(
             sequence_group->append_prompt_log_prob(token_logit - max_value - log_sum);
         }
         currently_processed_tokens += output_seq_len * num_running_sequences;
-        // For max_new_tokens == 0, we don't reach sampling so need to notify handle separately
-        if (sequence_group->get_max_new_tokens() == 0) {
-            sequence_group->notify_handle_echo_only();
-        }
     }
 }
 

--- a/src/cpp/src/continuous_batching/pipeline_impl.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.cpp
@@ -416,7 +416,7 @@ void ContinuousBatchingPipeline::ContinuousBatchingImpl::step() {
                 perf_metrics.load_time = m_load_time_ms;
                 sequence_group->get_generation_stream()->set_perf_metrics(std::move(perf_metrics));
                 sequence_group->set_out_of_memory();
-                sequence_group->notify_handle();
+                sequence_group->notify_handle_oom();
             }
         }
         _free_non_running_requests();

--- a/src/cpp/src/continuous_batching/pipeline_impl.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_impl.hpp
@@ -75,11 +75,7 @@ protected:
      * Releases non-running (finished, dropped or OOM) requests from running queue
      */
     void _free_non_running_requests();
-
-    /**
-     * Notify dropped requests by pushing empty output
-     */
-    void _notify_requests_dropped_by_handle();
+    void _notify_handles(const Scheduler::Output& scheduler_output);
 
     /**
      * Handles 'echo' generation parameter

--- a/src/cpp/src/llm/pipeline_static.cpp
+++ b/src/cpp/src/llm/pipeline_static.cpp
@@ -332,6 +332,7 @@ EncodedResults StatefulLLMPipeline::generate(
     SamplerOutput sampler_output = m_sampler.sample({sequence_group}, logits);
     raw_perf_counters.m_sampling_durations.emplace_back(
         PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+    sequence_group->notify_handle();
     stream_generated_tokens(streamer_ptr, handle);
 
     int64_t input_ids_data = -1;
@@ -368,6 +369,7 @@ EncodedResults StatefulLLMPipeline::generate(
         SamplerOutput sampler_output = m_sampler.sample({sequence_group}, m_request.get_tensor("logits"));
         raw_perf_counters.m_sampling_durations.emplace_back(
             PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+        sequence_group->notify_handle();
         stream_generated_tokens(streamer_ptr, handle);
     }
 

--- a/src/cpp/src/llm/pipeline_static.cpp
+++ b/src/cpp/src/llm/pipeline_static.cpp
@@ -60,6 +60,10 @@ void stream_generated_tokens(std::shared_ptr<ov::genai::StreamerBase> streamer_p
                              ov::genai::GenerationHandle& handle) {
     if (streamer_ptr && handle->can_read()) {
         std::unordered_map<uint64_t, ov::genai::GenerationOutput> token = handle->read();
+        if (token.empty()) {
+            // Empty terminator pushed by notify_handle_final()/notify_handle_oom() to unblock readers.
+            return;
+        }
         auto streaming_status = streamer_ptr->write(token.begin()->second.generated_ids);
         if (streaming_status == ov::genai::StreamingStatus::TOOL_CALL_STOP) {
             handle->stop(ov::genai::GenerationFinishReason::TOOL_CALL);

--- a/src/cpp/src/lm_encoding.cpp
+++ b/src/cpp/src/lm_encoding.cpp
@@ -200,6 +200,8 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
     SamplerOutput sampler_output = sampler.sample(sequence_groups, logits);
     raw_perf_counters.m_sampling_durations.emplace_back(
         PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+    for (auto& sg : sequence_groups)
+        sg->notify_handle();
     free_non_running_requests(); // handle sampler output
 
     raw_perf_counters.m_new_token_times.emplace_back(std::chrono::steady_clock::now());
@@ -322,6 +324,8 @@ ov::genai::utils::GenerationFinishInfo get_lm_encoded_results(
         sampler_output = sampler.sample(active_sequence_groups, m_llm.get_tensor("logits"));
         raw_perf_counters.m_sampling_durations.emplace_back(
             PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
+        for (auto& sg : active_sequence_groups)
+            sg->notify_handle();
         free_non_running_requests(); // handle sampler output
 
         raw_perf_counters.m_new_token_times.emplace_back(std::chrono::steady_clock::now());

--- a/src/cpp/src/sampling/sampler.cpp
+++ b/src/cpp/src/sampling/sampler.cpp
@@ -1700,10 +1700,7 @@ SequenceGroupSamplingInfo Sampler::sample_from_sequence_group(SequenceGroup::Ptr
     } else {
         OPENVINO_THROW("Unsupported sampling method");
     }
-    // Notify handle after sampling is done. 
-    // For non-streaming this is effective only when the generation is finished.
     OPENVINO_ASSERT(num_generated_tokens_to_validate >= assisting_pipeline_info.max_removed_tokens_per_request);
-    sequence_group->notify_handle();
     return sg_sampling_info;
 }
 

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -437,6 +437,7 @@ class SequenceGroup  : public std::enable_shared_from_this<SequenceGroup> {
     size_t m_output_seq_len = 0;
 
     size_t m_num_streamed_tokens = 0, m_stream_window_size = 0;
+    bool m_terminal_notification_sent = false;
     TimePoint m_start_time = std::chrono::steady_clock::now();
     PerfMetrics m_perf_metrics;
 
@@ -1064,7 +1065,16 @@ public:
             stream_output();
     }
 
+    // True once a terminal notification (final push + unblocking terminator) has reached the handle,
+    // however it was triggered (finished / OOM / echo-only / externally stopped / cancelled).
+    bool notified_terminal() const {
+        return m_terminal_notification_sent;
+    }
+
     void notify_handle_oom() {
+        if (m_terminal_notification_sent)
+            return;
+        m_terminal_notification_sent = true;
         stream_output();
         set_generation_status(GenerationStatus::IGNORED);
         push_empty_outputs();  // unblock any reader blocked in read() before the status change
@@ -1072,14 +1082,28 @@ public:
 
     // Push the final output for a finished group; must be called after set_perf_metrics() to close the metrics race.
     void notify_handle_final() {
+        if (m_terminal_notification_sent)
+            return;
         OPENVINO_ASSERT(has_finished());
+        m_terminal_notification_sent = true;
         stream_output();
         set_generation_status(GenerationStatus::FINISHED);
         push_empty_outputs();  // unblock any reader blocked in read() before the status change
     }
 
+    // Unblocks a reader stuck in read()/read_all() for a request stopped/cancelled by the user
+    // outside of the sampling loop (no new tokens are produced for this transition).
+    void notify_handle_stopped_or_cancelled() {
+        if (m_terminal_notification_sent)
+            return;
+        m_terminal_notification_sent = true;
+        push_empty_outputs();
+    }
+
     // Special notification path for max_new_tokens == 0 where we don't expect to return any new tokens, but only process prompt
     void notify_handle_echo_only() {
+        if (m_terminal_notification_sent)
+            return;
         // Called after metrics are updated; m_num_processed_tokens does not yet include
         // recently forwarded tokens, so it is our starting position.
         // we return m_num_scheduled_tokens tokens as they were forwarded in the current step, meaning context length is our last position.
@@ -1100,6 +1124,7 @@ public:
         outputs.emplace(0, output);
         m_generation_stream->push(std::move(outputs));
         if (last_token_position == get_prompt_len()) {
+            m_terminal_notification_sent = true;
             set_generation_status(GenerationStatus::FINISHED);
             push_empty_outputs();  // unblock any reader blocked in read() before the status change
         }

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -1018,11 +1018,8 @@ public:
     }
 
     void notify_handle() {
-        if (out_of_memory()) {
+        if (out_of_memory())
             set_generation_status(GenerationStatus::IGNORED);
-        } else if (has_finished()) {
-            set_generation_status(GenerationStatus::FINISHED);
-        }
         // For beam search streaming is not available, so we notify only upon finishing
         if (m_sampling_params.is_beam_search()) {
             if (has_finished()) {
@@ -1060,10 +1057,32 @@ public:
     }
 
 
+    // Push the final output for a finished group; must be called after set_perf_metrics() to close the metrics race.
+    void notify_handle_final() {
+        OPENVINO_ASSERT(has_finished());
+        set_generation_status(GenerationStatus::FINISHED);
+        if (m_sampling_params.is_beam_search()) {
+            push_outputs();
+        } else if (m_sampling_params.is_greedy_decoding() || m_sampling_params.is_multinomial() || m_sampling_params.is_tree_search()) {
+            if (num_total_seqs() == 1) {
+                const auto generated_len = m_sequences.front()->get_generated_len();
+                if (generated_len <= m_num_streamed_tokens) {
+                    push_finished_hidden_states();
+                    return;
+                }
+                const size_t num_to_push = generated_len - m_num_streamed_tokens;
+                push_partial_outputs(num_to_push);
+                m_num_streamed_tokens += num_to_push;
+            } else {
+                push_outputs();
+            }
+        }
+    }
+
     // Special notification path for max_new_tokens == 0 where we don't expect to return any new tokens, but only process prompt
     void notify_handle_echo_only() {
-        // This method is called after scheduling and before sampling,
-        // so m_num_processed_tokens does not include recently forwarded tokens hence this is our starting position
+        // Called after metrics are updated; m_num_processed_tokens does not yet include
+        // recently forwarded tokens, so it is our starting position.
         // we return m_num_scheduled_tokens tokens as they were forwarded in the current step, meaning context length is our last position.
         size_t first_token_position = m_num_processed_tokens;
         size_t last_token_position = get_context_len();

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -1061,22 +1061,7 @@ public:
     void notify_handle_final() {
         OPENVINO_ASSERT(has_finished());
         set_generation_status(GenerationStatus::FINISHED);
-        if (m_sampling_params.is_beam_search()) {
-            push_outputs();
-        } else if (m_sampling_params.is_greedy_decoding() || m_sampling_params.is_multinomial() || m_sampling_params.is_tree_search()) {
-            if (num_total_seqs() == 1) {
-                const auto generated_len = m_sequences.front()->get_generated_len();
-                if (generated_len <= m_num_streamed_tokens) {
-                    push_finished_hidden_states();
-                    return;
-                }
-                const size_t num_to_push = generated_len - m_num_streamed_tokens;
-                push_partial_outputs(num_to_push);
-                m_num_streamed_tokens += num_to_push;
-            } else {
-                push_outputs();
-            }
-        }
+        notify_handle();
     }
 
     // Special notification path for max_new_tokens == 0 where we don't expect to return any new tokens, but only process prompt

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -455,6 +455,43 @@ class SequenceGroup  : public std::enable_shared_from_this<SequenceGroup> {
         return false;
     }
 
+    void stream_output() {
+        // For beam search streaming is not available, so we notify only upon finishing
+        if (m_sampling_params.is_beam_search()) {
+            if (has_finished()) {
+                push_outputs();
+            }
+        } else if (m_sampling_params.is_greedy_decoding() || m_sampling_params.is_multinomial() || m_sampling_params.is_tree_search()) {
+            // We can stream only when one sequence is returned and we don't use stop strings that would be excluded from the output
+            // (after stop string is detected its tokens are already sent)
+            if (num_total_seqs() == 1) {
+                const auto generated_len = m_sequences.front()->get_generated_len();
+                if (has_finished()) {
+                    m_stream_window_size = 0;
+                }
+                // push empty output in case we won't stream generation res
+                if (generated_len <= (m_num_streamed_tokens + m_stream_window_size)) {
+                    if (has_finished()) {
+                        // All tokens already streamed; still deliver accumulated hidden states
+                        // (falls back to an empty terminator push when there are none).
+                        push_finished_hidden_states();
+                    }
+                    return;
+                }
+                // speculative decoding draft handling
+                if (generated_len < m_num_streamed_tokens) {
+                    m_num_streamed_tokens = generated_len;
+                }
+                OPENVINO_ASSERT(generated_len >= (m_num_streamed_tokens + m_stream_window_size));
+                size_t num_output_token_to_push = generated_len - m_num_streamed_tokens - m_stream_window_size;
+                push_partial_outputs(num_output_token_to_push);
+                m_num_streamed_tokens += (num_output_token_to_push);
+            } else if (has_finished()) {
+                push_outputs();
+            }
+        }
+    }
+
 public:
     using Ptr = std::shared_ptr<SequenceGroup>;
     using CPtr = std::shared_ptr<const SequenceGroup>;
@@ -1017,51 +1054,26 @@ public:
         m_generation_stream->push(std::move(outputs));
     }
 
+    // Convenience dispatcher for callers that don't know the terminal state in advance (e.g. non-CB pipelines).
     void notify_handle() {
         if (out_of_memory())
-            set_generation_status(GenerationStatus::IGNORED);
-        // For beam search streaming is not available, so we notify only upon finishing
-        if (m_sampling_params.is_beam_search()) {
-            if (has_finished()) {
-                push_outputs();
-            }
-        } else if (m_sampling_params.is_greedy_decoding() || m_sampling_params.is_multinomial() || m_sampling_params.is_tree_search()) {
-            // We can stream only when one sequence is returned and we don't use stop strings that would be excluded from the output
-            // (after stop string is detected its tokens are already sent)
-            if (num_total_seqs() == 1) {
-                const auto generated_len = m_sequences.front()->get_generated_len();
-                if (has_finished()) {
-                    m_stream_window_size = 0;
-                }
-                // push empty output in case we won't stream generation res
-                if (generated_len <= (m_num_streamed_tokens + m_stream_window_size)) {
-                    if (has_finished()) {
-                        // All tokens already streamed; still deliver accumulated hidden states
-                        // (falls back to an empty terminator push when there are none).
-                        push_finished_hidden_states();
-                    }
-                    return;
-                }
-                // speculative decoding draft handling
-                if (generated_len < m_num_streamed_tokens) {
-                    m_num_streamed_tokens = generated_len;
-                }
-                OPENVINO_ASSERT(generated_len >= (m_num_streamed_tokens + m_stream_window_size));
-                size_t num_output_token_to_push = generated_len - m_num_streamed_tokens - m_stream_window_size;
-                push_partial_outputs(num_output_token_to_push);
-                m_num_streamed_tokens += (num_output_token_to_push);
-            } else if (has_finished()) {
-                push_outputs();
-            }
-        }
+            notify_handle_oom();
+        else if (has_finished())
+            notify_handle_final();
+        else
+            stream_output();
     }
 
+    void notify_handle_oom() {
+        set_generation_status(GenerationStatus::IGNORED);
+        stream_output();
+    }
 
     // Push the final output for a finished group; must be called after set_perf_metrics() to close the metrics race.
     void notify_handle_final() {
         OPENVINO_ASSERT(has_finished());
         set_generation_status(GenerationStatus::FINISHED);
-        notify_handle();
+        stream_output();
     }
 
     // Special notification path for max_new_tokens == 0 where we don't expect to return any new tokens, but only process prompt

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -1065,15 +1065,17 @@ public:
     }
 
     void notify_handle_oom() {
-        set_generation_status(GenerationStatus::IGNORED);
         stream_output();
+        set_generation_status(GenerationStatus::IGNORED);
+        push_empty_outputs();  // unblock any reader blocked in read() before the status change
     }
 
     // Push the final output for a finished group; must be called after set_perf_metrics() to close the metrics race.
     void notify_handle_final() {
         OPENVINO_ASSERT(has_finished());
-        set_generation_status(GenerationStatus::FINISHED);
         stream_output();
+        set_generation_status(GenerationStatus::FINISHED);
+        push_empty_outputs();  // unblock any reader blocked in read() before the status change
     }
 
     // Special notification path for max_new_tokens == 0 where we don't expect to return any new tokens, but only process prompt
@@ -1092,12 +1094,15 @@ public:
 
         if (last_token_position == get_prompt_len()) {
             output.finish_reason = GenerationFinishReason::LENGTH;
-            set_generation_status(GenerationStatus::FINISHED);
             m_sequences[0]->set_status(SequenceStatus::FINISHED); // for cleanup
         }
         GenerationOutputs outputs;
         outputs.emplace(0, output);
         m_generation_stream->push(std::move(outputs));
+        if (last_token_position == get_prompt_len()) {
+            set_generation_status(GenerationStatus::FINISHED);
+            push_empty_outputs();  // unblock any reader blocked in read() before the status change
+        }
     }
 
     size_t get_max_new_tokens() const {

--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -325,6 +325,7 @@ std::pair<ov::genai::EncodedResults, bool> full_decode(ov::Tensor& encoder_hidde
         raw_metrics.m_sampling_durations.emplace_back(
             ov::genai::PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
     }
+    sequence_group->notify_handle();
     stream_generated_tokens(streamer, handle, return_timestamps);
 
     prepare_decoder_with_past(models.decoder_with_past, models.decoder, init_ids.size());
@@ -350,6 +351,7 @@ std::pair<ov::genai::EncodedResults, bool> full_decode(ov::Tensor& encoder_hidde
             raw_metrics.m_sampling_durations.emplace_back(
                 ov::genai::PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
         }
+        sequence_group->notify_handle();
         stream_generated_tokens(streamer, handle, return_timestamps);
     }
 

--- a/src/cpp/src/whisper/pipeline_static.cpp
+++ b/src/cpp/src/whisper/pipeline_static.cpp
@@ -287,6 +287,10 @@ void stream_generated_tokens(const std::shared_ptr<ov::genai::StreamerBase> stre
     }
 
     std::unordered_map<uint64_t, ov::genai::GenerationOutput> token = handle->read();
+    if (token.empty()) {
+        // Empty terminator pushed by notify_handle_final()/notify_handle_oom() to unblock readers.
+        return;
+    }
 
     auto streaming_status = streamer_ptr->write(token.begin()->second.generated_ids);
     if (streaming_status == ov::genai::StreamingStatus::CANCEL) {

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -114,6 +114,10 @@ std::pair<ov::genai::EncodedResults, bool> decode(std::shared_ptr<ov::genai::Whi
         }
 
         std::unordered_map<uint64_t, ov::genai::GenerationOutput> token = handle->read();
+        if (token.empty()) {
+            // Empty terminator pushed by notify_handle_final()/notify_handle_oom() to unblock readers.
+            return;
+        }
 
         auto streaming_status = streamer_ptr->write(token.begin()->second.generated_ids);
         if (streaming_status == ov::genai::StreamingStatus::CANCEL) {

--- a/src/cpp/src/whisper/whisper.cpp
+++ b/src/cpp/src/whisper/whisper.cpp
@@ -158,6 +158,7 @@ std::pair<ov::genai::EncodedResults, bool> decode(std::shared_ptr<ov::genai::Whi
         raw_metrics.m_sampling_durations.emplace_back(
             ov::genai::PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
     }
+    sequence_group->notify_handle();
     stream_generated_tokens();
 
     // "Generation" phase
@@ -231,6 +232,7 @@ std::pair<ov::genai::EncodedResults, bool> decode(std::shared_ptr<ov::genai::Whi
             raw_metrics.m_sampling_durations.emplace_back(
                 ov::genai::PerfMetrics::get_microsec(std::chrono::steady_clock::now() - sample_start));
         }
+        sequence_group->notify_handle();
     }
 
     stream_generated_tokens();

--- a/src/python/py_continuous_batching_pipeline.cpp
+++ b/src/python/py_continuous_batching_pipeline.cpp
@@ -336,8 +336,8 @@ void init_continuous_batching_pipeline(py::module_& m) {
         .def("can_read", &GenerationHandleImpl::can_read)
         .def("stop", &GenerationHandleImpl::stop, py::arg_v("finish_reason", GenerationFinishReason::STOP, "GenerationFinishReason.STOP"))
         .def("cancel", &GenerationHandleImpl::cancel)
-        .def("read", &GenerationHandleImpl::read)
-        .def("read_all", &GenerationHandleImpl::read_all)
+        .def("read", &GenerationHandleImpl::read, py::call_guard<py::gil_scoped_release>())
+        .def("read_all", &GenerationHandleImpl::read_all, py::call_guard<py::gil_scoped_release>())
         .def("get_perf_metrics", &GenerationHandleImpl::get_perf_metrics)
         .def("get_vlm_perf_metrics", &GenerationHandleImpl::get_vlm_perf_metrics);
 

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import math
 import sys
+import threading
 import numpy as np
 
 from pathlib import Path
@@ -1167,3 +1168,72 @@ def test_cb_different_seed_produces_different_output(model_facebook_opt_125m: OV
         f"Requests with different rng_seeds {rng_seeds} must produce at least one distinct output, "
         f"but all produced identical token sequences: {token_seqs[0]}"
     )
+
+
+def test_cb_perf_metrics_available_after_concurrent_read(model_facebook_opt_125m: OVConvertedModelSchema):
+    """Metrics must be committed before the final token push so the reader never hits the assertion."""
+    models_path = model_facebook_opt_125m.models_path
+    cb_pipe = ContinuousBatchingPipeline(models_path, SchedulerConfig(), "CPU")
+    config = GenerationConfig(max_new_tokens=10)
+
+    for i in range(50):
+        handle = cb_pipe.add_request(i, "1+1=", generation_config=config)
+        errors = []
+
+        def make_reader(h, errs):
+            def reader():
+                h.read_all()
+                # no sleep: immediate call is the exact race window the fix closes
+                try:
+                    metrics = h.get_perf_metrics()
+                    assert metrics.get_num_generated_tokens() > 0
+                except Exception as e:
+                    errs.append(e)
+
+            return reader
+
+        t = threading.Thread(target=make_reader(handle, errors))
+        t.start()
+        while cb_pipe.has_non_finished_requests():
+            cb_pipe.step()
+        t.join()
+        assert not errors, f"Iteration {i}: get_perf_metrics() raised: {errors[0]}"
+
+
+@pytest.mark.parametrize(
+    "generation_config_factory",
+    [
+        get_greedy,
+        get_beam_search,
+        get_multinomial_temperature,
+    ],
+)
+def test_cb_perf_metrics_valid_per_sampling_mode(
+    model_facebook_opt_125m: OVConvertedModelSchema,
+    generation_config_factory,
+):
+    """get_perf_metrics() must return valid data for every sampling mode after generation."""
+    models_path = model_facebook_opt_125m.models_path
+    cb_pipe = ContinuousBatchingPipeline(models_path, SchedulerConfig(), "CPU")
+    config = generation_config_factory()
+    config.max_new_tokens = 10
+    handle = cb_pipe.add_request(0, "What is OpenVINO?", generation_config=config)
+    while cb_pipe.has_non_finished_requests():
+        cb_pipe.step()
+    handle.read_all()
+    metrics = handle.get_perf_metrics()
+    assert metrics.get_num_generated_tokens() > 0
+    assert metrics.get_num_input_tokens() > 0
+
+
+def test_cb_perf_metrics_available_for_echo_only(model_facebook_opt_125m: OVConvertedModelSchema):
+    """Echo-only requests (max_new_tokens=0) use a separate notify path; metrics must still be set."""
+    models_path = model_facebook_opt_125m.models_path
+    cb_pipe = ContinuousBatchingPipeline(models_path, SchedulerConfig(), "CPU")
+    config = GenerationConfig(max_new_tokens=0, echo=True)
+    handle = cb_pipe.add_request(0, "What is OpenVINO?", generation_config=config)
+    while cb_pipe.has_non_finished_requests():
+        cb_pipe.step()
+    handle.read_all()
+    metrics = handle.get_perf_metrics()
+    assert metrics.get_num_input_tokens() > 0

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -1192,12 +1192,10 @@ def test_cb_perf_metrics_available_after_concurrent_read(model_facebook_opt_125m
 
             return reader
 
-        t = threading.Thread(target=make_reader(handle, errors), daemon=True)
+        t = threading.Thread(target=make_reader(handle, errors))
         t.start()
-        step_idx = 0
         while cb_pipe.has_non_finished_requests():
             cb_pipe.step()
-            step_idx += 1
         t.join()
         assert not errors, f"Iteration {i}: get_perf_metrics() raised: {errors[0]}"
 

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -1192,10 +1192,12 @@ def test_cb_perf_metrics_available_after_concurrent_read(model_facebook_opt_125m
 
             return reader
 
-        t = threading.Thread(target=make_reader(handle, errors))
+        t = threading.Thread(target=make_reader(handle, errors), daemon=True)
         t.start()
+        step_idx = 0
         while cb_pipe.has_non_finished_requests():
             cb_pipe.step()
+            step_idx += 1
         t.join()
         assert not errors, f"Iteration {i}: get_perf_metrics() raised: {errors[0]}"
 


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
The main purpose of this PR is to remove race condition happening in OVMS execution scenario where one thread runs pipeline execution and another reads from GenerationHandle. Currently holder of the handle has two synchronization points - first when tokens arrive and second when metrics are updated. The dual synchronization seems awkward and indicates architectural issue in my opinion. 
In this PR I change order in ContinuousBatching::step so that when GenerationHandle is notified, metrics are already set. User can we sure that calling get_perf_metrics will not fail due to timing issue (calling it between tokens being ready + generation status being switched and perf metrics being set).

Also I extracted notify handle call from sampler as it seems clearer logically to limit sampler logic to sampling and wrapped entire notification logic in a single method called directly in `step`.

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
