### PR TITLE
[CB][VLM] Fix Coverity uninitialized reads and destructor throws

### DIFF
--- a/src/cpp/src/continuous_batching/cache/block_manager.hpp
+++ b/src/cpp/src/continuous_batching/cache/block_manager.hpp
@@ -10,6 +10,7 @@
 #include <set>
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <limits>
 #include <utility>
 #include <vector>
@@ -268,9 +269,16 @@ public:
         for (auto& free_block : m_free_blocks_num) {
             const size_t free_and_overwritable_block_cnt = free_block + num_overwriteable_blocks();
             if (m_total_num_blocks != free_and_overwritable_block_cnt) {
-                GENAI_ERR("BlockAllocator leaked blocks. Expected num free blocks: %zu, actual: %zu",
-                          m_total_num_blocks,
-                          free_and_overwritable_block_cnt);
+                try {
+                    GENAI_ERR("BlockAllocator leaked blocks. Expected num free blocks: %zu, actual: %zu",
+                              m_total_num_blocks,
+                              free_and_overwritable_block_cnt);
+                } catch (...) {
+                    std::fprintf(stderr,
+                                 "BlockAllocator leaked blocks. Expected: %zu, actual: %zu\n",
+                                 m_total_num_blocks,
+                                 free_and_overwritable_block_cnt);
+                }
             }
         }
     }
@@ -675,9 +683,16 @@ public:
         const size_t leaked_tables = m_block_table.size();
         const uint64_t first_leaked_seq_id = leaked_tables > 0 ? m_block_table.begin()->first : 0;
         if (!m_block_table.empty()) {
-            GENAI_ERR("BlockManager leaked sequence block tables: %zu, first leaked sequence id: %llu",
-                      leaked_tables,
-                      static_cast<unsigned long long>(first_leaked_seq_id));
+            try {
+                GENAI_ERR("BlockManager leaked sequence block tables: %zu, first leaked sequence id: %llu",
+                          leaked_tables,
+                          static_cast<unsigned long long>(first_leaked_seq_id));
+            } catch (...) {
+                std::fprintf(stderr,
+                             "BlockManager leaked sequence block tables: %zu, first leaked sequence id: %llu\n",
+                             leaked_tables,
+                             static_cast<unsigned long long>(first_leaked_seq_id));
+            }
         }
     }
 

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -75,14 +75,14 @@ struct EncodedVideo {
     ov::Tensor video_features;
 
     /// @brief Number of video tokens required to append to a normalized prompt
-    size_t num_video_tokens;
+    size_t num_video_tokens = 0;
 
     /// @brief A size of an image used to compute embeddings for
     /// divided by ProcessorConfig's patch_size.
     ImageSize resized_source_size;
 
     /// @brief A number of encoded frames.
-    size_t frame_num;
+    size_t frame_num = 0;
 
     /// @brief Video metadata, used for video input processing and prompt normalization.
     VideoMetadata metadata;


### PR DESCRIPTION
## Description

Two Coverity fixes.

**CB destructors (CID 6465822, CID 6465814).** `GENAI_ERR` can throw, and an implicitly-`noexcept` destructor turns that into `std::terminate`. Now caught, with an `std::fprintf(stderr, ...)` fallback. Regression from #3827.

**`EncodedVideo` (CID 6465765, CID 6465769, CID 6923861, CID 6465768).** `num_video_tokens` and `frame_num` had no default initializers, so encoders copy one out indeterminate. `= 0` also covers `qwen3_vl/classes.cpp:397` and `qwen3_5`.

CID 6922826 and CID 6267146 are false positives (libstdc++ `std::variant` `_M_u`), triaged in Coverity.

CVS-192418

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [ ] N/A Tests have been updated or added to cover the new code. Nothing observable changes: the destructor diagnostics only run during a teardown that has already leaked, and no consumer reads the values the initializers replace.
- [x] This PR fully addresses the ticket. CVS-192418 covers the two destructor CIDs. No Jira ticket is filed for the four `EncodedVideo` CIDs.
- [ ] N/A I have made corresponding changes to the documentation.
