### PR TITLE
 Fix qwen3-next PAGED_ATTENTION flake and stop-string underflow in prompt lookup

### DIFF
--- a/src/cpp/src/sampling/sampler.cpp
+++ b/src/cpp/src/sampling/sampler.cpp
@@ -113,8 +113,9 @@ MatchStopStringResult match_stop_string(Tokenizer& tokenizer,
                       size_t draft_generated_tokens = 0) {
     MatchStopStringResult result;
     if (generated_tokens.size() >= stop_strings.first) {
-        // draft_generated_tokens is to handle case with >= 1 generated tokens per step
-        size_t offset = generated_tokens.size() - draft_generated_tokens;
+        // draft_generated_tokens is to handle case with >= 1 generated tokens per step. It is tracked per
+        // sequence group, so it can exceed this sequence's generated length - clamp to avoid underflowing.
+        size_t offset = generated_tokens.size() - std::min(draft_generated_tokens, generated_tokens.size());
         if (offset < stop_strings.first) {
             return result;
         }

--- a/tests/python_tests/test_llm_pipeline.py
+++ b/tests/python_tests/test_llm_pipeline.py
@@ -315,11 +315,7 @@ def test_linear_attention_batch_string_inputs(
     prompts: list[str],
     pipeline_type: PipelineType,
 ) -> None:
-    if (
-        llm_model.model_id == QWEN3_NEXT_MODEL_ID
-        and pipeline_type == PipelineType.PAGED_ATTENTION
-        and prompts == BATCHED_PROMPTS[1]
-    ):
+    if llm_model.model_id == QWEN3_NEXT_MODEL_ID and pipeline_type == PipelineType.PAGED_ATTENTION:
         # This tiny-random model has almost-equal logits, so PA and the reference sometimes pick different greedy tokens.
         # Tracking issue: CVS-192310
         pytest.xfail(


### PR DESCRIPTION
## Description
This PR fixes two intermittent CI failures.

#### 1. size_t underflow in match_stop_string

```
RuntimeError: Check 'm_generated_ids.size() >= n' failed at sequence_group.hpp:215
```

match_stop_string() computes `generated_tokens.size() - draft_generated_tokens`, where the draft count comes from SequenceGroup::get_num_tokens_to_validate(), tracked per sequence group, but subtracted from a per-sequence token list, and not refreshed after tokens are dropped. In Sampler::sample_from_sequence_group() these run back to back:

1. remove_last_tokens(trailing_draft_tokens) - rejected drafts dropped
2. align_all_sequence_len(...) - every sequence truncated to `min_generated_len
3. _try_finish_generation(...) → match_stop_string(..., get_num_tokens_to_validate())

After 1-2 a sequence can be shorter than that stale count, so the subtraction wraps and `generated_tokens.begin() + offset` is advanced past end(), producing a bogus to_remove. Clamping is a no-op whenever no underflow occurred. get_num_tokens_to_validate() is non-zero only on speculative/prompt-lookup paths, which is why PROMPT_LOOKUP_DECODING is the only failing pipeline.

Reproduced on unmodified master: run [31409922141](https://github.com/openvinotoolkit/openvino.genai/actions/runs/31409922141) fails the same test with an identical assertion and identical counts.

#### 2. qwen3-next xfail scoped too narrowly

`test_linear_attention_batch_string_inputs` already has an xfail for CVS-192310 (*"almost-equal logits, so PA and the reference sometimes pick different greedy tokens"*), but restricted to `BATCHED_PROMPTS[1]`. CI fails on `[0]` and `[3]`. Dropping the prompts condition makes the guard cover what its comment describes.

The same two parametrisations fail on unrelated PRs sharing base commit `f819dd52`, which cannot have caused them:

- [#4294](https://github.com/openvinotoolkit/openvino.genai/actions/runs/31493080904/job/93921015236?pr=4294) (tokenizer changes)
- [#4298](https://github.com/openvinotoolkit/openvino.genai/actions/runs/31486483146/job/93878264124?pr=4298) (video generation changes)


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] Tests have been updated or added to cover the new code. (tests already exist)
- [x] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- NA I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
