### PR TITLE
[CI] Add CI HF token for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -699,6 +699,7 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       EXTENSION_LIB_PATH: ${{ github.workspace }}/install/tests
+      HF_TOKEN_PATH: "C:\\mount\\secrets\\huggingface\\token-primary"
 
     steps:
       - name: Clone openvino.genai

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,7 @@ env:
   CMAKE_C_COMPILER_LAUNCHER: ccache
   CCACHE_MAXSIZE: 500Mi
   HF_HOME: C:/mount/caches/huggingface/win
+  HF_TOKEN_PATH: "C:\\mount\\secrets\\huggingface\\token-primary"
   OV_CACHE: C:/mount/caches/huggingface/.ov_cache/win/b53e4e21/
   OPENVINO_LOG_LEVEL: 1  # Windows fails with out of memory because of too verbose logging
   ARTIFACTS_SHARE: '/mount/build-artifacts'
@@ -699,7 +700,6 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       EXTENSION_LIB_PATH: ${{ github.workspace }}/install/tests
-      HF_TOKEN_PATH: "C:\\mount\\secrets\\huggingface\\token-primary"
 
     steps:
       - name: Clone openvino.genai


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

To avoid the sporadic CI failure:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\HostedTools\Python\3.11.9\x64\Scripts\wwb.exe\__main__.py", line 5, in <module>
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\whowhatbench\wwb.py", line 1504, in main
    base_model = load_model(
                 ^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\whowhatbench\model_loaders.py", line 1122, in load_model
    return load_text2image_model(model_id, device, ov_options, use_hf, use_genai, **sanitized_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\whowhatbench\model_loaders.py", line 450, in load_text2image_model
    model = TEXT2IMAGEPipeline.from_pretrained(model_id, device=device, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\utils\_validators.py", line 88, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\optimum\intel\openvino\modeling_diffusion.py", line 2812, in from_pretrained
    return ov_pipeline_class.from_pretrained(pretrained_model_or_path, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\optimum\intel\openvino\modeling_base.py", line 656, in from_pretrained
    return super().from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\optimum\modeling_base.py", line 341, in from_pretrained
    all_files, _ = TasksManager.get_model_files(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\optimum\exporters\tasks.py", line 554, in get_model_files
    all_files = hf_api.list_repo_files(
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\utils\_validators.py", line 88, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\hf_api.py", line 3808, in list_repo_files
    return [
           ^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\hf_api.py", line 3808, in <listcomp>
    return [
           ^
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\hf_api.py", line 3945, in list_repo_tree
    for path_info in paginate(path=tree_url, headers=headers, params={"recursive": recursive, "expand": expand}):
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\utils\_pagination.py", line 37, in paginate
    hf_raise_for_status(r)
  File "C:\HostedTools\Python\3.11.9\x64\Lib\site-packages\huggingface_hub\utils\_http.py", line 896, in hf_raise_for_status
    raise _format(HfHubHTTPError, message, response) from e
huggingface_hub.errors.HfHubHTTPError: (Request ID: Root=1-6a984375-053ffcd356bd06a75fb9c4b4;cb54c695-128c-4df6-991e-fbf6fedf0a8a)

429 Too Many Requests: you have reached your 'api' rate limit.
Retry after 71 seconds (0/500 requests remaining in current 300s window).
Url: https://huggingface.co/api/models/optimum-intel-internal-testing/stable-diffusion-3-tiny-random/tree/main?recursive=true&expand=false.
We had to rate limit your IP (4.155.23.141). To continue using our service, create a HF account or login to your existing account, and make sure you pass a HF_TOKEN if you're using the API.
```

Job example: https://github.com/openvinotoolkit/openvino.genai/actions/runs/33643122495/job/100300332279?pr=4395

Details:
I think the token is already mounted on Windows:
```
  - secret:
      name: huggingface-api-token-primary
      items:
        - key: HF_TOKEN
          path: token-primary
```
```
  volumeMounts:
    - mountPath: C:\mount\secrets\huggingface
      name: huggingface-tokens
      readOnly: true
```

So if we just read it to env variable, it might just work.
As far as I understand, the env variables are propagated to all child containers, and then HF read the token automatically: https://github.com/huggingface/huggingface_hub/blob/aea9b9de1284f54862df99820f963d6030803860/src/huggingface_hub/constants.py#L246-L254.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->