### PR TITLE
Optimize GPU LoRA switching with precision-aware tensor caching

### DIFF
--- a/src/cpp/include/openvino/genai/lora_adapter.hpp
+++ b/src/cpp/include/openvino/genai/lora_adapter.hpp
@@ -193,9 +193,6 @@ public:
 
     AdapterController(std::shared_ptr<ov::Model> model, const AdapterConfig& config, std::string device);
 
-    // Select the evaluator output type from the compiled inference precision hint and warm the cache.
-    void prepare(ov::InferRequest request);
-
     // Apply adapters configured in the current config set last time, or set and use new config given as optional `config` argument
     void apply(ov::InferRequest request, const std::optional<AdapterConfig>& config = std::nullopt);
 

--- a/src/cpp/include/openvino/genai/lora_adapter.hpp
+++ b/src/cpp/include/openvino/genai/lora_adapter.hpp
@@ -193,6 +193,9 @@ public:
 
     AdapterController(std::shared_ptr<ov::Model> model, const AdapterConfig& config, std::string device);
 
+    // Select the evaluator output type from the compiled inference precision hint and warm the cache.
+    void prepare(ov::InferRequest request);
+
     // Apply adapters configured in the current config set last time, or set and use new config given as optional `config` argument
     void apply(ov::InferRequest request, const std::optional<AdapterConfig>& config = std::nullopt);
 

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1856,13 +1856,10 @@ struct AdapterControllerImpl {
         ov::OutputVector concat_inputs;
         concat_inputs.reserve(inputs.size());
         const auto output_type = output.get_element_type();
-        ov::element::Type concat_type = ov::element::dynamic;
         for(size_t i = 0; i < inputs.size(); ++i) {
             NodePtr input = parameters[(alpha_only ? 1 : 3)*i + offset] = input_accessor(inputs[i]);
-            if(concat_type == ov::element::dynamic) {
-                concat_type = input->get_output_element_type(0);
-            } else if(input->get_output_element_type(0) != concat_type) {
-                input = std::make_shared<v0::Convert>(input, concat_type);
+            if(input->get_output_element_type(0) != output_type) {
+                input = std::make_shared<v0::Convert>(input, output_type);
             }
             if(input->get_output_partial_shape(0).rank().get_length() > 2) {
                 input = squeeze_2d(input);

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <cstdlib>
 #include <set>
 #include <map>
 #include <string>
@@ -13,6 +14,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <functional>
+#include <list>
 #include <memory>
 #include <cmath>
 
@@ -36,6 +38,7 @@
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
 #include "openvino/pass/manager.hpp"
+#include "openvino/runtime/properties.hpp"
 
 #include "openvino/genai/lora_adapter.hpp"
 
@@ -746,10 +749,16 @@ class InferRequestSignatureCache {
 public:
     using Signature = std::string;
 
-    InferRequestSignatureCache (const std::string& device) : device(device) {}
+    InferRequestSignatureCache(const std::string& device, const std::string& infer_device = {}) :
+        device(device),
+        infer_device(infer_device.empty() ? device : infer_device) {}
 
     bool exist (const Signature& signature) {
         return requests.count(signature);
+    }
+
+    void clear() {
+        requests.clear();
     }
 
     void insert (const Signature& signature, ov::ResultVector& results, ov::ParameterVector& parameters) {
@@ -817,6 +826,7 @@ public:
             outputs[bypass.second] = inputs[bypass.first];
         }
         request.infer();    // TODO: Consider using async to increase throughput, requires more complicated archestration
+
     }
 
 private:
@@ -827,6 +837,7 @@ private:
 
     std::unordered_map<Signature, RequestWithBypass> requests;
     std::string device;
+    std::string infer_device;
 };
 
 
@@ -1285,15 +1296,47 @@ struct AdapterControllerImpl {
     std::unordered_set<std::string> variable_names;
     AdapterConfig current_config;
     bool need_full_apply = true;
+    bool infer_device_is_gpu = false;
+    bool output_type_initialized = false;
+    std::optional<ov::element::Type> state_output_type_override;
     InferRequestSignatureCache lora_state_evaluators;
+
+    struct PreparedTensorCacheEntry {
+        AdapterConfig config;
+        std::vector<LoRAParts<ov::Tensor>> tensors;
+        size_t byte_size = 0;
+    };
+
+    // The cache owns evaluator output tensors for the controller lifetime. Keep a small
+    // LRU bound because every entry contains alpha/A/B outputs for every transformed layer.
+    static constexpr size_t prepared_tensor_cache_capacity = 8;
+    static constexpr size_t prepared_tensor_cache_max_bytes = 512 * 1024 * 1024;
+    std::list<PreparedTensorCacheEntry> prepared_tensor_cache;
+    size_t prepared_tensor_cache_byte_size = 0;
 
     // Stores the actual LoRA weight getter used for Constant tensor replacement
     // Needed to track which LoRA tensors were actually applied to suppress unused tensor warnings
     std::shared_ptr<LoRAWeightGetterDefault<NodePtr, NodePtr>> const_getter_impl;
 
-    AdapterControllerImpl(std::shared_ptr<ov::Model> model, const AdapterConfig& config) :
+    static std::string lora_evaluator_device(const std::string& infer_device) {
+        if (const char* env = std::getenv("OV_LORA_EVALUATOR_DEVICE")) {
+            if (env[0] != '\0') {
+                std::string requested_device(env);
+                if (requested_device == "INFER" || requested_device == "infer") {
+                    return infer_device;
+                }
+                return requested_device;
+            }
+        }
+        return "CPU";
+    }
+
+    AdapterControllerImpl(std::shared_ptr<ov::Model> model,
+                          const AdapterConfig& config,
+                          const std::string& device = "CPU") :
         current_config(config),  // FIXME: Compare current and passed configs and change incrementally
-        lora_state_evaluators("CPU")    // FIXME: Try to run on the same device that is used for model inference
+        infer_device_is_gpu(device.find("GPU") != std::string::npos),
+        lora_state_evaluators(lora_evaluator_device(device), device)
     {
         LoRAConstantGetter const_getter;
         LoRAParametersByWeightGetter params_getter;
@@ -1337,7 +1380,7 @@ struct AdapterControllerImpl {
                 ov::Tensor(params_getter.type, ov::Shape{0})
             };
             auto name = node->get_friendly_name();
-            auto lora_weight = prepare_lora_tensors(name, params_getter.weight_getter, lora_placeholder, /*set_empty_tensors=*/false, /*alpha_only=*/false);
+            auto lora_weight = prepare_lora_tensors(name, params_getter.weight_getter, lora_placeholder, /*set_empty_tensors=*/false, /*alpha_only=*/false, current_config);
             if(lora_weight.alpha) {
                 return LoRANode(
                     // TODO: Make sure that tensors will not be disposed during constant life time
@@ -1402,15 +1445,17 @@ struct AdapterControllerImpl {
         bool mode = false;
         bool alpha = false;
         bool adapter = false;
+        bool tensor_name_prefix = false;
 
         operator bool() const {
-            return mode || alpha || adapter;
+            return mode || alpha || adapter || tensor_name_prefix;
         }
     };
 
     ConfigChanged compare_configs(const AdapterConfig& config1, const AdapterConfig& config2) {
         ConfigChanged diff;
         diff.mode = config1.get_mode() != config2.get_mode();
+        diff.tensor_name_prefix = config1.get_tensor_name_prefix() != config2.get_tensor_name_prefix();
         // TODO: Use `set` from this commented block when the config change tracking is implemented at adapter granularity and will track order of adapters correctly
         // std::set<Adapter>
         //     adapters1(config1.adapters.begin(), config1.adapters.end()),
@@ -1432,20 +1477,23 @@ struct AdapterControllerImpl {
         // FIXME: If a part of LoRA state tensors are not set here, then need to carefully reset state in LLMPipeline where global reset is called after the generation
         ConfigChanged diff;
         if(config) {
-            diff = compare_configs(current_config, *config);
+            AdapterConfig updated_config = current_config;
+            updated_config.update(*config);
+            diff = compare_configs(current_config, updated_config);
             OPENVINO_ASSERT(
                 !diff.mode || config->get_mode() == AdapterConfig::MODE_AUTO,  // MODE_AUTO in this call means that mode is not changed
                 "AdapterConfig::mode cannot be changed and should be configured once for a model at the initialization");
             OPENVINO_ASSERT(
                 config->get_mode() == AdapterConfig::MODE_AUTO || config->get_mode() == AdapterConfig::MODE_DYNAMIC || config->get_mode() == AdapterConfig::MODE_STATIC_RANK || (!diff.alpha && !diff.adapter),
                 "Cannot change adapters and/or the alphas when not one of the dynamic modes are used.");
-            current_config.update(*config);
+            current_config = std::move(updated_config);
         }
+        prepare(infer_request);
         if(need_full_apply) {
             need_full_apply = false;
             set_new_adapter_tensors(infer_request);
         } else if(diff) {
-            if(diff.adapter) {
+            if(diff.adapter || diff.tensor_name_prefix) {
                 set_new_adapter_tensors(infer_request);
             } else if(diff.alpha)  {
                 set_new_adapter_alphas(infer_request);
@@ -1459,6 +1507,172 @@ struct AdapterControllerImpl {
 
     void set_new_adapter_alphas (ov::InferRequest& infer_request) {
         set_new_adapter_tensors(infer_request, /*alpha_only=*/true);
+    }
+
+    bool same_prepared_tensor_cache_key(const AdapterConfig& lhs, const AdapterConfig& rhs) const {
+        return lhs.get_mode() == rhs.get_mode() &&
+               lhs.get_tensor_name_prefix() == rhs.get_tensor_name_prefix() &&
+               lhs.get_adapters_and_alphas() == rhs.get_adapters_and_alphas();
+    }
+
+    void prepare(ov::InferRequest& infer_request) {
+        std::optional<ov::element::Type> new_output_type;
+        const auto compiled_model = infer_request.get_compiled_model();
+        ov::element::Type inference_precision = ov::element::dynamic;
+        if (infer_device_is_gpu) {
+            inference_precision = compiled_model.get_property(ov::hint::inference_precision);
+            OPENVINO_ASSERT(inference_precision == ov::element::f16 ||
+                                inference_precision == ov::element::f32 ||
+                                inference_precision == ov::element::dynamic,
+                            "Unsupported GPU inference precision hint for LoRA state preparation: ",
+                            inference_precision);
+            if (inference_precision == ov::element::f16) {
+                new_output_type = ov::element::f16;
+            }
+        }
+
+        if (output_type_initialized && state_output_type_override == new_output_type) {
+            return;
+        }
+
+        state_output_type_override = new_output_type;
+        output_type_initialized = true;
+        prepared_tensor_cache.clear();
+        prepared_tensor_cache_byte_size = 0;
+        lora_state_evaluators.clear();
+
+        prepare_initial_configs();
+    }
+
+    ov::element::Type state_output_type(const ov::op::util::VariableInfo& variable_info) const {
+        OPENVINO_ASSERT(output_type_initialized,
+                        "LoRA output type must be prepared after model compilation");
+        return state_output_type_override.value_or(variable_info.data_type);
+    }
+
+    LoRAParts<ov::Tensor> allocate_lora_state_tensors(const LoRAVarIDs& lora_var_ids) const {
+        return {
+            ov::Tensor(state_output_type(lora_var_ids.alpha),
+                       dynamic_to_static(lora_var_ids.alpha.data_shape)),
+            ov::Tensor(state_output_type(lora_var_ids.A),
+                       dynamic_to_static(lora_var_ids.A.data_shape)),
+            ov::Tensor(state_output_type(lora_var_ids.B),
+                       dynamic_to_static(lora_var_ids.B.data_shape))
+        };
+    }
+
+    std::vector<LoRAWeightGetter> make_weight_getters(const AdapterConfig& config) const {
+        std::vector<LoRAWeightGetter> weight_getters;
+        const auto& adapters = config.get_adapters();
+        weight_getters.reserve(adapters.size());
+        for (const auto& adapter : adapters) {
+            auto adapter_impl = get_adapter_impl(adapter);
+            weight_getters.emplace_back(
+                LoRAWeightGetterDefault<LoRAWeight, LoRANode>(&adapter_impl->get_tensors(),
+                                                              config.get_tensor_name_prefix().value_or(std::string())));
+        }
+        return weight_getters;
+    }
+
+    void validate_prepared_tensor(const ov::Tensor& tensor,
+                                  const ov::op::util::VariableInfo& variable_info,
+                                  const ov::element::Type& expected_type) const {
+        OPENVINO_ASSERT(tensor);
+        OPENVINO_ASSERT(tensor.get_element_type() == expected_type);
+        OPENVINO_ASSERT(variable_info.data_shape.compatible(ov::PartialShape(tensor.get_shape())));
+    }
+
+    std::vector<LoRAParts<ov::Tensor>> prepare_config_tensors(
+        const AdapterConfig& config,
+        const std::vector<LoRAWeightGetter>& weight_getters) {
+        std::vector<LoRAParts<ov::Tensor>> prepared_tensors;
+        prepared_tensors.reserve(variable_ids.size());
+        for (const auto& lora_var_ids : variable_ids) {
+            auto output_tensors = allocate_lora_state_tensors(lora_var_ids.second);
+            auto tensors = prepare_lora_tensors(lora_var_ids.first,
+                                                weight_getters,
+                                                output_tensors,
+                                                /*set_empty_adapters=*/true,
+                                                /*alpha_only=*/false,
+                                                config);
+            validate_prepared_tensor(tensors.alpha,
+                                     lora_var_ids.second.alpha,
+                                     state_output_type(lora_var_ids.second.alpha));
+            validate_prepared_tensor(tensors.A,
+                                     lora_var_ids.second.A,
+                                     state_output_type(lora_var_ids.second.A));
+            validate_prepared_tensor(tensors.B,
+                                     lora_var_ids.second.B,
+                                     state_output_type(lora_var_ids.second.B));
+            prepared_tensors.push_back(std::move(tensors));
+        }
+        return prepared_tensors;
+    }
+
+    size_t prepared_tensors_byte_size(const std::vector<LoRAParts<ov::Tensor>>& tensors) const {
+        size_t result = 0;
+        for (const auto& tensor_parts : tensors) {
+            result += tensor_parts.alpha.get_byte_size();
+            result += tensor_parts.A.get_byte_size();
+            result += tensor_parts.B.get_byte_size();
+        }
+        return result;
+    }
+
+    const std::vector<LoRAParts<ov::Tensor>>& get_or_prepare_config_tensors(
+        const AdapterConfig& config,
+        const std::vector<LoRAWeightGetter>& weight_getters,
+        bool& cache_hit) {
+        for (auto it = prepared_tensor_cache.begin(); it != prepared_tensor_cache.end(); ++it) {
+            if (same_prepared_tensor_cache_key(it->config, config)) {
+                cache_hit = true;
+                prepared_tensor_cache.splice(prepared_tensor_cache.begin(), prepared_tensor_cache, it);
+                return prepared_tensor_cache.front().tensors;
+            }
+        }
+
+        cache_hit = false;
+        auto tensors = prepare_config_tensors(config, weight_getters);
+        auto byte_size = prepared_tensors_byte_size(tensors);
+
+        // Retain a single oversized entry so a valid config still benefits from caching.
+        // Otherwise evict least-recently-used entries until both limits are satisfied.
+        while (!prepared_tensor_cache.empty() &&
+               (prepared_tensor_cache.size() >= prepared_tensor_cache_capacity ||
+                byte_size > prepared_tensor_cache_max_bytes ||
+                prepared_tensor_cache_byte_size > prepared_tensor_cache_max_bytes - byte_size)) {
+            prepared_tensor_cache_byte_size -= prepared_tensor_cache.back().byte_size;
+            prepared_tensor_cache.pop_back();
+        }
+        prepared_tensor_cache.push_front({config, std::move(tensors), byte_size});
+        prepared_tensor_cache_byte_size += byte_size;
+        return prepared_tensor_cache.front().tensors;
+    }
+
+    void prepare_initial_configs() {
+        if (variable_ids.empty()) {
+            return;
+        }
+
+        std::vector<AdapterConfig> configs;
+        AdapterConfig empty_config(current_config.get_mode());
+        empty_config.set_tensor_name_prefix(current_config.get_tensor_name_prefix());
+        configs.push_back(std::move(empty_config));
+
+        for (const auto& adapter_and_alpha : current_config.get_adapters_and_alphas()) {
+            AdapterConfig single_config(adapter_and_alpha.first,
+                                        adapter_and_alpha.second,
+                                        current_config.get_mode());
+            single_config.set_tensor_name_prefix(current_config.get_tensor_name_prefix());
+            configs.push_back(std::move(single_config));
+        }
+        configs.push_back(current_config);
+
+        for (const auto& config : configs) {
+            auto weight_getters = make_weight_getters(config);
+            bool cache_hit = false;
+            get_or_prepare_config_tensors(config, weight_getters, cache_hit);
+        }
     }
 
     void set_new_adapter_tensors(ov::InferRequest& infer_request, bool alpha_only = false) {        
@@ -1497,14 +1711,22 @@ struct AdapterControllerImpl {
             state_name_to_index[name] = i;
         }
 
+        // Prepare an unseen config once, then upload cached evaluator outputs.
+        bool cache_hit = false;
+        const auto& prepared_tensors = get_or_prepare_config_tensors(current_config, weight_getters, cache_hit);
+
+        auto prepared_tensor_it = prepared_tensors.begin();
         for(const auto& lora_var_ids : variable_ids) {
             // FIXME: Remove this mapping when the order of state will be the same as the order of variables
             LoRAIndices lora_indices;
             lora_indices.alpha = state_name_to_index.at(lora_var_ids.second.alpha.variable_id);
             lora_indices.A = state_name_to_index.at(lora_var_ids.second.A.variable_id);
             lora_indices.B = state_name_to_index.at(lora_var_ids.second.B.variable_id);
-            set_lora_tensors(state, lora_var_ids.first, lora_var_ids.second, lora_indices, weight_getters, alpha_only);
+            OPENVINO_ASSERT(prepared_tensor_it != prepared_tensors.end());
+            set_lora_tensors(state, lora_var_ids.first, lora_indices, *prepared_tensor_it, alpha_only);
+            ++prepared_tensor_it;
         }
+        OPENVINO_ASSERT(prepared_tensor_it == prepared_tensors.end());
 
         for (const auto& [const_name, var_info] : constant_variable_ids) {
 
@@ -1530,11 +1752,12 @@ struct AdapterControllerImpl {
                 state[const_lora_index].set_state(const_tensor);
             }
         }
-
     }
 
-    std::vector<LoRAWeight> collect_applicable_tensors (const std::string& lora_name, const std::vector<LoRAWeightGetter>& weight_getters) {
-        const auto& adapters = current_config.get_adapters();
+    std::vector<LoRAWeight> collect_applicable_tensors (const std::string& lora_name,
+                                                        const std::vector<LoRAWeightGetter>& weight_getters,
+                                                        const AdapterConfig& config) {
+        const auto& adapters = config.get_adapters();
         OPENVINO_ASSERT(weight_getters.size() == adapters.size());
         std::vector<LoRAWeight> result;
         result.reserve(weight_getters.size());
@@ -1543,7 +1766,7 @@ struct AdapterControllerImpl {
                 // TODO: Is it practical to use alpha from the adapter file itself. In the current code it is ignored and only alpha from config is used.
                 OPENVINO_ASSERT(lora_tensors->A);
                 OPENVINO_ASSERT(lora_tensors->B);
-                lora_tensors->alpha = alpha_as_constant(current_config.get_alpha(adapters[i]));
+                lora_tensors->alpha = alpha_as_constant(config.get_alpha(adapters[i]));
                 result.push_back(LoRAWeight(
                     std::dynamic_pointer_cast<v0::Constant>(lora_tensors->alpha),
                     std::dynamic_pointer_cast<v0::Constant>(lora_tensors->A),
@@ -1632,10 +1855,14 @@ struct AdapterControllerImpl {
     ) {
         ov::OutputVector concat_inputs;
         concat_inputs.reserve(inputs.size());
+        const auto output_type = output.get_element_type();
+        ov::element::Type concat_type = ov::element::dynamic;
         for(size_t i = 0; i < inputs.size(); ++i) {
             NodePtr input = parameters[(alpha_only ? 1 : 3)*i + offset] = input_accessor(inputs[i]);
-            if(input->get_output_element_type(0) != output.get_element_type()) {
-                input = std::make_shared<v0::Convert>(input, output.get_element_type());
+            if(concat_type == ov::element::dynamic) {
+                concat_type = input->get_output_element_type(0);
+            } else if(input->get_output_element_type(0) != concat_type) {
+                input = std::make_shared<v0::Convert>(input, concat_type);
             }
             if(input->get_output_partial_shape(0).rank().get_length() > 2) {
                 input = squeeze_2d(input);
@@ -1649,6 +1876,9 @@ struct AdapterControllerImpl {
             result = std::make_shared<v0::Concat>(concat_inputs, concat_axis);
         } else {
             result = concat_inputs.front().get_node_shared_ptr();
+        }
+        if(result->get_output_element_type(0) != output_type) {
+            result = std::make_shared<v0::Convert>(result, output_type);
         }
 
         results[offset] = std::make_shared<v0::Result>(result);
@@ -1711,7 +1941,7 @@ struct AdapterControllerImpl {
         return from_tensor_vector(output_tensors, alpha_only);
     }
 
-    ov::Shape dynamic_to_static(const ov::PartialShape& pshape) {
+    ov::Shape dynamic_to_static(const ov::PartialShape& pshape) const {
         ov::Shape shape(pshape.rank().get_length());
         for(size_t i = 0; i < pshape.rank().get_length(); ++i) {
             shape[i] = pshape[i].is_dynamic() ? 0 : pshape[i].get_length();
@@ -1722,17 +1952,10 @@ struct AdapterControllerImpl {
     void set_lora_tensors(
         std::vector<VariableState>& state,
         const std::string& name,
-        const LoRAVarIDs& lora_var_ids,
         const LoRAIndices& lora_indices,
-        const std::vector<LoRAWeightGetter>& weight_getters,
+        const LoRAParts<ov::Tensor>& new_tensors,
         bool alpha_only
     ) {
-        LoRAParts<ov::Tensor> lora_state_tensors{
-            ov::Tensor(lora_var_ids.alpha.data_type, dynamic_to_static(lora_var_ids.alpha.data_shape)),
-            alpha_only ? ov::Tensor() : ov::Tensor(lora_var_ids.A.data_type, dynamic_to_static(lora_var_ids.A.data_shape)),
-            alpha_only ? ov::Tensor() : ov::Tensor(lora_var_ids.B.data_type, dynamic_to_static(lora_var_ids.B.data_shape))
-        };
-        auto new_tensors = prepare_lora_tensors(name, weight_getters, lora_state_tensors, /*set_empty_adapters=*/true, alpha_only);
         state[lora_indices.alpha].set_state(new_tensors.alpha);
         if(!alpha_only) {
             state[lora_indices.A].set_state(new_tensors.A);
@@ -1745,9 +1968,10 @@ struct AdapterControllerImpl {
         const std::vector<LoRAWeightGetter>& weight_getters,
         LoRAParts<ov::Tensor>& output,
         bool set_empty_adapters,
-        bool alpha_only
+        bool alpha_only,
+        const AdapterConfig& config
     ) {
-        auto lora_tensors = collect_applicable_tensors(name, weight_getters);  // request A and B regardless of alpha_only, because it is a way to get lora_rank later when alpha is broadcasted
+        auto lora_tensors = collect_applicable_tensors(name, weight_getters, config);  // request A and B regardless of alpha_only, because it is a way to get lora_rank later when alpha is broadcasted
         LoRAParts<ov::Tensor> new_tensors;
         if(!lora_tensors.empty()) {
             new_tensors = concat_adapters(lora_tensors, output, alpha_only);
@@ -1761,6 +1985,8 @@ struct AdapterControllerImpl {
 
 AdapterController::AdapterController(std::shared_ptr<ov::Model> model, const AdapterConfig& config, std::string device)
 {
+    const std::string infer_device = device;
+
     // If AdapterConfig::MODE_AUTO is used, then set real mode depending on the device capabilities
     // TODO: Remove this code when devices become aligned on their capabilities for LoRA adapters
     if (config.get_mode() == AdapterConfig::MODE_AUTO) {
@@ -1776,7 +2002,7 @@ AdapterController::AdapterController(std::shared_ptr<ov::Model> model, const Ada
         if(default_mode != default_modes.end()) {
             AdapterConfig updated_config = config;
             updated_config.set_mode(default_mode->second);
-            m_pimpl = std::make_shared<AdapterControllerImpl>(model, updated_config);
+            m_pimpl = std::make_shared<AdapterControllerImpl>(model, updated_config, infer_device);
             return;
         } else {
             std::string device_msg;
@@ -1791,9 +2017,14 @@ AdapterController::AdapterController(std::shared_ptr<ov::Model> model, const Ada
                 << "To avoid this warning set one of the AdapterConfig::Mode values except MODE_AUTO.";
         }
     }
-    m_pimpl = std::make_shared<AdapterControllerImpl>(model, config);
+    m_pimpl = std::make_shared<AdapterControllerImpl>(model, config, infer_device);
 }
 
+void AdapterController::prepare(ov::InferRequest request) {
+    if (m_pimpl) {
+        m_pimpl->prepare(request);
+    }
+}
 
 // Call it every time when adapter config is changed; if adapter was configured as a static one, this call is not required
 void AdapterController::apply(ov::InferRequest request, const std::optional<AdapterConfig>& config) {

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1562,11 +1562,6 @@ struct AdapterControllerImpl {
         if (infer_device_is_gpu) {
             inference_precision =
                 get_inference_precision(compiled_model, execution_devices).value_or(ov::element::dynamic);
-            OPENVINO_ASSERT(inference_precision == ov::element::f16 ||
-                                inference_precision == ov::element::f32 ||
-                                inference_precision == ov::element::dynamic,
-                            "Unsupported GPU inference precision hint for LoRA state preparation: ",
-                            inference_precision);
             if (inference_precision == ov::element::f16) {
                 new_output_type = ov::element::f16;
             }
@@ -1689,6 +1684,12 @@ struct AdapterControllerImpl {
 
     void prepare_initial_configs() {
         if (variable_ids.empty()) {
+            return;
+        }
+
+        if (current_config.get_mode() == AdapterConfig::MODE_STATIC_RANK) {
+            auto weight_getters = make_weight_getters(current_config);
+            get_or_prepare_config_tensors(current_config, weight_getters);
             return;
         }
 

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -2020,12 +2020,6 @@ AdapterController::AdapterController(std::shared_ptr<ov::Model> model, const Ada
     m_pimpl = std::make_shared<AdapterControllerImpl>(model, config, infer_device);
 }
 
-void AdapterController::prepare(ov::InferRequest request) {
-    if (m_pimpl) {
-        m_pimpl->prepare(request);
-    }
-}
-
 // Call it every time when adapter config is changed; if adapter was configured as a static one, this call is not required
 void AdapterController::apply(ov::InferRequest request, const std::optional<AdapterConfig>& config) {
     OPENVINO_ASSERT(m_pimpl || !config || !*config,

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -749,9 +749,7 @@ class InferRequestSignatureCache {
 public:
     using Signature = std::string;
 
-    InferRequestSignatureCache(const std::string& device, const std::string& infer_device = {}) :
-        device(device),
-        infer_device(infer_device.empty() ? device : infer_device) {}
+    InferRequestSignatureCache(const std::string& device) : device(device) {}
 
     bool exist (const Signature& signature) {
         return requests.count(signature);
@@ -837,7 +835,6 @@ private:
 
     std::unordered_map<Signature, RequestWithBypass> requests;
     std::string device;
-    std::string infer_device;
 };
 
 
@@ -1334,7 +1331,7 @@ struct AdapterControllerImpl {
                           const AdapterConfig& config,
                           const std::string& device = "CPU") :
         current_config(config),  // FIXME: Compare current and passed configs and change incrementally
-        lora_state_evaluators(lora_evaluator_device(device), device)
+        lora_state_evaluators(lora_evaluator_device(device))
     {
         LoRAConstantGetter const_getter;
         LoRAParametersByWeightGetter params_getter;
@@ -1665,17 +1662,14 @@ struct AdapterControllerImpl {
 
     const std::vector<LoRAParts<ov::Tensor>>& get_or_prepare_config_tensors(
         const AdapterConfig& config,
-        const std::vector<LoRAWeightGetter>& weight_getters,
-        bool& cache_hit) {
+        const std::vector<LoRAWeightGetter>& weight_getters) {
         for (auto it = prepared_tensor_cache.begin(); it != prepared_tensor_cache.end(); ++it) {
             if (same_prepared_tensor_cache_key(it->config, config)) {
-                cache_hit = true;
                 prepared_tensor_cache.splice(prepared_tensor_cache.begin(), prepared_tensor_cache, it);
                 return prepared_tensor_cache.front().tensors;
             }
         }
 
-        cache_hit = false;
         auto tensors = prepare_config_tensors(config, weight_getters);
         auto byte_size = prepared_tensors_byte_size(tensors);
 
@@ -1714,8 +1708,7 @@ struct AdapterControllerImpl {
 
         for (const auto& config : configs) {
             auto weight_getters = make_weight_getters(config);
-            bool cache_hit = false;
-            get_or_prepare_config_tensors(config, weight_getters, cache_hit);
+            get_or_prepare_config_tensors(config, weight_getters);
         }
     }
 
@@ -1756,8 +1749,7 @@ struct AdapterControllerImpl {
         }
 
         // Prepare an unseen config once, then upload cached evaluator outputs.
-        bool cache_hit = false;
-        const auto& prepared_tensors = get_or_prepare_config_tensors(current_config, weight_getters, cache_hit);
+        const auto& prepared_tensors = get_or_prepare_config_tensors(current_config, weight_getters);
 
         auto prepared_tensor_it = prepared_tensors.begin();
         for(const auto& lora_var_ids : variable_ids) {
@@ -1767,7 +1759,7 @@ struct AdapterControllerImpl {
             lora_indices.A = state_name_to_index.at(lora_var_ids.second.A.variable_id);
             lora_indices.B = state_name_to_index.at(lora_var_ids.second.B.variable_id);
             OPENVINO_ASSERT(prepared_tensor_it != prepared_tensors.end());
-            set_lora_tensors(state, lora_var_ids.first, lora_indices, *prepared_tensor_it, alpha_only);
+            set_lora_tensors(state, lora_indices, *prepared_tensor_it, alpha_only);
             ++prepared_tensor_it;
         }
         OPENVINO_ASSERT(prepared_tensor_it == prepared_tensors.end());
@@ -1992,7 +1984,6 @@ struct AdapterControllerImpl {
 
     void set_lora_tensors(
         std::vector<VariableState>& state,
-        const std::string& name,
         const LoRAIndices& lora_indices,
         const LoRAParts<ov::Tensor>& new_tensors,
         bool alpha_only

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1296,7 +1296,6 @@ struct AdapterControllerImpl {
     std::unordered_set<std::string> variable_names;
     AdapterConfig current_config;
     bool need_full_apply = true;
-    bool infer_device_is_gpu = false;
     bool output_type_initialized = false;
     std::optional<ov::element::Type> state_output_type_override;
     InferRequestSignatureCache lora_state_evaluators;
@@ -1335,7 +1334,6 @@ struct AdapterControllerImpl {
                           const AdapterConfig& config,
                           const std::string& device = "CPU") :
         current_config(config),  // FIXME: Compare current and passed configs and change incrementally
-        infer_device_is_gpu(device.find("GPU") != std::string::npos),
         lora_state_evaluators(lora_evaluator_device(device), device)
     {
         LoRAConstantGetter const_getter;
@@ -1515,12 +1513,58 @@ struct AdapterControllerImpl {
                lhs.get_adapters_and_alphas() == rhs.get_adapters_and_alphas();
     }
 
+    std::optional<ov::element::Type> get_inference_precision(
+        const ov::CompiledModel& compiled_model,
+        const std::vector<std::string>& execution_devices) const {
+        const auto supported_properties = compiled_model.get_property(ov::supported_properties);
+        if (std::find(supported_properties.begin(),
+                      supported_properties.end(),
+                      ov::hint::inference_precision) != supported_properties.end()) {
+            return compiled_model.get_property(ov::hint::inference_precision);
+        }
+
+        if (std::find(supported_properties.begin(),
+                      supported_properties.end(),
+                      ov::device::properties) == supported_properties.end()) {
+            return std::nullopt;
+        }
+
+        const auto device_properties = compiled_model.get_property(ov::device::properties);
+        std::optional<ov::element::Type> inference_precision;
+        for (const auto& device : execution_devices) {
+            const auto device_it = device_properties.find(device);
+            if (device_it == device_properties.end()) {
+                return std::nullopt;
+            }
+
+            const auto& properties = device_it->second;
+            const auto precision_it = properties.find(ov::hint::inference_precision.name());
+            if (precision_it == properties.end()) {
+                return std::nullopt;
+            }
+
+            const auto device_precision = precision_it->second.as<ov::element::Type>();
+            if (inference_precision && *inference_precision != device_precision) {
+                return std::nullopt;
+            }
+            inference_precision = device_precision;
+        }
+        return inference_precision;
+    }
+
     void prepare(ov::InferRequest& infer_request) {
         std::optional<ov::element::Type> new_output_type;
         const auto compiled_model = infer_request.get_compiled_model();
         ov::element::Type inference_precision = ov::element::dynamic;
+        const auto execution_devices = compiled_model.get_property(ov::execution_devices);
+        const bool infer_device_is_gpu =
+            !execution_devices.empty() &&
+            std::all_of(execution_devices.begin(), execution_devices.end(), [](const std::string& device) {
+                return device.find("GPU") != std::string::npos;
+            });
         if (infer_device_is_gpu) {
-            inference_precision = compiled_model.get_property(ov::hint::inference_precision);
+            inference_precision =
+                get_inference_precision(compiled_model, execution_devices).value_or(ov::element::dynamic);
             OPENVINO_ASSERT(inference_precision == ov::element::f16 ||
                                 inference_precision == ov::element::f32 ||
                                 inference_precision == ov::element::dynamic,

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1474,7 +1474,7 @@ struct AdapterControllerImpl {
             diff.alpha = true;
         } else {
             for(auto const& adapter: adapters1) {
-                diff.alpha = config1.get_alpha(adapter) != config2.get_alpha(adapter);
+                diff.alpha |= config1.get_alpha(adapter) != config2.get_alpha(adapter);
             }
         }
         return diff;
@@ -1519,10 +1519,13 @@ struct AdapterControllerImpl {
     }
 
     // Checks whether two configs would produce the same prepared tensors, making one reusable for the other.
+    // Prepared A/B tensors don't depend on alpha (only the separately-uploaded alpha tensor does), so the
+    // key compares adapter identity only; keying on get_adapters_and_alphas() would miss the cache on every
+    // alpha-only change and force a full A/B recompute for what should be a cheap alpha update.
     bool same_prepared_tensor_cache_key(const AdapterConfig& lhs, const AdapterConfig& rhs) const {
         return lhs.get_mode() == rhs.get_mode() &&
                lhs.get_tensor_name_prefix() == rhs.get_tensor_name_prefix() &&
-               lhs.get_adapters_and_alphas() == rhs.get_adapters_and_alphas();
+               lhs.get_adapters() == rhs.get_adapters();
     }
 
     // Returns the inference precision shared by all execution devices, or nullopt if it can't be determined or differs across devices.

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1293,6 +1293,11 @@ struct AdapterControllerImpl {
     std::unordered_set<std::string> variable_names;
     AdapterConfig current_config;
     bool need_full_apply = true;
+    // Tracks which ov::InferRequest instance last received a full apply, since need_full_apply
+    // alone only reflects whether *some* request was initialized, not this one; a pipeline that
+    // recreates infer requests would otherwise skip set_new_adapter_tensors() for requests that
+    // were never actually initialized.
+    std::optional<ov::InferRequest> last_applied_infer_request;
     bool output_type_initialized = false;
     std::optional<ov::element::Type> state_output_type_override;
     InferRequestSignatureCache lora_state_evaluators;
@@ -1491,8 +1496,10 @@ struct AdapterControllerImpl {
             current_config = std::move(updated_config);
         }
         prepare(infer_request);
-        if(need_full_apply) {
+        bool is_new_infer_request = !last_applied_infer_request || *last_applied_infer_request != infer_request;
+        if(need_full_apply || is_new_infer_request) {
             need_full_apply = false;
+            last_applied_infer_request = infer_request;
             set_new_adapter_tensors(infer_request);
         } else if(diff) {
             if(diff.adapter || diff.tensor_name_prefix) {

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1305,6 +1305,13 @@ struct AdapterControllerImpl {
 
     // The cache owns evaluator output tensors for the controller lifetime. Keep a small
     // LRU bound because every entry contains alpha/A/B outputs for every transformed layer.
+    // Sized from measured LoRA adapters (r=64, BF16): a full adapter's prepared A/B tensors
+    // are ~252 MB, so 512 MiB covers roughly two full adapter configs before eviction kicks
+    // in; 8 entries bounds the config count for setups with many small/lightweight adapters,
+    // where the byte cap alone wouldn't trigger eviction soon enough. These numbers are
+    // model-dependent (rank, hidden size, and layer count all scale adapter size) and were
+    // not tuned per model; if a use case needs a different bound, exposing these as
+    // configurable properties is the natural next step.
     static constexpr size_t prepared_tensor_cache_capacity = 8;
     static constexpr size_t prepared_tensor_cache_max_bytes = 512 * 1024 * 1024;
     std::list<PreparedTensorCacheEntry> prepared_tensor_cache;
@@ -1504,12 +1511,14 @@ struct AdapterControllerImpl {
         set_new_adapter_tensors(infer_request, /*alpha_only=*/true);
     }
 
+    // Checks whether two configs would produce the same prepared tensors, making one reusable for the other.
     bool same_prepared_tensor_cache_key(const AdapterConfig& lhs, const AdapterConfig& rhs) const {
         return lhs.get_mode() == rhs.get_mode() &&
                lhs.get_tensor_name_prefix() == rhs.get_tensor_name_prefix() &&
                lhs.get_adapters_and_alphas() == rhs.get_adapters_and_alphas();
     }
 
+    // Returns the inference precision shared by all execution devices, or nullopt if it can't be determined or differs across devices.
     std::optional<ov::element::Type> get_inference_precision(
         const ov::CompiledModel& compiled_model,
         const std::vector<std::string>& execution_devices) const {
@@ -1549,10 +1558,10 @@ struct AdapterControllerImpl {
         return inference_precision;
     }
 
+    // Detects the LoRA state output type for the current infer request and resets the prepared tensor cache if it changed.
     void prepare(ov::InferRequest& infer_request) {
         std::optional<ov::element::Type> new_output_type;
         const auto compiled_model = infer_request.get_compiled_model();
-        ov::element::Type inference_precision = ov::element::dynamic;
         const auto execution_devices = compiled_model.get_property(ov::execution_devices);
         const bool infer_device_is_gpu =
             !execution_devices.empty() &&
@@ -1560,7 +1569,7 @@ struct AdapterControllerImpl {
                 return device.find("GPU") != std::string::npos;
             });
         if (infer_device_is_gpu) {
-            inference_precision =
+            const ov::element::Type inference_precision =
                 get_inference_precision(compiled_model, execution_devices).value_or(ov::element::dynamic);
             if (inference_precision == ov::element::f16) {
                 new_output_type = ov::element::f16;
@@ -1610,6 +1619,7 @@ struct AdapterControllerImpl {
         return weight_getters;
     }
 
+    // Asserts a prepared tensor has the expected type and a shape compatible with its target state.
     void validate_prepared_tensor(const ov::Tensor& tensor,
                                   const ov::op::util::VariableInfo& variable_info,
                                   const ov::element::Type& expected_type) const {
@@ -1618,6 +1628,7 @@ struct AdapterControllerImpl {
         OPENVINO_ASSERT(variable_info.data_shape.compatible(ov::PartialShape(tensor.get_shape())));
     }
 
+    // Evaluates and validates the alpha/A/B tensors for every LoRA-applicable layer for a given config.
     std::vector<LoRAParts<ov::Tensor>> prepare_config_tensors(
         const AdapterConfig& config,
         const std::vector<LoRAWeightGetter>& weight_getters) {
@@ -1645,6 +1656,7 @@ struct AdapterControllerImpl {
         return prepared_tensors;
     }
 
+    // Sums the byte size of all alpha/A/B tensors, used to track the prepared tensor cache against its byte limit.
     size_t prepared_tensors_byte_size(const std::vector<LoRAParts<ov::Tensor>>& tensors) const {
         size_t result = 0;
         for (const auto& tensor_parts : tensors) {
@@ -1655,6 +1667,7 @@ struct AdapterControllerImpl {
         return result;
     }
 
+    // Returns cached prepared tensors for a config if present, otherwise prepares and caches them, evicting LRU entries as needed.
     const std::vector<LoRAParts<ov::Tensor>>& get_or_prepare_config_tensors(
         const AdapterConfig& config,
         const std::vector<LoRAWeightGetter>& weight_getters) {

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1607,14 +1607,30 @@ struct AdapterControllerImpl {
         return state_output_type_override.value_or(variable_info.data_type);
     }
 
-    LoRAParts<ov::Tensor> allocate_lora_state_tensors(const LoRAVarIDs& lora_var_ids) const {
+    // Collapses the LoRA rank dimension so the tensor keeps its rank and remaining dimensions but
+    // holds no data. Used for the A/B outputs of an alpha-only update, which never reads them.
+    ov::Shape rank_collapsed_shape(const ov::PartialShape& data_shape, size_t rank_axis) const {
+        auto shape = dynamic_to_static(data_shape);
+        OPENVINO_ASSERT(rank_axis < shape.size());
+        shape[rank_axis] = 0;
+        return shape;
+    }
+
+    // An alpha-only update writes just the alpha state, so the A/B outputs are allocated empty
+    // instead of at full size: those allocations are the bulk of a prepared config (hundreds of MB
+    // for large adapters) and would otherwise negate the point of the alpha-only fast path. They
+    // are still allocated, rather than left default-constructed, because downstream code reads
+    // their element type and non-rank dimensions (see empty_adapters and get_lora_signature).
+    LoRAParts<ov::Tensor> allocate_lora_state_tensors(const LoRAVarIDs& lora_var_ids, bool alpha_only = false) const {
         return {
             ov::Tensor(state_output_type(lora_var_ids.alpha),
                        dynamic_to_static(lora_var_ids.alpha.data_shape)),
             ov::Tensor(state_output_type(lora_var_ids.A),
-                       dynamic_to_static(lora_var_ids.A.data_shape)),
+                       alpha_only ? rank_collapsed_shape(lora_var_ids.A.data_shape, 0)
+                                  : dynamic_to_static(lora_var_ids.A.data_shape)),
             ov::Tensor(state_output_type(lora_var_ids.B),
-                       dynamic_to_static(lora_var_ids.B.data_shape))
+                       alpha_only ? rank_collapsed_shape(lora_var_ids.B.data_shape, 1)
+                                  : dynamic_to_static(lora_var_ids.B.data_shape))
         };
     }
 
@@ -1649,7 +1665,7 @@ struct AdapterControllerImpl {
         std::vector<LoRAParts<ov::Tensor>> prepared_tensors;
         prepared_tensors.reserve(variable_ids.size());
         for (const auto& lora_var_ids : variable_ids) {
-            auto output_tensors = allocate_lora_state_tensors(lora_var_ids.second);
+            auto output_tensors = allocate_lora_state_tensors(lora_var_ids.second, alpha_only);
             auto tensors = prepare_lora_tensors(lora_var_ids.first,
                                                 weight_getters,
                                                 output_tensors,
@@ -1697,30 +1713,25 @@ struct AdapterControllerImpl {
         const AdapterConfig& config,
         const std::vector<LoRAWeightGetter>& weight_getters) {
         for (auto it = prepared_tensor_cache.begin(); it != prepared_tensor_cache.end(); ++it) {
-            if (same_prepared_tensor_cache_key(it->config, config)) {
-                prepared_tensor_cache.splice(prepared_tensor_cache.begin(), prepared_tensor_cache, it);
-                auto& entry = prepared_tensor_cache.front();
-                // The cache key covers adapter identity only, because A/B don't depend on alpha.
-                // The entry's alpha tensors, however, were evaluated under the alphas of the config
-                // that created it, so a hit from a config that differs only by alpha would otherwise
-                // apply a stale alpha. Re-evaluate just the alpha tensors in that case and keep the
-                // cached A/B: alpha is a small broadcast, while A/B are the expensive part.
-                if (!same_alphas(entry.config, config)) {
-                    auto fresh_alphas = prepare_config_tensors(config, weight_getters, /*alpha_only=*/true);
-                    OPENVINO_ASSERT(fresh_alphas.size() == entry.tensors.size());
-                    for (size_t i = 0; i < entry.tensors.size(); ++i) {
-                        entry.tensors[i].alpha = std::move(fresh_alphas[i].alpha);
-                    }
-                    entry.config = config;
-                    // Alpha shapes are alpha-independent today, but empty_adapters() can resize them,
-                    // so re-measure instead of assuming the entry's footprint is unchanged.
-                    const auto refreshed_byte_size = prepared_tensors_byte_size(entry.tensors);
-                    prepared_tensor_cache_byte_size -= entry.byte_size;
-                    prepared_tensor_cache_byte_size += refreshed_byte_size;
-                    entry.byte_size = refreshed_byte_size;
-                }
-                return entry.tensors;
+            if (!same_prepared_tensor_cache_key(it->config, config)) {
+                continue;
             }
+            // The cache key covers adapter identity only, because A/B don't depend on alpha. The
+            // entry's alpha tensors, however, were evaluated under the alphas of the config that
+            // created it, so a hit from a config that differs only by alpha would otherwise apply a
+            // stale alpha. Re-evaluate just the alpha tensors in that case and keep the cached A/B:
+            // alpha is a small broadcast, while A/B are the expensive part. Alpha tensors keep the
+            // shape and type declared by the variable, so the entry's byte size is unaffected.
+            if (!same_alphas(it->config, config)) {
+                auto fresh_alphas = prepare_config_tensors(config, weight_getters, /*alpha_only=*/true);
+                OPENVINO_ASSERT(fresh_alphas.size() == it->tensors.size());
+                for (size_t i = 0; i < it->tensors.size(); ++i) {
+                    it->tensors[i].alpha = std::move(fresh_alphas[i].alpha);
+                }
+                it->config = config;
+            }
+            prepared_tensor_cache.splice(prepared_tensor_cache.begin(), prepared_tensor_cache, it);
+            return prepared_tensor_cache.front().tensors;
         }
 
         auto tensors = prepare_config_tensors(config, weight_getters);
@@ -1896,8 +1907,11 @@ struct AdapterControllerImpl {
         return tensor ? get_tensor_signature(tensor.get_element_type(), overridden_shape) : Signature();
     }
 
-    Signature get_lora_signature(const std::vector<LoRAWeight>& inputs, const LoRAParts<ov::Tensor>& outputs) {
-        Signature signature;
+    Signature get_lora_signature(const std::vector<LoRAWeight>& inputs, const LoRAParts<ov::Tensor>& outputs, bool alpha_only) {
+        // The alpha-only model has a different arity than the full one (N parameters and a single
+        // result instead of 3N and 3), so it needs its own signature. Output tensors are allocated
+        // for alpha/A/B regardless of alpha_only, so they cannot tell the two models apart.
+        Signature signature = alpha_only ? "(alpha_only)" : Signature();
         for(const auto& input: inputs) {
             signature +=
                 std::string("(") +
@@ -1994,7 +2008,7 @@ struct AdapterControllerImpl {
     }
 
     LoRAParts<ov::Tensor> concat_adapters(const std::vector<LoRAWeight>& inputs, LoRAParts<ov::Tensor>& outputs, bool alpha_only) {
-        auto signature = get_lora_signature(inputs, outputs);
+        auto signature = get_lora_signature(inputs, outputs, alpha_only);
         size_t inputs_per_adapter = alpha_only ? 1 : 3;
         if(!lora_state_evaluators.exist(signature)) {
             // Prepare LoRA state evaluate model

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1331,7 +1331,7 @@ struct AdapterControllerImpl {
             if (env[0] != '\0') {
                 std::string requested_device(env);
                 if (requested_device == "INFER" || requested_device == "infer") {
-                    return infer_device;
+                    return infer_device.empty() ? "CPU" : infer_device;
                 }
                 return requested_device;
             }

--- a/src/cpp/src/lora/adapter.cpp
+++ b/src/cpp/src/lora/adapter.cpp
@@ -1518,10 +1518,12 @@ struct AdapterControllerImpl {
         set_new_adapter_tensors(infer_request, /*alpha_only=*/true);
     }
 
-    // Checks whether two configs would produce the same prepared tensors, making one reusable for the other.
-    // Prepared A/B tensors don't depend on alpha (only the separately-uploaded alpha tensor does), so the
-    // key compares adapter identity only; keying on get_adapters_and_alphas() would miss the cache on every
-    // alpha-only change and force a full A/B recompute for what should be a cheap alpha update.
+    // Checks whether two configs would produce the same prepared A/B tensors, making one reusable for
+    // the other. Prepared A/B tensors don't depend on alpha (only the separately-uploaded alpha tensor
+    // does), so the key compares adapter identity only; keying on get_adapters_and_alphas() would miss
+    // the cache on every alpha-only change and force a full A/B recompute for what should be a cheap
+    // alpha update. Since a hit therefore says nothing about alpha, get_or_prepare_config_tensors()
+    // re-evaluates the alpha tensors whenever the hit entry was built with different alphas.
     bool same_prepared_tensor_cache_key(const AdapterConfig& lhs, const AdapterConfig& rhs) const {
         return lhs.get_mode() == rhs.get_mode() &&
                lhs.get_tensor_name_prefix() == rhs.get_tensor_name_prefix() &&
@@ -1638,10 +1640,12 @@ struct AdapterControllerImpl {
         OPENVINO_ASSERT(variable_info.data_shape.compatible(ov::PartialShape(tensor.get_shape())));
     }
 
-    // Evaluates and validates the alpha/A/B tensors for every LoRA-applicable layer for a given config.
+    // Evaluates and validates the alpha (and, unless alpha_only, A/B) tensors for every
+    // LoRA-applicable layer for a given config.
     std::vector<LoRAParts<ov::Tensor>> prepare_config_tensors(
         const AdapterConfig& config,
-        const std::vector<LoRAWeightGetter>& weight_getters) {
+        const std::vector<LoRAWeightGetter>& weight_getters,
+        bool alpha_only = false) {
         std::vector<LoRAParts<ov::Tensor>> prepared_tensors;
         prepared_tensors.reserve(variable_ids.size());
         for (const auto& lora_var_ids : variable_ids) {
@@ -1650,17 +1654,19 @@ struct AdapterControllerImpl {
                                                 weight_getters,
                                                 output_tensors,
                                                 /*set_empty_adapters=*/true,
-                                                /*alpha_only=*/false,
+                                                alpha_only,
                                                 config);
             validate_prepared_tensor(tensors.alpha,
                                      lora_var_ids.second.alpha,
                                      state_output_type(lora_var_ids.second.alpha));
-            validate_prepared_tensor(tensors.A,
-                                     lora_var_ids.second.A,
-                                     state_output_type(lora_var_ids.second.A));
-            validate_prepared_tensor(tensors.B,
-                                     lora_var_ids.second.B,
-                                     state_output_type(lora_var_ids.second.B));
+            if (!alpha_only) {
+                validate_prepared_tensor(tensors.A,
+                                         lora_var_ids.second.A,
+                                         state_output_type(lora_var_ids.second.A));
+                validate_prepared_tensor(tensors.B,
+                                         lora_var_ids.second.B,
+                                         state_output_type(lora_var_ids.second.B));
+            }
             prepared_tensors.push_back(std::move(tensors));
         }
         return prepared_tensors;
@@ -1677,6 +1683,15 @@ struct AdapterControllerImpl {
         return result;
     }
 
+    // Returns whether both configs assign the same alpha to every adapter. Callers must have
+    // already established that the adapter lists match (see same_prepared_tensor_cache_key).
+    bool same_alphas(const AdapterConfig& lhs, const AdapterConfig& rhs) const {
+        const auto& adapters = lhs.get_adapters();
+        return std::all_of(adapters.begin(), adapters.end(), [&](const Adapter& adapter) {
+            return lhs.get_alpha(adapter) == rhs.get_alpha(adapter);
+        });
+    }
+
     // Returns cached prepared tensors for a config if present, otherwise prepares and caches them, evicting LRU entries as needed.
     const std::vector<LoRAParts<ov::Tensor>>& get_or_prepare_config_tensors(
         const AdapterConfig& config,
@@ -1684,7 +1699,27 @@ struct AdapterControllerImpl {
         for (auto it = prepared_tensor_cache.begin(); it != prepared_tensor_cache.end(); ++it) {
             if (same_prepared_tensor_cache_key(it->config, config)) {
                 prepared_tensor_cache.splice(prepared_tensor_cache.begin(), prepared_tensor_cache, it);
-                return prepared_tensor_cache.front().tensors;
+                auto& entry = prepared_tensor_cache.front();
+                // The cache key covers adapter identity only, because A/B don't depend on alpha.
+                // The entry's alpha tensors, however, were evaluated under the alphas of the config
+                // that created it, so a hit from a config that differs only by alpha would otherwise
+                // apply a stale alpha. Re-evaluate just the alpha tensors in that case and keep the
+                // cached A/B: alpha is a small broadcast, while A/B are the expensive part.
+                if (!same_alphas(entry.config, config)) {
+                    auto fresh_alphas = prepare_config_tensors(config, weight_getters, /*alpha_only=*/true);
+                    OPENVINO_ASSERT(fresh_alphas.size() == entry.tensors.size());
+                    for (size_t i = 0; i < entry.tensors.size(); ++i) {
+                        entry.tensors[i].alpha = std::move(fresh_alphas[i].alpha);
+                    }
+                    entry.config = config;
+                    // Alpha shapes are alpha-independent today, but empty_adapters() can resize them,
+                    // so re-measure instead of assuming the entry's footprint is unchanged.
+                    const auto refreshed_byte_size = prepared_tensors_byte_size(entry.tensors);
+                    prepared_tensor_cache_byte_size -= entry.byte_size;
+                    prepared_tensor_cache_byte_size += refreshed_byte_size;
+                    entry.byte_size = refreshed_byte_size;
+                }
+                return entry.tensors;
             }
         }
 
@@ -1772,8 +1807,18 @@ struct AdapterControllerImpl {
             state_name_to_index[name] = i;
         }
 
-        // Prepare an unseen config once, then upload cached evaluator outputs.
-        const auto& prepared_tensors = get_or_prepare_config_tensors(current_config, weight_getters);
+        // An alpha-only update needs neither the cached A/B nor a new cache entry, so evaluate
+        // just the alpha tensors directly. The full path goes through the cache, which refreshes
+        // stale alpha tensors on a hit (see get_or_prepare_config_tensors).
+        std::vector<LoRAParts<ov::Tensor>> alpha_only_tensors;
+        const std::vector<LoRAParts<ov::Tensor>>* prepared_tensors_ptr;
+        if (alpha_only) {
+            alpha_only_tensors = prepare_config_tensors(current_config, weight_getters, /*alpha_only=*/true);
+            prepared_tensors_ptr = &alpha_only_tensors;
+        } else {
+            prepared_tensors_ptr = &get_or_prepare_config_tensors(current_config, weight_getters);
+        }
+        const auto& prepared_tensors = *prepared_tensors_ptr;
 
         auto prepared_tensor_it = prepared_tensors.begin();
         for(const auto& lora_var_ids : variable_ids) {

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -183,6 +183,9 @@ private:
 
         m_language = compiled_language_model.create_infer_request();
         m_language.get_tensor("attention_mask").set_shape({1, 0});
+        if (m_adapter_controller) {
+            m_adapter_controller->prepare(m_language);
+        }
 
         // Reinsert device_properties so InputsEmbedder sub-models can resolve
         // per-role and per-device overrides via utils::get_model_properties(...).
@@ -234,6 +237,9 @@ private:
         m_language = utils::singleton_core().compile_model(
             language_model, device, lm_properties).create_infer_request();
         m_language.get_tensor("attention_mask").set_shape({1, 0});
+        if (m_adapter_controller) {
+            m_adapter_controller->prepare(m_language);
+        }
         finalize_initialization(language_model, kv_pos);
     }
 public:

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -184,7 +184,7 @@ private:
         m_language = compiled_language_model.create_infer_request();
         m_language.get_tensor("attention_mask").set_shape({1, 0});
         if (m_adapter_controller) {
-            m_adapter_controller->prepare(m_language);
+            m_adapter_controller->apply(m_language);
         }
 
         // Reinsert device_properties so InputsEmbedder sub-models can resolve
@@ -238,7 +238,7 @@ private:
             language_model, device, lm_properties).create_infer_request();
         m_language.get_tensor("attention_mask").set_shape({1, 0});
         if (m_adapter_controller) {
-            m_adapter_controller->prepare(m_language);
+            m_adapter_controller->apply(m_language);
         }
         finalize_initialization(language_model, kv_pos);
     }

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -873,7 +873,8 @@ private:
         if (m_is_chat_conversation) {
             if (m_use_full_chat_history) {
                 cache_state.reset_state();
-                m_language.reset_state();
+                // Keep LoRA state: reset_state() would clear it and apply() below does not restore it.
+                reset_language_state();
                 m_language.get_tensor("attention_mask").set_shape({1, 0});
             } else {
                 bool needs_full_reset = cache_state.needs_reset();

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -210,12 +210,10 @@ class TestLora:
         if not gpu_devices:
             pytest.skip("GPU device not available")
 
-        # Prefer GPU.1: on Raptor Lake + BMG (discrete) machines, GPU.0 (iGPU) has hit
-        # CL_OUT_OF_RESOURCES on this VLM+LoRA workload (see work_log_20260907_00.md).
-        # "Prefer discrete" isn't reliable across all generations (newer iGPUs are much
-        # stronger), but with exactly this known failure mode, GPU.1 is the safer default
-        # when more than one GPU is enumerated.
-        target_device = gpu_devices[0] if len(gpu_devices) == 1 else "GPU.1"
+        # Prefer the second enumerated GPU: the first (iGPU) has hit CL_OUT_OF_RESOURCES
+        # on this VLM+LoRA workload on some machines. Index into the discovered list
+        # instead of hardcoding "GPU.1", which isn't guaranteed by every driver.
+        target_device = gpu_devices[0] if len(gpu_devices) == 1 else gpu_devices[1]
 
         adapter_path, image_path = download_test_content
         assert os.path.exists(image_path), f"Missing test image: {image_path}"
@@ -226,8 +224,12 @@ class TestLora:
         adapter = ov_genai.Adapter(adapter_path)
         config_a = ov_genai.AdapterConfig()
         config_a.add(adapter, 2.0)
+        # Alpha 0.0 disables the adapter's contribution entirely, so config B is guaranteed to differ
+        # from config A observably. Nearby alphas (e.g. 0.5 vs 2.0) can produce identical greedy output
+        # on this model, which would make the "B differs from A" assertion below flaky rather than
+        # meaningful.
         config_b = ov_genai.AdapterConfig()
-        config_b.add(adapter, 0.5)
+        config_b.add(adapter, 0.0)
 
         # Force f16 inference precision so this test reliably exercises the f16-specific
         # prepared-tensor allocation/caching path in AdapterControllerImpl, rather than
@@ -254,7 +256,7 @@ class TestLora:
         # Asserting the outputs differ is what makes the A -> B -> A check below meaningful: without
         # it, ignoring alpha entirely would still satisfy every other assertion in this test.
         assert result_b.texts[0] != result_a_first.texts[0], (
-            "Config B (alpha=0.5) should not reproduce config A (alpha=2.0) output; "
+            "Config B (alpha=0.0) should not reproduce config A (alpha=2.0) output; "
             "identical output suggests the alpha update was ignored"
         )
 

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -260,6 +260,17 @@ class TestLora:
             "identical output suggests the alpha update was ignored"
         )
 
+        # The check above only shows B's output differs from A's, which greedy decoding could in
+        # principle satisfy even if alpha=0.0 weren't fully zeroing the adapter's contribution.
+        # Alpha=0.0 must exactly zero out the adapter's contribution, so its output should match a
+        # pipeline with no adapter applied at all; this is a stronger, decoding-independent check.
+        result_no_adapter = pipe.generate(
+            prompt, images=[image_tensor], generation_config=generation_config, adapters=ov_genai.AdapterConfig()
+        )
+        assert result_b.texts[0] == result_no_adapter.texts[0], (
+            "Config B (alpha=0.0) should exactly match a no-adapter baseline"
+        )
+
         result_a_second = pipe.generate(
             prompt, images=[image_tensor], generation_config=generation_config, adapters=config_a
         )

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -210,7 +210,12 @@ class TestLora:
         if not gpu_devices:
             pytest.skip("GPU device not available")
 
-        target_device = gpu_devices[0] if len(gpu_devices) == 1 else gpu_devices[1]
+        # Prefer GPU.1: on Raptor Lake + BMG (discrete) machines, GPU.0 (iGPU) has hit
+        # CL_OUT_OF_RESOURCES on this VLM+LoRA workload (see work_log_20260907_00.md).
+        # "Prefer discrete" isn't reliable across all generations (newer iGPUs are much
+        # stronger), but with exactly this known failure mode, GPU.1 is the safer default
+        # when more than one GPU is enumerated.
+        target_device = gpu_devices[0] if len(gpu_devices) == 1 else "GPU.1"
 
         adapter_path, image_path = download_test_content
         assert os.path.exists(image_path), f"Missing test image: {image_path}"
@@ -224,7 +229,16 @@ class TestLora:
         config_b = ov_genai.AdapterConfig()
         config_b.add(adapter, 0.5)
 
-        pipe = ov_genai.VLMPipeline(convert_model, target_device, ATTENTION_BACKEND="PA", adapters=config_a)
+        # Force f16 inference precision so this test reliably exercises the f16-specific
+        # prepared-tensor allocation/caching path in AdapterControllerImpl, rather than
+        # depending on the GPU plugin's default (which may resolve to "dynamic").
+        pipe = ov_genai.VLMPipeline(
+            convert_model,
+            target_device,
+            ATTENTION_BACKEND="PA",
+            adapters=config_a,
+            INFERENCE_PRECISION_HINT=ov.Type.f16,
+        )
 
         generation_config = ov_genai.GenerationConfig()
         generation_config.max_new_tokens = 100

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -18,7 +18,7 @@ class TestLora:
     @pytest.mark.parametrize("convert_model", ["TinyStories-1M"], indirect=True)
     @pytest.mark.parametrize("sample_args", ["How to create a table with two columns, one of them has type float, another one has type int?"])
     @pytest.mark.parametrize("download_test_content", ["adapter_model.safetensors"], indirect=True)
-    def test_python_sample_lora(self, convert_model, download_test_content, sample_args):      
+    def test_python_sample_lora(self, convert_model, download_test_content, sample_args):
         py_script = SAMPLES_PY_DIR / "text_generation/lora_greedy_causal_lm.py"
         py_command = [sys.executable, py_script, convert_model, download_test_content, sample_args]
         run_sample(py_command)
@@ -189,3 +189,59 @@ class TestLora:
             adapters=ov_genai.AdapterConfig(),
         )
         assert len(result_without_lora.texts[0]) > 0, "Generation without LoRA should produce output"
+
+    @pytest.mark.vlm
+    @pytest.mark.parametrize(
+        "convert_model, download_test_content, prompt",
+        [
+            pytest.param(
+                "Qwen2-VL-2B-Instruct",
+                ("qwen2b_lora_100_adapter_model.safetensors", "monalisa.jpg"),
+                "Who drew this painting?",
+            ),
+        ],
+        indirect=["convert_model", "download_test_content"],
+    )
+    def test_visual_language_lora_switch_gpu_precision_cache(self, convert_model, download_test_content, prompt):
+        # Covers the GPU inference-precision-aware prepared tensor cache in AdapterControllerImpl:
+        # switching configs must invalidate/reprepare cached tensors as needed, and switching back
+        # to a previously used config must still produce the same output as the first time it was used.
+        gpu_devices = [device for device in ov.Core().get_available_devices() if device.startswith("GPU")]
+        if not gpu_devices:
+            pytest.skip("GPU device not available")
+
+        target_device = gpu_devices[0] if len(gpu_devices) == 1 else "GPU.1"
+
+        adapter_path, image_path = download_test_content
+        assert os.path.exists(image_path), f"Missing test image: {image_path}"
+
+        image = Image.open(image_path).convert("RGB")
+        image_tensor = ov.Tensor(np.array(image))
+
+        adapter = ov_genai.Adapter(adapter_path)
+        config_a = ov_genai.AdapterConfig()
+        config_a.add(adapter, 2.0)
+        config_b = ov_genai.AdapterConfig()
+        config_b.add(adapter, 0.5)
+
+        pipe = ov_genai.VLMPipeline(convert_model, target_device, ATTENTION_BACKEND="PA", adapters=config_a)
+
+        generation_config = ov_genai.GenerationConfig()
+        generation_config.max_new_tokens = 100
+
+        result_a_first = pipe.generate(prompt, images=[image_tensor], generation_config=generation_config)
+        assert len(result_a_first.texts[0]) > 0, "Generation with config A should produce output"
+
+        result_b = pipe.generate(
+            prompt, images=[image_tensor], generation_config=generation_config, adapters=config_b
+        )
+        assert len(result_b.texts[0]) > 0, "Generation with config B should produce output"
+
+        result_a_second = pipe.generate(
+            prompt, images=[image_tensor], generation_config=generation_config, adapters=config_a
+        )
+        assert len(result_a_second.texts[0]) > 0, "Generation after switching back to config A should produce output"
+
+        assert result_a_second.texts[0] == result_a_first.texts[0], (
+            "Switching A -> B -> A should reproduce the original config A output"
+        )

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -210,7 +210,7 @@ class TestLora:
         if not gpu_devices:
             pytest.skip("GPU device not available")
 
-        target_device = gpu_devices[0] if len(gpu_devices) == 1 else "GPU.1"
+        target_device = gpu_devices[0] if len(gpu_devices) == 1 else gpu_devices[1]
 
         adapter_path, image_path = download_test_content
         assert os.path.exists(image_path), f"Missing test image: {image_path}"
@@ -232,9 +232,7 @@ class TestLora:
         result_a_first = pipe.generate(prompt, images=[image_tensor], generation_config=generation_config)
         assert len(result_a_first.texts[0]) > 0, "Generation with config A should produce output"
 
-        result_b = pipe.generate(
-            prompt, images=[image_tensor], generation_config=generation_config, adapters=config_b
-        )
+        result_b = pipe.generate(prompt, images=[image_tensor], generation_config=generation_config, adapters=config_b)
         assert len(result_b.texts[0]) > 0, "Generation with config B should produce output"
 
         result_a_second = pipe.generate(

--- a/tests/python_tests/samples/test_lora.py
+++ b/tests/python_tests/samples/test_lora.py
@@ -249,6 +249,15 @@ class TestLora:
         result_b = pipe.generate(prompt, images=[image_tensor], generation_config=generation_config, adapters=config_b)
         assert len(result_b.texts[0]) > 0, "Generation with config B should produce output"
 
+        # A and B share the same adapter and differ only by alpha. The prepared-tensor cache is keyed
+        # on adapter identity alone, so a stale cached alpha would make B silently reuse A's scaling.
+        # Asserting the outputs differ is what makes the A -> B -> A check below meaningful: without
+        # it, ignoring alpha entirely would still satisfy every other assertion in this test.
+        assert result_b.texts[0] != result_a_first.texts[0], (
+            "Config B (alpha=0.5) should not reproduce config A (alpha=2.0) output; "
+            "identical output suggests the alpha update was ignored"
+        )
+
         result_a_second = pipe.generate(
             prompt, images=[image_tensor], generation_config=generation_config, adapters=config_a
         )


### PR DESCRIPTION
## Description

Runtime LoRA switching previously ran the concat evaluator and then passed its outputs to `VariableState::set_state()`. When the evaluator output type did not match the GPU variable-state type, the GPU plugin fell back to element-wise CPU conversion and copy. Processing approximately 250 MB x 2 of LoRA tensor data made a single adapter switch take close to 500 ms.

This change prepares and caches the concat evaluator outputs per `AdapterConfig` during VLM construction. On GPU, when the compiled model's `ov::hint::inference_precision` is `f16`, the evaluator produces `f16` LoRA state tensors. Every other case preserves the declared state types. Matching the GPU state type avoids the CPU conversion loop and enables the direct GPU copy path.

The cache holds the large `A` and `B` tensors. On a cache hit, switching reuses them instead of running the concat evaluator for `A` and `B`. Alpha is not part of the cache key, so changing only alpha still reuses the cached `A` and `B`, and alpha alone is re-evaluated, which is cheap. A cache miss evaluates the configuration once and stores the result in a bounded LRU cache. Reapplying the same adapter remains a no-op. With cache hits and matching `f16` tensors, measured switching latency was reduced from close to 500 ms to approximately 30 ms.


Validation:

- `pre-commit run --from-ref upstream/master --to-ref HEAD`: passed
- Windows Release build: passed
- End-to-end VLM LoRA switching test: passed
- WWB accuracy comparison against the code before this change: no regression observed. Detailed results are available in CVS-187607.

CVS-187607

## Checklist:
- [x] Tests have been added: `test_visual_language_lora_switch_prepared_tensor_cache` (LoRA A→B→A switching + alpha-zero equivalence assertion).


## AI Assistance
- AI assistance used: yes