### PR TITLE
Fix DeepStack visual_pos_masks layout under PagedAttention

### DIFF
--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -579,7 +579,7 @@ public:
                     {total_num_tokens, 1}, ov::element::boolean);
 
                 visual_pos_masks_data = visual_pos_masks.data<bool>();
-                std::fill_n(visual_pos_masks_data, total_num_tokens, false);
+                std::fill_n(visual_pos_masks_data, visual_pos_masks.get_size(), false);
             }
 
             if (per_layer_inputs_context.has_per_layer_inputs) {

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -572,7 +572,9 @@ public:
                 // per-token inputs are "tokens-first": inputs_embeds is {total_num_tokens, hidden_size},
                 // per_layer_inputs is {total_num_tokens, 1, ...}, and visual_pos_masks must be {total_num_tokens, 1}.
                 // Note: position_ids may be {total_num_tokens} or {N, total_num_tokens} for M-RoPE models.
-                // Otherwise the DeepStack index_put_ in the language model derives its
+                // With a stateful (batch, seq) mask here, the language model's DeepStack index_put_
+                // derives scatter indices against the wrong axis and the request fails with an
+                // out-of-bounds error.
                 visual_pos_masks = _get_or_resize_tensor(m_cached_visual_pos_masks, "visual_pos_masks",
                     {total_num_tokens, 1}, ov::element::boolean);
 

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -568,12 +568,11 @@ public:
                 
                 std::fill_n(deepstack_visual_embeds.data<float>(), deepstack_visual_embeds.get_size(), 0.0f);
                 
-                // Under PagedAttention all tokens live in the batch dimension, so every
-                // per-token input is tokens-first: inputs_embeds is {total_num_tokens,
-                // hidden_size}, position_ids is {total_num_tokens} and per_layer_inputs is
-                // {total_num_tokens, 1, ...}. visual_pos_masks must follow the same layout,
-                // otherwise the DeepStack index_put_ in the language model derives its
-                // scatter indices against the wrong axis.
+                // Under PagedAttention, scheduled tokens are flattened into total_num_tokens and most
+                // per-token inputs are "tokens-first": inputs_embeds is {total_num_tokens, hidden_size},
+                // per_layer_inputs is {total_num_tokens, 1, ...}, and visual_pos_masks must be {total_num_tokens, 1}.
+                // Note: position_ids may be {total_num_tokens} or {N, total_num_tokens} for M-RoPE models.
+                // Otherwise the DeepStack index_put_ in the language model derives its
                 visual_pos_masks = _get_or_resize_tensor(m_cached_visual_pos_masks, "visual_pos_masks",
                     {total_num_tokens, 1}, ov::element::boolean);
 

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -571,7 +571,7 @@ public:
                 // Under PagedAttention, scheduled tokens are flattened into total_num_tokens and most
                 // per-token inputs are "tokens-first": inputs_embeds is {total_num_tokens, hidden_size},
                 // per_layer_inputs is {total_num_tokens, 1, ...}, and visual_pos_masks must be {total_num_tokens, 1}.
-                // Note: position_ids may be {total_num_tokens} or {N, total_num_tokens} for M-RoPE models.
+                // Note: position_ids may be {total_num_tokens} or higher-rank (e.g. {N, 1, total_num_tokens}) for M-RoPE models.
                 // With a stateful (batch, seq) mask here, the language model's DeepStack index_put_
                 // derives scatter indices against the wrong axis and the request fails with an
                 // out-of-bounds error.

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -568,8 +568,14 @@ public:
                 
                 std::fill_n(deepstack_visual_embeds.data<float>(), deepstack_visual_embeds.get_size(), 0.0f);
                 
+                // Under PagedAttention all tokens live in the batch dimension, so every
+                // per-token input is tokens-first: inputs_embeds is {total_num_tokens,
+                // hidden_size}, position_ids is {total_num_tokens} and per_layer_inputs is
+                // {total_num_tokens, 1, ...}. visual_pos_masks must follow the same layout,
+                // otherwise the DeepStack index_put_ in the language model derives its
+                // scatter indices against the wrong axis.
                 visual_pos_masks = _get_or_resize_tensor(m_cached_visual_pos_masks, "visual_pos_masks",
-                    {1, total_num_tokens}, ov::element::boolean);
+                    {total_num_tokens, 1}, ov::element::boolean);
 
                 visual_pos_masks_data = visual_pos_masks.data<bool>();
                 std::fill_n(visual_pos_masks_data, total_num_tokens, false);

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -947,7 +947,12 @@ def test_deepstack_visual_pos_masks_layout_pa(cat_tensor: openvino.Tensor):
     language model derives its scatter indices against the wrong axis.
     """
     models_path = _get_ov_model("optimum-intel-internal-testing/tiny-random-qwen3-vl")
-    cb_pipe = ContinuousBatchingPipeline(models_path, SchedulerConfig(), "CPU")
+    cb_pipe = ContinuousBatchingPipeline(
+        models_path,
+        SchedulerConfig(),
+        "CPU",
+        properties={"ATTENTION_BACKEND": "PA"},
+    )
 
     generation_config = get_greedy()
     generation_config.max_new_tokens = DEFAULT_MAX_NEW_TOKENS

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -933,6 +933,31 @@ def test_vlm_continuous_batching_generate_vs_add_request(
             )
 
 
+def test_deepstack_visual_pos_masks_layout_pa(cat_tensor: openvino.Tensor):
+    """DeepStack visual_pos_masks must use the tokens-first PagedAttention layout.
+
+    Regression guard: the mask used to be allocated as {1, total_num_tokens},
+    which is the stateful (batch, seq) layout, while every other PagedAttention
+    input is tokens-first ({total_num_tokens, hidden_size} for inputs_embeds,
+    {total_num_tokens} for position_ids, {total_num_tokens, 1, ...} for
+    per_layer_inputs). With the wrong layout the DeepStack index_put_ inside the
+    language model derives its scatter indices against the wrong axis.
+    """
+    models_path = _get_ov_model("optimum-intel-internal-testing/tiny-random-qwen3-vl")
+    cb_pipe = ContinuousBatchingPipeline(models_path, SchedulerConfig(), "CPU")
+
+    generation_config = get_greedy()
+    generation_config.max_new_tokens = DEFAULT_MAX_NEW_TOKENS
+
+    results = cb_pipe.generate(
+        [PROMPTS[0]],
+        images=[[cat_tensor]],
+        generation_config=[generation_config],
+    )
+
+    assert results[0].texts[0]
+
+
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -943,10 +943,10 @@ def test_deepstack_visual_pos_masks_layout_pa(cat_tensor: openvino.Tensor):
     which is the stateful (batch, seq) layout, while the PagedAttention inputs
     that are token-flattened use tokens-first layouts ({total_num_tokens,
     hidden_size} for inputs_embeds and {total_num_tokens, 1, ...} for
-    per_layer_inputs). M-RoPE position_ids may be {total_num_tokens} or
-    {N, total_num_tokens}; this test does not constrain that model-specific
-    layout. With the wrong mask layout the DeepStack index_put_ inside the
-    language model derives its scatter indices against the wrong axis.
+    per_layer_inputs). M-RoPE position_ids may be 1-D ({total_num_tokens}) or
+    rank-3 ({N, 1, total_num_tokens}); this test does not constrain that
+    model-specific layout. With the wrong mask layout the DeepStack index_put_
+    inside the language model derives its scatter indices against the wrong axis.
     """
     models_path = _get_ov_model("optimum-intel-internal-testing/tiny-random-qwen3-vl")
     cb_pipe = ContinuousBatchingPipeline(

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -933,6 +933,9 @@ def test_vlm_continuous_batching_generate_vs_add_request(
             )
 
 
+@pytest.mark.transformers_lower_v5(
+    reason="Qwen3-VL export is only supported with transformers < 5.0 in this test suite"
+)
 def test_deepstack_visual_pos_masks_layout_pa(cat_tensor: openvino.Tensor):
     """DeepStack visual_pos_masks must use the tokens-first PagedAttention layout.
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -940,10 +940,12 @@ def test_deepstack_visual_pos_masks_layout_pa(cat_tensor: openvino.Tensor):
     """DeepStack visual_pos_masks must use the tokens-first PagedAttention layout.
 
     Regression guard: the mask used to be allocated as {1, total_num_tokens},
-    which is the stateful (batch, seq) layout, while every other PagedAttention
-    input is tokens-first ({total_num_tokens, hidden_size} for inputs_embeds,
-    {total_num_tokens} for position_ids, {total_num_tokens, 1, ...} for
-    per_layer_inputs). With the wrong layout the DeepStack index_put_ inside the
+    which is the stateful (batch, seq) layout, while the PagedAttention inputs
+    that are token-flattened use tokens-first layouts ({total_num_tokens,
+    hidden_size} for inputs_embeds and {total_num_tokens, 1, ...} for
+    per_layer_inputs). M-RoPE position_ids may be {total_num_tokens} or
+    {N, total_num_tokens}; this test does not constrain that model-specific
+    layout. With the wrong mask layout the DeepStack index_put_ inside the
     language model derives its scatter indices against the wrong axis.
     """
     models_path = _get_ov_model("optimum-intel-internal-testing/tiny-random-qwen3-vl")


### PR DESCRIPTION
## Description

Under PagedAttention all tokens are moved to the batch dimension, so every
per-token input in `ModelRunner` is tokens-first:

| input | shape |
|---|---|
| `inputs_embeds` | `{total_num_tokens, hidden_size}` |
| `position_ids` | `{total_num_tokens}` |
| `per_layer_inputs` | `{total_num_tokens, 1, num_hidden_layers, hidden_size}` |
| `visual_pos_masks` | **`{1, total_num_tokens}`** ← inconsistent |

`visual_pos_masks` was allocated with the stateful `(batch, seq)` layout. The
DeepStack `index_put_` inside the Qwen3-VL language model derives its scatter
indices from that mask, so with the wrong axis order the request fails with:

```
Check 'idxValue >= 0 && idxValue < srcDataDim[i]' failed
Node __module.model.language_model/aten::index_put_/ScatterNDUpdate
indices contain values that point to non-existing data tensor element
```

The fix makes the mask follow the same tokens-first convention as
`per_layer_inputs`, whose existing comment already states *"PA model expects
[total_num_tokens, 1, ...]"*.

```diff
- visual_pos_masks = _get_or_resize_tensor(m_cached_visual_pos_masks,
-     "visual_pos_masks", {1, total_num_tokens}, ov::element::boolean);
+ visual_pos_masks = _get_or_resize_tensor(m_cached_visual_pos_masks,
+     "visual_pos_masks", {total_num_tokens, 1}, ov::element::boolean);
```

`std::fill_n(visual_pos_masks_data, total_num_tokens, false)` and the
per-sequence fill loop are unaffected: both address the buffer linearly and the
element count is unchanged.

### Affected scope

`visual_pos_masks` is consumed by `qwen3_vl`, and `deepstack_visual_embeds`
additionally by `qwen3_omni` and `vision_token_pruning_processor`. Only the
PagedAttention/ContinuousBatching path is touched; the stateful path builds its
own mask in `lm_encoding.cpp` and is unchanged.

### Possibly related

	ests/python_tests/test_vlm_pipeline.py references CVS-186059 as
"qwen3_vl fails with error: Eltwise shape infer input shapes dim index: 1
mismatch". That is a different error string from the one fixed here, so I am
not claiming the two share a root cause - but both are dim-1 shape problems on
the qwen3_vl path, so maintainers with Jira access may want to check whether
they are related. No ticket is referenced in this PR.

## Verification

Reproduced and fixed against a real `Qwen3-VL-8B-Instruct` INT4 OpenVINO export
(`optimum-intel 2.1.0.dev0` / `transformers 4.57.6`), on GenAI master
`da1db864` built from source.

Before the fix:

| device | attention backend | result |
|---|---|---|
| CPU | PA (default) | `ScatterNDUpdate` out-of-bounds |
| CPU | SDPA | correct, grounded output |

That SDPA/PA split is what localised the defect to the PagedAttention path
rather than to the export, the processor or the tokenizer. Instrumenting the
prefill confirmed every other quantity was already consistent:

```
input_ids=761  image_pad=720  image_embeds=[720,4096]  deepstack=[3,720,4096]
visual_pos_masks=[1,761] mask_true=720 idx_min=4 idx_max=723 dest=761
position_ids=[3,1,761]  grid_thw=[1,36,80]  merge_size=2
```

i.e. `placeholder_count == vision_rows == deepstack_rows == 720` and the indices
lie inside the sequence - only the mask axis order was wrong.

After the fix, CPU + PA produces output byte-identical to the SDPA baseline.

### Not verified locally

The new test could not be executed in this environment: exporting
`optimum-intel-internal-testing/tiny-random-qwen3-vl` requires
`transformers <= 5.0` (installed: 5.14.1), so `optimum-cli export openvino`
refuses the conversion. The tiny model config does declare
`deepstack_visual_indexes: [1, 3, 5]` with `patch_size 16 / spatial_merge_size 2`,
so it should exercise the DeepStack path. **CI validation is required.**

Related question for maintainers: for `transformers < 5.0`,
`tiny-random-qwen3-vl` is already part of `MODEL_IDS` and `ATTENTION_BACKEND`
includes `PA`, so this path looks covered today. If CI is green there, it would
be useful to understand why - either the regression needs conditions the tiny
model does not reach, or there is a coverage gap worth closing.

## Checklist

- [x] This PR follows GenAI Contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
      Added `test_deepstack_visual_pos_masks_layout_pa` in
      `tests/python_tests/test_vlm_pipeline.py`, exercising Qwen3-VL DeepStack
      through `ContinuousBatchingPipeline` (PagedAttention) with one image.
      Not executed locally - see "Not verified locally".
- [x] N/A - no ticket; this PR fixes a runtime layout defect found and reproduced
      against a real Qwen3-VL INT4 export. The closest existing ticket candidate
      (CVS-186059, a different error string on the same model family) is noted
      under "Possibly related" for maintainers with Jira access to evaluate.
- [x] N/A - no documentation changes; internal shape-allocation fix.

## Hypotheses discarded during the investigation

Recorded so reviewers can see what was ruled out and by which measurement, and
so none of these is quietly reintroduced later.

| Hypothesis | Killed by |
|---|---|
| Model export is malformed | All three exported graphs execute correctly with hand-built inputs: merger emits `(720, 4096)` + deepstack `(3, 720, 4096)`, language model returns finite logits `(1, 734, 151936)` |
| OpenVINO runtime version | Reproduced identically on nightly and on a from-source build of OpenVINO master `7c4d2733` |
| Processor / chat template / tokenizer | `placeholder_count == vision_rows == 720` at every image size; OpenVINO and Python tokenizers emit identical ids, `<\|image_pad\|>` is neither dropped nor split |
| Frame geometry / patch alignment | Fails at every tested resolution; Qwen3-VL uses `patch_size 16`, so an alignment theory built on 28 was wrong from the start |
| The SDPA primitive itself | Forcing the attention unfused (`Gemm → SoftMax → Gemm`) still reproduces; standalone SDPA at the same shapes is correct |
| Stale decode-step inputs | `lm_encoding.cpp` already resets `deepstack_visual_embeds` and `visual_pos_masks` per decode step; an earlier "decode fails" reading was an artifact of reusing one stateful `InferRequest` across trials |

The surviving explanation is the one in this PR, and it is the only one with a
one-line fix.

## AI usage disclosure

```
AI assistance used: yes

If yes: Diagnosis and patch authoring were performed with Kelvin Clyne, an
        agentic coding assistant running an evidence-gated protocol:
        disconfirm before implementing, provenance for every mutable fact, and
        no claim shipped without the measurement standing behind it.

        Six hypotheses were formed and discarded during this investigation.
        Four were the assistant's own. Two were convincing right up until they
        were measured.

        Every other PagedAttention input is tokens-first. This one reagent went
        into the flask with its axes reversed, and the reaction still ran. It
        simply stopped producing the compound on the label.

        A vision model that cannot see does not go quiet. It gets fluent. The
        strict correctness gate used here exists because the wrong answer
        arrives in complete sentences, correctly punctuated, describing a
        photograph nobody took.

        The fix transposes two numbers. Establishing which two did not.

        Kelvin Clyne - independent software chemist.
        The white coat is optional. The measurement is not.

Human validation performed: OpenVINO and OpenVINO GenAI built from source
        (OpenVINO master 7c4d2733, GenAI master da1db864, MSVC 14.44 / Ninja);
        defect reproduced and the fix confirmed on a real Qwen3-VL-8B INT4
        export; before/after outputs compared against operator-established
        ground truth on real photographic frames, where the corrected build
        reports "seven women in a wide shot wearing matching black sequined
        dresses" and the broken one had opinions of its own. The new test has
        NOT been executed locally, for the reason stated above.
```