### PR TITLE
[llm_bench] The path to media files in the prompt file may be placed anywhere

### DIFF
--- a/tools/llm_bench/llm_bench_utils/model_utils.py
+++ b/tools/llm_bench/llm_bench_utils/model_utils.py
@@ -364,7 +364,10 @@ def resolve_media_file_path(file_path, prompt_file_path):
     if not file_path:
         return file_path
     if not (file_path.startswith("http://") or file_path.startswith("https://")):
-        return os.path.join(os.path.dirname(prompt_file_path), file_path.replace("./", ""))
+        media_file_path = Path(file_path)
+        if media_file_path.is_absolute():
+            return str(media_file_path.resolve())
+        return str((Path(prompt_file_path).parent / media_file_path).resolve())
     return file_path
 
 


### PR DESCRIPTION
## Description
Media files were supposed to be in the same place as the prompt file, but now they can be placed anywhere.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-190649](https://jira.devtools.intel.com/browse/CVS-190649)


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
