### PR TITLE
Kokoro: Convert CACHE_DIR -> NPUW_CACHE_DIR

### DIFF
--- a/src/cpp/src/speech_generation/kokoro_tts_model.cpp
+++ b/src/cpp/src/speech_generation/kokoro_tts_model.cpp
@@ -301,14 +301,9 @@ ov::CompiledModel compile_kokoro_model(ov::Core& core,
         return core.compile_model(model_path, device, compile_properties);
     }
 
-    // In the case of NPU, set some NPUW properties, and reshape to static.
+    auto model = core.read_model(model_path);
 
-    set_default_property(compile_properties, "NPU_USE_NPUW", std::string{"YES"});
-    set_default_property(compile_properties, "NPUW_DEVICES", std::string{"NPU,CPU"});
-    set_default_property(compile_properties, "NPUW_KOKORO", std::string{"YES"});
-
-    auto model = core.read_model(model_path, {}, compile_properties);
-
+    // In the case of NPU, and reshape to static.
     std::map<std::string, ov::PartialShape> static_shapes;
     if (model->inputs().size() >= 1) {
         static_shapes.emplace(model->input(0).get_any_name(), ov::PartialShape{1, static_cast<int64_t>(static_input_ids_length)});
@@ -322,6 +317,21 @@ ov::CompiledModel compile_kokoro_model(ov::Core& core,
 
     if (!static_shapes.empty()) {
         model->reshape(static_shapes);
+    }
+
+    // enable use of NPUW's specialized Kokoro path.
+    set_default_property(compile_properties, "NPU_USE_NPUW", std::string{"YES"});
+    set_default_property(compile_properties, "NPUW_DEVICES", std::string{"NPU,CPU"});
+    set_default_property(compile_properties, "NPUW_KOKORO", std::string{"YES"});
+
+    // NPUW's KokoroCompiledModel doesn't support CACHE_DIR (it is silently ignored).
+    // It does support NPUW_CACHE_DIR, which has same effect.
+    // So, convert CACHE_DIR to NPUW_CACHE_DIR if it has been specified.
+    auto it = compile_properties.find("CACHE_DIR");
+    if (it != compile_properties.end()) {
+        auto cache_dir_val = it->second;
+        compile_properties.erase(it);
+        compile_properties["NPUW_CACHE_DIR"] = cache_dir_val;
     }
 
     return core.compile_model(model, device, compile_properties);

--- a/src/cpp/src/speech_generation/kokoro_tts_model.cpp
+++ b/src/cpp/src/speech_generation/kokoro_tts_model.cpp
@@ -303,7 +303,7 @@ ov::CompiledModel compile_kokoro_model(ov::Core& core,
 
     auto model = core.read_model(model_path);
 
-    // In the case of NPU, and reshape to static.
+    // In the case of NPU, reshape to static.
     std::map<std::string, ov::PartialShape> static_shapes;
     if (model->inputs().size() >= 1) {
         static_shapes.emplace(model->input(0).get_any_name(), ov::PartialShape{1, static_cast<int64_t>(static_input_ids_length)});
@@ -325,7 +325,7 @@ ov::CompiledModel compile_kokoro_model(ov::Core& core,
     set_default_property(compile_properties, "NPUW_KOKORO", std::string{"YES"});
 
     // NPUW's KokoroCompiledModel doesn't support CACHE_DIR (it is silently ignored).
-    // It does support NPUW_CACHE_DIR, which has same effect.
+    // It does support NPUW_CACHE_DIR, which has the same effect.
     // So, convert CACHE_DIR to NPUW_CACHE_DIR if it has been specified.
     auto it = compile_properties.find("CACHE_DIR");
     if (it != compile_properties.end()) {


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
NPUW doesn't support CACHE_DIR property directly -- it is silently ignored and has no effect. It currently needs to be specified as "NPUW_CACHE_DIR".

To improve usability / consistency for applications, this changeset converts CACHE_DIR to NPUW_CACHE_DIR on behalf of the application. 

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-193531

## Checklist:
- [X] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [N/A] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [X] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
