### PR TITLE
[OpenVINO] Support MiniCPM-V-4.6 with task image-text-to-text

### DIFF
--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -111,6 +111,15 @@ export const VLM_MODELS: VLMModelType[] = [
     ],
   },
   {
+    architecture: 'MiniCPMV4_6ForConditionalGeneration',
+    models: [
+      {
+        name: 'MiniCPM-V-4.6',
+        links: ['https://huggingface.co/openbmb/MiniCPM-V-4.6'],
+      },
+    ],
+  },
+  {
     architecture: 'MuseGlimmerForConditionalGeneration',
     models: [
       {

--- a/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
@@ -20,15 +20,16 @@ The prompt can contain `<ov_genai_image_i>` with `i` replaced with an actual zer
 6. nanoLLaVA-1.5: `<image>\n`
 7. MiniCPM-o-2_6: `<image>./</image>\n`
 8. MiniCPM-V-2_6: `<image>./</image>\n`
-9. Phi-3-vision: `<|image_i|>\n` - the index starts with one
-10. Phi-4-multimodal-instruct: `<|image_i|>\n` - the index starts with one
-11. Qwen2-VL: `<|vision_start|><|image_pad|><|vision_end|>`
-12. Qwen2.5-VL: `<|vision_start|><|image_pad|><|vision_end|>`
-13. Qwen3-VL: `<|vision_start|><|image_pad|><|vision_end|>`
-14. gemma-3-4b-it: `<start_of_image>`
-15. gemma3n: `<image_soft_token>`
-16. gemma4: `<|image|>`
-17. Muse Glimmer: `<|image|>`
+9. MiniCPM-V-4.6: `<|image_pad|>\n`
+10. Phi-3-vision: `<|image_i|>\n` - the index starts with one
+11. Phi-4-multimodal-instruct: `<|image_i|>\n` - the index starts with one
+12. Qwen2-VL: `<|vision_start|><|image_pad|><|vision_end|>`
+13. Qwen2.5-VL: `<|vision_start|><|image_pad|><|vision_end|>`
+14. Qwen3-VL: `<|vision_start|><|image_pad|><|vision_end|>`
+15. gemma-3-4b-it: `<start_of_image>`
+16. gemma3n: `<image_soft_token>`
+17. gemma4: `<|image|>`
+18. Muse Glimmer: `<|image|>`
 
 Model's native video tag can be used to refer to a video. These tags are:
 1. LLaVA-NeXT-Video: `<video>`

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -21,6 +21,7 @@
 #include "visual_language/llava_next/classes.hpp"
 #include "visual_language/llava_next_video/classes.hpp"
 #include "visual_language/internvl_chat/classes.hpp"
+#include "visual_language/minicpmv4_6/classes.hpp"
 #include "visual_language/gemma3/classes.hpp"
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
@@ -362,6 +363,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
 
     if (vlm_config.model_type == VLMModelType::MINICPM) {
         m_impl = std::make_shared<InputsEmbedderMiniCPM>(vlm_config, model_dir, tokenizer, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::MINICPMV4_6) {
+        m_impl = std::make_shared<InputsEmbedderMiniCPMV4_6>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::LLAVA) {
         m_impl = std::make_shared<InputsEmbedderLLaVA>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::NANOLLAVA) {
@@ -412,6 +415,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
 
     if (vlm_config.model_type == VLMModelType::MINICPM) {
         m_impl = std::make_shared<InputsEmbedderMiniCPM>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::MINICPMV4_6) {
+        m_impl = std::make_shared<InputsEmbedderMiniCPMV4_6>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::LLAVA) {
         m_impl = std::make_shared<InputsEmbedderLLaVA>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::NANOLLAVA) {

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -388,6 +388,7 @@ private:
     std::shared_ptr<IInputsEmbedder> m_impl;
 
     friend class InputsEmbedderMiniCPM;
+    friend class InputsEmbedderMiniCPMV4_6;
     friend class InputsEmbedderLLaVA;
     friend class InputsEmbedderNanoLLaVA;
     friend class InputsEmbedderLLaVANext;

--- a/src/cpp/src/visual_language/minicpmv4_6/classes.cpp
+++ b/src/cpp/src/visual_language/minicpmv4_6/classes.cpp
@@ -1,0 +1,515 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/minicpmv4_6/classes.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+#include "visual_language/clip.hpp"
+#include "utils.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+// The chat template renders an image as a single "<|image_pad|>" token. GenAI's
+// universal/native tag machinery inserts this native tag; normalize_prompt then
+// expands it into the full MiniCPM-V-4.6 placeholder structure.
+const std::string NATIVE_TAG = "<|image_pad|>";
+
+int ensure_divide(int length, int divisor) {
+    return std::max(static_cast<int>(std::round(static_cast<float>(length) / divisor) * divisor), divisor);
+}
+
+// Mirrors transformers MiniCPMV4_6ImageProcessor.find_best_resize.
+// image_size = {height, width}. Returns {best_height, best_width}.
+std::pair<int, int> find_best_resize(std::pair<int, int> image_size, int scale_resolution, int patch_size, bool allow_upscale) {
+    int height = image_size.first;
+    int width = image_size.second;
+    if ((static_cast<int64_t>(height) * width > static_cast<int64_t>(scale_resolution) * scale_resolution) || allow_upscale) {
+        double aspect_ratio = static_cast<double>(width) / height;
+        height = static_cast<int>(scale_resolution / std::sqrt(aspect_ratio));
+        width = static_cast<int>(height * aspect_ratio);
+    }
+    // factor 4 = two successive 2x2 spatial merges (ViT insert merger + downsample MLP)
+    int best_width = ensure_divide(width, patch_size * 4);
+    int best_height = ensure_divide(height, patch_size * 4);
+    return {best_height, best_width};
+}
+
+// Mirrors MiniCPMV4_6ImageProcessor.get_refine_size. grid = {grid_y, grid_x}.
+std::pair<int, int> get_refine_size(std::pair<int, int> image_size, std::pair<int, int> grid, int scale_resolution, int patch_size, bool allow_upscale) {
+    int height = image_size.first;
+    int width = image_size.second;
+    int grid_y = grid.first;
+    int grid_x = grid.second;
+
+    int refine_width = ensure_divide(width, grid_x);
+    int refine_height = ensure_divide(height, grid_y);
+
+    auto best = find_best_resize({refine_height / grid_y, refine_width / grid_x}, scale_resolution, patch_size, allow_upscale);
+    return {best.first * grid_y, best.second * grid_x};
+}
+
+// Mirrors MiniCPMV4_6ImageProcessor.get_sliced_grid. image_size = {height, width}.
+// Returns best_grid = {num_cols, num_rows}; {0, 0} means no slicing.
+std::pair<int, int> get_sliced_grid(std::pair<int, int> image_size, int max_slice_nums, int scale_resolution) {
+    int original_height = image_size.first;
+    int original_width = image_size.second;
+    double log_ratio = std::log(static_cast<double>(original_width) / original_height);
+    double ratio = static_cast<double>(original_width) * original_height / (static_cast<double>(scale_resolution) * scale_resolution);
+    int multiple = std::min(static_cast<int>(std::ceil(ratio)), max_slice_nums);
+    if (multiple <= 1) {
+        return {0, 0};
+    }
+
+    std::pair<int, int> best_grid{1, 1};
+    double min_error = std::numeric_limits<double>::infinity();
+    for (int num_slices : {multiple - 1, multiple, multiple + 1}) {
+        if (num_slices == 1 || num_slices > max_slice_nums) {
+            continue;
+        }
+        for (int num_rows = 1; num_rows <= num_slices; ++num_rows) {
+            if (num_slices % num_rows == 0) {
+                int num_cols = num_slices / num_rows;
+                double error = std::abs(log_ratio - std::log(static_cast<double>(num_rows) / num_cols));
+                if (error < min_error) {
+                    best_grid = {num_cols, num_rows};
+                    min_error = error;
+                }
+            }
+        }
+    }
+    return best_grid;
+}
+
+// Crop [y0:y0+ph, x0:x0+pw] from a u8 RGB (HWC) image.
+clip_image_u8 crop_patch(const clip_image_u8& img, int y0, int x0, int ph, int pw) {
+    clip_image_u8 patch;
+    patch.nx = pw;
+    patch.ny = ph;
+    patch.buf.resize(3 * ph * pw);
+    for (int y = 0; y < ph; ++y) {
+        for (int x = 0; x < pw; ++x) {
+            int src = 3 * ((y0 + y) * img.nx + (x0 + x));
+            int dst = 3 * (y * pw + x);
+            patch.buf[dst] = img.buf[src];
+            patch.buf[dst + 1] = img.buf[src + 1];
+            patch.buf[dst + 2] = img.buf[src + 2];
+        }
+    }
+    return patch;
+}
+
+// Mirrors MiniCPMV4_6ImageProcessor.reshape_by_patch.
+// Input: normalized CHW f32 image (H, W). Output: pixel_values tensor
+// [1, C, patch_size, (H/patch_size)*(W/patch_size)*patch_size].
+ov::Tensor reshape_by_patch(const clip_image_f32& img, int patch_size) {
+    const int C = 3;
+    const int H = img.ny;
+    const int W = img.nx;
+    const int grid_h = H / patch_size;
+    const int grid_w = W / patch_size;
+    const int L = grid_h * grid_w;  // number of patches
+    ov::Tensor pixel_values(ov::element::f32, ov::Shape{1, static_cast<size_t>(C), static_cast<size_t>(patch_size), static_cast<size_t>(L) * patch_size});
+    float* dst = pixel_values.data<float>();
+    const float* src = img.buf.data();  // CHW: src[c*H*W + y*W + x]
+    const size_t HW = static_cast<size_t>(H) * W;
+    // reshape_by_patch semantics: patches[c, kh, l*patch_size + kw] where
+    // l = row*grid_w + col enumerates patches row-major and (kh, kw) is the
+    // intra-patch coordinate.
+    const size_t out_last = static_cast<size_t>(L) * patch_size;
+    for (int c = 0; c < C; ++c) {
+        for (int row = 0; row < grid_h; ++row) {
+            for (int col = 0; col < grid_w; ++col) {
+                int l = row * grid_w + col;
+                for (int kh = 0; kh < patch_size; ++kh) {
+                    for (int kw = 0; kw < patch_size; ++kw) {
+                        int y = row * patch_size + kh;
+                        int x = col * patch_size + kw;
+                        float v = src[c * HW + static_cast<size_t>(y) * W + x];
+                        size_t out_idx = (static_cast<size_t>(c) * patch_size + kh) * out_last + static_cast<size_t>(l) * patch_size + kw;
+                        dst[out_idx] = v;
+                    }
+                }
+            }
+        }
+    }
+    return pixel_values;
+}
+
+// Mirrors _OVMiniCPMV4_6ForCausalLM._position_ids (bucketized interpolated positions).
+std::vector<int64_t> compute_position_ids(int grid_h, int grid_w, int num_patches_per_side) {
+    std::vector<double> boundaries;
+    for (int i = 1; i < num_patches_per_side; ++i) {
+        boundaries.push_back(static_cast<double>(i) / num_patches_per_side);
+    }
+    auto bucketize = [&](int n) {
+        // torch.arange(0, 1 - 1e-6, 1/n)
+        std::vector<int64_t> buckets;
+        const double step = 1.0 / n;
+        for (double frac = 0.0; frac < 1.0 - 1e-6; frac += step) {
+            // bucketize with right=True -> number of boundaries <= frac
+            int b = 0;
+            while (b < static_cast<int>(boundaries.size()) && boundaries[b] <= frac) {
+                ++b;
+            }
+            buckets.push_back(b);
+        }
+        return buckets;
+    };
+    std::vector<int64_t> bh = bucketize(grid_h);
+    std::vector<int64_t> bw = bucketize(grid_w);
+    std::vector<int64_t> pos_ids;
+    pos_ids.reserve(static_cast<size_t>(grid_h) * grid_w);
+    for (int64_t h : bh) {
+        for (int64_t w : bw) {
+            pos_ids.push_back(h * num_patches_per_side + w);
+        }
+    }
+    return pos_ids;
+}
+
+// Mirrors _OVMiniCPMV4_6ForCausalLM._grouping_index (permutation grouping a h x w grid
+// into row-major kernel_h x kernel_w blocks).
+std::vector<int64_t> grouping_index(int h, int w, int kernel_h, int kernel_w) {
+    std::vector<int64_t> out;
+    out.reserve(static_cast<size_t>(h) * w);
+    int H = h / kernel_h;
+    int W = w / kernel_w;
+    // index.reshape(H, kh, W, kw).permute(0, 2, 1, 3).reshape(-1)
+    for (int a = 0; a < H; ++a) {
+        for (int b = 0; b < W; ++b) {
+            for (int i = 0; i < kernel_h; ++i) {
+                for (int j = 0; j < kernel_w; ++j) {
+                    int row = a * kernel_h + i;
+                    int col = b * kernel_w + j;
+                    out.push_back(static_cast<int64_t>(row) * w + col);
+                }
+            }
+        }
+    }
+    return out;
+}
+
+} // namespace
+
+VisionEncoderMiniCPMV4_6::VisionEncoderMiniCPMV4_6(
+    const std::filesystem::path& model_dir,
+    const std::string& device,
+    const ov::AnyMap properties) :
+    VisionEncoder(model_dir, device, properties) {
+    load_vision_params(model_dir);
+}
+
+VisionEncoderMiniCPMV4_6::VisionEncoderMiniCPMV4_6(
+    const ModelsMap& models_map,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    VisionEncoder(models_map, config_dir_path, device, device_config) {
+    load_vision_params(config_dir_path);
+}
+
+void VisionEncoderMiniCPMV4_6::load_vision_params(const std::filesystem::path& config_dir_path) {
+    m_patch_size = m_processor_config.patch_size;
+    m_scale_resolution = m_processor_config.scale_resolution;
+    if (m_processor_config.max_slice_nums != 0) {
+        m_max_slice_nums = m_processor_config.max_slice_nums;
+    }
+    m_image_mean = m_processor_config.image_mean;
+    m_image_std = m_processor_config.image_std;
+
+    const auto config_path = config_dir_path / "config.json";
+    if (std::filesystem::exists(config_path)) {
+        std::ifstream stream(config_path);
+        if (stream.is_open()) {
+            auto cfg = nlohmann::json::parse(stream);
+            if (cfg.contains("vision_config")) {
+                const auto& vc = cfg.at("vision_config");
+                size_t vision_image_size = vc.value("image_size", static_cast<size_t>(980));
+                size_t patch = vc.value("patch_size", m_patch_size);
+                m_num_patches_per_side = vision_image_size / patch;
+                if (vc.contains("window_kernel_size") && vc.at("window_kernel_size").is_array() && vc.at("window_kernel_size").size() == 2) {
+                    m_window_kh = vc.at("window_kernel_size")[0].get<size_t>();
+                    m_window_kw = vc.at("window_kernel_size")[1].get<size_t>();
+                }
+            }
+            if (cfg.contains("merge_kernel_size") && cfg.at("merge_kernel_size").is_array() && cfg.at("merge_kernel_size").size() == 2) {
+                m_merge_kh = cfg.at("merge_kernel_size")[0].get<size_t>();
+                m_merge_kw = cfg.at("merge_kernel_size")[1].get<size_t>();
+            }
+            std::string downsample_mode = cfg.value("downsample_mode", std::string("16x"));
+            m_token_divisor = (downsample_mode == "4x") ? 4 : 16;
+        }
+    }
+}
+
+EncodedImage VisionEncoderMiniCPMV4_6::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+    const int patch_size = static_cast<int>(m_patch_size);
+    const int scale_resolution = static_cast<int>(m_scale_resolution);
+    const int max_slice_nums = static_cast<int>(m_max_slice_nums);
+
+    clip_image_u8 source = tensor_to_clip_image_u8(image);
+    const std::pair<int, int> image_size{source.ny, source.nx};  // {height, width}
+
+    std::pair<int, int> best_grid{0, 0};
+    if (m_slice_mode) {
+        best_grid = get_sliced_grid(image_size, max_slice_nums, scale_resolution);
+    }
+    const bool has_slices = best_grid.first > 0 && best_grid.second > 0;
+
+    // Build the ordered list of resized u8 patches: [source, *slices] and their
+    // patch-grid sizes {grid_h, grid_w}.
+    std::vector<clip_image_u8> patches_u8;
+    std::vector<std::pair<int, int>> patch_grids;  // {grid_h, grid_w} in patches
+
+    // Source image (always present).
+    auto src_size = find_best_resize(image_size, scale_resolution, patch_size, /*allow_upscale=*/!has_slices);
+    clip_image_u8 source_resized;
+    bicubic_resize(source, source_resized, src_size.second, src_size.first);  // (target_width, target_height)
+    patches_u8.push_back(std::move(source_resized));
+    patch_grids.push_back({src_size.first / patch_size, src_size.second / patch_size});
+
+    int slice_grid_h = 0;
+    int slice_grid_w = 0;
+    if (has_slices) {
+        auto refine = get_refine_size(image_size, best_grid, scale_resolution, patch_size, /*allow_upscale=*/true);
+        clip_image_u8 refine_img;
+        bicubic_resize(source, refine_img, refine.second, refine.first);  // (target_width, target_height)
+        int grid_y = best_grid.first;   // num rows of the slice grid
+        int grid_x = best_grid.second;  // num cols of the slice grid
+        int patch_h = refine.first / grid_y;
+        int patch_w = refine.second / grid_x;
+        slice_grid_h = patch_h / patch_size;
+        slice_grid_w = patch_w / patch_size;
+        for (int y = 0; y + patch_h <= refine.first; y += patch_h) {
+            for (int x = 0; x + patch_w <= refine.second; x += patch_w) {
+                patches_u8.push_back(crop_patch(refine_img, y, x, patch_h, patch_w));
+                patch_grids.push_back({slice_grid_h, slice_grid_w});
+            }
+        }
+    }
+
+    // Run the vision encoder for each patch and concatenate the visual tokens.
+    clip_ctx_double mean_std;
+    for (int c = 0; c < 3; ++c) {
+        mean_std.image_mean[c] = static_cast<double>(m_image_mean[c]) * 255.0;
+        mean_std.image_std[c] = static_cast<double>(m_image_std[c]) * 255.0;
+    }
+
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+
+    std::vector<ov::Tensor> patch_features;
+    size_t total_tokens = 0;
+    size_t hidden_size = 0;
+    for (size_t p = 0; p < patches_u8.size(); ++p) {
+        int grid_h = patch_grids[p].first;
+        int grid_w = patch_grids[p].second;
+        clip_image_f32 normalized = normalize_and_convert_to_chw(patches_u8[p], mean_std);
+        ov::Tensor pixel_values = reshape_by_patch(normalized, patch_size);
+
+        std::vector<int64_t> position_ids = compute_position_ids(grid_h, grid_w, static_cast<int>(m_num_patches_per_side));
+        std::vector<int64_t> window_index = grouping_index(grid_h, grid_w, static_cast<int>(m_window_kh), static_cast<int>(m_window_kw));
+        std::vector<int64_t> merge_index = grouping_index(grid_h / static_cast<int>(m_window_kh), grid_w / static_cast<int>(m_window_kw), static_cast<int>(m_merge_kh), static_cast<int>(m_merge_kw));
+
+        ov::Tensor position_ids_t(ov::element::i64, ov::Shape{1, position_ids.size()});
+        std::copy(position_ids.begin(), position_ids.end(), position_ids_t.data<int64_t>());
+        ov::Tensor window_index_t(ov::element::i64, ov::Shape{window_index.size()});
+        std::copy(window_index.begin(), window_index.end(), window_index_t.data<int64_t>());
+        ov::Tensor merge_index_t(ov::element::i64, ov::Shape{merge_index.size()});
+        std::copy(merge_index.begin(), merge_index.end(), merge_index_t.data<int64_t>());
+
+        encoder.set_tensor("pixel_values", pixel_values);
+        encoder.set_tensor("position_ids", position_ids_t);
+        encoder.set_tensor("window_index", window_index_t);
+        encoder.set_tensor("merge_index", merge_index_t);
+        encoder.infer();
+
+        const ov::Tensor& out = encoder.get_output_tensor();  // [num_tokens, hidden]
+        ov::Tensor feat(out.get_element_type(), out.get_shape());
+        std::memcpy(feat.data(), out.data(), out.get_byte_size());
+        total_tokens += feat.get_shape().at(0);
+        hidden_size = feat.get_shape().at(1);
+        patch_features.push_back(std::move(feat));
+    }
+
+    // Concatenate along the token dimension -> [total_tokens, hidden_size].
+    ov::Tensor resized_source(ov::element::f32, ov::Shape{total_tokens, hidden_size});
+    float* dst = resized_source.data<float>();
+    size_t offset = 0;
+    for (const auto& feat : patch_features) {
+        std::memcpy(dst + offset, feat.data(), feat.get_byte_size());
+        offset += feat.get_size();
+    }
+
+    EncodedImage encoded;
+    encoded.resized_source = std::move(resized_source);
+    encoded.resized_source_size = ImageSize{static_cast<size_t>(patch_grids[0].first), static_cast<size_t>(patch_grids[0].second)};
+    encoded.original_image_size = ImageSize{static_cast<size_t>(source.ny), static_cast<size_t>(source.nx)};
+    encoded.num_image_tokens = total_tokens;
+    size_t num_source_tokens = static_cast<size_t>(patch_grids[0].first) * patch_grids[0].second / m_token_divisor;
+    size_t per_slice_tokens = has_slices ? (static_cast<size_t>(slice_grid_h) * slice_grid_w / m_token_divisor) : 0;
+    // num_rows = best_grid[0] (grid_y), num_cols = best_grid[1] (grid_x); {0,0} if no slices.
+    encoded.patches_grid = has_slices ? std::make_pair(best_grid.first, best_grid.second) : std::make_pair(0, 0);
+    encoded.slices_shape = ov::Shape{num_source_tokens, per_slice_tokens};
+    return encoded;
+}
+
+InputsEmbedderMiniCPMV4_6::InputsEmbedderMiniCPMV4_6(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) { }
+
+InputsEmbedderMiniCPMV4_6::InputsEmbedderMiniCPMV4_6(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) { }
+
+std::string InputsEmbedderMiniCPMV4_6::build_image_placeholder(const EncodedImage& image, size_t image_id) const {
+    const std::string& image_pad = m_vlm_config.image_pad_token;
+    size_t num_source_tokens = image.slices_shape.size() > 0 ? image.slices_shape[0] : image.num_image_tokens;
+    size_t per_slice_tokens = image.slices_shape.size() > 1 ? image.slices_shape[1] : 0;
+    int num_rows = image.patches_grid.first;
+    int num_cols = image.patches_grid.second;
+
+    std::string placeholder;
+    if (m_vlm_config.use_image_id) {
+        placeholder += m_vlm_config.im_id_start + std::to_string(image_id) + m_vlm_config.im_id_end;
+    }
+    placeholder += m_vlm_config.im_start;
+    for (size_t i = 0; i < num_source_tokens; ++i) {
+        placeholder += image_pad;
+    }
+    placeholder += m_vlm_config.im_end;
+
+    if (num_rows > 0 && num_cols > 0) {
+        std::string slice_placeholder = m_vlm_config.slice_start;
+        for (size_t i = 0; i < per_slice_tokens; ++i) {
+            slice_placeholder += image_pad;
+        }
+        slice_placeholder += m_vlm_config.slice_end;
+        std::string slices;
+        for (int r = 0; r < num_rows; ++r) {
+            if (r > 0) {
+                slices += "\n";
+            }
+            for (int c = 0; c < num_cols; ++c) {
+                slices += slice_placeholder;
+            }
+        }
+        placeholder += slices;
+    }
+    return placeholder;
+}
+
+NormalizedPrompt InputsEmbedderMiniCPMV4_6::normalize_prompt(
+    const std::string& prompt,
+    size_t base_id,
+    const std::vector<EncodedImage>& images
+) const {
+    auto [unified_prompt, images_sequence] = normalize(prompt, NATIVE_TAG, NATIVE_TAG + '\n', base_id, images.size());
+
+    size_t searched_pos = 0;
+    size_t local_image_index = 0;
+    for (size_t new_image_id : images_sequence) {
+        const EncodedImage& enc = images.at(new_image_id - base_id);
+        std::string expanded = build_image_placeholder(enc, local_image_index);
+        searched_pos = unified_prompt.find(NATIVE_TAG, searched_pos);
+        OPENVINO_ASSERT(searched_pos != std::string::npos, "Image placeholder not found in prompt.");
+        unified_prompt.replace(searched_pos, NATIVE_TAG.length(), expanded);
+        searched_pos += expanded.length();
+        ++local_image_index;
+    }
+
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+namespace {
+
+ov::Tensor merge_text_and_image_embeddings(
+    const ov::Tensor& input_ids,
+    const ov::Tensor& text_embeds,
+    const std::vector<const EncodedImage*>& image_embeds,
+    int64_t image_pad_token_id) {
+    ov::Shape shape = text_embeds.get_shape();
+    size_t seq_len = shape.at(1);
+    size_t embed_dim = shape.at(2);
+
+    ov::Tensor merged(text_embeds.get_element_type(), shape);
+    const float* text_data = text_embeds.data<float>();
+    const int64_t* ids = input_ids.data<int64_t>();
+    float* out = merged.data<float>();
+
+    size_t image_idx = 0;
+    size_t token_in_image = 0;
+    const float* cur_image_data = image_embeds.empty() ? nullptr : image_embeds[0]->resized_source.data<float>();
+    size_t cur_image_tokens = image_embeds.empty() ? 0 : image_embeds[0]->resized_source.get_shape().at(0);
+
+    for (size_t j = 0; j < seq_len; ++j) {
+        size_t offset = j * embed_dim;
+        if (ids[j] == image_pad_token_id && image_idx < image_embeds.size()) {
+            std::copy_n(cur_image_data + token_in_image * embed_dim, embed_dim, out + offset);
+            ++token_in_image;
+            if (token_in_image == cur_image_tokens) {
+                ++image_idx;
+                token_in_image = 0;
+                if (image_idx < image_embeds.size()) {
+                    cur_image_data = image_embeds[image_idx]->resized_source.data<float>();
+                    cur_image_tokens = image_embeds[image_idx]->resized_source.get_shape().at(0);
+                }
+            }
+        } else {
+            std::copy_n(text_data + offset, embed_dim, out + offset);
+        }
+    }
+    return merged;
+}
+
+} // namespace
+
+ov::Tensor InputsEmbedderMiniCPMV4_6::get_inputs_embeds(
+    const std::string& unified_prompt,
+    const std::vector<ov::genai::EncodedImage>& images,
+    ov::genai::VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& images_sequence) {
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
+
+    if (images.empty()) {
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+
+    std::vector<const EncodedImage*> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(&images.at(new_image_id));
+    }
+
+    auto start_tokenizer_time = std::chrono::steady_clock::now();
+    ov::Tensor encoded_pad = m_tokenizer.encode(m_vlm_config.image_pad_token, ov::genai::add_special_tokens(false)).input_ids;
+    auto end_tokenizer_time = std::chrono::steady_clock::now();
+    OPENVINO_ASSERT(metrics.raw_metrics.tokenization_durations.size() > 0);
+    metrics.raw_metrics.tokenization_durations[metrics.raw_metrics.tokenization_durations.size() - 1] += ov::genai::MicroSeconds(PerfMetrics::get_microsec(end_tokenizer_time - start_tokenizer_time));
+    int64_t image_pad_token_id = encoded_pad.data<int64_t>()[encoded_pad.get_size() - 1];
+
+    return merge_text_and_image_embeddings(input_ids, text_embeds, image_embeds, image_pad_token_id);
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/minicpmv4_6/classes.hpp
+++ b/src/cpp/src/visual_language/minicpmv4_6/classes.hpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+// MiniCPM-V-4.6 (model_type "minicpmv4_6").
+//
+// Architecture differs fundamentally from the classic MiniCPM-V (2.x/o) family:
+//  - Vision tower is a NaViT-style SigLIP encoder with window/merge downsampling.
+//    The exported openvino_vision_embeddings_model consumes NaViT-patchified
+//    ``pixel_values`` together with ``position_ids``/``window_index``/``merge_index``
+//    and directly returns the merged visual tokens (no separate resampler).
+//  - Language backbone is a Qwen3.5 text model that uses plain 1D position ids
+//    and merges visual tokens by replacing the ``<|image_pad|>`` placeholder ids
+//    with the vision features (masked scatter), like LLaVA / InternVL.
+class VisionEncoderMiniCPMV4_6 : public VisionEncoder {
+public:
+    VisionEncoderMiniCPMV4_6(
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap properties);
+
+    VisionEncoderMiniCPMV4_6(
+        const ModelsMap& models_map,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+
+private:
+    void load_vision_params(const std::filesystem::path& config_dir_path);
+
+    size_t m_num_patches_per_side = 70;  // vision_config.image_size / patch_size
+    size_t m_patch_size = 14;
+    size_t m_scale_resolution = 448;
+    size_t m_max_slice_nums = 9;
+    size_t m_window_kh = 2;
+    size_t m_window_kw = 2;
+    size_t m_merge_kh = 2;
+    size_t m_merge_kw = 2;
+    size_t m_token_divisor = 16;  // 16x downsample -> grid_h*grid_w/16 tokens
+    bool m_slice_mode = true;
+    std::array<float, 3> m_image_mean{0.5f, 0.5f, 0.5f};
+    std::array<float, 3> m_image_std{0.5f, 0.5f, 0.5f};
+};
+
+class InputsEmbedderMiniCPMV4_6 : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderMiniCPMV4_6(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderMiniCPMV4_6(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt,
+                                 const std::vector<ov::genai::EncodedImage>& images,
+                                 ov::genai::VLMPerfMetrics& metrics,
+                                 bool recalculate_merged_embeddings = true,
+                                 const std::vector<size_t>& image_sequence = {}) override;
+
+    NormalizedPrompt normalize_prompt(
+        const std::string& prompt,
+        size_t base_id,
+        const std::vector<EncodedImage>& images
+    ) const override;
+
+private:
+    std::string build_image_placeholder(const EncodedImage& image, size_t image_id) const;
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -21,6 +21,7 @@
 #include "visual_language/llava_next/classes.hpp"
 #include "visual_language/llava_next_video/classes.hpp"
 #include "visual_language/internvl_chat/classes.hpp"
+#include "visual_language/minicpmv4_6/classes.hpp"
 #include "visual_language/gemma3/classes.hpp"
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
@@ -113,6 +114,8 @@ VideoProcessorConfig VisionEncoder::get_video_processor_config() const {
 VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir, const VLMModelType model_type, const std::string& device, const ov::AnyMap properties) {
     if (model_type == VLMModelType::MINICPM) {
         return std::make_shared<VisionEncoderMiniCPM>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::MINICPMV4_6) {
+        return std::make_shared<VisionEncoderMiniCPMV4_6>(model_dir, device, properties);
     } else if (model_type == VLMModelType::LLAVA) {
         return std::make_shared<VisionEncoderLLaVA>(model_dir, device, properties);
     } else if (model_type == VLMModelType::NANOLLAVA) {
@@ -162,6 +165,8 @@ VisionEncoder::Ptr VisionEncoder::create(
     const ov::AnyMap device_config) {
     if (model_type == VLMModelType::MINICPM) {
         return std::make_shared<VisionEncoderMiniCPM>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::MINICPMV4_6) {
+        return std::make_shared<VisionEncoderMiniCPMV4_6>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::LLAVA) {
         return std::make_shared<VisionEncoderLLaVA>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::NANOLLAVA) {

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -15,6 +15,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
     static const std::unordered_map<std::string, VLMModelType> model_types_map = {
         {"minicpmv", VLMModelType::MINICPM},
         {"minicpmo", VLMModelType::MINICPM},
+        {"minicpmv4_6", VLMModelType::MINICPMV4_6},
         {"llava", VLMModelType::LLAVA},
         {"llava-qwen2", VLMModelType::NANOLLAVA},
         {"llava_next", VLMModelType::LLAVA_NEXT},

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -14,6 +14,7 @@ namespace ov::genai {
 
 enum class VLMModelType {
     MINICPM,
+    MINICPMV4_6,
     LLAVA,
     NANOLLAVA,
     LLAVA_NEXT,

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -168,6 +168,11 @@ else:
 MODEL_GEMMA = "optimum-intel-internal-testing/tiny-random-gemma3"
 MODEL_GEMMA3N = "optimum-intel-internal-testing/tiny-random-gemma3n"
 MODEL_QWEN3_OMNI = "optimum-intel-internal-testing/tiny-random-qwen3-omni"
+# MiniCPM-V-4.6 (model_type "minicpmv4_6"): NaViT SigLIP vision tower + Qwen3.5 text
+# backbone. Requires transformers >= 5.7 and optimum-intel with minicpmv4_6 export
+# support. The matching tiny-random fixture follows the optimum-intel naming used in
+# optimum-intel/tests/openvino/utils_tests.py.
+MODEL_MINICPMV4_6 = "optimum-intel-internal-testing/tiny-random-minicpmv4_6"
 
 MODEL_IDS: list[str] = []
 if is_transformers_version("<", "5.0"):
@@ -189,6 +194,7 @@ else:
         "optimum-intel-internal-testing/tiny-random-phi3-vision",
         "optimum-intel-internal-testing/tiny-random-phi-4-multimodal",
         "qnguyen3/nanoLLaVA",
+        MODEL_MINICPMV4_6,
         *VIDEO_MODEL_IDS,
     ]
 
@@ -219,6 +225,7 @@ IMAGE_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
     "optimum-intel-internal-testing/tiny-random-gemma4-31B": lambda idx: "<|image|>",
     "optimum-intel-internal-testing/tiny-random-muse-glimmer": lambda idx: "<|image|>",
     "qnguyen3/nanoLLaVA": lambda idx: "<image>\n",
+    MODEL_MINICPMV4_6: lambda idx: "<|image_pad|>",
     VIDEOCHAT_FLASH_QWEN_MODEL_ID: lambda idx: f"<|image_{idx + 1}|>\n",
 }
 
@@ -241,6 +248,7 @@ VIDEO_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
 RESOLUTION_BY_MODEL: dict[str, int | None] = {
     "optimum-intel-internal-testing/tiny-random-gemma3": 32,
     "qnguyen3/nanoLLaVA": 384,
+    MODEL_MINICPMV4_6: 448,
     "optimum-intel-internal-testing/tiny-random-llava-next-video": 336,
     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6": 448,
     "optimum-intel-internal-testing/tiny-random-qwen2vl": 336,
@@ -348,6 +356,10 @@ def _maybe_skip_unsupported_model_export(model_id: str) -> None:
     ] and is_transformers_version("<", "5.10.0"):
         pytest.skip(
             "ValueError: The current version of Transformers does not allow for the export of the model. Minimum required is 5.10.0."
+        )
+    if model_id == MODEL_MINICPMV4_6 and is_transformers_version("<", "5.7.0"):
+        pytest.skip(
+            "ValueError: The current version of Transformers does not allow for the export of MiniCPM-V-4.6. Minimum required is 5.7.0."
         )
     if _is_videochat_flash_qwen_model(model_id) and not is_optimum_intel_version_for_videochat_flash_qwen():
         pytest.skip("ValueError: The current version of optimum-intel does not support videochat_flash_qwen")

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -1,6 +1,7 @@
 from .llava import LLAVAInputsPreprocessor, NanoLlavaInputsPreprocessor
 from .minicpmv import MiniCPMVInputsPreprocessor
 from .minicpmo import MiniCPMOInputsPreprocessor
+from .minicpmv4_6 import MiniCPMV4_6InputsPreprocessor
 from .internvl import InternVLInputsPreprocessor
 from .phi3 import Phi3MMInputsPreprocessor
 from .phi4 import Phi4MMInputsPreprocessor
@@ -31,6 +32,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "phi4_multimodal": Phi4MMInputsPreprocessor,
     "phi3_v": Phi3MMInputsPreprocessor,
     "minicpmv": MiniCPMVInputsPreprocessor,
+    "minicpmv4_6": MiniCPMV4_6InputsPreprocessor,
     "minicpmo": MiniCPMOInputsPreprocessor,
     "llava_next": LLAVAInputsPreprocessor,
     "llava-qwen2": NanoLlavaInputsPreprocessor,

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/minicpmv4_6.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/minicpmv4_6.py
@@ -1,0 +1,103 @@
+import numpy as np
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+)
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+from typing import TYPE_CHECKING, Optional, Union, Any
+import torch
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+class MiniCPMV4_6InputsPreprocessor(VLMInputsPreprocessor):
+    """Inputs preprocessor for openbmb/MiniCPM-V-4.6 (model_type="minicpmv4_6").
+
+    Unlike the legacy MiniCPM-V/-o models, MiniCPM-V-4.6 ships a modern
+    transformers processor (``MiniCPMV4_6Processor``) that follows the standard
+    image-text-to-text convention: images are declared in the chat content as
+    ``{"type": "image"}`` items (expanded to the ``<|image_pad|>`` image token by
+    the chat template) and ``processor(images=..., text=...)`` returns
+    ``input_ids``, ``attention_mask``, ``pixel_values`` and ``target_sizes``.
+    This differs from the legacy ``MiniCPMVInputsPreprocessor`` which relies on
+    the ``(<image>./</image>)`` placeholder and ``image_bound``/``tgt_sizes``
+    outputs, so a dedicated preprocessor is required.
+    """
+
+    def __init__(self, chat_mode: bool = False, model: Optional[Any] = None):
+        super().__init__(chat_mode)
+        if model is not None:
+            self.def_image_token_id = getattr(model.config, "image_token_id", 248056)
+        else:
+            self.def_image_token_id = 248056
+
+    def update_chat_history_with_answer(self, answer):
+        self.chat_history.append({"role": "assistant", "content": [{"type": "text", "text": answer}]})
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        self.update_images(image)
+        content = []
+        if image is not None:
+            if not isinstance(image, list):
+                image = [image]
+            content.extend([{"type": "image"}] * len(image))
+
+        content.append({"type": "text", "text": text})
+
+        if self.chat_mode:
+            self.chat_history.append({"role": "user", "content": content})
+            conversation = self.chat_history
+        else:
+            conversation = [{"role": "user", "content": content}]
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
+
+        inputs = processor(images=self.images, text=text_prompt, return_tensors="pt")
+
+        return inputs
+
+    def align_inputs_with_cache(self, model: Any, inputs: dict, full_tokenized_chat: torch.Tensor, prefix_len: int):
+        # Only native torch/HF models need image inputs shifted with respect to
+        # the shared prefix cache; Optimum OpenVINO handles this internally.
+        if "transformers" not in str(type(model)):
+            return inputs
+
+        if "pixel_values" not in inputs:
+            return inputs
+
+        image_token_id = getattr(model.config, "image_token_id", self.def_image_token_id)
+
+        full_tokenized_chat_list = full_tokenized_chat[0].tolist()
+        total_image_tokens = full_tokenized_chat_list.count(image_token_id)
+        if total_image_tokens == 0:
+            return inputs
+
+        new_input_ids = full_tokenized_chat_list[prefix_len:]
+        new_image_tokens = new_input_ids.count(image_token_id)
+
+        # If none of the current-turn image tokens are outside the cached prefix,
+        # the images are fully covered by the cache and must not be re-fed.
+        if new_image_tokens == 0:
+            inputs.pop("pixel_values", None)
+            inputs.pop("target_sizes", None)
+
+        return inputs

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -523,6 +523,52 @@ def check_args(args):
 def load_prompts(args):
     if args.dataset is None:
         return None
+    # Allow passing a local CSV file through the same --dataset interface.
+    # This keeps VLM evaluation deterministic and independent of remote dataset
+    # availability. The CSV must contain a "prompts" column and may optionally
+    # contain "images" and "videos" columns (paths or None). Image paths are
+    # resolved relative to the CSV file location when not absolute.
+    dataset_path = Path(args.dataset)
+    if dataset_path.suffix.lower() == ".csv" and dataset_path.is_file():
+        from transformers.image_utils import load_image
+
+        base_dir = dataset_path.resolve().parent
+        df = pd.read_csv(dataset_path)
+        if "prompts" not in df.columns:
+            raise ValueError(
+                f"Local dataset CSV '{dataset_path}' must contain a 'prompts' column, "
+                f"got columns: {list(df.columns)}."
+            )
+
+        def _resolve_media(value):
+            if value is None:
+                return None
+            # pandas represents empty cells as NaN (float)
+            if isinstance(value, float) and pd.isna(value):
+                return None
+            text = str(value).strip()
+            if text == "" or text.lower() == "none":
+                return None
+            path = Path(text)
+            if not path.is_absolute():
+                path = (base_dir / path)
+            return str(path)
+
+        prompts = list(df["prompts"])
+        if "images" in df.columns:
+            images = [
+                load_image(resolved) if (resolved := _resolve_media(v)) is not None else None
+                for v in df["images"]
+            ]
+        else:
+            images = [None] * len(prompts)
+        if "videos" in df.columns:
+            videos = [_resolve_media(v) for v in df["videos"]]
+        else:
+            videos = [None] * len(prompts)
+
+        return {"prompts": prompts, "images": images, "videos": videos}
+
     split = "validation"
     if args.split is not None:
         split = args.split
@@ -990,11 +1036,20 @@ def genai_gen_reranking(model, tokenizer, query, documents):
 
 
 def is_model_with_automatic_crop(config):
+    model_type = getattr(config, "model_type", "")
+    # MiniCPM-V-4.6 (model_type="minicpmv4_6") is a standard transformers
+    # image-text-to-text model: its generate() returns the full input+output
+    # sequence, so the question must be cropped like for other HF VLMs. Only the
+    # legacy custom-code MiniCPM-V/-o models return an already-cropped decoded
+    # answer and must keep crop_question=False. The substring check below would
+    # otherwise wrongly match "minicpmv" inside "minicpmv4_6".
+    if model_type == "minicpmv4_6":
+        return False
     return (
-        "internvl" in config.model_type
-        or "minicpmv" in config.model_type
-        or "minicpmo" in config.model_type
-        or "videochat_flash_qwen" in config.model_type
+        "internvl" in model_type
+        or "minicpmv" in model_type
+        or "minicpmo" in model_type
+        or "videochat_flash_qwen" in model_type
     )
 
 


### PR DESCRIPTION
## Reproduce generation

```python
from PIL import Image
import openvino_genai

pipe = openvino_genai.VLMPipeline("output_dir", "CPU")
image = Image.new("RGB", (64, 64), "white")
result = pipe.generate("Describe this image.", image=image, max_new_tokens=10)
print(result.texts[0])
```

## Validation

**Machine Info:**

- **CPU Model:** Intel(R) Core(TM) i9-14900
- **GPU:** Intel Corporation Device a780 (rev 04)
- **RAM:** 125.54 GiB

**WWB Accuracy:**

- **fp16 CPU (Paged Attention):** 0.954467

- **int8 CPU (Paged Attention):** 0.938869

- **int4 CPU (Paged Attention):** 0.858006

- **fp16 GPU (Paged Attention):** 0.95235

- **int8 GPU (Paged Attention):** 0.949714

- **int4 GPU (Paged Attention):** 0.844128

**OpenVINO GenAI Validation Backend:**

- **fp16 CPU GenAI:** Paged Attention
- **int8 CPU GenAI:** Paged Attention
- **int4 CPU GenAI:** Paged Attention
- **fp16 GPU GenAI:** Paged Attention
- **int8 GPU GenAI:** Paged Attention
- **int4 GPU GenAI:** Paged Attention

**LLM Bench Performance:**

- **fp16 CPU - GenAI:**
  - **1st:** 703.41ms
  - **2nd:** 30.99ms/tok
  - **Throughput:** 32.27 tok/s

- **int8 CPU - GenAI:**
  - **1st:** 415.00ms
  - **2nd:** 17.93ms/tok
  - **Throughput:** 55.78 tok/s

- **int4 CPU - GenAI:**
  - **1st:** 397.13ms
  - **2nd:** 14.13ms/tok
  - **Throughput:** 70.78 tok/s

- **fp16 GPU - GenAI:**
  - **1st:** 743.90ms
  - **2nd:** 33.97ms/tok
  - **Throughput:** 29.44 tok/s

- **int8 GPU - GenAI:**
  - **1st:** 862.02ms
  - **2nd:** 22.53ms/tok
  - **Throughput:** 44.38 tok/s

- **int4 GPU - GenAI:**
  - **1st:** 920.25ms
  - **2nd:** 21.66ms/tok
  - **Throughput:** 46.16 tok/s

**Validation Warnings:**

- SOURCE CHANGED AFTER PR VALIDATION handled: optimum-intel model_patcher.py refactor (MiniCPMV4_6VisionEmbeddingsModelPatcher inherits LlavaImageEmbeddingModelPatcher via _patched_forward) plus rebuilt GenAI. Preserved FP16 export/similarity discarded and re-exported/re-measured. Reused only unaffected inputs (wwb_vlm_dataset/gt.csv HF baseline, inputs.csv).
- INT4 export with plain --weight-format int4 (group-size 128) previously failed with nncf.InvalidGroupSizeError on rotary_emb MatMul (channel size 1); re-exported here with --group-size-fallback adjust (successful). Informational INT4 precision only.
- GPU was available and used for all GPU measurements (Core().available_devices reports ['CPU','GPU']); no SDPA fallback required on either device — all FP16 GenAI runs passed with default PagedAttention.
- INT4 CPU GenAI similarity 0.858006 is below the configured threshold 0.86
- INT4 GPU GenAI similarity 0.844128 is below the configured threshold 0.86

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1945

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.
