### PR TITLE
[SD Eagle3] fix kv cache mismatch of kv update model with main model

### DIFF
--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
@@ -102,8 +102,8 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::Eagle3DecodingImpl(const ov::gen
     // Read the runtime KV cache precision from the compiled main model's key_cache input port: plugins may resolve the
     // actual cache precision (e.g. CPU promoting to bf16 based on inference precision) independently of that hint, and
     // the reorder model must match the precision of the tensors actually bound by the scheduler.
-    auto rt_kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
-    auto kv_cache_precision =
+    const auto rt_kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
+    const auto kv_cache_precision =
         m_main_pipeline->get_model_property(ov::hint::kv_cache_precision.name()).as<ov::element::Type>();
     // transformation for kv update model: u4 KV cache is stored as u8 internally,
     // so the reorder pass operates on u8 while the original precision is preserved in rt_info.

--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
@@ -91,26 +91,25 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::Eagle3DecodingImpl(const ov::gen
     ov::genai::ModelDesc kv_model_desc;
     kv_model_desc.model = kv_model;
     kv_model_desc.device = std::move(main_device);
+    // only kv cache information is needed for kv update model
+    if (main_model_desc.properties.count(ov::hint::kv_cache_precision.name()) > 0) {
+        kv_model_desc.properties[ov::hint::kv_cache_precision.name()] =
+            main_model_desc.properties.at(ov::hint::kv_cache_precision.name());
+    } else {
+        GENAI_INFO("kv cache precision not specified in main model properties. leave to plugin for default precision.");
+    }
 
-    // Read the KV cache precision from the compiled main model's key_cache input port rather than
-    // the ov::hint::kv_cache_precision property: plugins may resolve the actual cache precision
-    // (e.g. CPU promoting to bf16 based on inference precision) independently of that hint, and the
-    // reorder model must match the precision of the tensors actually bound by the scheduler.
-    auto kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
+    // Read the runtime KV cache precision from the compiled main model's key_cache input port: plugins may resolve the
+    // actual cache precision (e.g. CPU promoting to bf16 based on inference precision) independently of that hint, and
+    // the reorder model must match the precision of the tensors actually bound by the scheduler.
+    auto rt_kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
+    auto kv_cache_precision =
+        m_main_pipeline->get_model_property(ov::hint::kv_cache_precision.name()).as<ov::element::Type>();
     // transformation for kv update model: u4 KV cache is stored as u8 internally,
     // so the reorder pass operates on u8 while the original precision is preserved in rt_info.
     kv_model->set_rt_info(kv_cache_precision, "auxiliary_kv_cache_precision");
-    if (kv_cache_precision == ov::element::u4) {
-        kv_cache_precision = ov::element::u8;
-    }
-    ov::pass::PaKVReorderFusion(kv_cache_precision).run_on_model(kv_model);
-    // Pass the resolved (post u4->u8) precision explicitly instead of forwarding the raw
-    // ov::hint::kv_cache_precision value from main_model_desc.properties: for u4 caches that raw
-    // value would still say "u4" while PaKVReorderFusion above already rewrote the key_cache./
-    // value_cache. parameters to u8, and some plugins (e.g. GPU) give an explicitly user-set
-    // kv_cache_precision property priority over the auxiliary_kv_cache_precision rt_info, which
-    // would reintroduce a precision mismatch between the property and the actual parameter type.
-    kv_model_desc.properties[ov::hint::kv_cache_precision.name()] = kv_cache_precision;
+    ov::pass::PaKVReorderFusion(rt_kv_cache_precision).run_on_model(kv_model);
+
     m_kv_update_wrapper = std::make_shared<KVUpdateWrapper>(kv_model_desc);
 
     m_perf_metrics = ov::genai::SDPerModelsPerfMetrics();

--- a/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/eagle3_strategy.cpp
@@ -91,17 +91,19 @@ ContinuousBatchingPipeline::Eagle3DecodingImpl::Eagle3DecodingImpl(const ov::gen
     ov::genai::ModelDesc kv_model_desc;
     kv_model_desc.model = kv_model;
     kv_model_desc.device = std::move(main_device);
-    // only kv cache information is needed for kv update model
+    // as of now, only kv cache information is needed for kv update model
     if (main_model_desc.properties.count(ov::hint::kv_cache_precision.name()) > 0) {
         kv_model_desc.properties[ov::hint::kv_cache_precision.name()] =
             main_model_desc.properties.at(ov::hint::kv_cache_precision.name());
     } else {
-        GENAI_INFO("kv cache precision not specified in main model properties. leave to plugin for default precision.");
+        GENAI_INFO("kv cache precision not specified in main model properties. Leave to the plugin for default precision.");
     }
 
     // Read the runtime KV cache precision from the compiled main model's key_cache input port: plugins may resolve the
-    // actual cache precision (e.g. CPU promoting to bf16 based on inference precision) independently of that hint, and
-    // the reorder model must match the precision of the tensors actually bound by the scheduler.
+    // actual cache precision independently of that hint (e.g. CPU promoting to bf16 when kv cache precision hint is
+    // fp16, GPU promoting to i8 when kv cache precision hint is u8, and for GPU, when the hint is u4, the kv data are
+    // packed as uint8 and be reinterpreted to u4 inside plugin), and the reorder model must match the precision of the
+    // tensors actually bound by the runtime.
     const auto rt_kv_cache_precision = m_main_pipeline->get_kv_cache_element_type();
     const auto kv_cache_precision =
         m_main_pipeline->get_model_property(ov::hint::kv_cache_precision.name()).as<ov::element::Type>();

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -602,15 +602,22 @@ speculative_cases = [
 ]
 
 # u8 stores the KV cache quantized, which selects different attention kernels than f16.
-kv_cache_precisions = [ov.Type.f16, ov.Type.u8]
+# None leaves the hint unset so the plugin resolves the cache type for the main and KV-update models.
+kv_cache_precisions = [ov.Type.f16, ov.Type.u8, None]
 
 
-def kv_cache_precision_id(kv_cache_precision: ov.Type) -> str:
+def kv_cache_precision_id(kv_cache_precision: ov.Type | None) -> str:
+    if kv_cache_precision is None:
+        return "kv_cache_precision=unset"
     return f"kv_cache_precision={kv_cache_precision.get_type_name()}"
 
 
-def get_llm_properties_with_kv_cache_precision(kv_cache_precision: ov.Type) -> dict:
-    return get_default_llm_properties() | {hints.kv_cache_precision: kv_cache_precision}
+def get_llm_properties_for_kv_cache_precision(kv_cache_precision: ov.Type | None) -> dict:
+    properties = get_default_llm_properties()
+    if kv_cache_precision is None:
+        properties.pop(hints.kv_cache_precision, None)
+        return properties
+    return properties | {hints.kv_cache_precision: kv_cache_precision}
 
 
 @pytest.mark.parametrize(
@@ -640,7 +647,7 @@ def test_speculative_decoding_extended_perf_metrics(
             model_path,
             pipeline_type=pipeline_type,
             draft_model_path=draft_model_path,
-            ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
+            ov_config=get_llm_properties_for_kv_cache_precision(kv_cache_precision),
         )
         return ov_pipe.generate([prompt], generation_config).extended_perf_metrics
 
@@ -751,7 +758,7 @@ def test_eagle3_sd_string_inputs(main_model, main_device, draft_model, draft_dev
         main_model_path,
         pipeline_type=PipelineType.SPECULATIVE_DECODING,
         draft_model_path=draft_model_path,
-        ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
+        ov_config=get_llm_properties_for_kv_cache_precision(kv_cache_precision),
     )
 
     # Run reference HF model:
@@ -1142,7 +1149,7 @@ def test_eagle3_tree_decode(
         main_model_path,
         pipeline_type=PipelineType.SPECULATIVE_DECODING,
         draft_model_path=draft_model_path,
-        ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
+        ov_config=get_llm_properties_for_kv_cache_precision(kv_cache_precision),
     )
 
     # Test with tree-based configuration

--- a/tests/python_tests/test_continuous_batching.py
+++ b/tests/python_tests/test_continuous_batching.py
@@ -13,6 +13,7 @@ from shutil import rmtree
 from optimum.intel.utils.import_utils import is_transformers_version
 
 import openvino as ov
+import openvino.properties.hint as hints
 from openvino_genai import ContinuousBatchingPipeline, LLMPipeline, GenerationConfig, SchedulerConfig, draft_model, GenerationFinishReason, ChatHistory
 
 from test_sampling import RandomSamplingTestStruct, get_current_platform_ref_texts
@@ -21,7 +22,7 @@ from utils.generation_config import get_greedy, get_beam_search, \
     get_multinomial_all_parameters, get_multinomial_temperature_and_num_return_sequence, \
     get_multinomial_temperature_and_top_k, get_multinomial_temperature, get_multinomial_temperature_and_top_p
 from utils.atomic_download import AtomicDownloadManager
-from utils.constants import get_ov_cache_converted_models_dir
+from utils.constants import get_default_llm_properties, get_ov_cache_converted_models_dir
 from utils.hugging_face import (
     OVConvertedModelSchema,
     download_and_convert_model,
@@ -600,6 +601,18 @@ speculative_cases = [
     eagle_models_and_input[0],
 ]
 
+# u8 stores the KV cache quantized, which selects different attention kernels than f16.
+kv_cache_precisions = [ov.Type.f16, ov.Type.u8]
+
+
+def kv_cache_precision_id(kv_cache_precision: ov.Type) -> str:
+    return f"kv_cache_precision={kv_cache_precision.get_type_name()}"
+
+
+def get_llm_properties_with_kv_cache_precision(kv_cache_precision: ov.Type) -> dict:
+    return get_default_llm_properties() | {hints.kv_cache_precision: kv_cache_precision}
+
+
 @pytest.mark.parametrize(
     "pipeline_type", 
     [
@@ -608,7 +621,10 @@ speculative_cases = [
     ]
 )
 @pytest.mark.parametrize("main_model_id,draft_model_id, prompt", speculative_cases)
-def test_speculative_decoding_extended_perf_metrics(pipeline_type: PipelineType, main_model_id, draft_model_id, prompt):
+@pytest.mark.parametrize("kv_cache_precision", kv_cache_precisions, ids=kv_cache_precision_id)
+def test_speculative_decoding_extended_perf_metrics(
+    pipeline_type: PipelineType, main_model_id, draft_model_id, prompt, kv_cache_precision
+):
     def run_extended_perf_metrics_collection(
         model_id: str,
         generation_config: GenerationConfig,
@@ -620,7 +636,12 @@ def test_speculative_decoding_extended_perf_metrics(pipeline_type: PipelineType,
         draft_model_path = None
         if draft_model_id is not None:
             draft_model_path = download_and_convert_model(draft_model_id).models_path
-        ov_pipe = create_ov_pipeline(model_path, pipeline_type=pipeline_type, draft_model_path=draft_model_path)
+        ov_pipe = create_ov_pipeline(
+            model_path,
+            pipeline_type=pipeline_type,
+            draft_model_path=draft_model_path,
+            ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
+        )
         return ov_pipe.generate([prompt], generation_config).extended_perf_metrics
 
     import time
@@ -714,7 +735,8 @@ devices = [("CPU", "CPU")]
 
 @pytest.mark.parametrize("main_model,draft_model,prompt", eagle_models_and_input)
 @pytest.mark.parametrize("main_device,draft_device", devices)
-def test_eagle3_sd_string_inputs(main_model, main_device, draft_model, draft_device, prompt):
+@pytest.mark.parametrize("kv_cache_precision", kv_cache_precisions, ids=kv_cache_precision_id)
+def test_eagle3_sd_string_inputs(main_model, main_device, draft_model, draft_device, prompt, kv_cache_precision):
     # Download and convert model:
     main_model_schema = download_and_convert_model(main_model)
     main_opt_model = main_model_schema.opt_model
@@ -726,7 +748,10 @@ def test_eagle3_sd_string_inputs(main_model, main_device, draft_model, draft_dev
     # Create OpenVINO GenAI pipeline:
 
     ov_pipe = create_ov_pipeline(
-        main_model_path, pipeline_type=PipelineType.SPECULATIVE_DECODING, draft_model_path=draft_model_path
+        main_model_path,
+        pipeline_type=PipelineType.SPECULATIVE_DECODING,
+        draft_model_path=draft_model_path,
+        ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
     )
 
     # Run reference HF model:
@@ -1100,7 +1125,10 @@ def test_eagle3_prefix_caching_add_request_no_crash(target_prompt_tokens: int, e
 @pytest.mark.parametrize("main_model,draft_model,prompt", eagle_models_and_input)
 @pytest.mark.parametrize("main_device,draft_device", devices)
 @pytest.mark.parametrize("branching_factor,tree_depth", [(4, 2), (8, 4), (6, 3), (1, 0), (1, 4)])
-def test_eagle3_tree_decode(main_model, main_device, draft_model, draft_device, prompt, branching_factor, tree_depth):
+@pytest.mark.parametrize("kv_cache_precision", kv_cache_precisions, ids=kv_cache_precision_id)
+def test_eagle3_tree_decode(
+    main_model, main_device, draft_model, draft_device, prompt, branching_factor, tree_depth, kv_cache_precision
+):
     """Test EAGLE3 with tree-based speculative decoding using different tree configurations."""
     # Download and convert model
     main_model_schema = download_and_convert_model(main_model)
@@ -1111,7 +1139,10 @@ def test_eagle3_tree_decode(main_model, main_device, draft_model, draft_device, 
 
     # Create pipeline
     ov_pipe = create_ov_pipeline(
-        main_model_path, pipeline_type=PipelineType.SPECULATIVE_DECODING, draft_model_path=draft_model_path
+        main_model_path,
+        pipeline_type=PipelineType.SPECULATIVE_DECODING,
+        draft_model_path=draft_model_path,
+        ov_config=get_llm_properties_with_kv_cache_precision(kv_cache_precision),
     )
 
     # Test with tree-based configuration


### PR DESCRIPTION
This pull request enhances support for testing and configuring KV cache precision in the speculative decoding  for the EAGLE3 strategy. The main changes include improved handling of KV cache precision selection in the C++ implementation, and expanded Python test coverage to parameterize and validate behavior across different KV cache precisions (`f16`, `u8`, and unset). This ensures that the pipeline and plugin handle cache precision consistently and robustly.

**KV Cache Precision Handling Improvements:**

* The C++ implementation in `eagle3_strategy.cpp` now explicitly distinguishes between the runtime KV cache precision of the input ports and the property hint, ensuring the correct precision is used for model transformation and plugin configuration. It logs when the precision is unset and avoids mismatches between model properties and actual tensor types.

**Test Suite Enhancements:**

* Python tests in `test_continuous_batching.py` now parameterize over different KV cache precisions (`f16`, `u8`, and unset), allowing comprehensive validation of pipeline behavior for each setting. Helper functions were added to generate appropriate configuration dictionaries and test IDs. [[1]](diffhunk://#diff-46367752413258387bf181db2fc0a85c7d1f5ac3b62a743f0891c922139b4b54R604-R622) [[2]](diffhunk://#diff-46367752413258387bf181db2fc0a85c7d1f5ac3b62a743f0891c922139b4b54L611-R634)

## Description
Fix the regression of kv cache mismatch with runtime introduced by [openvinotoolkit/openvino.genai#4227](https://github.com/openvinotoolkit/openvino.genai/pull/4227).

The default kv precision for cpu is u8, gpu is u4
wwb data  (target model: [qwen3-8b/]  eagle3 model: [qwen3_8b_eagle3/]):
<img width="550" height="212" alt="image" src="https://github.com/user-attachments/assets/62fea37b-385f-439d-91db-5709f2030139" />

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-193994

One punch data covering GPU tests will be update once finished.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
