### PR TITLE
Extend VLM perf metrics

### DIFF
--- a/samples/cpp/visual_language_chat/benchmark_vlm.cpp
+++ b/samples/cpp/visual_language_chat/benchmark_vlm.cpp
@@ -158,7 +158,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "Tokenization time: " << metrics.get_tokenization_duration().mean << " ± " << metrics.get_tokenization_duration().std << " ms" << std::endl;
     std::cout << "Detokenization time: " << metrics.get_detokenization_duration().mean << " ± " << metrics.get_detokenization_duration().std << " ms" << std::endl;
     std::cout << "Embeddings preparation time: " << metrics.get_prepare_embeddings_duration().mean << " ± " << metrics.get_prepare_embeddings_duration().std << " ms" << std::endl;
-    std::cout << "  Vision encoding time: " << metrics.get_vision_encoder_duration().mean << " ± " << metrics.get_vision_encoder_duration().std << " ms" << std::endl;
+    std::cout << "  Vision encoding time: " << metrics.get_vision_encoding_duration().mean << " ± " << metrics.get_vision_encoding_duration().std << " ms" << std::endl;
     std::cout << "  Text embedding time: " << metrics.get_text_embedding_duration().mean << " ± " << metrics.get_text_embedding_duration().std << " ms" << std::endl;
     std::cout << "TTFT: " << metrics.get_ttft().mean  << " ± " << metrics.get_ttft().std << " ms" << std::endl;
     std::cout << "TPOT: " << metrics.get_tpot().mean  << " ± " << metrics.get_tpot().std << " ms/token " << std::endl;

--- a/samples/cpp/visual_language_chat/benchmark_vlm.cpp
+++ b/samples/cpp/visual_language_chat/benchmark_vlm.cpp
@@ -158,6 +158,8 @@ int main(int argc, char* argv[]) try {
     std::cout << "Tokenization time: " << metrics.get_tokenization_duration().mean << " ± " << metrics.get_tokenization_duration().std << " ms" << std::endl;
     std::cout << "Detokenization time: " << metrics.get_detokenization_duration().mean << " ± " << metrics.get_detokenization_duration().std << " ms" << std::endl;
     std::cout << "Embeddings preparation time: " << metrics.get_prepare_embeddings_duration().mean << " ± " << metrics.get_prepare_embeddings_duration().std << " ms" << std::endl;
+    std::cout << "  Vision encoding time: " << metrics.get_vision_encoder_duration().mean << " ± " << metrics.get_vision_encoder_duration().std << " ms" << std::endl;
+    std::cout << "  Text embedding time: " << metrics.get_text_embedding_duration().mean << " ± " << metrics.get_text_embedding_duration().std << " ms" << std::endl;
     std::cout << "TTFT: " << metrics.get_ttft().mean  << " ± " << metrics.get_ttft().std << " ms" << std::endl;
     std::cout << "TPOT: " << metrics.get_tpot().mean  << " ± " << metrics.get_tpot().std << " ms/token " << std::endl;
     std::cout << "Throughput: " << metrics.get_throughput().mean  << " ± " << metrics.get_throughput().std << " tokens/s" << std::endl;

--- a/samples/python/visual_language_chat/benchmark_vlm.py
+++ b/samples/python/visual_language_chat/benchmark_vlm.py
@@ -184,7 +184,7 @@ def main():
     print(
         f"Embeddings preparation time: {perf_metrics.get_prepare_embeddings_duration().mean:.2f} ± {perf_metrics.get_prepare_embeddings_duration().std:.2f} ms")
     print(
-        f"  Vision encoding time: {perf_metrics.get_vision_encoder_duration().mean:.2f} ± {perf_metrics.get_vision_encoder_duration().std:.2f} ms"
+        f"  Vision encoding time: {perf_metrics.get_vision_encoding_duration().mean:.2f} ± {perf_metrics.get_vision_encoding_duration().std:.2f} ms"
     )
     print(
         f"  Text embedding time: {perf_metrics.get_text_embedding_duration().mean:.2f} ± {perf_metrics.get_text_embedding_duration().std:.2f} ms"

--- a/samples/python/visual_language_chat/benchmark_vlm.py
+++ b/samples/python/visual_language_chat/benchmark_vlm.py
@@ -183,6 +183,12 @@ def main():
         f"Detokenization time: {perf_metrics.get_detokenization_duration().mean:.2f} ± {perf_metrics.get_detokenization_duration().std:.2f} ms")
     print(
         f"Embeddings preparation time: {perf_metrics.get_prepare_embeddings_duration().mean:.2f} ± {perf_metrics.get_prepare_embeddings_duration().std:.2f} ms")
+    print(
+        f"  Vision encoding time: {perf_metrics.get_vision_encoder_duration().mean:.2f} ± {perf_metrics.get_vision_encoder_duration().std:.2f} ms"
+    )
+    print(
+        f"  Text embedding time: {perf_metrics.get_text_embedding_duration().mean:.2f} ± {perf_metrics.get_text_embedding_duration().std:.2f} ms"
+    )
     print(f"TTFT: {perf_metrics.get_ttft().mean:.2f} ± {perf_metrics.get_ttft().std:.2f} ms")
     print(f"TPOT: {perf_metrics.get_tpot().mean:.2f} ± {perf_metrics.get_tpot().std:.2f} ms/token")
     print(f"Throughput: {perf_metrics.get_throughput().mean:.2f} ± {perf_metrics.get_throughput().std:.2f} tokens/s")

--- a/src/cpp/include/openvino/genai/perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/perf_metrics.hpp
@@ -183,6 +183,20 @@ struct OPENVINO_GENAI_EXPORTS PerfMetrics {
      * @param duration steady clock duration
      */
     static float get_microsec(std::chrono::steady_clock::duration duration);
+
+    /**
+     * @brief Emplace duration into the vector of microseconds.
+     *
+     * @param target_durations Vector of microseconds to store the duration.
+     * @param start_time Start time of the duration.
+     * @param end_time End time of the duration (default: now).
+     */
+    static void emplace_duration(
+        std::vector<MicroSeconds>& target_durations,
+        const TimePoint& start_time,
+        const TimePoint& end_time = std::chrono::steady_clock::now()
+    );
+
     PerfMetrics operator+(const PerfMetrics& metrics) const;
     PerfMetrics& operator+=(const PerfMetrics& right);
 

--- a/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
@@ -8,12 +8,15 @@
 #include "openvino/genai/perf_metrics.hpp"
 #include "openvino/genai/visibility.hpp"
 
-
 namespace ov::genai {
 
 struct OPENVINO_GENAI_EXPORTS VLMRawPerfMetrics {
     /** @brief Duration of preparation of embeddings */
     std::vector<MicroSeconds> prepare_embeddings_durations;
+    /** @brief Duration of vision encoder processing */
+    std::vector<MicroSeconds> vision_encoder_durations;
+    /** @brief Duration of text embedding calculation */
+    std::vector<MicroSeconds> text_embedding_durations;
     /** @brief Number of image slices produced for each input image */
     std::vector<size_t> per_image_slice_counts;
 };
@@ -21,16 +24,29 @@ struct OPENVINO_GENAI_EXPORTS VLMRawPerfMetrics {
 struct OPENVINO_GENAI_EXPORTS VLMPerfMetrics : public PerfMetrics {
     /** @brief Mean and standard deviation of preparation of embeddings in milliseconds */
     MeanStdPair prepare_embeddings_duration;
+    /** @brief Mean and standard deviation of vision encoder processing in milliseconds */
+    MeanStdPair vision_encoder_duration;
+    /** @brief Mean and standard deviation of text embedding calculation in milliseconds */
+    MeanStdPair text_embedding_duration;
     /** @brief Total number of image slices produced for the request */
     size_t total_image_slice_count = 0;
 
     MeanStdPair get_prepare_embeddings_duration();
+    MeanStdPair get_vision_encoder_duration();
+    MeanStdPair get_text_embedding_duration();
     size_t get_total_image_slice_count();
 
     VLMPerfMetrics() = default;
 
-    explicit VLMPerfMetrics(const PerfMetrics& perf_metrics) : PerfMetrics(perf_metrics), prepare_embeddings_duration(), total_image_slice_count(0) {};
-    explicit VLMPerfMetrics(PerfMetrics&& perf_metrics) noexcept : PerfMetrics(std::move(perf_metrics)), prepare_embeddings_duration(), total_image_slice_count(0) {};
+    explicit VLMPerfMetrics(const PerfMetrics& perf_metrics)
+        : PerfMetrics(perf_metrics),
+          prepare_embeddings_duration(),
+          total_image_slice_count(0){};
+
+    explicit VLMPerfMetrics(PerfMetrics&& perf_metrics) noexcept
+        : PerfMetrics(std::move(perf_metrics)),
+          prepare_embeddings_duration(),
+          total_image_slice_count(0){};
 
     void evaluate_statistics(std::optional<TimePoint> start_time = std::nullopt) override;
 
@@ -39,4 +55,4 @@ struct OPENVINO_GENAI_EXPORTS VLMPerfMetrics : public PerfMetrics {
     VLMRawPerfMetrics vlm_raw_metrics;
 };
 
-}
+}  // namespace ov::genai

--- a/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
@@ -13,9 +13,9 @@ namespace ov::genai {
 struct OPENVINO_GENAI_EXPORTS VLMRawPerfMetrics {
     /** @brief Duration of preparation of embeddings */
     std::vector<MicroSeconds> prepare_embeddings_durations;
-    /** @brief Duration of vision encoder processing */
-    std::vector<MicroSeconds> vision_encoder_durations;
-    /** @brief Duration of text embedding calculation */
+    /** @brief Duration of vision encoding */
+    std::vector<MicroSeconds> vision_encoding_durations;
+    /** @brief Duration of text embedding */
     std::vector<MicroSeconds> text_embedding_durations;
     /** @brief Number of image slices produced for each input image */
     std::vector<size_t> per_image_slice_counts;
@@ -24,15 +24,15 @@ struct OPENVINO_GENAI_EXPORTS VLMRawPerfMetrics {
 struct OPENVINO_GENAI_EXPORTS VLMPerfMetrics : public PerfMetrics {
     /** @brief Mean and standard deviation of preparation of embeddings in milliseconds */
     MeanStdPair prepare_embeddings_duration;
-    /** @brief Mean and standard deviation of vision encoder processing in milliseconds */
-    MeanStdPair vision_encoder_duration;
-    /** @brief Mean and standard deviation of text embedding calculation in milliseconds */
+    /** @brief Mean and standard deviation of vision encoding in milliseconds */
+    MeanStdPair vision_encoding_duration;
+    /** @brief Mean and standard deviation of text embedding in milliseconds */
     MeanStdPair text_embedding_duration;
     /** @brief Total number of image slices produced for the request */
     size_t total_image_slice_count = 0;
 
     MeanStdPair get_prepare_embeddings_duration();
-    MeanStdPair get_vision_encoder_duration();
+    MeanStdPair get_vision_encoding_duration();
     MeanStdPair get_text_embedding_duration();
     size_t get_total_image_slice_count();
 

--- a/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/perf_metrics.hpp
@@ -15,6 +15,8 @@ struct OPENVINO_GENAI_EXPORTS VLMRawPerfMetrics {
     std::vector<MicroSeconds> prepare_embeddings_durations;
     /** @brief Duration of vision encoding */
     std::vector<MicroSeconds> vision_encoding_durations;
+    /** @brief Duration of audio encoding */
+    std::vector<MicroSeconds> audio_encoding_durations;
     /** @brief Duration of text embedding */
     std::vector<MicroSeconds> text_embedding_durations;
     /** @brief Number of image slices produced for each input image */
@@ -26,6 +28,8 @@ struct OPENVINO_GENAI_EXPORTS VLMPerfMetrics : public PerfMetrics {
     MeanStdPair prepare_embeddings_duration;
     /** @brief Mean and standard deviation of vision encoding in milliseconds */
     MeanStdPair vision_encoding_duration;
+    /** @brief Mean and standard deviation of audio encoding in milliseconds */
+    MeanStdPair audio_encoding_duration;
     /** @brief Mean and standard deviation of text embedding in milliseconds */
     MeanStdPair text_embedding_duration;
     /** @brief Total number of image slices produced for the request */
@@ -33,6 +37,7 @@ struct OPENVINO_GENAI_EXPORTS VLMPerfMetrics : public PerfMetrics {
 
     MeanStdPair get_prepare_embeddings_duration();
     MeanStdPair get_vision_encoding_duration();
+    MeanStdPair get_audio_encoding_duration();
     MeanStdPair get_text_embedding_duration();
     size_t get_total_image_slice_count();
 

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -365,16 +365,16 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         const auto& prompt = prompts[0];
         auto start_get_inputs_embeds = std::chrono::steady_clock::now();
 
-        const auto vision_encoder_start = std::chrono::steady_clock::now();
+        const auto vision_encoding_start = std::chrono::steady_clock::now();
         encoded_images = m_inputs_embedder->encode_images(images_vector[0]);
         m_history_images.insert(m_history_images.end(), encoded_images.begin(), encoded_images.end());
         
         encoded_videos = m_inputs_embedder->encode_videos(videos_vector[0], videos_metadata_vector[0]);
         m_history_videos.insert(m_history_videos.end(), encoded_videos.begin(), encoded_videos.end());
-        const auto vision_encoder_end = std::chrono::steady_clock::now();
+        const auto vision_encoding_end = std::chrono::steady_clock::now();
 
-        vlm_perf_metrics[0].vlm_raw_metrics.vision_encoder_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+        vlm_perf_metrics[0].vlm_raw_metrics.vision_encoding_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
         );
 
         vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
@@ -442,17 +442,17 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             const auto& prompt = prompts[i];
             const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
 
-            const auto vision_encoder_start = std::chrono::steady_clock::now();
+            const auto vision_encoding_start = std::chrono::steady_clock::now();
             auto images_to_encode = images_vector.size() > 0 ? images_vector[i] : std::vector<ov::Tensor>{};
             const auto encoded_images = m_inputs_embedder->encode_images(images_to_encode);
             
             auto videos_to_encode = videos_vector.size() > 0 ? videos_vector[i] : std::vector<ov::Tensor>{};
             auto videos_metadata = videos_metadata_vector.size() > 0 ? videos_metadata_vector[i] : std::vector<ov::genai::VideoMetadata>{};
             const auto encoded_videos = m_inputs_embedder->encode_videos(videos_to_encode, videos_metadata);
-            const auto vision_encoder_end = std::chrono::steady_clock::now();
-            
-            vlm_perf_metrics[i].vlm_raw_metrics.vision_encoder_durations.emplace_back(
-                PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+            const auto vision_encoding_end = std::chrono::steady_clock::now();
+
+            vlm_perf_metrics[i].vlm_raw_metrics.vision_encoding_durations.emplace_back(
+                PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
             );
             
             vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
@@ -691,8 +691,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         auto processed_chat_data = chat_contexts[i].process(images_vector[i], videos_vector[i], videos_metadata_vector[i]);
 
-        vlm_perf_metrics[i].vlm_raw_metrics.vision_encoder_durations.emplace_back(
-            processed_chat_data.vision_encoder_duration
+        vlm_perf_metrics[i].vlm_raw_metrics.vision_encoding_durations.emplace_back(
+            processed_chat_data.vision_encoding_duration
         );
 
         const auto template_start = std::chrono::steady_clock::now();
@@ -827,12 +827,12 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
         const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
         
-        const auto vision_encoder_start = std::chrono::steady_clock::now();
+        const auto vision_encoding_start = std::chrono::steady_clock::now();
         const auto encoded_images = m_inputs_embedder->encode_images(images);
         const auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
-        const auto vision_encoder_end = std::chrono::steady_clock::now();
-        metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+        const auto vision_encoding_end = std::chrono::steady_clock::now();
+        metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
         );
 
         vlm_utils::update_image_slice_counts(metrics, encoded_images);

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -382,8 +382,12 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
         if (!m_pending_audios_batches.empty() && !m_pending_audios_batches[0].empty()) {
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
-            // TODO Wrap encode_audios with perf metrics as well
+            const auto audio_encoding_start = std::chrono::steady_clock::now();
             m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
+            const auto audio_encoding_end = std::chrono::steady_clock::now();
+            vlm_perf_metrics[0].vlm_raw_metrics.audio_encoding_durations.emplace_back(
+                PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
+            );
         }
 
         auto [unified_prompt, image_sequence, video_sequence] =
@@ -461,8 +465,12 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             // encode_audios overwrites the embedder's audio cache, so this must run per-prompt.
             if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
                 std::lock_guard<std::mutex> lock(m_embeddings_mutex);
-                // TODO Wrap encode_audios with perf metrics as well
+                const auto audio_encoding_start = std::chrono::steady_clock::now();
                 m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
+                const auto audio_encoding_end = std::chrono::steady_clock::now();
+                vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations.emplace_back(
+                    PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
+                );
             }
 
             auto [unified_prompt, image_sequence, video_sequence] =
@@ -683,7 +691,12 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         // encode_audios overwrites the embedder's audio cache, so this must run per-history.
         if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+            const auto audio_encoding_start = std::chrono::steady_clock::now();
             m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
+            const auto audio_encoding_end = std::chrono::steady_clock::now();
+            vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations.emplace_back(
+                PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
+            );
         }
 
         VLMChatContext chat_context(histories[i], m_vision_registry, *m_inputs_embedder);

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -152,7 +152,7 @@ std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPip
         for (size_t idx = 0; idx < res.m_generation_ids.size(); ++idx) {
             const auto decode_start = std::chrono::steady_clock::now();
             generated.push_back(m_tokenizer.decode(res.m_generation_ids.at(idx)));
-            raw_counters.detokenization_durations.emplace_back(std::chrono::steady_clock::now() - decode_start);
+            PerfMetrics::emplace_duration(raw_counters.detokenization_durations, decode_start);
             if (m_is_chat_conversation && 0 == idx && res.m_status != ov::genai::GenerationStatus::CANCEL) {
                 m_history.push_back({{"role", "assistant"}, {"content", generated.back()}});
             }
@@ -160,8 +160,7 @@ std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPip
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
-        perf_metrics.raw_metrics.generate_durations.emplace_back(
-            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
+        PerfMetrics::emplace_duration(perf_metrics.raw_metrics.generate_durations, start_time);
         // Reevaluate taking into account tokenization/detokenization times.
         perf_metrics.m_evaluated = false;
         perf_metrics.evaluate_statistics(start_time);
@@ -261,14 +260,12 @@ std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPip
         for (size_t idx = 0; idx < encoded_result.m_generation_ids.size(); ++idx) {
             const auto decode_start = std::chrono::steady_clock::now();
             decoded_outputs.push_back(m_tokenizer.decode(encoded_result.m_generation_ids.at(idx)));
-
-            raw_counters.detokenization_durations.emplace_back(std::chrono::steady_clock::now() - decode_start);
+            PerfMetrics::emplace_duration(raw_counters.detokenization_durations, decode_start);
         }
 
         // The same perf metrics for each sequence, only tokenization/detokenization will differ.
         perf_metrics.raw_metrics.generate_durations.clear();
-        perf_metrics.raw_metrics.generate_durations.emplace_back(
-            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start_time));
+        PerfMetrics::emplace_duration(perf_metrics.raw_metrics.generate_durations, start_time);
         // Reevaluate taking into accound tokenization/detokenization times.
         perf_metrics.m_evaluated = false;
         perf_metrics.evaluate_statistics(start_time);
@@ -371,11 +368,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         
         encoded_videos = m_inputs_embedder->encode_videos(videos_vector[0], videos_metadata_vector[0]);
         m_history_videos.insert(m_history_videos.end(), encoded_videos.begin(), encoded_videos.end());
-        const auto vision_encoding_end = std::chrono::steady_clock::now();
 
-        vlm_perf_metrics[0].vlm_raw_metrics.vision_encoding_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
-        );
+        PerfMetrics::emplace_duration(vlm_perf_metrics[0].vlm_raw_metrics.vision_encoding_durations, vision_encoding_start);
 
         vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
 
@@ -384,10 +378,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
             const auto audio_encoding_start = std::chrono::steady_clock::now();
             m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
-            const auto audio_encoding_end = std::chrono::steady_clock::now();
-            vlm_perf_metrics[0].vlm_raw_metrics.audio_encoding_durations.emplace_back(
-                PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
-            );
+            PerfMetrics::emplace_duration(vlm_perf_metrics[0].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
         }
 
         auto [unified_prompt, image_sequence, video_sequence] =
@@ -400,9 +391,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         const auto template_start = std::chrono::steady_clock::now();
         std::string templated_history = m_tokenizer.apply_chat_template(m_history, true);
-        vlm_perf_metrics[0].raw_metrics.chat_template_durations.emplace_back(
-            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - template_start)
-        );
+        PerfMetrics::emplace_duration(vlm_perf_metrics[0].raw_metrics.chat_template_durations, template_start);
 
         m_inputs_embedder->set_apply_chat_template_status(false);
 
@@ -437,10 +426,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         lm_extra_inputs_list.push_back(m_inputs_embedder->get_lm_extra_inputs());
 
-        auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
-            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
-
+        PerfMetrics::emplace_duration(vlm_perf_metrics[0].vlm_raw_metrics.prepare_embeddings_durations, start_get_inputs_embeds);
     } else {
         for (size_t i = 0; i < prompts.size(); i++) {
             const auto& prompt = prompts[i];
@@ -453,12 +439,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             auto videos_to_encode = videos_vector.size() > 0 ? videos_vector[i] : std::vector<ov::Tensor>{};
             auto videos_metadata = videos_metadata_vector.size() > 0 ? videos_metadata_vector[i] : std::vector<ov::genai::VideoMetadata>{};
             const auto encoded_videos = m_inputs_embedder->encode_videos(videos_to_encode, videos_metadata);
-            const auto vision_encoding_end = std::chrono::steady_clock::now();
+            PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.vision_encoding_durations, vision_encoding_start);
 
-            vlm_perf_metrics[i].vlm_raw_metrics.vision_encoding_durations.emplace_back(
-                PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
-            );
-            
             vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
 
             // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
@@ -467,10 +449,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                 std::lock_guard<std::mutex> lock(m_embeddings_mutex);
                 const auto audio_encoding_start = std::chrono::steady_clock::now();
                 m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
-                const auto audio_encoding_end = std::chrono::steady_clock::now();
-                vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations.emplace_back(
-                    PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
-                );
+                PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
             }
 
             auto [unified_prompt, image_sequence, video_sequence] =
@@ -507,9 +486,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
             lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
 
-            auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-            vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
-                PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+            PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations, start_get_inputs_embeds);
         }
     }
     std::vector<VLMDecodedResults> results;
@@ -539,9 +516,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             gen_result.scores.push_back(result.m_scores.at(idx));
         }
         gen_result.finish_reasons = result.m_finish_reasons;
-        auto decode_end_time = std::chrono::steady_clock::now();
-        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(
-            PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+        PerfMetrics::emplace_duration(gen_result.perf_metrics.raw_metrics.detokenization_durations, decode_start_time);
 
         gen_result.perf_metrics.m_evaluated = false;
         gen_result.perf_metrics.evaluate_statistics(generate_start_time);
@@ -693,10 +668,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
             const auto audio_encoding_start = std::chrono::steady_clock::now();
             m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
-            const auto audio_encoding_end = std::chrono::steady_clock::now();
-            vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations.emplace_back(
-                PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
-            );
+            PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
         }
 
         VLMChatContext chat_context(histories[i], m_vision_registry, *m_inputs_embedder);
@@ -713,10 +685,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             processed_chat_data.normalized_history,
             true
         );
-        vlm_perf_metrics[i].raw_metrics.chat_template_durations.emplace_back(
-            PerfMetrics::get_microsec(std::chrono::steady_clock::now() - template_start)
-        );
-
+        PerfMetrics::emplace_duration(vlm_perf_metrics[i].raw_metrics.chat_template_durations, template_start);
 
         m_inputs_embedder->set_apply_chat_template_status(false);
 
@@ -747,9 +716,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         lm_extra_inputs_list.push_back(deep_copy_tensors_map(m_inputs_embedder->get_lm_extra_inputs()));
 
-        auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
-            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+        PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.prepare_embeddings_durations, start_get_inputs_embeds);
     }
 
     std::vector<EncodedGenerationResult> encoded_results = generate(input_embeds_list,
@@ -781,9 +748,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             gen_result.scores.push_back(result.m_scores.at(idx));
         }
         gen_result.finish_reasons = result.m_finish_reasons;
-        auto decode_end_time = std::chrono::steady_clock::now();
-        gen_result.perf_metrics.raw_metrics.detokenization_durations.emplace_back(
-            PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+        PerfMetrics::emplace_duration(gen_result.perf_metrics.raw_metrics.detokenization_durations, decode_start_time);
 
         gen_result.perf_metrics.m_evaluated = false;
         gen_result.perf_metrics.evaluate_statistics(generate_start_time);
@@ -843,10 +808,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
         const auto vision_encoding_start = std::chrono::steady_clock::now();
         const auto encoded_images = m_inputs_embedder->encode_images(images);
         const auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
-        const auto vision_encoding_end = std::chrono::steady_clock::now();
-        metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start)
-        );
+        PerfMetrics::emplace_duration(metrics.vlm_raw_metrics.vision_encoding_durations, vision_encoding_start);
 
         vlm_utils::update_image_slice_counts(metrics, encoded_images);
 
@@ -874,9 +836,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
                 video_sequence
             );
         }
-        const auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        metrics.vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
-            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
+        PerfMetrics::emplace_duration(metrics.vlm_raw_metrics.prepare_embeddings_durations, start_get_inputs_embeds);
         handle = add_request(request_id,
                              inputs,
                              sampling_params,

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -786,56 +786,13 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     return results;
 }
 
-// TODO Check if this override can fallback to the other add_request overloads to avoid code duplication
 GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
     uint64_t request_id,
     const std::string& prompt,
-    const std::vector<ov::Tensor>& rgbs,
-    GenerationConfig sampling_params) {
-    OPENVINO_ASSERT(m_model_input_type == ModelInputType::EMBEDDINGS, "Model doesn't support embeddings.");
-    ov::genai::VLMPerfMetrics metrics;
-    ov::Tensor inputs;
-    std::optional<ov::Tensor> token_type_ids;
-    // FIXME prompt_ids is not populated for VLM prompt lookup with add_request API
-    std::optional<ov::Tensor> prompt_ids;
-    GenerationHandle handle;
-    {
-        std::lock_guard<std::mutex> lock(m_embeddings_mutex);
-        const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
-        m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
-
-        const auto vision_encoder_start = std::chrono::steady_clock::now();
-        const auto encoded_images = m_inputs_embedder->encode_images(rgbs);
-        vlm_utils::update_image_slice_counts(metrics, encoded_images);
-        const auto vision_encoder_end = std::chrono::steady_clock::now();
-        metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
-        );
-
-        const auto [unified_prompt, image_sequence, video_sequence] =
-            m_inputs_embedder->normalize_prompt(prompt, 0, encoded_images);
-        if (m_inputs_embedder->has_token_type_ids()) {
-            std::tie(inputs, token_type_ids) = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(unified_prompt,
-                                                                                                        encoded_images,
-                                                                                                        metrics,
-                                                                                                        true,
-                                                                                                        image_sequence);
-        } else {
-            inputs =
-                m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, metrics, true, image_sequence);
-        }
-        const auto end_get_inputs_embeds = std::chrono::steady_clock::now();
-        metrics.vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
-            PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));
-        handle = add_request(request_id,
-                             inputs,
-                             sampling_params,
-                             token_type_ids,
-                             prompt_ids,
-                             m_inputs_embedder->get_lm_extra_inputs());
-        handle->m_generation_stream->set_vlm_perf_metrics(std::move(metrics));
-    }
-    return handle;
+    const std::vector<ov::Tensor>& images,
+    GenerationConfig sampling_params
+) {
+    return add_request(request_id, prompt, images, {}, {}, sampling_params);
 }
 
 GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
@@ -860,7 +817,6 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
     OPENVINO_ASSERT(m_model_input_type == ModelInputType::EMBEDDINGS, "Model doesn't support embeddings.");
     ov::genai::VLMPerfMetrics metrics;
     ov::Tensor inputs;
-    // token_type_ids is not supported for video inputs
     std::optional<ov::Tensor> token_type_ids;
     // FIXME prompt_ids is not populated for VLM prompt lookup with add_request API
     std::optional<ov::Tensor> prompt_ids;
@@ -872,15 +828,38 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
         
         const auto vision_encoder_start = std::chrono::steady_clock::now();
         const auto encoded_images = m_inputs_embedder->encode_images(images);
-        vlm_utils::update_image_slice_counts(metrics, encoded_images);
         const auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
         const auto vision_encoder_end = std::chrono::steady_clock::now();
         metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
             PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
         );
 
-        const auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, 0, 0, encoded_images, encoded_videos);
-        inputs = m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, encoded_videos, metrics, true, image_sequence, video_sequence);
+        vlm_utils::update_image_slice_counts(metrics, encoded_images);
+
+        const auto [unified_prompt, image_sequence, video_sequence] =
+            m_inputs_embedder->normalize_prompt(prompt, 0, 0, encoded_images, encoded_videos);
+
+        if (m_inputs_embedder->has_token_type_ids()) {
+            std::tie(inputs, token_type_ids) = m_inputs_embedder->get_inputs_embeds_with_token_type_ids(
+                unified_prompt,
+                encoded_images,
+                encoded_videos,
+                metrics,
+                true,
+                image_sequence,
+                video_sequence
+            );
+        } else {
+            inputs = m_inputs_embedder->get_inputs_embeds(
+                unified_prompt,
+                encoded_images,
+                encoded_videos,
+                metrics,
+                true,
+                image_sequence,
+                video_sequence
+            );
+        }
         const auto end_get_inputs_embeds = std::chrono::steady_clock::now();
         metrics.vlm_raw_metrics.prepare_embeddings_durations.emplace_back(
             PerfMetrics::get_microsec(end_get_inputs_embeds - start_get_inputs_embeds));

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -365,16 +365,24 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         const auto& prompt = prompts[0];
         auto start_get_inputs_embeds = std::chrono::steady_clock::now();
 
+        const auto vision_encoder_start = std::chrono::steady_clock::now();
         encoded_images = m_inputs_embedder->encode_images(images_vector[0]);
+        
         vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
         m_history_images.insert(m_history_images.end(), encoded_images.begin(), encoded_images.end());
-
+        
         encoded_videos = m_inputs_embedder->encode_videos(videos_vector[0], videos_metadata_vector[0]);
         m_history_videos.insert(m_history_videos.end(), encoded_videos.begin(), encoded_videos.end());
+        
+        const auto vision_encoder_end = std::chrono::steady_clock::now();
+        vlm_perf_metrics[0].vlm_raw_metrics.vision_encoder_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+        );
 
         // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
         if (!m_pending_audios_batches.empty() && !m_pending_audios_batches[0].empty()) {
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+            // TODO Wrap encode_audios with perf metrics as well
             m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
         }
 
@@ -432,8 +440,9 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     } else {
         for (size_t i = 0; i < prompts.size(); i++) {
             const auto& prompt = prompts[i];
-            auto start_get_inputs_embeds = std::chrono::steady_clock::now();
+            const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
 
+            const auto vision_encoder_start = std::chrono::steady_clock::now();
             auto images_to_encode = images_vector.size() > 0 ? images_vector[i] : std::vector<ov::Tensor>{};
             const auto encoded_images = m_inputs_embedder->encode_images(images_to_encode);
             vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
@@ -442,10 +451,16 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             auto videos_metadata = videos_metadata_vector.size() > 0 ? videos_metadata_vector[i] : std::vector<ov::genai::VideoMetadata>{};
             const auto encoded_videos = m_inputs_embedder->encode_videos(videos_to_encode, videos_metadata);
 
+            const auto vision_encoder_end = std::chrono::steady_clock::now();
+            vlm_perf_metrics[i].vlm_raw_metrics.vision_encoder_durations.emplace_back(
+                PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+            );
+
             // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
             // encode_audios overwrites the embedder's audio cache, so this must run per-prompt.
             if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
                 std::lock_guard<std::mutex> lock(m_embeddings_mutex);
+                // TODO Wrap encode_audios with perf metrics as well
                 m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
             }
 
@@ -675,6 +690,10 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         auto processed_chat_data = chat_contexts[i].process(images_vector[i], videos_vector[i], videos_metadata_vector[i]);
 
+        vlm_perf_metrics[i].vlm_raw_metrics.vision_encoder_durations.emplace_back(
+            processed_chat_data.vision_encoder_duration
+        );
+
         const auto template_start = std::chrono::steady_clock::now();
         std::string templated_history = m_tokenizer.apply_chat_template(
             processed_chat_data.normalized_history,
@@ -767,6 +786,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     return results;
 }
 
+// TODO Check if this override can fallback to the other add_request overloads to avoid code duplication
 GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
     uint64_t request_id,
     const std::string& prompt,
@@ -783,8 +803,14 @@ GenerationHandle ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_re
         std::lock_guard<std::mutex> lock(m_embeddings_mutex);
         const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
+
+        const auto vision_encoder_start = std::chrono::steady_clock::now();
         const auto encoded_images = m_inputs_embedder->encode_images(rgbs);
         vlm_utils::update_image_slice_counts(metrics, encoded_images);
+        const auto vision_encoder_end = std::chrono::steady_clock::now();
+        metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+        );
 
         const auto [unified_prompt, image_sequence, video_sequence] =
             m_inputs_embedder->normalize_prompt(prompt, 0, encoded_images);
@@ -843,9 +869,15 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
         std::lock_guard<std::mutex> lock(m_embeddings_mutex);
         const auto start_get_inputs_embeds = std::chrono::steady_clock::now();
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
+        
+        const auto vision_encoder_start = std::chrono::steady_clock::now();
         const auto encoded_images = m_inputs_embedder->encode_images(images);
         vlm_utils::update_image_slice_counts(metrics, encoded_images);
         const auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
+        const auto vision_encoder_end = std::chrono::steady_clock::now();
+        metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
+        );
 
         const auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, 0, 0, encoded_images, encoded_videos);
         inputs = m_inputs_embedder->get_inputs_embeds(unified_prompt, encoded_images, encoded_videos, metrics, true, image_sequence, video_sequence);

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -367,17 +367,17 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         const auto vision_encoder_start = std::chrono::steady_clock::now();
         encoded_images = m_inputs_embedder->encode_images(images_vector[0]);
-        
-        vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
         m_history_images.insert(m_history_images.end(), encoded_images.begin(), encoded_images.end());
         
         encoded_videos = m_inputs_embedder->encode_videos(videos_vector[0], videos_metadata_vector[0]);
         m_history_videos.insert(m_history_videos.end(), encoded_videos.begin(), encoded_videos.end());
-        
         const auto vision_encoder_end = std::chrono::steady_clock::now();
+
         vlm_perf_metrics[0].vlm_raw_metrics.vision_encoder_durations.emplace_back(
             PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
         );
+
+        vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
 
         // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
         if (!m_pending_audios_batches.empty() && !m_pending_audios_batches[0].empty()) {
@@ -445,16 +445,17 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             const auto vision_encoder_start = std::chrono::steady_clock::now();
             auto images_to_encode = images_vector.size() > 0 ? images_vector[i] : std::vector<ov::Tensor>{};
             const auto encoded_images = m_inputs_embedder->encode_images(images_to_encode);
-            vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
-
+            
             auto videos_to_encode = videos_vector.size() > 0 ? videos_vector[i] : std::vector<ov::Tensor>{};
             auto videos_metadata = videos_metadata_vector.size() > 0 ? videos_metadata_vector[i] : std::vector<ov::genai::VideoMetadata>{};
             const auto encoded_videos = m_inputs_embedder->encode_videos(videos_to_encode, videos_metadata);
-
             const auto vision_encoder_end = std::chrono::steady_clock::now();
+            
             vlm_perf_metrics[i].vlm_raw_metrics.vision_encoder_durations.emplace_back(
                 PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start)
             );
+            
+            vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
 
             // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
             // encode_audios overwrites the embedder's audio cache, so this must run per-prompt.

--- a/src/cpp/src/perf_metrics.cpp
+++ b/src/cpp/src/perf_metrics.cpp
@@ -119,6 +119,14 @@ float PerfMetrics::get_microsec(std::chrono::steady_clock::duration duration) {
     return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
+void PerfMetrics::emplace_duration(
+    std::vector<MicroSeconds>& target_durations,
+    const TimePoint& start_time,
+    const TimePoint& end_time
+) {
+    target_durations.emplace_back(get_microsec(end_time - start_time));
+}
+
 void PerfMetrics::evaluate_statistics(std::optional<TimePoint> start_time) {
     if (m_evaluated){
         return;

--- a/src/cpp/src/visual_language/gemma3/classes.cpp
+++ b/src/cpp/src/visual_language/gemma3/classes.cpp
@@ -148,7 +148,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma3::get_inputs_embeds_with_t
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/gemma3n/classes.cpp
+++ b/src/cpp/src/visual_language/gemma3n/classes.cpp
@@ -150,7 +150,7 @@ ov::Tensor InputsEmbedderGemma3n::get_inputs_embeds(const std::string& prompt,
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -568,7 +568,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::compute_inputs_embeds(
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     encode_vision_token_ids();
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -265,6 +265,18 @@ std::vector<ov::Tensor> InputsEmbedder::IInputsEmbedder::to_single_image_tensors
     return single_image_tensors;
 }
 
+ov::Tensor InputsEmbedder::IInputsEmbedder::get_text_embedding(
+    EmbeddingsRequest& req,
+    const ov::Tensor& input_ids,
+    ov::genai::VLMPerfMetrics& metrics
+) {
+    const auto start = std::chrono::steady_clock::now();
+    ov::Tensor result = m_embedding->infer(req, input_ids);
+    metrics.vlm_raw_metrics.text_embedding_durations.emplace_back(
+        PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start));
+    return result;
+}
+
 std::vector<ov::genai::EncodedImage> InputsEmbedder::IInputsEmbedder::encode_images(const std::vector<ov::Tensor>& images) {
     std::vector<EncodedImage> encoded_images;
     std::vector<ov::Tensor> single_images = to_single_image_tensors(images);

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -270,10 +270,9 @@ ov::Tensor InputsEmbedder::IInputsEmbedder::get_text_embedding(
     const ov::Tensor& input_ids,
     ov::genai::VLMPerfMetrics& metrics
 ) {
-    const auto start = std::chrono::steady_clock::now();
+    const auto text_embedding_start = std::chrono::steady_clock::now();
     ov::Tensor result = m_embedding->infer(req, input_ids);
-    metrics.vlm_raw_metrics.text_embedding_durations.emplace_back(
-        PerfMetrics::get_microsec(std::chrono::steady_clock::now() - start));
+    PerfMetrics::emplace_duration(metrics.vlm_raw_metrics.text_embedding_durations, text_embedding_start);
     return result;
 }
 

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -351,6 +351,12 @@ private:
         */
         std::vector<ov::Tensor> to_single_image_tensors(const std::vector<ov::Tensor>& images);
 
+        ov::Tensor get_text_embedding(
+            EmbeddingsRequest& req,
+            const ov::Tensor& input_ids,
+            ov::genai::VLMPerfMetrics& metrics
+        );
+
         /**
          * @brief Check if CDPruner is available and enabled.
          * @return true if CDPruner processor exists, is available, and enabled (pruning_ratio > 0)

--- a/src/cpp/src/visual_language/internvl_chat/classes.cpp
+++ b/src/cpp/src/visual_language/internvl_chat/classes.cpp
@@ -270,7 +270,7 @@ ov::Tensor InputsEmbedderInternVLChat::get_inputs_embeds(const std::string& unif
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/llava/classes.cpp
+++ b/src/cpp/src/visual_language/llava/classes.cpp
@@ -122,7 +122,7 @@ ov::Tensor InputsEmbedderLLaVA::get_inputs_embeds(const std::string& unified_pro
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/llava_next/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next/classes.cpp
@@ -388,7 +388,7 @@ ov::Tensor InputsEmbedderLLaVANext::get_inputs_embeds(const std::string& unified
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/llava_next_video/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next_video/classes.cpp
@@ -489,7 +489,7 @@ ov::Tensor InputsEmbedderLLaVANextVideo::get_inputs_embeds(
     ov::Tensor input_ids = get_encoded_input_ids(prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (image_embeds.empty() && video_embeds.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/minicpm/classes.cpp
+++ b/src/cpp/src/visual_language/minicpm/classes.cpp
@@ -638,7 +638,7 @@ ov::Tensor InputsEmbedderMiniCPM::get_inputs_embeds(const std::string& unified_p
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor inputs_embeds = m_embedding->infer(req, encoded_input);
+    ov::Tensor inputs_embeds = get_text_embedding(req, encoded_input, metrics);
 
     OPENVINO_ASSERT(
         m_vlm_config.hidden_size == inputs_embeds.get_shape().at(2),

--- a/src/cpp/src/visual_language/muse_glimmer/classes.cpp
+++ b/src/cpp/src/visual_language/muse_glimmer/classes.cpp
@@ -416,7 +416,7 @@ ov::Tensor InputsEmbedderMuseGlimmer::get_inputs_embeds(
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (image_embeds.empty() && videos_sequence.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/nanollava/classes.cpp
+++ b/src/cpp/src/visual_language/nanollava/classes.cpp
@@ -162,7 +162,7 @@ ov::Tensor InputsEmbedderNanoLLaVA::get_inputs_embeds(const std::string& unified
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     if (images.empty()) {
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());

--- a/src/cpp/src/visual_language/perf_metrics.cpp
+++ b/src/cpp/src/visual_language/perf_metrics.cpp
@@ -11,6 +11,16 @@ MeanStdPair VLMPerfMetrics::get_prepare_embeddings_duration() {
     return prepare_embeddings_duration;
 }
 
+MeanStdPair VLMPerfMetrics::get_vision_encoder_duration() {
+    evaluate_statistics();
+    return vision_encoder_duration;
+}
+
+MeanStdPair VLMPerfMetrics::get_text_embedding_duration() {
+    evaluate_statistics();
+    return text_embedding_duration;
+}
+
 size_t VLMPerfMetrics::get_total_image_slice_count() {
     evaluate_statistics();
     return total_image_slice_count;
@@ -22,6 +32,9 @@ void VLMPerfMetrics::evaluate_statistics(std::optional<TimePoint> start_time) {
     }
 
     prepare_embeddings_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.prepare_embeddings_durations);
+    vision_encoder_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.vision_encoder_durations);
+    text_embedding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.text_embedding_durations);
+
     total_image_slice_count = 0;
     for (const auto count : vlm_raw_metrics.per_image_slice_counts) {
         total_image_slice_count += count;
@@ -37,14 +50,35 @@ VLMPerfMetrics VLMPerfMetrics::operator+(const VLMPerfMetrics& right) const {
 
     auto& result_prepare_embeddings_durations = result.vlm_raw_metrics.prepare_embeddings_durations;
     auto& right_prepare_embeddings_durations = right.vlm_raw_metrics.prepare_embeddings_durations;
-    result_prepare_embeddings_durations.insert(result_prepare_embeddings_durations.end(),
-                                                right_prepare_embeddings_durations.begin(),
-                                                right_prepare_embeddings_durations.end());
+    result_prepare_embeddings_durations.insert(
+        result_prepare_embeddings_durations.end(),
+        right_prepare_embeddings_durations.begin(),
+        right_prepare_embeddings_durations.end()
+    );
+
+    auto& result_vision_encoder_durations = result.vlm_raw_metrics.vision_encoder_durations;
+    auto& right_vision_encoder_durations = right.vlm_raw_metrics.vision_encoder_durations;
+    result_vision_encoder_durations.insert(
+        result_vision_encoder_durations.end(),
+        right_vision_encoder_durations.begin(),
+        right_vision_encoder_durations.end()
+    );
+
+    auto& result_text_embedding_durations = result.vlm_raw_metrics.text_embedding_durations;
+    auto& right_text_embedding_durations = right.vlm_raw_metrics.text_embedding_durations;
+    result_text_embedding_durations.insert(
+        result_text_embedding_durations.end(),
+        right_text_embedding_durations.begin(),
+        right_text_embedding_durations.end()
+    );
+
     auto& result_per_image_slice_counts = result.vlm_raw_metrics.per_image_slice_counts;
     const auto& right_per_image_slice_counts = right.vlm_raw_metrics.per_image_slice_counts;
-    result_per_image_slice_counts.insert(result_per_image_slice_counts.end(),
-                                         right_per_image_slice_counts.begin(),
-                                         right_per_image_slice_counts.end());
+    result_per_image_slice_counts.insert(
+        result_per_image_slice_counts.end(),
+        right_per_image_slice_counts.begin(),
+        right_per_image_slice_counts.end()
+    );
     return result;
 }
-}
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/perf_metrics.cpp
+++ b/src/cpp/src/visual_language/perf_metrics.cpp
@@ -11,9 +11,9 @@ MeanStdPair VLMPerfMetrics::get_prepare_embeddings_duration() {
     return prepare_embeddings_duration;
 }
 
-MeanStdPair VLMPerfMetrics::get_vision_encoder_duration() {
+MeanStdPair VLMPerfMetrics::get_vision_encoding_duration() {
     evaluate_statistics();
-    return vision_encoder_duration;
+    return vision_encoding_duration;
 }
 
 MeanStdPair VLMPerfMetrics::get_text_embedding_duration() {
@@ -32,7 +32,7 @@ void VLMPerfMetrics::evaluate_statistics(std::optional<TimePoint> start_time) {
     }
 
     prepare_embeddings_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.prepare_embeddings_durations);
-    vision_encoder_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.vision_encoder_durations);
+    vision_encoding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.vision_encoding_durations);
     text_embedding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.text_embedding_durations);
 
     total_image_slice_count = 0;
@@ -56,12 +56,12 @@ VLMPerfMetrics VLMPerfMetrics::operator+(const VLMPerfMetrics& right) const {
         right_prepare_embeddings_durations.end()
     );
 
-    auto& result_vision_encoder_durations = result.vlm_raw_metrics.vision_encoder_durations;
-    auto& right_vision_encoder_durations = right.vlm_raw_metrics.vision_encoder_durations;
-    result_vision_encoder_durations.insert(
-        result_vision_encoder_durations.end(),
-        right_vision_encoder_durations.begin(),
-        right_vision_encoder_durations.end()
+    auto& result_vision_encoding_durations = result.vlm_raw_metrics.vision_encoding_durations;
+    auto& right_vision_encoding_durations = right.vlm_raw_metrics.vision_encoding_durations;
+    result_vision_encoding_durations.insert(
+        result_vision_encoding_durations.end(),
+        right_vision_encoding_durations.begin(),
+        right_vision_encoding_durations.end()
     );
 
     auto& result_text_embedding_durations = result.vlm_raw_metrics.text_embedding_durations;

--- a/src/cpp/src/visual_language/perf_metrics.cpp
+++ b/src/cpp/src/visual_language/perf_metrics.cpp
@@ -16,6 +16,11 @@ MeanStdPair VLMPerfMetrics::get_vision_encoding_duration() {
     return vision_encoding_duration;
 }
 
+MeanStdPair VLMPerfMetrics::get_audio_encoding_duration() {
+    evaluate_statistics();
+    return audio_encoding_duration;
+}
+
 MeanStdPair VLMPerfMetrics::get_text_embedding_duration() {
     evaluate_statistics();
     return text_embedding_duration;
@@ -33,6 +38,7 @@ void VLMPerfMetrics::evaluate_statistics(std::optional<TimePoint> start_time) {
 
     prepare_embeddings_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.prepare_embeddings_durations);
     vision_encoding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.vision_encoding_durations);
+    audio_encoding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.audio_encoding_durations);
     text_embedding_duration = ov::genai::calc_mean_and_std(vlm_raw_metrics.text_embedding_durations);
 
     total_image_slice_count = 0;
@@ -62,6 +68,14 @@ VLMPerfMetrics VLMPerfMetrics::operator+(const VLMPerfMetrics& right) const {
         result_vision_encoding_durations.end(),
         right_vision_encoding_durations.begin(),
         right_vision_encoding_durations.end()
+    );
+
+    auto& result_audio_encoding_durations = result.vlm_raw_metrics.audio_encoding_durations;
+    auto& right_audio_encoding_durations = right.vlm_raw_metrics.audio_encoding_durations;
+    result_audio_encoding_durations.insert(
+        result_audio_encoding_durations.end(),
+        right_audio_encoding_durations.begin(),
+        right_audio_encoding_durations.end()
     );
 
     auto& result_text_embedding_durations = result.vlm_raw_metrics.text_embedding_durations;

--- a/src/cpp/src/visual_language/phi3_vision/classes.cpp
+++ b/src/cpp/src/visual_language/phi3_vision/classes.cpp
@@ -960,7 +960,7 @@ ov::Tensor InputsEmbedderPhi3V::get_inputs_embeds(const std::string& image_promp
     ov::Tensor inputs_embeds = vlm_utils::build_inputs_embeds_from_text_and_visual_chunks(
         tokens,
         [&](const ov::Tensor& text_chunk) {
-            return m_embedding->infer(req, text_chunk);
+            return get_text_embedding(req, text_chunk, metrics);
         },
         images_features_proj,
         base_id,

--- a/src/cpp/src/visual_language/phi4mm/classes.cpp
+++ b/src/cpp/src/visual_language/phi4mm/classes.cpp
@@ -847,7 +847,7 @@ ov::Tensor InputsEmbedderPhi4MM::get_inputs_embeds(
     ov::Tensor inputs_embeds = vlm_utils::build_inputs_embeds_from_text_and_visual_chunks(
         tokens,
         [&](const ov::Tensor& text_chunk) {
-            return m_embedding->infer(req, text_chunk);
+            return get_text_embedding(req, text_chunk, metrics);
         },
         images_features_proj,
         base_id,

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -366,18 +366,12 @@ public:
         
         const auto audio_encoding_start = std::chrono::steady_clock::now();
         m_inputs_embedder->encode_audios(audios);
-        const auto audio_encoding_end = std::chrono::steady_clock::now();
-        perf_metrics.vlm_raw_metrics.audio_encoding_durations.emplace_back(
-            PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
-        );
+        PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
 
         const auto vision_encoding_start = std::chrono::steady_clock::now();
         auto encoded_images = m_inputs_embedder->encode_images(images);
         auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
-        const auto vision_encoding_end = std::chrono::steady_clock::now();
-
-        perf_metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start));
+        PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.vision_encoding_durations, vision_encoding_start);
 
         vlm_utils::update_image_slice_counts(perf_metrics, encoded_images);
 
@@ -388,7 +382,7 @@ public:
 
             const auto template_start = std::chrono::steady_clock::now();
             unified_prompt = m_tokenizer.apply_chat_template(m_history, true);
-            raw_counters.chat_template_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - template_start));
+            PerfMetrics::emplace_duration(raw_counters.chat_template_durations, template_start);
 
             if (m_use_full_chat_history) {
                 m_history_vision_count.emplace_back(std::make_pair(video_sequence.size(), image_sequence.size()));
@@ -497,8 +491,9 @@ public:
         auto& res_raw_counters = decoded.perf_metrics.raw_metrics;
         decoded.perf_metrics.num_input_tokens = perf_metrics.num_input_tokens;
         decoded.perf_metrics.load_time = this->get_load_time();
-        res_raw_counters.generate_durations.emplace_back(PerfMetrics::get_microsec(generate_end_time - generate_start_time));
-        res_raw_counters.detokenization_durations.emplace_back(PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+        PerfMetrics::emplace_duration(res_raw_counters.generate_durations, generate_start_time, generate_end_time);
+        PerfMetrics::emplace_duration(res_raw_counters.detokenization_durations, decode_start_time, decode_end_time);
+        
         res_raw_counters.tokenization_durations.insert(res_raw_counters.tokenization_durations.end(), raw_counters.tokenization_durations.begin(), raw_counters.tokenization_durations.end());
         res_raw_counters.chat_template_durations.insert(res_raw_counters.chat_template_durations.end(), raw_counters.chat_template_durations.begin(), raw_counters.chat_template_durations.end());
 
@@ -606,7 +601,7 @@ public:
             processed_chat_data.normalized_history,
             true
         );
-        raw_counters.chat_template_durations.emplace_back(PerfMetrics::get_microsec(std::chrono::steady_clock::now() - template_start));
+        PerfMetrics::emplace_duration(raw_counters.chat_template_durations, template_start);
 
         ov::genai::utils::GenerationFinishInfo generation_finish_info;
 
@@ -673,8 +668,8 @@ public:
         auto& res_raw_counters = decoded.perf_metrics.raw_metrics;
         decoded.perf_metrics.num_input_tokens = perf_metrics.num_input_tokens;
         decoded.perf_metrics.load_time = this->get_load_time();
-        res_raw_counters.generate_durations.emplace_back(PerfMetrics::get_microsec(generate_end_time - generate_start_time));
-        res_raw_counters.detokenization_durations.emplace_back(PerfMetrics::get_microsec(decode_end_time - decode_start_time));
+        PerfMetrics::emplace_duration(res_raw_counters.generate_durations, generate_start_time, generate_end_time);
+        PerfMetrics::emplace_duration(res_raw_counters.detokenization_durations, decode_start_time, decode_end_time);
         res_raw_counters.tokenization_durations.insert(res_raw_counters.tokenization_durations.end(), raw_counters.tokenization_durations.begin(), raw_counters.tokenization_durations.end());
         res_raw_counters.chat_template_durations.insert(res_raw_counters.chat_template_durations.end(), raw_counters.chat_template_durations.begin(), raw_counters.chat_template_durations.end());
 
@@ -857,8 +852,7 @@ private:
                 history_vision_count
             );
         }
-        const auto embeddings_end_time = std::chrono::steady_clock::now();
-        perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.emplace_back(PerfMetrics::get_microsec(embeddings_end_time - embeddings_start_time));
+        PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.prepare_embeddings_durations, embeddings_start_time);
 
         if (m_is_npu) {
             // Prefill model in NPU is reshaped to NPUW_LLM_MAX_PROMPT_LEN x NPUW_LLM_MAX_PROMPT_LEN

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -363,8 +363,13 @@ public:
                                                            generation_config.relevance_weight);
 
         const auto embeddings_start_time = std::chrono::steady_clock::now();
-        // TODO Wrap encode_audios with perf metrics as well
+        
+        const auto audio_encoding_start = std::chrono::steady_clock::now();
         m_inputs_embedder->encode_audios(audios);
+        const auto audio_encoding_end = std::chrono::steady_clock::now();
+        perf_metrics.vlm_raw_metrics.audio_encoding_durations.emplace_back(
+            PerfMetrics::get_microsec(audio_encoding_end - audio_encoding_start)
+        );
 
         const auto vision_encoding_start = std::chrono::steady_clock::now();
         auto encoded_images = m_inputs_embedder->encode_images(images);
@@ -503,16 +508,25 @@ public:
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.begin(),
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.end()
         );
+
         decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.insert(
             decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.end(),
             perf_metrics.vlm_raw_metrics.vision_encoding_durations.begin(),
             perf_metrics.vlm_raw_metrics.vision_encoding_durations.end()
         );
+
+        decoded.perf_metrics.vlm_raw_metrics.audio_encoding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.audio_encoding_durations.end(),
+            perf_metrics.vlm_raw_metrics.audio_encoding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.audio_encoding_durations.end()
+        );
+
         decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(
             decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.end(),
             perf_metrics.vlm_raw_metrics.text_embedding_durations.begin(),
             perf_metrics.vlm_raw_metrics.text_embedding_durations.end()
         );
+        
         decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.insert(
             decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.end(),
             perf_metrics.vlm_raw_metrics.per_image_slice_counts.begin(),
@@ -675,6 +689,12 @@ public:
             decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.end(),
             perf_metrics.vlm_raw_metrics.vision_encoding_durations.begin(),
             perf_metrics.vlm_raw_metrics.vision_encoding_durations.end()
+        );
+
+        decoded.perf_metrics.vlm_raw_metrics.audio_encoding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.audio_encoding_durations.end(),
+            perf_metrics.vlm_raw_metrics.audio_encoding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.audio_encoding_durations.end()
         );
 
         decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -366,13 +366,13 @@ public:
         // TODO Wrap encode_audios with perf metrics as well
         m_inputs_embedder->encode_audios(audios);
 
-        const auto vision_encoder_start = std::chrono::steady_clock::now();
+        const auto vision_encoding_start = std::chrono::steady_clock::now();
         auto encoded_images = m_inputs_embedder->encode_images(images);
         auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
-        const auto vision_encoder_end = std::chrono::steady_clock::now();
+        const auto vision_encoding_end = std::chrono::steady_clock::now();
 
-        perf_metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
-            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start));
+        perf_metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start));
 
         vlm_utils::update_image_slice_counts(perf_metrics, encoded_images);
 
@@ -503,10 +503,10 @@ public:
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.begin(),
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.end()
         );
-        decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.insert(
-            decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.end(),
-            perf_metrics.vlm_raw_metrics.vision_encoder_durations.begin(),
-            perf_metrics.vlm_raw_metrics.vision_encoder_durations.end()
+        decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.end(),
+            perf_metrics.vlm_raw_metrics.vision_encoding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.vision_encoding_durations.end()
         );
         decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(
             decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.end(),
@@ -577,7 +577,7 @@ public:
 
         auto processed_chat_data = chat_context.process(images, videos, videos_metadata);
 
-        perf_metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(processed_chat_data.vision_encoder_duration);
+        perf_metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(processed_chat_data.vision_encoding_duration);
 
         bool use_full_history = processed_chat_data.needs_kv_cache_reset || m_use_full_chat_history;
 
@@ -671,10 +671,10 @@ public:
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.end()
         );
 
-        decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.insert(
-            decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.end(),
-            perf_metrics.vlm_raw_metrics.vision_encoder_durations.begin(),
-            perf_metrics.vlm_raw_metrics.vision_encoder_durations.end()
+        decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.vision_encoding_durations.end(),
+            perf_metrics.vlm_raw_metrics.vision_encoding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.vision_encoding_durations.end()
         );
 
         decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -363,10 +363,19 @@ public:
                                                            generation_config.relevance_weight);
 
         const auto embeddings_start_time = std::chrono::steady_clock::now();
+        // TODO Wrap encode_audios with perf metrics as well
         m_inputs_embedder->encode_audios(audios);
+
+        const auto vision_encoder_start = std::chrono::steady_clock::now();
         auto encoded_images = m_inputs_embedder->encode_images(images);
-        vlm_utils::update_image_slice_counts(perf_metrics, encoded_images);
         auto encoded_videos = m_inputs_embedder->encode_videos(videos, videos_metadata);
+        const auto vision_encoder_end = std::chrono::steady_clock::now();
+
+        perf_metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(
+            PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start));
+
+        vlm_utils::update_image_slice_counts(perf_metrics, encoded_images);
+
         auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
 
         if (m_is_chat_conversation) {
@@ -494,6 +503,16 @@ public:
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.begin(),
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.end()
         );
+        decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.end(),
+            perf_metrics.vlm_raw_metrics.vision_encoder_durations.begin(),
+            perf_metrics.vlm_raw_metrics.vision_encoder_durations.end()
+        );
+        decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.end(),
+            perf_metrics.vlm_raw_metrics.text_embedding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.text_embedding_durations.end()
+        );
         decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.insert(
             decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.end(),
             perf_metrics.vlm_raw_metrics.per_image_slice_counts.begin(),
@@ -557,6 +576,8 @@ public:
         VLMChatContext chat_context(history, m_vision_registry, *m_inputs_embedder);
 
         auto processed_chat_data = chat_context.process(images, videos, videos_metadata);
+
+        perf_metrics.vlm_raw_metrics.vision_encoder_durations.emplace_back(processed_chat_data.vision_encoder_duration);
 
         bool use_full_history = processed_chat_data.needs_kv_cache_reset || m_use_full_chat_history;
 
@@ -649,6 +670,19 @@ public:
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.begin(),
             perf_metrics.vlm_raw_metrics.prepare_embeddings_durations.end()
         );
+
+        decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.vision_encoder_durations.end(),
+            perf_metrics.vlm_raw_metrics.vision_encoder_durations.begin(),
+            perf_metrics.vlm_raw_metrics.vision_encoder_durations.end()
+        );
+
+        decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.insert(
+            decoded.perf_metrics.vlm_raw_metrics.text_embedding_durations.end(),
+            perf_metrics.vlm_raw_metrics.text_embedding_durations.begin(),
+            perf_metrics.vlm_raw_metrics.text_embedding_durations.end()
+        );
+
         decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.insert(
             decoded.perf_metrics.vlm_raw_metrics.per_image_slice_counts.end(),
             perf_metrics.vlm_raw_metrics.per_image_slice_counts.begin(),

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -1136,7 +1136,7 @@ ov::Tensor InputsEmbedderQwen2VL::get_inputs_embeds(const std::string& unified_p
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     int64_t vision_start_token_id = m_vision_token_ids["vision_start"];
     int64_t vision_end_token_id = m_vision_token_ids["vision_end"];

--- a/src/cpp/src/visual_language/qwen3_vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_vl/classes.cpp
@@ -715,7 +715,7 @@ ov::Tensor InputsEmbedderQwen3VL::get_inputs_embeds(
     m_last_input_ids = input_ids;
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     int64_t vision_start_token_id = m_vision_token_ids.at("vision_start");
     int64_t vision_end_token_id = m_vision_token_ids.at("vision_end");

--- a/src/cpp/src/visual_language/videochat_flash/classes.cpp
+++ b/src/cpp/src/visual_language/videochat_flash/classes.cpp
@@ -1150,7 +1150,7 @@ ov::Tensor InputsEmbedderVideoChatFlashQwen::get_inputs_embeds(const std::string
     ov::Tensor inputs_embeds = vlm_utils::build_inputs_embeds_from_text_and_visual_chunks(
         tokens,
         [&](const ov::Tensor& text_chunk) {
-            return m_embedding->infer(req, text_chunk);
+            return get_text_embedding(req, text_chunk, metrics);
         },
         images_features_proj,
         base_id,

--- a/src/cpp/src/visual_language/vlm_chat_context.cpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.cpp
@@ -40,7 +40,10 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
     std::vector<size_t> new_image_indices = m_history_state->register_images(new_images);
     std::vector<size_t> new_video_indices = m_history_state->register_videos(new_videos);
     
+    const auto vision_encoder_start = std::chrono::steady_clock::now();
     encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata);
+    const auto vision_encoder_end = std::chrono::steady_clock::now();
+    result.vision_encoder_duration = PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start);
     
     fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices);
     

--- a/src/cpp/src/visual_language/vlm_chat_context.cpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "visual_language/vlm_chat_context.hpp"
+#include "continuous_batching/timer.hpp"
 
 namespace ov::genai {
 
@@ -40,10 +41,10 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
     std::vector<size_t> new_image_indices = m_history_state->register_images(new_images);
     std::vector<size_t> new_video_indices = m_history_state->register_videos(new_videos);
     
-    const auto vision_encoding_start = std::chrono::steady_clock::now();
+    ManualTimer vision_encoding_timer("Vision Encoding");
+    vision_encoding_timer.start();
     encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata);
-    const auto vision_encoding_end = std::chrono::steady_clock::now();
-    result.vision_encoding_duration = PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start);
+    vision_encoding_timer.end();
     
     fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices);
     
@@ -73,6 +74,8 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
     result.vision_counts = m_history_state->build_vision_counts();
     
     result.needs_kv_cache_reset = m_initial_messages_metadata_count == 0 || history_modified;
+
+    result.vision_encoding_duration = vision_encoding_timer.get_duration_microsec();
     
     return result;
 }

--- a/src/cpp/src/visual_language/vlm_chat_context.cpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.cpp
@@ -40,10 +40,10 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
     std::vector<size_t> new_image_indices = m_history_state->register_images(new_images);
     std::vector<size_t> new_video_indices = m_history_state->register_videos(new_videos);
     
-    const auto vision_encoder_start = std::chrono::steady_clock::now();
+    const auto vision_encoding_start = std::chrono::steady_clock::now();
     encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata);
-    const auto vision_encoder_end = std::chrono::steady_clock::now();
-    result.vision_encoder_duration = PerfMetrics::get_microsec(vision_encoder_end - vision_encoder_start);
+    const auto vision_encoding_end = std::chrono::steady_clock::now();
+    result.vision_encoding_duration = PerfMetrics::get_microsec(vision_encoding_end - vision_encoding_start);
     
     fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices);
     

--- a/src/cpp/src/visual_language/vlm_chat_context.hpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.hpp
@@ -37,7 +37,7 @@ public:
 
         bool needs_kv_cache_reset = false;
 
-        float vision_encoder_duration = 0.0f;
+        float vision_encoding_duration = 0.0f;
     };
 
     VLMChatContext(

--- a/src/cpp/src/visual_language/vlm_chat_context.hpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.hpp
@@ -36,6 +36,8 @@ public:
         std::vector<std::pair<size_t, size_t>> vision_counts;
 
         bool needs_kv_cache_reset = false;
+
+        float vision_encoder_duration;
     };
 
     VLMChatContext(

--- a/src/cpp/src/visual_language/vlm_chat_context.hpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.hpp
@@ -37,7 +37,7 @@ public:
 
         bool needs_kv_cache_reset = false;
 
-        float vision_encoder_duration;
+        float vision_encoder_duration = 0.0f;
     };
 
     VLMChatContext(

--- a/src/js/include/vlm_pipeline/perf_metrics.hpp
+++ b/src/js/include/vlm_pipeline/perf_metrics.hpp
@@ -17,6 +17,7 @@ public:
 
     Napi::Value get_prepare_embeddings_duration(const Napi::CallbackInfo& info);
     Napi::Value get_vision_encoding_duration(const Napi::CallbackInfo& info);
+    Napi::Value get_audio_encoding_duration(const Napi::CallbackInfo& info);
     Napi::Value get_text_embedding_duration(const Napi::CallbackInfo& info);
     Napi::Value get_total_image_slice_count(const Napi::CallbackInfo& info);
     Napi::Value get_raw_metrics(const Napi::CallbackInfo& info);

--- a/src/js/include/vlm_pipeline/perf_metrics.hpp
+++ b/src/js/include/vlm_pipeline/perf_metrics.hpp
@@ -16,7 +16,7 @@ public:
     static Napi::Object wrap(Napi::Env env, const ov::genai::VLMPerfMetrics& metrics);
 
     Napi::Value get_prepare_embeddings_duration(const Napi::CallbackInfo& info);
-    Napi::Value get_vision_encoder_duration(const Napi::CallbackInfo& info);
+    Napi::Value get_vision_encoding_duration(const Napi::CallbackInfo& info);
     Napi::Value get_text_embedding_duration(const Napi::CallbackInfo& info);
     Napi::Value get_total_image_slice_count(const Napi::CallbackInfo& info);
     Napi::Value get_raw_metrics(const Napi::CallbackInfo& info);

--- a/src/js/include/vlm_pipeline/perf_metrics.hpp
+++ b/src/js/include/vlm_pipeline/perf_metrics.hpp
@@ -16,6 +16,9 @@ public:
     static Napi::Object wrap(Napi::Env env, const ov::genai::VLMPerfMetrics& metrics);
 
     Napi::Value get_prepare_embeddings_duration(const Napi::CallbackInfo& info);
+    Napi::Value get_vision_encoder_duration(const Napi::CallbackInfo& info);
+    Napi::Value get_text_embedding_duration(const Napi::CallbackInfo& info);
+    Napi::Value get_total_image_slice_count(const Napi::CallbackInfo& info);
     Napi::Value get_raw_metrics(const Napi::CallbackInfo& info);
     Napi::Value get_vlm_raw_metrics(const Napi::CallbackInfo& info);
 };

--- a/src/js/lib/perfMetrics.ts
+++ b/src/js/lib/perfMetrics.ts
@@ -41,6 +41,14 @@ export type RawMetrics = {
 export type VLMRawMetrics = {
   /** Durations for embedding preparation in milliseconds. */
   prepareEmbeddingsDurations: number[];
+  /** Durations for vision encoding in milliseconds. */
+  visionEncodingDurations: number[];
+  /** Durations for audio encoding in milliseconds. */
+  audioEncodingDurations: number[];
+  /** Durations for text embedding in milliseconds. */
+  textEmbeddingDurations: number[];
+  /** Number of image slices produced for each input image */
+  perImageSliceCounts: number[];
 };
 
 /** Structure with raw performance metrics for Whisper generation. */
@@ -116,6 +124,19 @@ export interface PerfMetrics {
 export interface VLMPerfMetrics extends PerfMetrics {
   /** Returns the mean and standard deviation of embeddings preparation duration in milliseconds. */
   getPrepareEmbeddingsDuration(): MeanStdPair;
+
+  /** Returns the mean and standard deviation of vision encoding duration in milliseconds. */
+  getVisionEncodingDuration(): MeanStdPair;
+
+  /** Returns the mean and standard deviation of audio encoding duration in milliseconds. */
+  getAudioEncodingDuration(): MeanStdPair;
+
+  /** Returns the mean and standard deviation of text embedding duration in milliseconds. */
+  getTextEmbeddingDuration(): MeanStdPair;
+
+  /** Returns the total number of image slices produced for the request. */
+  getTotalImageSliceCount(): number;
+
   /** VLM specific raw metrics */
   vlmRawMetrics: VLMRawMetrics;
 

--- a/src/js/src/vlm_pipeline/perf_metrics.cpp
+++ b/src/js/src/vlm_pipeline/perf_metrics.cpp
@@ -17,7 +17,7 @@ Napi::Function VLMPerfMetricsWrapper::get_class(Napi::Env env) {
         InstanceMethod("getPrepareEmbeddingsDuration", &VLMPerfMetricsWrapper::get_prepare_embeddings_duration)
     );
     properties.push_back(
-        InstanceMethod("getVisionEncoderDuration", &VLMPerfMetricsWrapper::get_vision_encoder_duration)
+        InstanceMethod("getVisionEncodingDuration", &VLMPerfMetricsWrapper::get_vision_encoding_duration)
     );
     properties.push_back(
         InstanceMethod("getTextEmbeddingDuration", &VLMPerfMetricsWrapper::get_text_embedding_duration)
@@ -43,9 +43,9 @@ Napi::Value VLMPerfMetricsWrapper::get_prepare_embeddings_duration(const Napi::C
     return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_prepare_embeddings_duration());
 }
 
-Napi::Value VLMPerfMetricsWrapper::get_vision_encoder_duration(const Napi::CallbackInfo& info) {
-    VALIDATE_ARGS_COUNT(info, 0, "getVisionEncoderDuration()");
-    return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_vision_encoder_duration());
+Napi::Value VLMPerfMetricsWrapper::get_vision_encoding_duration(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getVisionEncodingDuration()");
+    return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_vision_encoding_duration());
 }
 
 Napi::Value VLMPerfMetricsWrapper::get_text_embedding_duration(const Napi::CallbackInfo& info) {
@@ -73,10 +73,10 @@ Napi::Value VLMPerfMetricsWrapper::get_vlm_raw_metrics(const Napi::CallbackInfo&
     );
     
     obj.Set(
-        "visionEncoderDurations",
+        "visionEncodingDurations",
         cpp_to_js<std::vector<float>, Napi::Value>(
             info.Env(),
-            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::vision_encoder_durations)
+            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::vision_encoding_durations)
         )
     );
     

--- a/src/js/src/vlm_pipeline/perf_metrics.cpp
+++ b/src/js/src/vlm_pipeline/perf_metrics.cpp
@@ -20,6 +20,9 @@ Napi::Function VLMPerfMetricsWrapper::get_class(Napi::Env env) {
         InstanceMethod("getVisionEncodingDuration", &VLMPerfMetricsWrapper::get_vision_encoding_duration)
     );
     properties.push_back(
+        InstanceMethod("getAudioEncodingDuration", &VLMPerfMetricsWrapper::get_audio_encoding_duration)
+    );
+    properties.push_back(
         InstanceMethod("getTextEmbeddingDuration", &VLMPerfMetricsWrapper::get_text_embedding_duration)
     );
     properties.push_back(
@@ -46,6 +49,11 @@ Napi::Value VLMPerfMetricsWrapper::get_prepare_embeddings_duration(const Napi::C
 Napi::Value VLMPerfMetricsWrapper::get_vision_encoding_duration(const Napi::CallbackInfo& info) {
     VALIDATE_ARGS_COUNT(info, 0, "getVisionEncodingDuration()");
     return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_vision_encoding_duration());
+}
+
+Napi::Value VLMPerfMetricsWrapper::get_audio_encoding_duration(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getAudioEncodingDuration()");
+    return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_audio_encoding_duration());
 }
 
 Napi::Value VLMPerfMetricsWrapper::get_text_embedding_duration(const Napi::CallbackInfo& info) {
@@ -77,6 +85,14 @@ Napi::Value VLMPerfMetricsWrapper::get_vlm_raw_metrics(const Napi::CallbackInfo&
         cpp_to_js<std::vector<float>, Napi::Value>(
             info.Env(),
             get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::vision_encoding_durations)
+        )
+    );
+    
+    obj.Set(
+        "audioEncodingDurations",
+        cpp_to_js<std::vector<float>, Napi::Value>(
+            info.Env(),
+            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::audio_encoding_durations)
         )
     );
     

--- a/src/js/src/vlm_pipeline/perf_metrics.cpp
+++ b/src/js/src/vlm_pipeline/perf_metrics.cpp
@@ -14,7 +14,17 @@ VLMPerfMetricsWrapper::VLMPerfMetricsWrapper(const Napi::CallbackInfo& info)
 Napi::Function VLMPerfMetricsWrapper::get_class(Napi::Env env) {
     auto properties = BasePerfMetricsWrapper<VLMPerfMetricsWrapper, ov::genai::VLMPerfMetrics>::get_class_properties();
     properties.push_back(
-        InstanceMethod("getPrepareEmbeddingsDuration", &VLMPerfMetricsWrapper::get_prepare_embeddings_duration));
+        InstanceMethod("getPrepareEmbeddingsDuration", &VLMPerfMetricsWrapper::get_prepare_embeddings_duration)
+    );
+    properties.push_back(
+        InstanceMethod("getVisionEncoderDuration", &VLMPerfMetricsWrapper::get_vision_encoder_duration)
+    );
+    properties.push_back(
+        InstanceMethod("getTextEmbeddingDuration", &VLMPerfMetricsWrapper::get_text_embedding_duration)
+    );
+    properties.push_back(
+        InstanceMethod("getTotalImageSliceCount", &VLMPerfMetricsWrapper::get_total_image_slice_count)
+    );
     properties.push_back(InstanceAccessor("vlmRawMetrics", &VLMPerfMetricsWrapper::get_vlm_raw_metrics, nullptr));
     return DefineClass(env, "VLMPerfMetrics", properties);
 }
@@ -33,16 +43,58 @@ Napi::Value VLMPerfMetricsWrapper::get_prepare_embeddings_duration(const Napi::C
     return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_prepare_embeddings_duration());
 }
 
+Napi::Value VLMPerfMetricsWrapper::get_vision_encoder_duration(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getVisionEncoderDuration()");
+    return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_vision_encoder_duration());
+}
+
+Napi::Value VLMPerfMetricsWrapper::get_text_embedding_duration(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getTextEmbeddingDuration()");
+    return perf_utils::create_mean_std_pair(info.Env(), _metrics.get_text_embedding_duration());
+}
+
+Napi::Value VLMPerfMetricsWrapper::get_total_image_slice_count(const Napi::CallbackInfo& info) {
+    VALIDATE_ARGS_COUNT(info, 0, "getTotalImageSliceCount()");
+    return Napi::Number::New(info.Env(), _metrics.get_total_image_slice_count());
+}
+
 Napi::Value VLMPerfMetricsWrapper::get_raw_metrics(const Napi::CallbackInfo& info) {
     return BasePerfMetricsWrapper<VLMPerfMetricsWrapper, ov::genai::VLMPerfMetrics>::get_raw_metrics(info);
 }
 
 Napi::Value VLMPerfMetricsWrapper::get_vlm_raw_metrics(const Napi::CallbackInfo& info) {
     Napi::Object obj = Napi::Object::New(info.Env());
-    obj.Set("prepareEmbeddingsDurations",
-            cpp_to_js<std::vector<float>, Napi::Value>(
-                info.Env(),
-                get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::prepare_embeddings_durations)));
+    obj.Set(
+        "prepareEmbeddingsDurations",
+        cpp_to_js<std::vector<float>, Napi::Value>(
+            info.Env(),
+            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::prepare_embeddings_durations)
+        )
+    );
+    
+    obj.Set(
+        "visionEncoderDurations",
+        cpp_to_js<std::vector<float>, Napi::Value>(
+            info.Env(),
+            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::vision_encoder_durations)
+        )
+    );
+    
+    obj.Set(
+        "textEmbeddingDurations",
+        cpp_to_js<std::vector<float>, Napi::Value>(
+            info.Env(),
+            get_ms(_metrics.vlm_raw_metrics, &ov::genai::VLMRawPerfMetrics::text_embedding_durations)
+        )
+    );
+    
+    obj.Set(
+        "perImageSliceCounts",
+        cpp_to_js<std::vector<size_t>, Napi::Value>(
+            info.Env(),
+            _metrics.vlm_raw_metrics.per_image_slice_counts
+        )
+    );
 
     return obj;
 }

--- a/src/js/tests/vlmPipeline.test.js
+++ b/src/js/tests/vlmPipeline.test.js
@@ -198,7 +198,7 @@ describe("VLMPipeline", { skip: process.platform === "darwin" }, () => {
     const { audioEncodingDurations } = result.perfMetrics.vlmRawMetrics;
     assert.ok(
       Array.isArray(audioEncodingDurations),
-      "Raw audio encoding durationz should be an array",
+      "Raw audio encoding durations should be an array",
     );
 
     const totalImageSliceCount = result.perfMetrics.getTotalImageSliceCount();

--- a/src/js/tests/vlmPipeline.test.js
+++ b/src/js/tests/vlmPipeline.test.js
@@ -169,17 +169,45 @@ describe("VLMPipeline", { skip: process.platform === "darwin" }, () => {
       "Number of tokens should be between 0 and max_new_tokens",
     );
     // VLM-specific properties
-    const prepareEmbeddings = result.perfMetrics.getPrepareEmbeddingsDuration();
+    const metricAndRawPairs = [
+      [
+        result.perfMetrics.getPrepareEmbeddingsDuration(),
+        result.perfMetrics.vlmRawMetrics.prepareEmbeddingsDurations,
+      ],
+      [
+        result.perfMetrics.getVisionEncodingDuration(),
+        result.perfMetrics.vlmRawMetrics.visionEncodingDurations,
+      ],
+      [
+        result.perfMetrics.getAudioEncodingDuration(),
+        result.perfMetrics.vlmRawMetrics.audioEncodingDurations,
+      ],
+      [
+        result.perfMetrics.getTextEmbeddingDuration(),
+        result.perfMetrics.vlmRawMetrics.textEmbeddingDurations,
+      ],
+    ];
+
+    for (const [metric, raw] of metricAndRawPairs) {
+      assert.ok(typeof metric.mean === "number", "Metric should have mean value");
+      assert.ok(Array.isArray(raw), "Raw metric should be an array");
+      assert.ok(raw.length > 0, "Raw metric should have at least one value");
+    }
+
+    const totalImageSliceCount = result.perfMetrics.getTotalImageSliceCount();
     assert.ok(
-      typeof prepareEmbeddings.mean === "number",
-      "PrepareEmbeddingsDuration should have mean",
+      typeof totalImageSliceCount === "number",
+      "Total image slice count should be a number",
     );
-    const { prepareEmbeddingsDurations } = result.perfMetrics.vlmRawMetrics;
+    const { perImageSliceCounts } = result.perfMetrics.vlmRawMetrics;
     assert.ok(
-      Array.isArray(prepareEmbeddingsDurations),
-      "Should have duration of preparation of embeddings",
+      Array.isArray(perImageSliceCounts),
+      "perImageSliceCounts raw metric should be an array",
     );
-    assert.ok(prepareEmbeddingsDurations.length > 0, "Should have at least one duration value");
+    assert.ok(
+      perImageSliceCounts.length > 0,
+      "perImageSliceCounts raw metric should have at least one value",
+    );
   });
 
   it("should get tokenizer from pipeline", () => {

--- a/src/js/tests/vlmPipeline.test.js
+++ b/src/js/tests/vlmPipeline.test.js
@@ -179,10 +179,6 @@ describe("VLMPipeline", { skip: process.platform === "darwin" }, () => {
         result.perfMetrics.vlmRawMetrics.visionEncodingDurations,
       ],
       [
-        result.perfMetrics.getAudioEncodingDuration(),
-        result.perfMetrics.vlmRawMetrics.audioEncodingDurations,
-      ],
-      [
         result.perfMetrics.getTextEmbeddingDuration(),
         result.perfMetrics.vlmRawMetrics.textEmbeddingDurations,
       ],
@@ -193,6 +189,17 @@ describe("VLMPipeline", { skip: process.platform === "darwin" }, () => {
       assert.ok(Array.isArray(raw), "Raw metric should be an array");
       assert.ok(raw.length > 0, "Raw metric should have at least one value");
     }
+
+    const audioEncodingDuration = result.perfMetrics.getAudioEncodingDuration();
+    assert.ok(
+      typeof audioEncodingDuration.mean === "number",
+      "Audio encoding duration should be a number",
+    );
+    const { audioEncodingDurations } = result.perfMetrics.vlmRawMetrics;
+    assert.ok(
+      Array.isArray(audioEncodingDurations),
+      "Raw audio encoding durationz should be an array",
+    );
 
     const totalImageSliceCount = result.perfMetrics.getTotalImageSliceCount();
     assert.ok(

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -5395,6 +5395,9 @@ class VLMPerfMetrics(PerfMetrics):
         :param get_vision_encoding_duration: Returns mean and standard deviation of vision encoding duration in milliseconds
         :type get_vision_encoding_duration: MeanStdPair
     
+        :param get_audio_encoding_duration: Returns mean and standard deviation of audio encoding duration in milliseconds
+        :type get_audio_encoding_duration: MeanStdPair
+    
         :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
         :type get_text_embedding_duration: MeanStdPair
     
@@ -5405,6 +5408,8 @@ class VLMPerfMetrics(PerfMetrics):
         :type VLMRawPerfMetrics:
     """
     def __init__(self) -> None:
+        ...
+    def get_audio_encoding_duration(self) -> MeanStdPair:
         ...
     def get_prepare_embeddings_duration(self) -> MeanStdPair:
         ...
@@ -5795,6 +5800,9 @@ class VLMRawPerfMetrics:
         :param vision_encoding_durations: Durations of vision encoding.
         :type vision_encoding_durations: list[MicroSeconds]
     
+        :param audio_encoding_durations: Durations of audio encoding.
+        :type audio_encoding_durations: list[MicroSeconds]
+    
         :param text_embedding_durations: Durations of text embedding.
         :type text_embedding_durations: list[MicroSeconds]
     
@@ -5802,6 +5810,9 @@ class VLMRawPerfMetrics:
         :type per_image_slice_counts: list[int]
     """
     def __init__(self) -> None:
+        ...
+    @property
+    def audio_encoding_durations(self) -> list[float]:
         ...
     @property
     def per_image_slice_counts(self) -> list[int]:

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -5392,6 +5392,15 @@ class VLMPerfMetrics(PerfMetrics):
         :param get_prepare_embeddings_duration: Returns mean and standard deviation of embeddings preparation duration in milliseconds
         :type get_prepare_embeddings_duration: MeanStdPair
     
+        :param get_vision_encoder_duration: Returns mean and standard deviation of vision encoder duration in milliseconds
+        :type get_vision_encoder_duration: MeanStdPair
+    
+        :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
+        :type get_text_embedding_duration: MeanStdPair
+    
+        :param get_total_image_slice_count: Total number of image slices produced for the request.
+        :type get_total_image_slice_count: int
+    
         :param vlm_raw_metrics: VLM specific raw metrics
         :type VLMRawPerfMetrics:
     """
@@ -5399,11 +5408,15 @@ class VLMPerfMetrics(PerfMetrics):
         ...
     def get_prepare_embeddings_duration(self) -> MeanStdPair:
         ...
+    def get_text_embedding_duration(self) -> MeanStdPair:
+        ...
     def get_total_image_slice_count(self) -> int:
         """
         Returns the total number of image slices processed for the request.
         An input image without explicit slicing metadata counts as one slice.
         """
+    def get_vision_encoder_duration(self) -> MeanStdPair:
+        ...
     @property
     def vlm_raw_metrics(self) -> VLMRawPerfMetrics:
         ...
@@ -5778,6 +5791,15 @@ class VLMRawPerfMetrics:
     
         :param prepare_embeddings_durations: Durations of embeddings preparation.
         :type prepare_embeddings_durations: list[MicroSeconds]
+    
+        :param vision_encoder_durations: Durations of vision encoder execution.
+        :type vision_encoder_durations: list[MicroSeconds]
+    
+        :param text_embedding_durations: Durations of text embedding execution.
+        :type text_embedding_durations: list[MicroSeconds]
+    
+        :param per_image_slice_counts: Number of image slices processed for each input image.
+        :type per_image_slice_counts: list[int]
     """
     def __init__(self) -> None:
         ...
@@ -5786,6 +5808,12 @@ class VLMRawPerfMetrics:
         ...
     @property
     def prepare_embeddings_durations(self) -> list[float]:
+        ...
+    @property
+    def text_embedding_durations(self) -> list[float]:
+        ...
+    @property
+    def vision_encoder_durations(self) -> list[float]:
         ...
 class VideoGenerationConfig:
     adapters: openvino_genai.py_openvino_genai.AdapterConfig | None

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -5392,8 +5392,8 @@ class VLMPerfMetrics(PerfMetrics):
         :param get_prepare_embeddings_duration: Returns mean and standard deviation of embeddings preparation duration in milliseconds
         :type get_prepare_embeddings_duration: MeanStdPair
     
-        :param get_vision_encoder_duration: Returns mean and standard deviation of vision encoder duration in milliseconds
-        :type get_vision_encoder_duration: MeanStdPair
+        :param get_vision_encoding_duration: Returns mean and standard deviation of vision encoding duration in milliseconds
+        :type get_vision_encoding_duration: MeanStdPair
     
         :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
         :type get_text_embedding_duration: MeanStdPair
@@ -5415,7 +5415,7 @@ class VLMPerfMetrics(PerfMetrics):
         Returns the total number of image slices processed for the request.
         An input image without explicit slicing metadata counts as one slice.
         """
-    def get_vision_encoder_duration(self) -> MeanStdPair:
+    def get_vision_encoding_duration(self) -> MeanStdPair:
         ...
     @property
     def vlm_raw_metrics(self) -> VLMRawPerfMetrics:
@@ -5792,10 +5792,10 @@ class VLMRawPerfMetrics:
         :param prepare_embeddings_durations: Durations of embeddings preparation.
         :type prepare_embeddings_durations: list[MicroSeconds]
     
-        :param vision_encoder_durations: Durations of vision encoder execution.
-        :type vision_encoder_durations: list[MicroSeconds]
+        :param vision_encoding_durations: Durations of vision encoding.
+        :type vision_encoding_durations: list[MicroSeconds]
     
-        :param text_embedding_durations: Durations of text embedding execution.
+        :param text_embedding_durations: Durations of text embedding.
         :type text_embedding_durations: list[MicroSeconds]
     
         :param per_image_slice_counts: Number of image slices processed for each input image.
@@ -5813,7 +5813,7 @@ class VLMRawPerfMetrics:
     def text_embedding_durations(self) -> list[float]:
         ...
     @property
-    def vision_encoder_durations(self) -> list[float]:
+    def vision_encoding_durations(self) -> list[float]:
         ...
 class VideoGenerationConfig:
     adapters: openvino_genai.py_openvino_genai.AdapterConfig | None

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -113,6 +113,9 @@ auto raw_perf_metrics_docstring = R"(
     :param vision_encoding_durations: Durations of vision encoding.
     :type vision_encoding_durations: list[MicroSeconds]
 
+    :param audio_encoding_durations: Durations of audio encoding.
+    :type audio_encoding_durations: list[MicroSeconds]
+
     :param text_embedding_durations: Durations of text embedding.
     :type text_embedding_durations: list[MicroSeconds]
 
@@ -128,6 +131,9 @@ auto perf_metrics_docstring = R"(
 
     :param get_vision_encoding_duration: Returns mean and standard deviation of vision encoding duration in milliseconds
     :type get_vision_encoding_duration: MeanStdPair
+
+    :param get_audio_encoding_duration: Returns mean and standard deviation of audio encoding duration in milliseconds
+    :type get_audio_encoding_duration: MeanStdPair
 
     :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
     :type get_text_embedding_duration: MeanStdPair
@@ -278,6 +284,9 @@ void init_vlm_pipeline(py::module_& m) {
         .def_property_readonly("vision_encoding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
             return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::vision_encoding_durations);
         })
+        .def_property_readonly("audio_encoding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
+            return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::audio_encoding_durations);
+        })
         .def_property_readonly("text_embedding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
             return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::text_embedding_durations);
         })
@@ -287,6 +296,7 @@ void init_vlm_pipeline(py::module_& m) {
         .def(py::init<>())
         .def("get_prepare_embeddings_duration", &ov::genai::VLMPerfMetrics::get_prepare_embeddings_duration)
         .def("get_vision_encoding_duration", &ov::genai::VLMPerfMetrics::get_vision_encoding_duration)
+        .def("get_audio_encoding_duration", &ov::genai::VLMPerfMetrics::get_audio_encoding_duration)
         .def("get_text_embedding_duration", &ov::genai::VLMPerfMetrics::get_text_embedding_duration)
         .def("get_total_image_slice_count", &ov::genai::VLMPerfMetrics::get_total_image_slice_count,
              R"(Returns the total number of image slices processed for the request.

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -109,6 +109,15 @@ auto raw_perf_metrics_docstring = R"(
 
     :param prepare_embeddings_durations: Durations of embeddings preparation.
     :type prepare_embeddings_durations: list[MicroSeconds]
+
+    :param vision_encoder_durations: Durations of vision encoder execution.
+    :type vision_encoder_durations: list[MicroSeconds]
+
+    :param text_embedding_durations: Durations of text embedding execution.
+    :type text_embedding_durations: list[MicroSeconds]
+
+    :param per_image_slice_counts: Number of image slices processed for each input image.
+    :type per_image_slice_counts: list[int]
 )";
 
 auto perf_metrics_docstring = R"(
@@ -116,6 +125,15 @@ auto perf_metrics_docstring = R"(
 
     :param get_prepare_embeddings_duration: Returns mean and standard deviation of embeddings preparation duration in milliseconds
     :type get_prepare_embeddings_duration: MeanStdPair
+
+    :param get_vision_encoder_duration: Returns mean and standard deviation of vision encoder duration in milliseconds
+    :type get_vision_encoder_duration: MeanStdPair
+
+    :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
+    :type get_text_embedding_duration: MeanStdPair
+
+    :param get_total_image_slice_count: Total number of image slices produced for the request.
+    :type get_total_image_slice_count: int
 
     :param vlm_raw_metrics: VLM specific raw metrics
     :type VLMRawPerfMetrics:
@@ -257,11 +275,19 @@ void init_vlm_pipeline(py::module_& m) {
         .def_property_readonly("prepare_embeddings_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
             return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::prepare_embeddings_durations);
         })
+        .def_property_readonly("vision_encoder_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
+            return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::vision_encoder_durations);
+        })
+        .def_property_readonly("text_embedding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
+            return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::text_embedding_durations);
+        })
         .def_readonly("per_image_slice_counts", &ov::genai::VLMRawPerfMetrics::per_image_slice_counts);
 
     py::class_<ov::genai::VLMPerfMetrics, ov::genai::PerfMetrics>(m, "VLMPerfMetrics", perf_metrics_docstring)
         .def(py::init<>())
         .def("get_prepare_embeddings_duration", &ov::genai::VLMPerfMetrics::get_prepare_embeddings_duration)
+        .def("get_vision_encoder_duration", &ov::genai::VLMPerfMetrics::get_vision_encoder_duration)
+        .def("get_text_embedding_duration", &ov::genai::VLMPerfMetrics::get_text_embedding_duration)
         .def("get_total_image_slice_count", &ov::genai::VLMPerfMetrics::get_total_image_slice_count,
              R"(Returns the total number of image slices processed for the request.
 An input image without explicit slicing metadata counts as one slice.)")

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -110,10 +110,10 @@ auto raw_perf_metrics_docstring = R"(
     :param prepare_embeddings_durations: Durations of embeddings preparation.
     :type prepare_embeddings_durations: list[MicroSeconds]
 
-    :param vision_encoder_durations: Durations of vision encoder execution.
-    :type vision_encoder_durations: list[MicroSeconds]
+    :param vision_encoding_durations: Durations of vision encoding.
+    :type vision_encoding_durations: list[MicroSeconds]
 
-    :param text_embedding_durations: Durations of text embedding execution.
+    :param text_embedding_durations: Durations of text embedding.
     :type text_embedding_durations: list[MicroSeconds]
 
     :param per_image_slice_counts: Number of image slices processed for each input image.
@@ -126,8 +126,8 @@ auto perf_metrics_docstring = R"(
     :param get_prepare_embeddings_duration: Returns mean and standard deviation of embeddings preparation duration in milliseconds
     :type get_prepare_embeddings_duration: MeanStdPair
 
-    :param get_vision_encoder_duration: Returns mean and standard deviation of vision encoder duration in milliseconds
-    :type get_vision_encoder_duration: MeanStdPair
+    :param get_vision_encoding_duration: Returns mean and standard deviation of vision encoding duration in milliseconds
+    :type get_vision_encoding_duration: MeanStdPair
 
     :param get_text_embedding_duration: Returns mean and standard deviation of text embedding duration in milliseconds
     :type get_text_embedding_duration: MeanStdPair
@@ -275,8 +275,8 @@ void init_vlm_pipeline(py::module_& m) {
         .def_property_readonly("prepare_embeddings_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
             return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::prepare_embeddings_durations);
         })
-        .def_property_readonly("vision_encoder_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
-            return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::vision_encoder_durations);
+        .def_property_readonly("vision_encoding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
+            return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::vision_encoding_durations);
         })
         .def_property_readonly("text_embedding_durations", [](const ov::genai::VLMRawPerfMetrics& rw) {
             return common_utils::get_ms(rw, &ov::genai::VLMRawPerfMetrics::text_embedding_durations);
@@ -286,7 +286,7 @@ void init_vlm_pipeline(py::module_& m) {
     py::class_<ov::genai::VLMPerfMetrics, ov::genai::PerfMetrics>(m, "VLMPerfMetrics", perf_metrics_docstring)
         .def(py::init<>())
         .def("get_prepare_embeddings_duration", &ov::genai::VLMPerfMetrics::get_prepare_embeddings_duration)
-        .def("get_vision_encoder_duration", &ov::genai::VLMPerfMetrics::get_vision_encoder_duration)
+        .def("get_vision_encoding_duration", &ov::genai::VLMPerfMetrics::get_vision_encoding_duration)
         .def("get_text_embedding_duration", &ov::genai::VLMPerfMetrics::get_text_embedding_duration)
         .def("get_total_image_slice_count", &ov::genai::VLMPerfMetrics::get_total_image_slice_count,
              R"(Returns the total number of image slices processed for the request.

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -885,6 +885,12 @@ def test_vlm_continuous_batching_generate_vs_add_request(
         assert len(vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations) == len(
             cb_vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations
         )
+        assert len(vlm_perf_metrics.vlm_raw_metrics.vision_encoder_durations) == len(
+            cb_vlm_perf_metrics.vlm_raw_metrics.vision_encoder_durations
+        )
+        assert len(vlm_perf_metrics.vlm_raw_metrics.text_embedding_durations) == len(
+            cb_vlm_perf_metrics.vlm_raw_metrics.text_embedding_durations
+        )
 
         assert vlm_perf_metrics.get_prepare_embeddings_duration().mean > 0
         assert cb_vlm_perf_metrics.get_prepare_embeddings_duration().mean > 0
@@ -892,9 +898,6 @@ def test_vlm_continuous_batching_generate_vs_add_request(
         if images or videos:
             assert vlm_perf_metrics.get_vision_encoder_duration().mean > 0
             assert cb_vlm_perf_metrics.get_vision_encoder_duration().mean > 0
-        else:
-            assert vlm_perf_metrics.get_vision_encoder_duration().mean == 0
-            assert cb_vlm_perf_metrics.get_vision_encoder_duration().mean == 0
 
         assert vlm_perf_metrics.get_text_embedding_duration().mean > 0
         assert cb_vlm_perf_metrics.get_text_embedding_duration().mean > 0

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -1448,6 +1448,7 @@ def test_perf_metrics(
     metrics_and_raw_pairs = [
         (perf_metrics.get_prepare_embeddings_duration(), vlm_raw_metrics.prepare_embeddings_durations),
         (perf_metrics.get_vision_encoding_duration(), vlm_raw_metrics.vision_encoding_durations),
+        (perf_metrics.get_audio_encoding_duration(), vlm_raw_metrics.audio_encoding_durations),
         (perf_metrics.get_text_embedding_duration(), vlm_raw_metrics.text_embedding_durations),
     ]
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -885,8 +885,8 @@ def test_vlm_continuous_batching_generate_vs_add_request(
         assert len(vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations) == len(
             cb_vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations
         )
-        assert len(vlm_perf_metrics.vlm_raw_metrics.vision_encoder_durations) == len(
-            cb_vlm_perf_metrics.vlm_raw_metrics.vision_encoder_durations
+        assert len(vlm_perf_metrics.vlm_raw_metrics.vision_encoding_durations) == len(
+            cb_vlm_perf_metrics.vlm_raw_metrics.vision_encoding_durations
         )
         assert len(vlm_perf_metrics.vlm_raw_metrics.text_embedding_durations) == len(
             cb_vlm_perf_metrics.vlm_raw_metrics.text_embedding_durations
@@ -896,8 +896,8 @@ def test_vlm_continuous_batching_generate_vs_add_request(
         assert cb_vlm_perf_metrics.get_prepare_embeddings_duration().mean > 0
 
         if images or videos:
-            assert vlm_perf_metrics.get_vision_encoder_duration().mean > 0
-            assert cb_vlm_perf_metrics.get_vision_encoder_duration().mean > 0
+            assert vlm_perf_metrics.get_vision_encoding_duration().mean > 0
+            assert cb_vlm_perf_metrics.get_vision_encoding_duration().mean > 0
 
         assert vlm_perf_metrics.get_text_embedding_duration().mean > 0
         assert cb_vlm_perf_metrics.get_text_embedding_duration().mean > 0
@@ -1423,11 +1423,11 @@ def test_perf_metrics(
 
     prepare_embeddings_mean = perf_metrics.get_prepare_embeddings_duration().mean
     assert 0 < prepare_embeddings_mean < generate_time
-    vision_encoder_mean = perf_metrics.get_vision_encoder_duration().mean
-    assert 0 < vision_encoder_mean < prepare_embeddings_mean
+    vision_encoding_mean = perf_metrics.get_vision_encoding_duration().mean
+    assert 0 < vision_encoding_mean < prepare_embeddings_mean
     text_embedding_mean = perf_metrics.get_text_embedding_duration().mean
     assert 0 < text_embedding_mean < prepare_embeddings_mean
-    assert 0 < vision_encoder_mean + text_embedding_mean < prepare_embeddings_mean
+    assert 0 < vision_encoding_mean + text_embedding_mean < prepare_embeddings_mean
 
     squared_generate_time = generate_time * generate_time
     assert 0 <= perf_metrics.get_ttft().std < squared_generate_time
@@ -1439,7 +1439,7 @@ def test_perf_metrics(
     assert 0 <= perf_metrics.get_tokenization_duration().std < squared_generate_time
     assert 0 <= perf_metrics.get_detokenization_duration().std < squared_generate_time
     assert 0 <= perf_metrics.get_prepare_embeddings_duration().std < squared_generate_time
-    assert 0 <= perf_metrics.get_vision_encoder_duration().std < squared_generate_time
+    assert 0 <= perf_metrics.get_vision_encoding_duration().std < squared_generate_time
     assert 0 <= perf_metrics.get_text_embedding_duration().std < squared_generate_time
 
     # assert that calculating statistics manually from the raw counters we get the same results as from PerfMetrics
@@ -1447,7 +1447,7 @@ def test_perf_metrics(
 
     metrics_and_raw_pairs = [
         (perf_metrics.get_prepare_embeddings_duration(), vlm_raw_metrics.prepare_embeddings_durations),
-        (perf_metrics.get_vision_encoder_duration(), vlm_raw_metrics.vision_encoder_durations),
+        (perf_metrics.get_vision_encoding_duration(), vlm_raw_metrics.vision_encoding_durations),
         (perf_metrics.get_text_embedding_duration(), vlm_raw_metrics.text_embedding_durations),
     ]
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -885,8 +885,20 @@ def test_vlm_continuous_batching_generate_vs_add_request(
         assert len(vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations) == len(
             cb_vlm_perf_metrics.vlm_raw_metrics.prepare_embeddings_durations
         )
+
         assert vlm_perf_metrics.get_prepare_embeddings_duration().mean > 0
         assert cb_vlm_perf_metrics.get_prepare_embeddings_duration().mean > 0
+
+        if images or videos:
+            assert vlm_perf_metrics.get_vision_encoder_duration().mean > 0
+            assert cb_vlm_perf_metrics.get_vision_encoder_duration().mean > 0
+        else:
+            assert vlm_perf_metrics.get_vision_encoder_duration().mean == 0
+            assert cb_vlm_perf_metrics.get_vision_encoder_duration().mean == 0
+
+        assert vlm_perf_metrics.get_text_embedding_duration().mean > 0
+        assert cb_vlm_perf_metrics.get_text_embedding_duration().mean > 0
+
         assert (
             vlm_perf_metrics.vlm_raw_metrics.per_image_slice_counts
             == cb_vlm_perf_metrics.vlm_raw_metrics.per_image_slice_counts
@@ -1405,7 +1417,14 @@ def test_perf_metrics(
     assert 0 < perf_metrics.get_generate_duration().mean < generate_time
     assert 0 < perf_metrics.get_tokenization_duration().mean < generate_time
     assert 0 < perf_metrics.get_detokenization_duration().mean < generate_time
-    assert 0 < perf_metrics.get_prepare_embeddings_duration().mean < generate_time
+
+    prepare_embeddings_mean = perf_metrics.get_prepare_embeddings_duration().mean
+    assert 0 < prepare_embeddings_mean < generate_time
+    vision_encoder_mean = perf_metrics.get_vision_encoder_duration().mean
+    assert 0 < vision_encoder_mean < prepare_embeddings_mean
+    text_embedding_mean = perf_metrics.get_text_embedding_duration().mean
+    assert 0 < text_embedding_mean < prepare_embeddings_mean
+    assert 0 < vision_encoder_mean + text_embedding_mean < prepare_embeddings_mean
 
     squared_generate_time = generate_time * generate_time
     assert 0 <= perf_metrics.get_ttft().std < squared_generate_time
@@ -1416,17 +1435,23 @@ def test_perf_metrics(
     assert 0 <= perf_metrics.get_generate_duration().std < squared_generate_time
     assert 0 <= perf_metrics.get_tokenization_duration().std < squared_generate_time
     assert 0 <= perf_metrics.get_detokenization_duration().std < squared_generate_time
-    assert (
-        0 <= perf_metrics.get_prepare_embeddings_duration().std < squared_generate_time
-    )
+    assert 0 <= perf_metrics.get_prepare_embeddings_duration().std < squared_generate_time
+    assert 0 <= perf_metrics.get_vision_encoder_duration().std < squared_generate_time
+    assert 0 <= perf_metrics.get_text_embedding_duration().std < squared_generate_time
 
     # assert that calculating statistics manually from the raw counters we get the same results as from PerfMetrics
     vlm_raw_metrics = perf_metrics.vlm_raw_metrics
 
-    raw_dur = np.array(vlm_raw_metrics.prepare_embeddings_durations) / 1000.0
-    mean_dur, std_dur = perf_metrics.get_prepare_embeddings_duration()
-    assert np.allclose(mean_dur, np.mean(raw_dur))
-    assert np.allclose(std_dur, np.std(raw_dur))
+    metrics_and_raw_pairs = [
+        (perf_metrics.get_prepare_embeddings_duration(), vlm_raw_metrics.prepare_embeddings_durations),
+        (perf_metrics.get_vision_encoder_duration(), vlm_raw_metrics.vision_encoder_durations),
+        (perf_metrics.get_text_embedding_duration(), vlm_raw_metrics.text_embedding_durations),
+    ]
+
+    for (mean_duration, std_duration), raw_metrics in metrics_and_raw_pairs:
+        raw_durations = np.array(raw_metrics) / 1000.0
+        assert np.allclose(mean_duration, np.mean(raw_durations))
+        assert np.allclose(std_duration, np.std(raw_durations))
 
     # Test per-image and request-level image slice metrics.
     assert perf_metrics.get_total_image_slice_count() > 0


### PR DESCRIPTION
## Description
This PR extends VLM perf metrics with two additional values:
- vision encoding duration (vision preprocessing + vision embedding)
- audio encoding duration
- text embedding duration

It also updates Python and JS bindings, samples and tests for new detailed metrics.

CVS-187605

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. 
- [x] This PR fully addresses the ticket. 
- N/A - I have made corresponding changes to the documentation.
