### PR TITLE
Bump product version 2026.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(UNIX AND NOT (APPLE OR ANDROID OR CYGWIN))
 endif()
 
 project(OpenVINOGenAI
-        VERSION 2026.4.0.0
+        VERSION 2026.5.0.0
         DESCRIPTION "OpenVINO GenAI"
         HOMEPAGE_URL "https://github.com/openvinotoolkit/openvino.genai"
         LANGUAGES CXX C)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openvino-genai"
-version = "2026.4.0.0"
+version = "2026.5.0.0"
 description = "Library of the most popular Generative AI model pipelines, optimized execution methods, and samples"
 requires-python = ">=3.10"
 readme = { file = "src/README.md", content-type="text/markdown" }
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython"
 ]
 dependencies = [
-    "openvino_tokenizers~=2026.4.0.0.dev"
+    "openvino_tokenizers~=2026.5.0.0.dev"
 ]
 [project.optional-dependencies]
 testing = ["pytest>=6.0"]
@@ -53,7 +53,7 @@ options = {"ENABLE_PYTHON" = "ON", "BUILD_TOKENIZERS" = "OFF", "ENABLE_SAMPLES" 
 [build-system]
 requires = [
     "py-build-cmake==0.5.0",
-    "openvino~=2026.4.0.0.dev",
+    "openvino~=2026.5.0.0.dev",
     "pybind11-stubgen==2.5.5",
     "cmake~=3.26.0; platform_system != 'Darwin' or platform_machine == 'x86_64'",
     "cmake~=4.3.0; platform_system == 'Darwin' and platform_machine == 'arm64'",

--- a/samples/deployment-requirements.txt
+++ b/samples/deployment-requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
-openvino_genai~=2026.4.0.0.dev
+openvino_genai~=2026.5.0.0.dev
 librosa==0.11.0  # For Whisper
 pillow==12.3.0  # Image processing for VLMs
 json5==0.15.0  # For ReAct

--- a/samples/export-requirements.txt
+++ b/samples/export-requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
-openvino-tokenizers[transformers]~=2026.4.0.0.dev
+openvino-tokenizers[transformers]~=2026.5.0.0.dev
 https://github.com/huggingface/optimum-intel/archive/4f1a926025ac7e5236c8661ab868640ce8076998.tar.gz#egg=optimum-intel
 einops==0.8.2  # For Qwen
 transformers_stream_generator==0.0.5  # For Qwen


### PR DESCRIPTION
Bumps the product version to 2026.5.0 on `master`, following the creation of the 2026.4.0 release branch.

Raised by the `administration/bumpProductVersion` Jenkins job.

Includes `thirdparty/openvino_tokenizers` pointed at `824033c3061d73d50784872248cdb55aa04674aa`, since openvinotoolkit/openvino_tokenizers has already been merged.