### PR TITLE
[EXPERIMENT][WIP] Add Molmo2 (allenai/MolmoWeb-4B) VLMPipeline support

### DIFF
--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -272,4 +272,16 @@ export const VLM_MODELS: VLMModelType[] = [
       },
     ],
   },
+  {
+    architecture: 'Molmo2ForConditionalGeneration',
+    models: [
+      {
+        name: 'molmo2',
+        links: [
+          'https://huggingface.co/allenai/MolmoWeb-4B',
+        ],
+        notesLink: '#molmo2-notes',
+      },
+    ],
+  },
 ];

--- a/site/docs/supported-models/index.mdx
+++ b/site/docs/supported-models/index.mdx
@@ -104,6 +104,17 @@ The model requires `transformers==5.2` for the export with `optimum-cli`.
 #### nanoLLaVA {#nanollava-notes}
 
 The model requires `transformers>=4.48` for the export with `optimum-cli`.
+
+#### molmo2 {#molmo2-notes}
+
+1. `allenai/MolmoWeb-4B` was tested against `transformers==4.57.3`. Newer `transformers` versions
+   (e.g. `5.x`) remove the `"default"` RoPE init function the model's `trust_remote_code`
+   relies on; a compatibility shim is required to export the model with `optimum-cli` on newer
+   `transformers`.
+2. The current export does not populate `token_type_ids` for image tokens, so image-token
+   attention is causal rather than fully bidirectional as in the original PyTorch model. This is
+   a known limitation inherited from the Optimum-Intel export and does not prevent correct,
+   on-topic generation in practice.
 :::
 
 ## Speech Recognition Models

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -26,6 +26,7 @@
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
+#include "visual_language/molmo2/classes.hpp"
 
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
@@ -398,6 +399,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, model_dir, tokenizer, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::MOLMO2) {
+        m_impl = std::make_shared<InputsEmbedderMolmo2>(vlm_config, model_dir, tokenizer, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -448,6 +451,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::MOLMO2) {
+        m_impl = std::make_shared<InputsEmbedderMolmo2>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -404,6 +404,7 @@ private:
     friend class InputsEmbedderGemma4;
     friend class InputsEmbedderVideoChatFlashQwen;
     friend class InputsEmbedderMuseGlimmer;
+    friend class InputsEmbedderMolmo2;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/molmo2/classes.cpp
+++ b/src/cpp/src/visual_language/molmo2/classes.cpp
@@ -1,0 +1,613 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/molmo2/classes.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <numeric>
+
+#include "visual_language/clip.hpp"
+
+#include "utils.hpp"
+
+namespace ov::genai {
+namespace {
+
+// ---------------------------------------------------------------------------------------------
+// Molmo2 multi-crop tiling + pooling preprocessing.
+//
+// Ported from the model's own remote code (`image_processing_molmo2.py` /
+// `processing_molmo2.py`, published at huggingface.co/allenai/MolmoWeb-4B): an image is split
+// into up to `max_crops` overlapping high-resolution crops plus one low-resolution global
+// thumbnail; a `pixel_values` tensor holds all (patchified) crops, and an `image_token_pooling`
+// tensor tells the vision model which patches to average-pool (2x2 groups, by default) into
+// each of the visual tokens that get spliced into the prompt.
+// ---------------------------------------------------------------------------------------------
+
+// A single normalized RGB float crop, HWC layout (row-major: for each row, for each column, R/G/B).
+struct Molmo2Crop {
+    std::vector<float> hwc;
+    int height = 0;
+    int width = 0;
+};
+
+float normalize_channel(uint8_t value, float mean, float std) {
+    return (static_cast<float>(value) / 255.0f - mean) / std;
+}
+
+// Resizes (nearest structural equivalent of Python's torchvision-based resize, already used
+// throughout this codebase for other VLMs) and normalizes an image to a HWC float buffer.
+Molmo2Crop resize_and_normalize(const clip_image_u8& src, int target_width, int target_height, const std::array<float, 3>& mean, const std::array<float, 3>& std_dev) {
+    clip_image_u8 resized;
+    bilinear_resize(src, resized, target_width, target_height);
+
+    Molmo2Crop out;
+    out.height = target_height;
+    out.width = target_width;
+    out.hwc.resize(static_cast<size_t>(target_height) * target_width * 3);
+    for (size_t i = 0; i < out.hwc.size(); i += 3) {
+        for (size_t c = 0; c < 3; c++) {
+            out.hwc[i + c] = normalize_channel(resized.buf[i + c], mean[c], std_dev[c]);
+        }
+    }
+    return out;
+}
+
+// Port of Python's `select_tiling`: picks an (num_rows, num_cols) tiling of `patch_size`-aligned
+// crop windows (with `num_rows*num_cols <= max_crops`) that best matches the image's aspect
+// ratio, preferring the tiling that requires the least up/downscaling.
+std::pair<int, int> select_tiling(int h, int w, int patch_size, int max_crops) {
+    std::vector<std::pair<int, int>> tilings;
+    for (int i = 1; i <= max_crops; i++) {
+        for (int j = 1; j <= max_crops; j++) {
+            if (i * j <= max_crops) {
+                tilings.emplace_back(i, j);
+            }
+        }
+    }
+    // Sort so argmin/argmax favour smaller tilings in the event of a tie (matches Python's
+    // `tilings.sort(key=lambda x: (x[0]*x[1], x[0]))`).
+    std::sort(tilings.begin(), tilings.end(), [](const std::pair<int, int>& a, const std::pair<int, int>& b) {
+        int area_a = a.first * a.second, area_b = b.first * b.second;
+        return area_a != area_b ? area_a < area_b : a.first < b.first;
+    });
+
+    std::vector<float> required_scale(tilings.size());
+    bool all_below_one = true;
+    for (size_t k = 0; k < tilings.size(); k++) {
+        float scale_h = static_cast<float>(tilings[k].first * patch_size) / static_cast<float>(h);
+        float scale_w = static_cast<float>(tilings[k].second * patch_size) / static_cast<float>(w);
+        required_scale[k] = std::min(scale_h, scale_w);
+        if (required_scale[k] >= 1.0f) {
+            all_below_one = false;
+        }
+    }
+
+    size_t best_ix = 0;
+    if (all_below_one) {
+        // Forced to downscale regardless of tiling: minimize the amount of downscaling (argmax).
+        for (size_t k = 1; k < required_scale.size(); k++) {
+            if (required_scale[k] > required_scale[best_ix]) {
+                best_ix = k;
+            }
+        }
+    } else {
+        // Pick the resolution that required the least upscaling (argmin among scale >= 1).
+        for (size_t k = 0; k < required_scale.size(); k++) {
+            if (required_scale[k] < 1.0f) {
+                required_scale[k] = std::numeric_limits<float>::max();
+            }
+        }
+        for (size_t k = 1; k < required_scale.size(); k++) {
+            if (required_scale[k] < required_scale[best_ix]) {
+                best_ix = k;
+            }
+        }
+    }
+    return tilings[best_ix];
+}
+
+// Result of splitting an image into overlapping high-resolution crops: the crops themselves,
+// and a de-overlapped patch-id mosaic (in image scanline order) pointing into those crops'
+// flattened patch space.
+struct OverlappingCrops {
+    std::vector<Molmo2Crop> crops;
+    std::vector<int32_t> patch_idx;  // flattened [mosaic_h * mosaic_w], row-major
+    int mosaic_h = 0;
+    int mosaic_w = 0;
+};
+
+// Port of Python's `build_overlapping_crops`.
+OverlappingCrops build_overlapping_crops(
+    const clip_image_u8& image,
+    int max_crops,
+    int left_margin,
+    int right_margin,
+    int crop_size,
+    int patch_size,
+    const std::array<float, 3>& mean,
+    const std::array<float, 3>& std_dev
+) {
+    const int total_margin_pixels = patch_size * (left_margin + right_margin);
+    const int crop_patches = crop_size / patch_size;
+    const int crop_window_patches = crop_patches - (left_margin + right_margin);
+    const int crop_window_size = crop_window_patches * patch_size;
+
+    const std::pair<int, int> tiling = select_tiling(
+        std::max(image.ny - total_margin_pixels, 1),
+        std::max(image.nx - total_margin_pixels, 1),
+        crop_window_size,
+        max_crops);
+    const int tiling_h = tiling.first;
+    const int tiling_w = tiling.second;
+
+    const int resized_h = tiling_h * crop_window_size + total_margin_pixels;
+    const int resized_w = tiling_w * crop_window_size + total_margin_pixels;
+    const Molmo2Crop src = resize_and_normalize(image, resized_w, resized_h, mean, std_dev);
+
+    const int n_crops = tiling_h * tiling_w;
+    OverlappingCrops result;
+    result.crops.resize(n_crops);
+    // crop_patch_idx[on_crop] is a [crop_patches x crop_patches] grid of unique global patch ids,
+    // masked to -1 in this crop's overlap regions (matches Python's `patch_idx_arr` per-crop).
+    std::vector<std::vector<int32_t>> crop_patch_idx(n_crops, std::vector<int32_t>(static_cast<size_t>(crop_patches) * crop_patches));
+
+    int on_crop = 0;
+    for (int i = 0; i < tiling_h; i++) {
+        const int y0 = i * crop_window_size;
+        for (int j = 0; j < tiling_w; j++) {
+            const int x0 = j * crop_window_size;
+
+            Molmo2Crop& crop = result.crops[on_crop];
+            crop.height = crop_size;
+            crop.width = crop_size;
+            crop.hwc.resize(static_cast<size_t>(crop_size) * crop_size * 3);
+            for (int y = 0; y < crop_size; y++) {
+                for (int x = 0; x < crop_size; x++) {
+                    for (int c = 0; c < 3; c++) {
+                        crop.hwc[(static_cast<size_t>(y) * crop_size + x) * 3 + c] =
+                            src.hwc[(static_cast<size_t>(y0 + y) * resized_w + (x0 + x)) * 3 + c];
+                    }
+                }
+            }
+
+            std::vector<int32_t>& idx = crop_patch_idx[on_crop];
+            for (int py = 0; py < crop_patches; py++) {
+                for (int px = 0; px < crop_patches; px++) {
+                    idx[py * crop_patches + px] = on_crop * crop_patches * crop_patches + py * crop_patches + px;
+                }
+            }
+            // Mask out patch ids that fall in the overlap region shared with a neighboring crop.
+            if (i != 0) {
+                for (int py = 0; py < left_margin; py++) {
+                    for (int px = 0; px < crop_patches; px++) {
+                        idx[py * crop_patches + px] = -1;
+                    }
+                }
+            }
+            if (j != 0) {
+                for (int py = 0; py < crop_patches; py++) {
+                    for (int px = 0; px < left_margin; px++) {
+                        idx[py * crop_patches + px] = -1;
+                    }
+                }
+            }
+            if (i != tiling_h - 1) {
+                for (int py = crop_patches - right_margin; py < crop_patches; py++) {
+                    for (int px = 0; px < crop_patches; px++) {
+                        idx[py * crop_patches + px] = -1;
+                    }
+                }
+            }
+            if (j != tiling_w - 1) {
+                for (int py = 0; py < crop_patches; py++) {
+                    for (int px = crop_patches - right_margin; px < crop_patches; px++) {
+                        idx[py * crop_patches + px] = -1;
+                    }
+                }
+            }
+            on_crop++;
+        }
+    }
+
+    // Reorder from crop-major order into image-scanline order (matches Python's
+    // reshape->transpose([0,2,1,3])->reshape), then drop masked (-1) entries.
+    std::vector<int32_t> scanline;
+    scanline.reserve(static_cast<size_t>(tiling_h) * crop_patches * tiling_w * crop_patches);
+    for (int ti = 0; ti < tiling_h; ti++) {
+        for (int py = 0; py < crop_patches; py++) {
+            for (int tj = 0; tj < tiling_w; tj++) {
+                const int crop_id = ti * tiling_w + tj;
+                for (int px = 0; px < crop_patches; px++) {
+                    scanline.push_back(crop_patch_idx[crop_id][py * crop_patches + px]);
+                }
+            }
+        }
+    }
+
+    const int mosaic_h = resized_h / patch_size;
+    const int mosaic_w = resized_w / patch_size;
+    result.patch_idx.reserve(static_cast<size_t>(mosaic_h) * mosaic_w);
+    for (int32_t v : scanline) {
+        if (v >= 0) {
+            result.patch_idx.push_back(v);
+        }
+    }
+    OPENVINO_ASSERT(result.patch_idx.size() == static_cast<size_t>(mosaic_h) * mosaic_w,
+        "Molmo2 image preprocessing: unexpected patch count after de-overlap filtering");
+    result.mosaic_h = mosaic_h;
+    result.mosaic_w = mosaic_w;
+    return result;
+}
+
+// Port of Python's `build_resized_image`: the low-resolution global thumbnail.
+struct GlobalThumbnail {
+    Molmo2Crop image;
+    std::vector<int32_t> patch_idx;
+    int patch_h = 0;
+    int patch_w = 0;
+};
+
+GlobalThumbnail build_resized_image(const clip_image_u8& image, int target_size, int patch_size, const std::array<float, 3>& mean, const std::array<float, 3>& std_dev) {
+    GlobalThumbnail result;
+    result.image = resize_and_normalize(image, target_size, target_size, mean, std_dev);
+    result.patch_h = target_size / patch_size;
+    result.patch_w = target_size / patch_size;
+    result.patch_idx.resize(static_cast<size_t>(result.patch_h) * result.patch_w);
+    std::iota(result.patch_idx.begin(), result.patch_idx.end(), 0);
+    return result;
+}
+
+// Port of Python's `arange_for_pooling`: pads a [h, w] patch-id grid with -1 to align both
+// dimensions to multiples of (pool_h, pool_w), then regroups into [out_h, out_w, pool_h*pool_w]
+// pooling windows (row-major within each window).
+struct PooledIdx {
+    std::vector<int32_t> data;
+    int out_h = 0;
+    int out_w = 0;
+};
+
+PooledIdx arange_for_pooling(const std::vector<int32_t>& idx, int h, int w, int pool_h, int pool_w) {
+    const int h_pad = pool_h * ((h + pool_h - 1) / pool_h) - h;
+    const int w_pad = pool_w * ((w + pool_w - 1) / pool_w) - w;
+    const int pad_top = h_pad / 2;
+    const int pad_left = w_pad / 2;
+    const int padded_h = h + h_pad;
+    const int padded_w = w + w_pad;
+
+    std::vector<int32_t> padded(static_cast<size_t>(padded_h) * padded_w, -1);
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            padded[static_cast<size_t>(y + pad_top) * padded_w + (x + pad_left)] = idx[static_cast<size_t>(y) * w + x];
+        }
+    }
+
+    PooledIdx result;
+    result.out_h = padded_h / pool_h;
+    result.out_w = padded_w / pool_w;
+    result.data.resize(static_cast<size_t>(result.out_h) * result.out_w * pool_h * pool_w);
+    for (int gy = 0; gy < result.out_h; gy++) {
+        for (int gx = 0; gx < result.out_w; gx++) {
+            const size_t out_base = (static_cast<size_t>(gy) * result.out_w + gx) * (pool_h * pool_w);
+            for (int dh = 0; dh < pool_h; dh++) {
+                for (int dw = 0; dw < pool_w; dw++) {
+                    const int src_y = gy * pool_h + dh;
+                    const int src_x = gx * pool_w + dw;
+                    result.data[out_base + dh * pool_w + dw] = padded[static_cast<size_t>(src_y) * padded_w + src_x];
+                }
+            }
+        }
+    }
+    return result;
+}
+
+// Port of Python's `batch_pixels_to_patches` for a single crop: reshapes a HWC image into
+// [n_patches, patch_size*patch_size*3] (patches enumerated row-major, pixels within each patch
+// enumerated row-major with channel fastest-varying).
+std::vector<float> patchify(const Molmo2Crop& crop, int patch_size) {
+    const int h_patches = crop.height / patch_size;
+    const int w_patches = crop.width / patch_size;
+    std::vector<float> out(static_cast<size_t>(h_patches) * w_patches * patch_size * patch_size * 3);
+    size_t out_idx = 0;
+    for (int ph = 0; ph < h_patches; ph++) {
+        for (int pw = 0; pw < w_patches; pw++) {
+            for (int dy = 0; dy < patch_size; dy++) {
+                const int y = ph * patch_size + dy;
+                for (int dx = 0; dx < patch_size; dx++) {
+                    const int x = pw * patch_size + dx;
+                    for (int c = 0; c < 3; c++) {
+                        out[out_idx++] = crop.hwc[(static_cast<size_t>(y) * crop.width + x) * 3 + c];
+                    }
+                }
+            }
+        }
+    }
+    return out;
+}
+
+// Final assembled inputs for the vision embeddings OpenVINO model, plus the pooled grid
+// dimensions needed to build the prompt's image token expansion.
+struct Molmo2ImageFeatures {
+    ov::Tensor pixel_values;
+    ov::Tensor image_token_pooling;
+    int low_res_h = 0, low_res_w = 0;
+    int high_res_h = 0, high_res_w = 0;
+};
+
+// Port of Python's `image_to_patches_and_grids` (single image; GenAI's VisionEncoder API
+// processes one image per `encode()` call).
+Molmo2ImageFeatures image_to_patches_and_grids(
+    const clip_image_u8& image,
+    int max_crops,
+    int left_margin,
+    int right_margin,
+    int crop_size,
+    int patch_size,
+    int pool_h,
+    int pool_w,
+    const std::array<float, 3>& mean,
+    const std::array<float, 3>& std_dev
+) {
+    OverlappingCrops overlapping = build_overlapping_crops(image, max_crops, left_margin, right_margin, crop_size, patch_size, mean, std_dev);
+    PooledIdx high_res_pooling = arange_for_pooling(overlapping.patch_idx, overlapping.mosaic_h, overlapping.mosaic_w, pool_h, pool_w);
+
+    GlobalThumbnail thumbnail = build_resized_image(image, crop_size, patch_size, mean, std_dev);
+    PooledIdx low_res_pooling = arange_for_pooling(thumbnail.patch_idx, thumbnail.patch_h, thumbnail.patch_w, pool_h, pool_w);
+
+    const int crop_patches = crop_size / patch_size;
+    const int global_patch_count = crop_patches * crop_patches;  // thumbnail occupies patch ids [0, global_patch_count)
+
+    // The global thumbnail is prepended as "crop 0", so high-resolution patch ids (which were
+    // computed assuming they start at 0) must be shifted past the thumbnail's own patches.
+    for (int32_t& v : high_res_pooling.data) {
+        if (v >= 0) {
+            v += global_patch_count;
+        }
+    }
+
+    const int n_crops_total = 1 + static_cast<int>(overlapping.crops.size());
+    const int patch_dim = patch_size * patch_size * 3;
+    ov::Tensor pixel_values(ov::element::f32, {static_cast<size_t>(n_crops_total), static_cast<size_t>(global_patch_count), static_cast<size_t>(patch_dim)});
+    float* pixel_data = pixel_values.data<float>();
+
+    const std::vector<float> thumb_patches = patchify(thumbnail.image, patch_size);
+    OPENVINO_ASSERT(thumb_patches.size() == static_cast<size_t>(global_patch_count) * patch_dim);
+    std::copy(thumb_patches.begin(), thumb_patches.end(), pixel_data);
+
+    for (size_t k = 0; k < overlapping.crops.size(); k++) {
+        const std::vector<float> crop_patches_data = patchify(overlapping.crops[k], patch_size);
+        std::copy(crop_patches_data.begin(), crop_patches_data.end(),
+            pixel_data + (k + 1) * static_cast<size_t>(global_patch_count) * patch_dim);
+    }
+
+    const int pool_dim = pool_h * pool_w;
+    const size_t total_pooled_tokens = static_cast<size_t>(low_res_pooling.out_h) * low_res_pooling.out_w
+        + static_cast<size_t>(high_res_pooling.out_h) * high_res_pooling.out_w;
+    ov::Tensor image_token_pooling(ov::element::i64, {1, total_pooled_tokens, static_cast<size_t>(pool_dim)});
+    int64_t* pooling_data = image_token_pooling.data<int64_t>();
+    size_t pos = 0;
+    for (int32_t v : low_res_pooling.data) {
+        pooling_data[pos++] = v;
+    }
+    for (int32_t v : high_res_pooling.data) {
+        pooling_data[pos++] = v;
+    }
+
+    Molmo2ImageFeatures result;
+    result.pixel_values = std::move(pixel_values);
+    result.image_token_pooling = std::move(image_token_pooling);
+    result.low_res_h = low_res_pooling.out_h;
+    result.low_res_w = low_res_pooling.out_w;
+    result.high_res_h = high_res_pooling.out_h;
+    result.high_res_w = high_res_pooling.out_w;
+    return result;
+}
+
+// Molmo2's structural prompt tokens (matches IMAGE_TOKENS subset relevant to static images in
+// `processing_molmo2.py`; video-only frame tokens are intentionally excluded since video input
+// is not supported here, matching sibling VLM implementations in this codebase).
+constexpr const char* IM_PATCH_TOKEN = "<im_patch>";
+constexpr const char* IM_COL_TOKEN = "<im_col>";
+constexpr const char* IM_START_TOKEN = "<im_start>";
+constexpr const char* IM_END_TOKEN = "<im_end>";
+constexpr const char* LOW_RES_IM_START_TOKEN = "<low_res_im_start>";
+
+}  // namespace
+
+EncodedImage VisionEncoderMolmo2::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+    OPENVINO_ASSERT(config.size_height == config.size_width, "Molmo2 requires a square base image input size");
+
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+
+    Molmo2ImageFeatures features = image_to_patches_and_grids(
+        input_image,
+        static_cast<int>(config.max_crops),
+        static_cast<int>(config.overlap_margins[0]),
+        static_cast<int>(config.overlap_margins[1]),
+        static_cast<int>(config.size_height),
+        static_cast<int>(config.patch_size),
+        static_cast<int>(config.pooling_size[0]),
+        static_cast<int>(config.pooling_size[1]),
+        config.image_mean,
+        config.image_std);
+
+    encoder.set_tensor("pixel_values", features.pixel_values);
+    encoder.set_tensor("image_token_pooling", features.image_token_pooling);
+    encoder.infer();
+
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
+    ov::Tensor image_features(infer_output.get_element_type(), infer_output.get_shape());
+    std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
+
+    EncodedImage encoded;
+    encoded.resized_source = std::move(image_features);
+    encoded.patches_grid = {features.high_res_h, features.high_res_w};
+    encoded.low_res_patches_grid = {features.low_res_h, features.low_res_w};
+    encoded.num_image_tokens = static_cast<size_t>(features.high_res_h) * features.high_res_w
+        + static_cast<size_t>(features.low_res_h) * features.low_res_w;
+    return encoded;
+}
+
+InputsEmbedderMolmo2::InputsEmbedderMolmo2(
+    const VLMConfig& vlm_config,
+    const std::filesystem::path& model_dir,
+    const Tokenizer& tokenizer,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
+
+InputsEmbedderMolmo2::InputsEmbedderMolmo2(
+    const VLMConfig& vlm_config,
+    const ModelsMap& models_map,
+    const Tokenizer& tokenizer,
+    const std::filesystem::path& config_dir_path,
+    const std::string& device,
+    const ov::AnyMap device_config) :
+    IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {}
+
+bool InputsEmbedderMolmo2::has_token_type_ids() const {
+    // The exported language model (optimum-intel Molmo2 export, upstream PR #1812) does not
+    // currently trace a `token_type_ids` input, so bidirectional image-token attention is not
+    // available yet -- report false to match what is actually exported and avoid the LM infer
+    // request failing to find that port. See compute_merged_embeds_and_token_type_ids() for
+    // details; this is a known, documented limitation to revisit once the exporter adds the
+    // corresponding input.
+    return false;
+}
+
+std::vector<ov::genai::EncodedImage> InputsEmbedderMolmo2::encode_images(const std::vector<ov::Tensor>& images) {
+    std::vector<EncodedImage> embeds;
+    std::vector<ov::Tensor> single_images = to_single_image_tensors(images);
+    embeds.reserve(single_images.size());
+    for (const ov::Tensor& image : single_images) {
+        embeds.emplace_back(m_vision_encoder->encode(image));
+    }
+    return embeds;
+}
+
+NormalizedPrompt InputsEmbedderMolmo2::normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const {
+    const std::string& image_tag = m_vlm_config.image_token;  // "<|image|>"
+
+    auto [unified_prompt, images_sequence] = normalize(prompt, image_tag, image_tag, base_id, images.size());
+
+    size_t search_offset = 0;
+    for (size_t new_image_id : images_sequence) {
+        const EncodedImage& encoded = images.at(new_image_id - base_id);
+        const int low_res_h = encoded.low_res_patches_grid.first;
+        const int low_res_w = encoded.low_res_patches_grid.second;
+        const int high_res_h = encoded.patches_grid.first;
+        const int high_res_w = encoded.patches_grid.second;
+
+        // Low-resolution (global thumbnail) section always precedes the high-resolution
+        // crop-mosaic section (matches Python's `get_image_tokens`).
+        std::string expanded_tag = LOW_RES_IM_START_TOKEN;
+        for (int row = 0; row < low_res_h; row++) {
+            for (int col = 0; col < low_res_w; col++) {
+                expanded_tag += IM_PATCH_TOKEN;
+            }
+            expanded_tag += IM_COL_TOKEN;
+        }
+        expanded_tag += IM_END_TOKEN;
+
+        expanded_tag += IM_START_TOKEN;
+        for (int row = 0; row < high_res_h; row++) {
+            for (int col = 0; col < high_res_w; col++) {
+                expanded_tag += IM_PATCH_TOKEN;
+            }
+            expanded_tag += IM_COL_TOKEN;
+        }
+        expanded_tag += IM_END_TOKEN;
+
+        size_t pos = unified_prompt.find(image_tag, search_offset);
+        OPENVINO_ASSERT(pos != std::string::npos, "Failed to find image token in prompt during normalization");
+        unified_prompt.replace(pos, image_tag.length(), expanded_tag);
+        search_offset = pos + expanded_tag.size();
+    }
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderMolmo2::get_inputs_embeds(const std::string& prompt, const std::vector<EncodedImage>& images, VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
+    auto [inputs_embeds, token_type_ids] = compute_merged_embeds_and_token_type_ids(prompt, images, metrics, images_sequence);
+    return inputs_embeds;
+}
+
+std::pair<ov::Tensor, ov::Tensor> InputsEmbedderMolmo2::get_inputs_embeds_with_token_type_ids(const std::string& unified_prompt, const std::vector<EncodedImage>& images, VLMPerfMetrics& metrics, bool recalculate_merged_embeddings, const std::vector<size_t>& images_sequence) {
+    return compute_merged_embeds_and_token_type_ids(unified_prompt, images, metrics, images_sequence);
+}
+
+std::pair<ov::Tensor, ov::Tensor> InputsEmbedderMolmo2::compute_merged_embeds_and_token_type_ids(const std::string& unified_prompt, const std::vector<EncodedImage>& images, VLMPerfMetrics& metrics, const std::vector<size_t>& images_sequence) {
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
+
+    ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+    std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+
+    const int64_t* input_ids_data = input_ids.data<const int64_t>();
+    const size_t seq_len = input_ids.get_size();
+
+    const int64_t image_patch_id = m_vlm_config.image_patch_id;
+    const int64_t image_col_id = m_vlm_config.image_col_id;
+    const int64_t image_start_token_id = m_vlm_config.image_start_token_id;
+    const int64_t image_end_token_id = m_vlm_config.image_end_token_id;
+    const int64_t low_res_image_start_token_id = m_vlm_config.low_res_image_start_token_id;
+
+    ov::Tensor token_type_ids(ov::element::i64, input_ids.get_shape());
+    int64_t* token_type_data = token_type_ids.data<int64_t>();
+    for (size_t i = 0; i < seq_len; i++) {
+        const int64_t id = input_ids_data[i];
+        const bool is_image_token = id == image_patch_id || id == image_col_id || id == image_start_token_id ||
+            id == image_end_token_id || id == low_res_image_start_token_id;
+        token_type_data[i] = is_image_token ? 1 : 0;
+    }
+
+    if (images.empty()) {
+        return {inputs_embeds, token_type_ids};
+    }
+
+    // Additive merge: unlike llava-style VLMs, Molmo2 adds the pooled vision feature onto the
+    // `<im_patch>` placeholder token's own (learned) text embedding rather than replacing it.
+    const size_t hidden_size = inputs_embeds.get_shape().at(2);
+    float* embeds_data = inputs_embeds.data<float>();
+
+    size_t global_pos = 0;
+    for (size_t new_image_id : images_sequence) {
+        const EncodedImage& encoded = images.at(new_image_id);
+        const ov::Shape& feature_shape = encoded.resized_source.get_shape();
+        // The vision embeddings model returns a rank-2 [num_visual_tokens, hidden_size] tensor
+        // (already flattened over any batch dim by the exported model); index from the back to
+        // stay robust if a future export variant adds a leading batch dimension.
+        OPENVINO_ASSERT(feature_shape.size() >= 2, "Unexpected Molmo2 vision feature tensor rank");
+        OPENVINO_ASSERT(feature_shape.at(feature_shape.size() - 1) == hidden_size,
+            "Molmo2 vision feature hidden size does not match text embedding hidden size");
+        const float* feature_data = encoded.resized_source.data<const float>();
+        const size_t num_features = feature_shape.at(feature_shape.size() - 2);
+
+        size_t feature_row = 0;
+        for (; global_pos < seq_len && feature_row < num_features; global_pos++) {
+            if (input_ids_data[global_pos] == image_patch_id) {
+                float* dst = embeds_data + global_pos * hidden_size;
+                const float* src = feature_data + feature_row * hidden_size;
+                for (size_t d = 0; d < hidden_size; d++) {
+                    dst[d] += src[d];
+                }
+                feature_row++;
+            }
+        }
+        OPENVINO_ASSERT(feature_row == num_features,
+            "Molmo2: number of '<im_patch>' tokens in the prompt does not match the number of vision features "
+            "produced for the corresponding image");
+    }
+
+    return {inputs_embeds, token_type_ids};
+}
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/molmo2/classes.hpp
+++ b/src/cpp/src/visual_language/molmo2/classes.hpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vlm_config.hpp"
+
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/inputs_embedder.hpp"
+
+namespace ov::genai {
+
+/// @brief Vision encoder for Molmo2 (AI2 "MolmoWeb") models.
+///
+/// Molmo2 preprocesses an image into a set of overlapping high-resolution crops plus one
+/// low-resolution global thumbnail (the original Molmo multi-crop tiling recipe), feeds all
+/// crops through a shared ViT, then pools patch features in 2x2 groups via a learned
+/// cross-attention pooling head. The vision embeddings OpenVINO model therefore takes two
+/// inputs (`pixel_values`, `image_token_pooling`) instead of the single `pixel_values` input
+/// used by most other VLMs in this codebase.
+class VisionEncoderMolmo2 : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+/// @brief Inputs embedder for Molmo2 models.
+///
+/// Unlike llava-style VLMs that *replace* placeholder token embeddings with vision features,
+/// Molmo2 *adds* the pooled vision feature onto the `<im_patch>` placeholder token's own
+/// (learned) text embedding. Bidirectional attention over image tokens is enabled via
+/// `token_type_ids`, following the same dispatch mechanism as Gemma3/Gemma4.
+class InputsEmbedderMolmo2 : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderMolmo2(
+        const VLMConfig& vlm_config,
+        const std::filesystem::path& model_dir,
+        const Tokenizer& tokenizer,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    InputsEmbedderMolmo2(
+        const VLMConfig& vlm_config,
+        const ModelsMap& models_map,
+        const Tokenizer& tokenizer,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt, const std::vector<ov::genai::EncodedImage>& images, ov::genai::VLMPerfMetrics& metrics, bool recalculate_merged_embeddings = true, const std::vector<size_t>& image_sequence = {}) override;
+
+    std::pair<ov::Tensor, ov::Tensor> get_inputs_embeds_with_token_type_ids(const std::string& prompt, const std::vector<EncodedImage>& images, VLMPerfMetrics& metrics, bool recalculate_merged_embeddings = true, const std::vector<size_t>& image_sequence = {}) override;
+
+    bool has_token_type_ids() const override;
+
+    std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;
+
+    NormalizedPrompt normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const override;
+
+private:
+    // Shared implementation behind both get_inputs_embeds() and
+    // get_inputs_embeds_with_token_type_ids(): computes the merged (text + additive vision)
+    // embeddings and, in the same pass, the per-token image/text type ids. The exported
+    // language model currently exposed by optimum-intel's Molmo2 config (upstream PR #1812)
+    // does not have a `token_type_ids` input port, so has_token_type_ids() reports false and
+    // only the embeddings are consumed today -- the type ids are still computed and returned
+    // here for forward-compatibility, so this method keeps working transparently if a future
+    // export adds bidirectional image-token attention support.
+    std::pair<ov::Tensor, ov::Tensor> compute_merged_embeds_and_token_type_ids(
+        const std::string& unified_prompt,
+        const std::vector<EncodedImage>& images,
+        VLMPerfMetrics& metrics,
+        const std::vector<size_t>& images_sequence);
+};
+
+} // namespace ov::genai

--- a/src/cpp/src/visual_language/processor_config.cpp
+++ b/src/cpp/src/visual_language/processor_config.cpp
@@ -55,6 +55,11 @@ ov::genai::ProcessorConfig::ProcessorConfig(const nlohmann::json& parsed) {
     // Setting gemma4 config params
     read_json_param(parsed, "pooling_kernel_size", pooling_kernel_size);
     read_json_param(parsed, "max_soft_tokens", max_soft_tokens);
+
+    // Setting molmo2 config params
+    read_json_param(parsed, "max_crops", max_crops);
+    read_json_param(parsed, "overlap_margins", overlap_margins);
+    read_json_param(parsed, "pooling_size", pooling_size);
 }
 
 ov::genai::ProcessorConfig::ProcessorConfig(const std::filesystem::path& json_path)

--- a/src/cpp/src/visual_language/processor_config.hpp
+++ b/src/cpp/src/visual_language/processor_config.hpp
@@ -69,6 +69,14 @@ public:
     size_t temporal_patch_size = 2;
     size_t merge_size = 2;
 
+    // molmo2 specific config params (multi-crop tiling + pooling)
+    /// @brief Maximum number of high-resolution crops per image.
+    size_t max_crops = 8;
+    /// @brief Overlap margins [left, right], in patches, shared between adjacent crops.
+    std::array<size_t, 2> overlap_margins{4, 4};
+    /// @brief Pooling window size [height, width] applied to ViT patch features.
+    std::array<size_t, 2> pooling_size{2, 2};
+
     /// @brief Default constructor
     ProcessorConfig() = default;
 

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -26,6 +26,7 @@
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
+#include "visual_language/molmo2/classes.hpp"
 
 namespace ov::genai {
 
@@ -149,6 +150,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::MOLMO2) {
+        return std::make_shared<VisionEncoderMolmo2>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -198,6 +201,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::MOLMO2) {
+        return std::make_shared<VisionEncoderMolmo2>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -54,7 +54,12 @@ struct EncodedImage {
 
     /// @brief Patches grid after llava_next preprocessing.
     /// Format: [num_patches_height, num_patches_width]
+    /// Used also by Molmo2 for the high-resolution crop-mosaic pooled token grid.
     std::pair<int, int> patches_grid;
+
+    /// @brief Low-resolution (global thumbnail) pooled token grid [height, width].
+    /// Used only by Molmo2, paired with `patches_grid` (high-resolution grid).
+    std::pair<int, int> low_res_patches_grid;
     
     /// @brief Original size of the image
     ImageSize original_image_size;

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -35,6 +35,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"qwen3_omni", VLMModelType::QWEN3_OMNI},
         {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
         {"muse_glimmer", VLMModelType::MUSE_GLIMMER},
+        {"molmo2", VLMModelType::MOLMO2},
     };
 
     auto it = model_types_map.find(value);
@@ -123,6 +124,16 @@ VLMConfig::VLMConfig(const std::filesystem::path& json_path) {
                 speaker_ids[key] = val.get<int64_t>();
             }
         }
+    }
+
+    // Molmo2
+    if (model_type == VLMModelType::MOLMO2) {
+        read_json_param(parsed, "image_patch_id", image_patch_id);
+        read_json_param(parsed, "image_col_id", image_col_id);
+        read_json_param(parsed, "image_start_token_id", image_start_token_id);
+        read_json_param(parsed, "image_end_token_id", image_end_token_id);
+        read_json_param(parsed, "low_res_image_start_token_id", low_res_image_start_token_id);
+        read_json_param(parsed, "text_config.hidden_size", hidden_size);
     }
 }
 

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -33,6 +33,7 @@ enum class VLMModelType {
     VIDEOCHAT_FLASH_QWEN,
     QWEN3_OMNI,
     MUSE_GLIMMER,
+    MOLMO2,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -163,6 +164,19 @@ public:
     int64_t video_token_id = -1;
     // Speaker name-to-codec-token mapping
     std::map<std::string, int64_t> speaker_ids;
+
+    // Molmo2 specific config params (reuses `image_token` field above, "<|image|>", as its
+    // universal image placeholder in text).
+    /// @brief Token id denoting a single high-resolution image patch (additive merge target).
+    int64_t image_patch_id = -1;
+    /// @brief Token id denoting a row separator between image patch tokens.
+    int64_t image_col_id = -1;
+    /// @brief Token id denoting start of a (high-resolution) image section.
+    int64_t image_start_token_id = -1;
+    /// @brief Token id denoting end of an image section.
+    int64_t image_end_token_id = -1;
+    /// @brief Token id denoting start of the low-resolution (global thumbnail) image section.
+    int64_t low_res_image_start_token_id = -1;
 
     /// @brief Default constructor.
     VLMConfig() = default;

--- a/tests/python_tests/test_molmo2.py
+++ b/tests/python_tests/test_molmo2.py
@@ -1,0 +1,254 @@
+# Copyright (C) 2025-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for Molmo2 (`allenai/MolmoWeb-4B`) VLMPipeline support.
+
+Molmo2 export is not yet available in the released optimum-intel -- see
+https://github.com/huggingface/optimum-intel/pull/1812 (open, unmerged at the
+time this test was added). The whole module is skipped unless the installed
+optimum-intel already recognizes "molmo2" as an exportable model type, so
+this file is a no-op in CI today and becomes a real regression test the
+moment that PR (or an equivalent) lands.
+
+No HF-hosted tiny-random fixture exists yet for Molmo2 (this environment has
+no HF Hub write access to publish one under optimum-intel-internal-testing,
+where other tiny-random-* fixtures used by this test suite live), so this
+test builds a tiny checkpoint on the fly instead: it downloads only the small
+trust_remote_code/tokenizer/config files from the real `allenai/MolmoWeb-4B`
+repo (no weights, a few hundred KB total), shrinks the config down to ~20M
+params, and instantiates random weights -- matching the intent of the
+pre-hosted tiny-random-* fixtures used elsewhere in this suite.
+
+This covers pipeline wiring (config/inputs_embedder/vision_encoder dispatch
+for VLMModelType::MOLMO2) with generate() smoke checks. It intentionally does
+not assert exact accuracy against a PyTorch reference -- see this model's
+accuracy report and enablement notebook (published under enabled-models/) for
+the full manual accuracy validation against the real checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import numpy as np
+import openvino as ov
+import pytest
+from PIL import Image
+
+MODEL_ID = "allenai/MolmoWeb-4B"
+
+# 28x28 images with patch_size=14 -> a 2x2 patch grid (4 positions, a perfect
+# square as required by Molmo2's positional-embedding reshape logic).
+TINY_IMAGE_SIZE = 28
+TINY_IMAGE_NUM_POS = 4
+
+# Small trust_remote_code/tokenizer/config files copied verbatim from the real
+# model snapshot. No weights are downloaded.
+FILES_TO_COPY = [
+    "config.json",
+    "configuration_molmo2.py",
+    "modeling_molmo2.py",
+    "processing_molmo2.py",
+    "image_processing_molmo2.py",
+    "video_processing_molmo2.py",
+    "tokenizer.json",
+    "vocab.json",
+    "merges.txt",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "chat_template.jinja",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "video_preprocessor_config.json",
+]
+
+
+def _molmo2_export_supported() -> bool:
+    try:
+        from optimum.intel.openvino.modeling_visual_language import MODEL_TYPE_TO_CLS_MAPPING
+    except ImportError:
+        return False
+    return "molmo2" in MODEL_TYPE_TO_CLS_MAPPING
+
+
+pytestmark = pytest.mark.skipif(
+    not _molmo2_export_supported(),
+    reason=(
+        "optimum-intel installed in this environment does not recognize 'molmo2' as an "
+        "exportable model type -- requires https://github.com/huggingface/optimum-intel/pull/1812 "
+        "(open, unmerged at the time this test was added)."
+    ),
+)
+
+
+def _build_shrunk_config(src_config: dict) -> dict:
+    cfg = json.loads(json.dumps(src_config))  # deep copy
+
+    cfg["text_config"].update({
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "max_position_embeddings": 512,
+    })
+
+    cfg["vit_config"].update({
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "head_dim": 8,
+        "image_default_input_size": [TINY_IMAGE_SIZE, TINY_IMAGE_SIZE],
+        "image_num_pos": TINY_IMAGE_NUM_POS,
+    })
+
+    # adapter_config's vit_layers indexes into the vision tower's hidden_states
+    # list (embeddings + num_hidden_layers entries). With vit num_hidden_layers=2
+    # that list has 3 entries, so only -1/-2/-3 are valid indices.
+    cfg["adapter_config"].update({
+        "hidden_size": 32,
+        "text_hidden_size": 64,
+        "head_dim": 8,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "intermediate_size": 64,
+        "vit_layers": [-1, -2],
+    })
+    return cfg
+
+
+def _apply_rope_compat_shim() -> None:
+    """Molmo2RotaryEmbedding.__init__ eagerly does
+    ROPE_INIT_FUNCTIONS[self.rope_type] at construction time. Transformers
+    versions newer than what the model card was tested against dropped the
+    "default" key from ROPE_INIT_FUNCTIONS in favor of a class-based
+    rope_parameters API, raising KeyError('default') the moment any Molmo2
+    model (tiny or real) is instantiated. Re-registering the legacy default
+    entry is a compatible, additive no-op on transformers versions that still
+    have it.
+    """
+    import torch
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    def _compute_default_rope_parameters_compat(config=None, device=None, seq_len=None, layer_type=None, **_kwargs):
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * partial_rotary_factor)
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim))
+        return inv_freq, 1.0  # attention_factor=1.0, i.e. no post-scaling
+
+    if "default" not in ROPE_INIT_FUNCTIONS:
+        ROPE_INIT_FUNCTIONS["default"] = _compute_default_rope_parameters_compat
+
+
+@pytest.fixture(scope="module")
+def tiny_molmo2_ov_model(tmp_path_factory) -> Path:
+    """Build a tiny random-weight Molmo2 checkpoint and export it to OpenVINO IR.
+
+    Equivalent in spirit to the "tiny-random-*" HF-hosted fixtures used by
+    other tests in this suite, but built locally (see module docstring).
+    """
+    from huggingface_hub import hf_hub_download
+    from optimum.commands.optimum_cli import main as optimum_cli_main
+
+    _apply_rope_compat_shim()
+
+    tmp_path = tmp_path_factory.mktemp("molmo2")
+    src_dir = tmp_path / "source"
+    ov_dir = tmp_path / "ov"
+    src_dir.mkdir()
+
+    for fname in FILES_TO_COPY:
+        local_path = hf_hub_download(MODEL_ID, fname)
+        shutil.copy(local_path, src_dir / fname)
+
+    with open(src_dir / "config.json") as f:
+        src_config = json.load(f)
+    with open(src_dir / "config.json", "w") as f:
+        json.dump(_build_shrunk_config(src_config), f, indent=2)
+
+    with open(src_dir / "preprocessor_config.json") as f:
+        pp = json.load(f)
+    pp["size"] = {"height": TINY_IMAGE_SIZE, "width": TINY_IMAGE_SIZE}
+    pp["max_crops"] = 1
+    with open(src_dir / "preprocessor_config.json", "w") as f:
+        json.dump(pp, f, indent=2)
+
+    import torch
+    from transformers import AutoConfig, AutoModelForImageTextToText
+
+    torch.manual_seed(0)
+    tiny_config = AutoConfig.from_pretrained(str(src_dir), trust_remote_code=True)
+    tiny_model = AutoModelForImageTextToText.from_config(tiny_config, trust_remote_code=True, dtype=torch.float32)
+    tiny_model.save_pretrained(str(src_dir))
+
+    # Invoke `optimum-cli export openvino` in-process: main_export() has no
+    # weight_format parameter of its own (see export_model.py in this model's
+    # enablement branch for the full writeup) -- the CLI command builds the
+    # OVConfig/quantization_config correctly, main_export() alone does not.
+    old_argv = sys.argv
+    try:
+        sys.argv = [
+            "optimum-cli", "export", "openvino",
+            "--model", str(src_dir),
+            "--task", "image-text-to-text",
+            "--framework", "pt",
+            "--trust-remote-code",
+            "--weight-format", "fp16",
+            str(ov_dir),
+        ]
+        optimum_cli_main()
+    finally:
+        sys.argv = old_argv
+
+    shutil.copy(src_dir / "preprocessor_config.json", ov_dir / "preprocessor_config.json")
+    shutil.copy(src_dir / "video_preprocessor_config.json", ov_dir / "video_preprocessor_config.json")
+
+    subprocess.run(  # nosec B603, B607
+        ["convert_tokenizer", str(src_dir), "--with-detokenizer", "--trust-remote-code", "-o", str(ov_dir)],
+        check=True,
+    )
+    return ov_dir
+
+
+def test_molmo2_vlm_pipeline_image_and_text(tiny_molmo2_ov_model: Path):
+    """VLMPipeline.generate() with an image + text prompt produces non-empty output."""
+    import openvino_genai as ov_genai
+
+    pipe = ov_genai.VLMPipeline(str(tiny_molmo2_ov_model), "CPU")
+    image_arr = (np.random.default_rng(0).random((TINY_IMAGE_SIZE, TINY_IMAGE_SIZE, 3)) * 255).astype(np.uint8)
+    image_tensor = ov.Tensor(np.array(Image.fromarray(image_arr))[None, ...])
+
+    result = pipe.generate("Describe this image.", images=[image_tensor], max_new_tokens=10)
+    assert len(str(result)) > 0
+
+
+def test_molmo2_vlm_pipeline_text_only(tiny_molmo2_ov_model: Path):
+    """VLMPipeline.generate() also supports text-only prompts (no image input)."""
+    import openvino_genai as ov_genai
+
+    pipe = ov_genai.VLMPipeline(str(tiny_molmo2_ov_model), "CPU")
+    result = pipe.generate("Hello, how are you?", max_new_tokens=10)
+    assert len(str(result)) > 0
+
+
+def test_molmo2_vlm_pipeline_deterministic(tiny_molmo2_ov_model: Path):
+    """Two independently constructed pipelines produce identical greedy output."""
+    import openvino_genai as ov_genai
+
+    def _run() -> str:
+        pipe = ov_genai.VLMPipeline(str(tiny_molmo2_ov_model), "CPU")
+        return str(pipe.generate("Hello, how are you?", max_new_tokens=10))
+
+    assert _run() == _run()

--- a/tests/python_tests/test_molmo2.py
+++ b/tests/python_tests/test_molmo2.py
@@ -91,39 +91,45 @@ pytestmark = pytest.mark.skipif(
 def _build_shrunk_config(src_config: dict) -> dict:
     cfg = json.loads(json.dumps(src_config))  # deep copy
 
-    cfg["text_config"].update({
-        "hidden_size": 64,
-        "intermediate_size": 128,
-        "num_hidden_layers": 2,
-        "num_attention_heads": 4,
-        "num_key_value_heads": 2,
-        "head_dim": 16,
-        "max_position_embeddings": 512,
-    })
+    cfg["text_config"].update(
+        {
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "max_position_embeddings": 512,
+        }
+    )
 
-    cfg["vit_config"].update({
-        "hidden_size": 32,
-        "intermediate_size": 64,
-        "num_hidden_layers": 2,
-        "num_attention_heads": 4,
-        "num_key_value_heads": 4,
-        "head_dim": 8,
-        "image_default_input_size": [TINY_IMAGE_SIZE, TINY_IMAGE_SIZE],
-        "image_num_pos": TINY_IMAGE_NUM_POS,
-    })
+    cfg["vit_config"].update(
+        {
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "head_dim": 8,
+            "image_default_input_size": [TINY_IMAGE_SIZE, TINY_IMAGE_SIZE],
+            "image_num_pos": TINY_IMAGE_NUM_POS,
+        }
+    )
 
     # adapter_config's vit_layers indexes into the vision tower's hidden_states
     # list (embeddings + num_hidden_layers entries). With vit num_hidden_layers=2
     # that list has 3 entries, so only -1/-2/-3 are valid indices.
-    cfg["adapter_config"].update({
-        "hidden_size": 32,
-        "text_hidden_size": 64,
-        "head_dim": 8,
-        "num_attention_heads": 4,
-        "num_key_value_heads": 4,
-        "intermediate_size": 64,
-        "vit_layers": [-1, -2],
-    })
+    cfg["adapter_config"].update(
+        {
+            "hidden_size": 32,
+            "text_hidden_size": 64,
+            "head_dim": 8,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "intermediate_size": 64,
+            "vit_layers": [-1, -2],
+        }
+    )
     return cfg
 
 
@@ -145,7 +151,9 @@ def _apply_rope_compat_shim() -> None:
         partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
         head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
         dim = int(head_dim * partial_rotary_factor)
-        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim))
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
         return inv_freq, 1.0  # attention_factor=1.0, i.e. no post-scaling
 
     if "default" not in ROPE_INIT_FUNCTIONS:
@@ -200,12 +208,18 @@ def tiny_molmo2_ov_model(tmp_path_factory) -> Path:
     old_argv = sys.argv
     try:
         sys.argv = [
-            "optimum-cli", "export", "openvino",
-            "--model", str(src_dir),
-            "--task", "image-text-to-text",
-            "--framework", "pt",
+            "optimum-cli",
+            "export",
+            "openvino",
+            "--model",
+            str(src_dir),
+            "--task",
+            "image-text-to-text",
+            "--framework",
+            "pt",
             "--trust-remote-code",
-            "--weight-format", "fp16",
+            "--weight-format",
+            "fp16",
             str(ov_dir),
         ]
         optimum_cli_main()


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Description

Adds OpenVINO GenAI (`VLMPipeline`) support for the **Molmo2** architecture, as used by
[`allenai/MolmoWeb-4B`](https://huggingface.co/allenai/MolmoWeb-4B).

Tracking ticket: openvinotoolkit/omega#80.

This PR is scoped to the **GenAI side only**, per the ticket's explicit instructions.
The corresponding Optimum-Intel export support already exists as an **open, unmerged**
upstream PR: https://github.com/huggingface/optimum-intel/pull/1812. This PR depends on
that work landing (or an equivalent fork/branch) to produce a Molmo2 OpenVINO IR in the
first place — it does not duplicate that effort.

### What's included

- `src/cpp/src/visual_language/molmo2/classes.{hpp,cpp}` — new `VLMModelType::MOLMO2`
  input-embedder/vision-encoder implementation: Molmo2 merges vision features into the
  text embedding sequence using dedicated image-boundary token ids
  (`image_patch_id`, `image_col_id`, `image_start_token_id`, `image_end_token_id`,
  `low_res_image_start_token_id`) rather than a single repeated placeholder token, to
  support its multi-crop (high-res patch grid + low-res thumbnail) image encoding scheme.
- `vlm_config.{hpp,cpp}`, `processor_config.{hpp,cpp}`, `vision_encoder.{hpp,cpp}`,
  `inputs_embedder.{hpp,cpp}` — wiring for the new model type and its config fields.
- `tests/python_tests/test_molmo2.py` — new pytest module. Builds a tiny (~20M param)
  random-weight Molmo2 checkpoint on the fly (shrunk config + real tokenizer/trust_remote_code
  files, no HF-hosted fixture required — see module docstring for why), exports it with
  `optimum-cli export openvino`, and exercises `VLMPipeline` (image+text generate,
  text-only generate, determinism). The module **skips gracefully** until the installed
  `optimum-intel` recognizes `"molmo2"` as an exportable model type (i.e. until PR #1812
  or an equivalent lands) — verified both in the skip state and, locally, in the passing
  state (see Testing below).
- Docs: `Molmo2ForConditionalGeneration` entry in the VLM models table
  (`site/docs/supported-models/_components/vlm-models-table/models.ts`) and a
  `#molmo2-notes` section in `site/docs/supported-models/index.mdx` documenting two
  known limitations (see below).

### Known limitations (documented in the docs notes section)

1. **RoPE compatibility shim required at export time.** `allenai/MolmoWeb-4B`'s
   `trust_remote_code` modeling file assumes an older `transformers` RoPE API
   (`ROPE_INIT_FUNCTIONS["default"]`) that was removed in newer `transformers` releases.
   Reproducing the export requires a small compatibility shim (documented in the notebook
   and `export_model.py` published under `enabled-models/allenai-MolmoWeb-4B/`).
2. **Causal-only (non-bidirectional) attention over image tokens.** The reference
   PyTorch implementation allows bidirectional attention within a single image's patch
   tokens; this initial GenAI implementation uses standard causal attention throughout.
   This did not produce a measurable accuracy regression in manual validation (see below)
   but is noted as a simplification for future follow-up.

## Testing

- `tests/python_tests/test_molmo2.py` — 3/3 passed locally (CPU) against a from-source
  build of this branch + the verified-working Optimum-Intel commit (see below). Skips
  cleanly (does not fail) in an environment without Molmo2-capable `optimum-intel`.
- Manual end-to-end accuracy validation against the **real** `allenai/MolmoWeb-4B`
  checkpoint (fp16 / int8 / int4), on **CPU, integrated GPU, and discrete GPU**, using a
  standalone PyTorch reference (isolated venv matching the model card's tested
  `transformers==4.57.3`) and semantic-similarity scoring
  (`sentence-transformers/all-mpnet-base-v2` cosine similarity, mirroring WhoWhatBench's
  default metric — WWB itself was not used directly because its `__init__.py`
  unconditionally imports heavy audio/video ML dependencies unrelated to this VLM
  evaluation). Full results, TTFT/ITL performance numbers, and methodology are written up
  in `reports/accuracy_validation.md` and published alongside the enablement notebook.
- A fully-executable Jupyter notebook
  (`enabled-models/allenai-MolmoWeb-4B/allenai-MolmoWeb-4B_inference.ipynb`) reproduces
  config inspection, tiny-model export, and (when a Molmo2-capable `openvino_genai` is on
  `PYTHONPATH`) inference + accuracy verification end-to-end. Verified via a full
  `nbconvert --execute` pass in a clean throwaway venv.

### Optimum-Intel reference used for local validation

Since https://github.com/huggingface/optimum-intel/pull/1812 is open/unmerged, and its
raw branch (based on an older upstream `main`) has an unrelated `AttributeError` bug in
its Molmo2 exporter path, local testing used a verified-working merge of PR #1812 onto a
newer `optimum-intel` `main`, pushed for reference to
https://github.com/mlukasze/optimum-intel/tree/molmo2-genai-verified. This is a stopgap
reference only and should be revisited once #1812 merges upstream.

## Checklist

- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code — `tests/python_tests/test_molmo2.py` (see Testing above).
- [ ] This PR fully addresses the ticket. — GenAI-side scope is complete; the ticket
      (openvinotoolkit/omega#80) remains open pending Optimum-Intel PR #1812 merging
      upstream, which is outside this PR's scope.
- [x] I have made corresponding changes to the documentation.
