### PR TITLE
[DOCS] Document VLM prefix caching

### DIFF
--- a/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
@@ -115,9 +115,9 @@ Similar to [text generation](/docs/use-cases/text-generation/#use-different-gene
   </LanguageTabs>
 </BasicGenerationConfiguration>
 
-### Reuse Shared Prompt Prefixes
+### Continuous Batching, PagedAttention, and Prefix Caching
 
-Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous batching backend, which uses PagedAttention. Set `enable_prefix_caching` explicitly to keep completed KV-cache blocks available for later requests to the same pipeline. Requests whose resulting input-embedding prefix is identical can then reuse those blocks, which may reduce prefill work and time to first token (TTFT) after the first request. For multimodal requests, both the text and the corresponding visual inputs must match; matching tokenized text alone is not sufficient.
+Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous batching (CB) backend, which uses PagedAttention (PA). Set `enable_prefix_caching` explicitly to keep completed KV-cache blocks available for later requests to the same pipeline. Requests whose resulting input-embedding prefix is identical can then reuse those blocks, which may reduce prefill work and time to first token (TTFT) after the first request. For multimodal requests, both the text and the corresponding visual inputs must match; matching tokenized text alone is not sufficient.
 
 <LanguageTabs>
     <TabItemPython>
@@ -127,7 +127,7 @@ Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous ba
         model_path = "path/to/exported_vlm"
         scheduler_config = ov_genai.SchedulerConfig()
         scheduler_config.enable_prefix_caching = True
-        scheduler_config.cache_size = 2  # GiB
+        scheduler_config.cache_size = 2  # GB
 
         pipe = ov_genai.VLMPipeline(
             model_path,
@@ -153,7 +153,7 @@ Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous ba
         const std::string model_path = "path/to/exported_vlm";
         ov::genai::SchedulerConfig scheduler_config;
         scheduler_config.enable_prefix_caching = true;
-        scheduler_config.cache_size = 2;  // GiB
+        scheduler_config.cache_size = 2;  // GB
 
         ov::genai::VLMPipeline pipe(
             model_path,
@@ -177,7 +177,7 @@ Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous ba
     </TabItemCpp>
 </LanguageTabs>
 
-`cache_size` is the maximum cache allocation in GiB and must fit in available device memory. If `num_kv_blocks` and `cache_size` are both set, `num_kv_blocks` takes precedence; leaving both at zero enables dynamic cache allocation. Cached blocks are scoped to the pipeline instance and can be overwritten under cache pressure.
+`cache_size` is the maximum cache allocation in GB and must fit in available device memory. If `num_kv_blocks` and `cache_size` are both set, `num_kv_blocks` takes precedence; leaving both at zero enables dynamic cache allocation. Cached blocks are scoped to the pipeline instance and can be overwritten under cache pressure.
 
 On supported platforms, `VLMPipeline` may select PagedAttention automatically and currently uses a latency-oriented scheduler configuration with prefix caching enabled. Supplying `scheduler_config` replaces those scheduler defaults; because a new `SchedulerConfig` has prefix caching disabled, set `enable_prefix_caching = True` as shown above. Explicit selection requires PagedAttention support (available on x86-64 and ARM64) and is not available for `VLMPipeline` on NPU. Initialization also depends on whether the model graph and target device support the PagedAttention path; prefix reuse and its performance benefit therefore vary by model, device, prefix length, and cache pressure.
 

--- a/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
@@ -117,7 +117,7 @@ Similar to [text generation](/docs/use-cases/text-generation/#use-different-gene
 
 ### Reuse Shared Prompt Prefixes
 
-Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous batching backend, which uses PagedAttention. Set `enable_prefix_caching` explicitly to keep completed KV-cache blocks available for later requests to the same pipeline. Requests with the same tokenized prefix can then reuse those blocks, which may reduce prefill work and time to first token (TTFT) after the first request.
+Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous batching backend, which uses PagedAttention. Set `enable_prefix_caching` explicitly to keep completed KV-cache blocks available for later requests to the same pipeline. Requests whose resulting input-embedding prefix is identical can then reuse those blocks, which may reduce prefill work and time to first token (TTFT) after the first request. For multimodal requests, both the text and the corresponding visual inputs must match; matching tokenized text alone is not sufficient.
 
 <LanguageTabs>
     <TabItemPython>

--- a/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
@@ -115,6 +115,72 @@ Similar to [text generation](/docs/use-cases/text-generation/#use-different-gene
   </LanguageTabs>
 </BasicGenerationConfiguration>
 
+### Reuse Shared Prompt Prefixes
+
+Pass a `SchedulerConfig` to `VLMPipeline` to explicitly select the continuous batching backend, which uses PagedAttention. Set `enable_prefix_caching` explicitly to keep completed KV-cache blocks available for later requests to the same pipeline. Requests with the same tokenized prefix can then reuse those blocks, which may reduce prefill work and time to first token (TTFT) after the first request.
+
+<LanguageTabs>
+    <TabItemPython>
+        ```python
+        import openvino_genai as ov_genai
+
+        model_path = "path/to/exported_vlm"
+        scheduler_config = ov_genai.SchedulerConfig()
+        scheduler_config.enable_prefix_caching = True
+        scheduler_config.cache_size = 2  # GiB
+
+        pipe = ov_genai.VLMPipeline(
+            model_path,
+            "GPU",
+            scheduler_config=scheduler_config,
+        )
+
+        generation_config = ov_genai.GenerationConfig()
+        generation_config.max_new_tokens = 40
+
+        shared_prefix = "You are a helpful assistant. " * 100
+        for question in ("Summarize the instructions.", "List the key points."):
+            result = pipe.generate(
+                shared_prefix + question,
+                generation_config=generation_config,
+            )
+            print(result.texts[0])
+            print(f"TTFT: {result.perf_metrics.get_ttft().mean:.2f} ms")
+        ```
+    </TabItemPython>
+    <TabItemCpp>
+        ```cpp
+        const std::string model_path = "path/to/exported_vlm";
+        ov::genai::SchedulerConfig scheduler_config;
+        scheduler_config.enable_prefix_caching = true;
+        scheduler_config.cache_size = 2;  // GiB
+
+        ov::genai::VLMPipeline pipe(
+            model_path,
+            "GPU",
+            ov::genai::scheduler_config(scheduler_config));
+
+        ov::genai::GenerationConfig generation_config;
+        generation_config.max_new_tokens = 40;
+
+        std::string shared_prefix;
+        for (std::size_t i = 0; i < 100; ++i)
+            shared_prefix += "You are a helpful assistant. ";
+        for (const auto& question : {"Summarize the instructions.", "List the key points."}) {
+            auto result = pipe.generate(
+                shared_prefix + question,
+                ov::genai::generation_config(generation_config));
+            std::cout << result.texts[0] << std::endl;
+            std::cout << "TTFT: " << result.perf_metrics.get_ttft().mean << " ms" << std::endl;
+        }
+        ```
+    </TabItemCpp>
+</LanguageTabs>
+
+`cache_size` is the maximum cache allocation in GiB and must fit in available device memory. If `num_kv_blocks` and `cache_size` are both set, `num_kv_blocks` takes precedence; leaving both at zero enables dynamic cache allocation. Cached blocks are scoped to the pipeline instance and can be overwritten under cache pressure.
+
+On supported platforms, `VLMPipeline` may select PagedAttention automatically and currently uses a latency-oriented scheduler configuration with prefix caching enabled. Supplying `scheduler_config` replaces those scheduler defaults; because a new `SchedulerConfig` has prefix caching disabled, set `enable_prefix_caching = True` as shown above. Explicit selection requires PagedAttention support (available on x86-64 and ARM64) and is not available for `VLMPipeline` on NPU. Initialization also depends on whether the model graph and target device support the PagedAttention path; prefix reuse and its performance benefit therefore vary by model, device, prefix length, and cache pressure.
+
 ### Video Metadata and Sampling
 
 When a video is provided as an input, video metadata can be passed along with the video to control the sampling of video frames.


### PR DESCRIPTION
## Description

Documents how passing `scheduler_config` to `VLMPipeline` explicitly selects the continuous-batching/PagedAttention backend and how to enable prefix caching. Adds copyable Python and C++ examples, explains the automatic latency-oriented default versus an explicit `SchedulerConfig`, and records cache sizing, lifetime, platform, device, and model-path limits.

The cache-hit description now reflects VLM implementation semantics: the resulting input-embedding prefix must match, including corresponding visual inputs; matching tokenized text alone is not sufficient for multimodal requests.

Fixes #4343

## Validation

- `npm run lint:fix`
- `npm run build` (passed; the build reports pre-existing broken links in generated sample pages)
- Python code-fence syntax compilation with `compile(...)`
- `pre-commit run --files site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx`
- `git diff --check upstream/master`

## AI assistance disclosure

AI assistance used: yes.

How: Codex assisted with source-path analysis, documentation drafting, code review, and validation orchestration.

Contributor-side validation: the final diff, Python/C++ constructors, backend-selection code, and prefix-cache hashing path were reviewed, and the validation commands above were run.

## Checklist:

- [x] I have read the [contributing guide](https://github.com/openvinotoolkit/openvino.genai/blob/master/CONTRIBUTING.md)
- [x] The documentation is updated
- [x] The change fully addresses the linked documentation ticket
- [x] Tests are not applicable to this documentation-only change; lint, build, syntax, and pre-commit checks passed