### PR TITLE
[26.4] kokoro: Truncate phonemes segments that are > 510 in length (#4385)

### DIFF
--- a/src/cpp/src/speech_generation/kokoro_tts_model.cpp
+++ b/src/cpp/src/speech_generation/kokoro_tts_model.cpp
@@ -999,16 +999,29 @@ Text2SpeechDecodedResults KokoroTTSImpl::synthesize_from_phoneme_chunks(
 
     const auto& vocab = m_runtime->vocab();
     const uint32_t context_length = m_runtime->context_length();
+    const size_t max_input_phoneme_length = std::min<size_t>(
+        generation_config.max_phoneme_length,
+        context_length > 2 ? static_cast<size_t>(context_length - 2) : static_cast<size_t>(0));
+    OPENVINO_ASSERT(max_input_phoneme_length > 0,
+                    "Kokoro context length must be greater than 2 to include BOS/EOS and at least one token");
 
     for (const auto& phoneme_chunks : all_phoneme_chunks) {
         std::vector<float> merged_audio;
 
         for (const auto& phonemes : phoneme_chunks) {
+            auto codepoints = from_utf8(phonemes);
+            const size_t uncapped_phoneme_length = codepoints.size();
+            if (uncapped_phoneme_length > max_input_phoneme_length) {
+                GENAI_WARN("Kokoro phoneme chunk length %zu exceeds limit %zu. Truncating to fit model input.",
+                           uncapped_phoneme_length,
+                           max_input_phoneme_length);
+                codepoints.resize(max_input_phoneme_length);
+            }
+
             std::vector<int64_t> token_ids;
-            token_ids.reserve(phonemes.size() + 2);
+            token_ids.reserve(codepoints.size() + 2);
             token_ids.push_back(0);
 
-            const auto codepoints = from_utf8(phonemes);
             for (char32_t cp : codepoints) {
                 const std::string key = to_utf8(cp);
                 auto it = vocab.find(key);


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. --> 
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->
This PR fixes some corner case issues, where exceptions are thrown because token_ids (from tokenized phonemes) exceed 512 (the max context length).

For Kokoro model, phonemized intermediate result is split into several chunks, where each chunk is very likely to have length <= 510.

Although, it is possible that there are corner cases where a size slightly larger is produced (e.g. 511). In python implementation of Kokoro, these cases are simply truncated:

https://github.com/hexgrad/kokoro/blob/dfb907a02bba8152ca444717ca5d78747ccb4bec/kokoro/pipeline.py#L390

```
...
                    elif len(ps) > 510:
                        logger.warning(f"Unexpected len(ps) == {len(ps)} > 510 and ps == '{ps}'")
                        ps = ps[:510]
...
```

This truncation is what was missing from our GenAI implementation. So, for corner cases where a phonemized chunk happen to overrun the 510 token limit, instead of truncating it, we hit this exception:
```
[2026-08-26T07:06:17.472Z] Kokoro tokenized length exceeds model context length: 513 > 512
```

Anyway, the fix is to introduce the same truncation logic for GenAI implementation.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. --> CVS-193390

## Checklist:
- [X] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [N/A] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [X] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [N/A] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run
github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->

