### PR TITLE
Fix text embedding duration collection for Deepseek-OCR-2

### DIFF
--- a/src/cpp/src/visual_language/deepseek_ocr2/classes.cpp
+++ b/src/cpp/src/visual_language/deepseek_ocr2/classes.cpp
@@ -483,7 +483,7 @@ ov::Tensor InputsEmbedderDeepseekOCR2::get_inputs_embeds(const std::string& unif
     ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
     EmbeddingsRequest& req = embeddings_request_guard.get();
-    ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
 
     size_t total_visual_tokens = 0;
     for (const ov::Tensor& image_embed : image_embeds) {

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2406,9 +2406,6 @@ OPTIMUM_VS_GENAI_MODEL_EXPECTED_FAIL_CASES = {
     "*tiny-random-gemma4-unified-it/SDPA/CPP/text-only": "CVS-190429",
     "*tiny-random-gemma4-unified-it/PA/CPP/image*": "CVS-190429",
     "*tiny-random-gemma4-unified-it/PA/CPP/text-only": "CVS-190429",
-    # Gemma4 models (with token_type_ids input) PA cases with image input
-    "*tiny-random-gemma4-moe/PA/*/image*": "CVS-189723",
-    "*tiny-random-gemma4-31B/PA/*/image*": "CVS-189723",
     # Gemma4 video inputs (not yet supported by optimum)
     "*tiny-random-gemma4*/*/video*": "CVS-190256",
     # qwen2vl cases that use 70x70 video resolution


### PR DESCRIPTION
## Description
This PR fixes text embedding duration metric collection for Deepseek-OCR-2 model as a leftover after #4313.
Also it unskips vlm tests for gemma4-moe and gemma4-31B models that was fixed on OV side.

CVS-187605


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). 
- N/A - Tests have been updated or added to cover the new code. 
- N/A - This PR fully addresses the ticket. 
- N/A - I have made corresponding changes to the documentation.
