### PR TITLE
[llm_bench] Fixed running the video_gen task with prompt from cmd and alignment def parameters

### DIFF
--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -355,7 +355,10 @@ def get_argparser():
         "--streaming", action="store_true", help="Set whether to use streaming mode, only applicable to LLM."
     )
     parser.add_argument(
-        "--num_steps", type=greater_than_zero, required=False, help="Number of inference steps for image generation"
+        "--num_steps",
+        type=greater_than_zero,
+        required=False,
+        help="Number of inference steps for Image and Video Generation.",
     )
     parser.add_argument(
         "--height",

--- a/tools/llm_bench/benchmark.py
+++ b/tools/llm_bench/benchmark.py
@@ -354,16 +354,18 @@ def get_argparser():
     parser.add_argument(
         "--streaming", action="store_true", help="Set whether to use streaming mode, only applicable to LLM."
     )
-    parser.add_argument("--num_steps", type=int, required=False, help="Number of inference steps for image generation")
+    parser.add_argument(
+        "--num_steps", type=greater_than_zero, required=False, help="Number of inference steps for image generation"
+    )
     parser.add_argument(
         "--height",
-        type=int,
+        type=greater_than_zero,
         required=False,
         help="Generated image height. Applicable only for Image and Video Generation.",
     )
     parser.add_argument(
         "--width",
-        type=int,
+        type=greater_than_zero,
         required=False,
         help="Generated image width. Applicable only for Image and Video Generation.",
     )
@@ -380,7 +382,7 @@ def get_argparser():
     )
     parser.add_argument(
         "--num_frames",
-        type=int,
+        type=greater_than_zero,
         required=False,
         help="Number of frames in generated video. Applicable only for Video Generation.",
     )

--- a/tools/llm_bench/llm_bench_utils/pt_utils.py
+++ b/tools/llm_bench/llm_bench_utils/pt_utils.py
@@ -638,7 +638,7 @@ def create_video_gen_model(model_path, device, memory_data_collector, **kwargs):
             pipe, backend, memory_data_collector if kwargs.get("mem_consumption") else None
         )
         pipe = compiled_model
-    tokenizer = None
+
     bench_hook = None
     use_genai = False
-    return pipe, tokenizer, from_pretrain_time, bench_hook, use_genai
+    return pipe, pipe.tokenizer, from_pretrain_time, bench_hook, use_genai

--- a/tools/llm_bench/task/video_generation.py
+++ b/tools/llm_bench/task/video_generation.py
@@ -25,6 +25,7 @@ DEFAULT_NUM_INF_STEPS = 25
 DEFAULT_NUM_FRAMES = 9
 DEFAULT_WIDTH = 704
 DEFAULT_HEIGHT = 480
+DEFAULT_MAX_SEQUENCE_LENGTH = 128
 
 
 def collect_input_args(
@@ -56,7 +57,7 @@ def collect_input_args(
     if "negative_prompt" in input_param:
         input_args["negative_prompt"] = input_param["negative_prompt"]
 
-    input_args["max_sequence_length"] = 256
+    input_args["max_sequence_length"] = DEFAULT_MAX_SEQUENCE_LENGTH
     return input_args
 
 

--- a/tools/llm_bench/task/video_generation.py
+++ b/tools/llm_bench/task/video_generation.py
@@ -82,7 +82,12 @@ class TextToVideoOptimum(CommonPipeline):
 
         self.time_collection_hook = time_collection_hook
 
-        self.rng = torch.Generator(device="cpu")
+        model_device = getattr(self.model, "device", None)
+        try:
+            rng_device = torch.device(model_device) if model_device is not None else torch.device("cpu")
+        except Exception:
+            rng_device = torch.device("cpu")
+        self.rng = torch.Generator(device=rng_device)
 
     @execution_time_in_sec
     def generate(self, input_data: Any, **kwargs):
@@ -360,7 +365,7 @@ class TextToVideoGenAI(CommonPipeline):
 
         self.mem_consumption_meter.start(iter_num)
         generation_result = self.generate(
-            input_param["prompt"], generator=openvino_genai.TorchGenerator(self.seed), guidance_scale=1, **input_args
+            input_param["prompt"], generator=openvino_genai.TorchGenerator(self.seed), **input_args
         )
         memory_metrics = self.mem_consumption_meter.iter_stop_and_collect_data(iter_num, dict_format=False)
 

--- a/tools/llm_bench/task/video_generation.py
+++ b/tools/llm_bench/task/video_generation.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-import logging as log
+import torch
 
+from PIL import Image
+import logging as log
 from typing import Any
 from pathlib import Path
 from transformers import set_seed
-
-from PIL import Image
 
 import llm_bench_utils
 import llm_bench_utils.metrics_print as metrics_print
@@ -21,6 +21,10 @@ FW_UTILS = {"pt": llm_bench_utils.pt_utils, "ov": llm_bench_utils.ov_utils}
 
 MS_PER_SEC = 1000
 DEFAULT_FRAME_RATE = 25
+DEFAULT_NUM_INF_STEPS = 25
+DEFAULT_NUM_FRAMES = 9
+DEFAULT_WIDTH = 704
+DEFAULT_HEIGHT = 480
 
 
 def collect_input_args(
@@ -52,6 +56,7 @@ def collect_input_args(
     if "negative_prompt" in input_param:
         input_args["negative_prompt"] = input_param["negative_prompt"]
 
+    input_args["max_sequence_length"] = 256
     return input_args
 
 
@@ -69,13 +74,15 @@ class TextToVideoOptimum(CommonPipeline):
         self.genai = False
 
         self.use_case = args.get("use_case")
-        self.num_steps = args.get("num_steps")
-        self.num_frames = args.get("num_frames")
-        self.frame_rate = args.get("frame_rate")
-        self.height = args.get("height")
-        self.width = args.get("width")
+        self.num_steps = args.get("num_steps") or DEFAULT_NUM_INF_STEPS
+        self.num_frames = args.get("num_frames") or DEFAULT_NUM_FRAMES
+        self.frame_rate = args.get("frame_rate") or DEFAULT_FRAME_RATE
+        self.height = args.get("height") or DEFAULT_HEIGHT
+        self.width = args.get("width") or DEFAULT_WIDTH
 
         self.time_collection_hook = time_collection_hook
+
+        self.rng = torch.Generator(device="cpu")
 
     @execution_time_in_sec
     def generate(self, input_data: Any, **kwargs):
@@ -195,7 +202,9 @@ class TextToVideoOptimum(CommonPipeline):
         self.print_batch_size_info(iter_num, input_args)
 
         self.mem_consumption_meter.start(iter_num)
-        generation_result, generation_time = self.generate(input_param["prompt"], **input_args)
+        generation_result, generation_time = self.generate(
+            input_param["prompt"], generator=self.rng.manual_seed(self.seed), **input_args
+        )
         memory_metrics = self.mem_consumption_meter.iter_stop_and_collect_data(iter_num, dict_format=False)
 
         iter_data = {}
@@ -230,11 +239,11 @@ class TextToVideoGenAI(CommonPipeline):
         self.genai = True
 
         self.use_case = args.get("use_case")
-        self.num_steps = args.get("num_steps")
-        self.num_frames = args.get("num_frames")
-        self.frame_rate = args.get("frame_rate")
-        self.height = args.get("height")
-        self.width = args.get("width")
+        self.num_steps = args.get("num_steps") or DEFAULT_NUM_INF_STEPS
+        self.num_frames = args.get("num_frames") or DEFAULT_NUM_FRAMES
+        self.frame_rate = args.get("frame_rate") or DEFAULT_FRAME_RATE
+        self.height = args.get("height") or DEFAULT_HEIGHT
+        self.width = args.get("width") or DEFAULT_WIDTH
 
     def generate(self, input_data: Any, **kwargs):
         return self.model.generate(input_data, **kwargs)
@@ -334,6 +343,8 @@ class TextToVideoGenAI(CommonPipeline):
         return iter_data, result_md5_list
 
     def run(self, input_param: dict, iter_num: int, prompt_index: int, proc_id: int, bench_hook) -> tuple[dict, list]:
+        import openvino_genai
+
         set_seed(self.seed)
 
         input_args = collect_input_args(
@@ -348,7 +359,9 @@ class TextToVideoGenAI(CommonPipeline):
         self.print_batch_size_info(iter_num, input_args)
 
         self.mem_consumption_meter.start(iter_num)
-        generation_result = self.generate(input_param["prompt"], **input_args)
+        generation_result = self.generate(
+            input_param["prompt"], generator=openvino_genai.TorchGenerator(self.seed), guidance_scale=1, **input_args
+        )
         memory_metrics = self.mem_consumption_meter.iter_stop_and_collect_data(iter_num, dict_format=False)
 
         iter_data, _ = self.postprocess_output_info(


### PR DESCRIPTION
## Description
cmd:
python benchmark.py -d CPU -n 3  -mc 0 -m /home/labuser/work/mnt_13/WW33_llm-optimum_2026.4.0-22741/ltx-video/pytorch/ov/FP16/ --task text-to-video 
cause to error since num_inference_steps is not define, fixed in this PR.
+ set default parameters so they are clear and the same for both backends.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
