### PR TITLE
Patch Qwen3 chat template with unsupported syntax

### DIFF
--- a/src/cpp/src/visual_language/qwen3_5/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_5/classes.cpp
@@ -12,7 +12,9 @@ InputsEmbedderQwen3_5::InputsEmbedderQwen3_5(
     const Tokenizer& tokenizer,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen3VL(vlm_config, model_dir, tokenizer, device, device_config) {}
+) : InputsEmbedderQwen3VL(vlm_config, model_dir, tokenizer, device, device_config) {
+    patch_chat_template();
+}
 
 InputsEmbedderQwen3_5::InputsEmbedderQwen3_5(
     const VLMConfig& vlm_config,
@@ -21,7 +23,20 @@ InputsEmbedderQwen3_5::InputsEmbedderQwen3_5(
     const std::filesystem::path& config_dir_path,
     const std::string& device,
     const ov::AnyMap device_config
-) : InputsEmbedderQwen3VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {}
+) : InputsEmbedderQwen3VL(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {
+    patch_chat_template();
+}
+
+void InputsEmbedderQwen3_5::patch_chat_template() {
+    std::string patched_chat_template = m_tokenizer.get_chat_template();
+    // minja does not support "undefined" keyword for "is" operator:
+    // e.g. "if enable_thinking is undefined" in Qwen3.8 chat template.
+    // Replace with supported syntax "not var is defined"
+    const std::regex var_is_undefined_pattern{R"((\b[\w\.]+)\s+is\s+undefined)"};
+    patched_chat_template = std::regex_replace(patched_chat_template, var_is_undefined_pattern, "not $1 is defined");
+
+    m_tokenizer.set_chat_template(patched_chat_template);
+}
 
 std::pair<ov::Tensor, int64_t> InputsEmbedderQwen3_5::create_position_ids(
     const ov::Tensor& input_ids_tensor,

--- a/src/cpp/src/visual_language/qwen3_5/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_5/classes.hpp
@@ -54,6 +54,8 @@ protected:
         const int64_t vision_start_token_id,
         const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
     ) override;
+
+    void patch_chat_template();
 };
 
 } // namespace ov::genai


### PR DESCRIPTION
## Description
Minja chat template engine does not support "undefined" keyword for "is" operator (e.g. "if enable_thinking is undefined").
This PR patches chat template with supported syntax "not var is defined".

CVS-192692

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- N/A - Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the ticket.
- N/A - I have made corresponding changes to the documentation.
