### PR TITLE
[Whisper] Decompose cross-attention SDPA for NPU too, matching CPU/GPU

### DIFF
--- a/src/cpp/src/utils.cpp
+++ b/src/cpp/src/utils.cpp
@@ -109,7 +109,6 @@ void update_npu_config_whisper(ov::AnyMap& config,
     update_config(config, {"NPUW_LLM", "YES"});
     update_config(config, {"NPUW_WHISPER", "YES"});
     rename_key(config, "WHISPER_EOS_TOKEN", "NPUW_WHISPER_EOS_TOKEN");
-    rename_key(config, "WHISPER_DECOMPOSE_SDPA", "NPUW_WHISPER_DECOMPOSE_SDPA");
 
     update_config(config, {"NPUW_LLM_BATCH_DIM", kv_pos.batch});
     update_config(config, {"NPUW_LLM_SEQ_LEN_DIM", kv_pos.seq_len});

--- a/src/cpp/src/whisper/models/statefull_decoder.cpp
+++ b/src/cpp/src/whisper/models/statefull_decoder.cpp
@@ -34,6 +34,11 @@ WhisperStatefullDecoder::WhisperStatefullDecoder(const std::filesystem::path& mo
 
     m_has_cache_position = utils::has_input(model, "cache_position");
 
+    if (m_decompose_cross_attention_spda_ops) {
+        ov::genai::decompose_scaled_dot_product_attention_for_whisper(model);
+        ov::genai::add_cross_attention_qk_scaled_scores_outputs_for_whisper(model);
+    }
+
     ov::CompiledModel compiled_model;
     if (device == "NPU") {
         auto kv_pos = ov::genai::utils::get_kv_axes_pos(model);
@@ -43,11 +48,6 @@ WhisperStatefullDecoder::WhisperStatefullDecoder(const std::filesystem::path& mo
         utils::KVDesc kv_desc;
         std::tie(compiled_model, kv_desc) = utils::compile_decoder_for_npu(model, properties, kv_pos, true);
     } else {
-        if (m_decompose_cross_attention_spda_ops) {
-            ov::genai::decompose_scaled_dot_product_attention_for_whisper(model);
-            ov::genai::add_cross_attention_qk_scaled_scores_outputs_for_whisper(model);
-        }
-
         utils::apply_slice_before_matmul_transformation(model);
 
         compiled_model = core.compile_model(model, device, properties);

--- a/src/cpp/src/whisper/pipeline.cpp
+++ b/src/cpp/src/whisper/pipeline.cpp
@@ -94,10 +94,6 @@ public:
             auto eos_token = m_generation_config.eos_token_id == -1 ? m_tokenizer.get_eos_token_id()
                                                                     : m_generation_config.eos_token_id;
             properties_copy.insert({"WHISPER_EOS_TOKEN", eos_token});
-
-            if (m_generation_config.word_timestamps) {
-                properties_copy.insert({"WHISPER_DECOMPOSE_SDPA", m_generation_config.word_timestamps});
-            }
         } else {
             compiled_model = core.compile_model(models_path / "openvino_encoder_model.xml", device, properties_copy);
         }


### PR DESCRIPTION
Reverts the NPU special-case added for CVS-179287: cross-attention SDPA decomposition for word-level timestamps now runs unconditionally (gated only by word_timestamps) instead of being skipped for NPU and signalled to NPUW via a WHISPER_DECOMPOSE_SDPA property. DO NOT MERGE before openvinotoolkit/openvino#37402 (makes NPUW's Whisper passes tolerant of decomposed SDPA) is merged - until then this would hit the CVS-179287 crash again.

Part 2 of 3 for CVS-184242 

### Tickets:
- [CVS-184242](https://jira.devtools.intel.com/browse/CVS-184242)