### PR TITLE
[CI] Make test content download atomic to avoid corrupted shared cache

### DIFF
--- a/tests/python_tests/samples/conftest.py
+++ b/tests/python_tests/samples/conftest.py
@@ -7,6 +7,7 @@ import json
 import pytest
 import shutil
 import logging
+import uuid
 import requests
 from importlib import metadata
 from pathlib import Path
@@ -464,11 +465,18 @@ def download_test_content(request):
         if not os.path.exists(file_path):
             logger.info(f"Downloading test content from {file_url} to {file_path}...")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            response = requests.get(file_url, stream=True)
-            response.raise_for_status()
-            with open(file_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+            temp_path = f"{file_path}.tmp_{uuid.uuid4().hex[:8]}"
+            try:
+                response = requests.get(file_url, stream=True)
+                response.raise_for_status()
+                with open(temp_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                os.replace(temp_path, file_path)
+            except Exception:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+                raise
             logger.info(f"Downloaded test content to {file_path}")
         else:
             logger.info(f"Test content already exists at {file_path}")


### PR DESCRIPTION
## Description

CVS-193070

`test_cpp_tool_benchmark` (Tools tests, Windows) failed on every PR on 2026-08-19 with: `[json.exception.parse_error.101] parse error at line 1594473, column 491: ... missing closing quote`


#### Cause

download_test_content in `tests/python_tests/samples/conftest.py` streams the download directly to the final cache path. If the transfer is interrupted, a truncated file is left behind, and the `os.path.exists()` check treats it as complete on all subsequent runs.

That is what happened in [run 32210833659, attempt 1](https://github.com/openvinotoolkit/openvino.genai/actions/runs/32210833659/attempts/1) (Tools tests, 03:55 UTC, the first job to populate the day's `.ov_cache/win/.../20260819` folder). The ShareGPT download died mid-stream: `urllib3.exceptions.ProtocolError: ('Connection broken: IncompleteRead(327238867 bytes read, 345599075 more expected)')`


327,238,867 + 345,599,075 = 672,837,942 bytes, which is the file's Content-Length on hf. The truncated 327MB file stayed at the final path. Since the OV_CACHE day folder is shared by all Windows runners, every later job that day (e.g. [32236261371](https://github.com/openvinotoolkit/openvino.genai/actions/runs/32236261371), [32218248194](https://github.com/openvinotoolkit/openvino.genai/actions/runs/32218248194), [32242846268](https://github.com/openvinotoolkit/openvino.genai/actions/runs/32242846268/job/96043848909), [32246735815](https://github.com/openvinotoolkit/openvino.genai/actions/runs/32246735815/job/96052993722?pr=4247)) logged `Test content already exists` and failed at the identical byte offset.

This went unnoticed until now because only the first Tools job of each day downloads the file, and the date-partitioned cache self-clears at midnight.

#### Fix

Download to a unique temp file and `os.replace()` it into place only after the stream completes; remove the temp file on failure. This is the same temp-then-rename pattern `AtomicDownloadManager` already uses for model downloads in this file. An interrupted download now leaves nothing behind, so the next session retries instead of consuming a partial file.


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
