### PR TITLE
[Qwen3-ASR] Fix encoder remainder output token count

### DIFF
--- a/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/encoder.cpp
+++ b/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/encoder.cpp
@@ -79,8 +79,26 @@ ov::Tensor Qwen3ASREncoder::chunk_mel_features(const WhisperFeatures& features) 
 }
 
 size_t Qwen3ASREncoder::get_remainder_output_tokens(const size_t remainder_frames, const size_t tokens_per_full_chunk) {
-    // Integer ceil of: remainder_frames * tokens_per_full_chunk / m_encoder_chunk_frames.
-    return (remainder_frames * tokens_per_full_chunk + m_encoder_chunk_frames - 1) / m_encoder_chunk_frames;
+    // The encoder downsamples time with three Conv2d stages (kernel=3, stride=2, padding=1), each
+    // yielding out = ceil(in / 2). Mirrors _get_feat_extract_output_lengths() in the original Qwen
+    // ASR implementation.
+    size_t output_tokens = remainder_frames;
+    for (size_t i = 0; i < 3; ++i) {
+        output_tokens = (output_tokens + 1) / 2;
+    }
+
+    OPENVINO_ASSERT(output_tokens <= tokens_per_full_chunk,
+                    "Qwen3-ASR encoder tail chunk yields more tokens than a full chunk: ",
+                    output_tokens,
+                    " > ",
+                    tokens_per_full_chunk,
+                    " (remainder_frames=",
+                    remainder_frames,
+                    ", encoder_chunk_frames=",
+                    m_encoder_chunk_frames,
+                    "). Check that the model config matches the exported encoder geometry.");
+
+    return output_tokens;
 }
 
 ov::Tensor Qwen3ASREncoder::merge_chunked_encoder_output(const ov::Tensor& chunked_output, size_t remainder_frames) {

--- a/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/encoder.hpp
+++ b/src/cpp/src/automatic_speech_recognition/models/qwen3-asr/encoder.hpp
@@ -20,8 +20,8 @@ private:
     InferRequest m_request;
     Qwen3ASRConfig m_model_config;
 
-    // The original Qwen3-ASR encoder processes mel spectrograms in chunks of N_WINDOW*2=200 frames,
-    // applies positional embeddings per-chunk (positions 0..24), and uses windowed attention.
+    // The original Qwen3-ASR encoder processes mel spectrograms in chunks of n_window * 2 frames
+    // and applies positional embeddings independently to each chunk.
     const size_t m_encoder_chunk_frames = m_model_config.n_window * 2;
 
     ov::Tensor chunk_mel_features(const WhisperFeatures& features);


### PR DESCRIPTION
### Problem

Qwen3-ASR splits mel features into n_window * 2 frame chunks. For the final partial chunk, GenAI calculated the number of valid encoder output tokens proportionally:

``` c++
ceil(remainder_frames * tokens_per_full_chunk / chunk_frames)
```
while we have three discrete convolution downsampling:
``` C++
ceil(ceil(ceil(r / 2) / 2) / 2)
```

So, this formula does not always match the encoder's actual downsampling when n_window=50 (100 frames → 13 tokens).

For example, with 208 mel frames:
```
100 + 100 + 8
```

original Qwen keeps:
```
13 + 13 + 1 = 27
```
while GenAI kept:
```
13 + 13 + 2 = 28
```
### Fix

Calculate the valid remainder output length using the actual encoder geometry: three Conv2d stages with stride=2, each producing ceil(input / 2).

The chunking and zero-padding behavior is unchanged.

Also correct the encoder comment that assumed N_WINDOW*2=200.

### Verification
- [x] exhaustive remainder check for `1..99`:  fixed implementation matches the original Qwen formula for all values; previous formula mismatches 30/99 remainder values;
- [x] 208-frame case: 28 -> 27, matching original Qwen;
- [x] existing Qwen3-ASR Python tests: 13 passed.