### PR TITLE
[EXPERIMENT][WIP] Add ModernBERT (mmBERT) to embedding docs/tests

### DIFF
--- a/site/docs/supported-models/_components/embedding-models-table/models.ts
+++ b/site/docs/supported-models/_components/embedding-models-table/models.ts
@@ -25,6 +25,15 @@ export const EMBEDDING_MODELS: EmbeddingModelType[] = [
     ],
   },
   {
+    architecture: 'ModernBertModel',
+    modalities: ['Text'],
+    models: [
+      {
+        links: ['https://huggingface.co/jhu-clsp/mmBERT-small'],
+      },
+    ],
+  },
+  {
     architecture: 'MPNetForMaskedLM',
     modalities: ['Text'],
     models: [

--- a/tests/python_tests/test_rag.py
+++ b/tests/python_tests/test_rag.py
@@ -28,6 +28,7 @@ from samples.conftest import TEST_FILES
 EMBEDDINGS_TEST_MODELS = [
     "BAAI/bge-small-en-v1.5",
     "mixedbread-ai/mxbai-embed-xsmall-v1",
+    "jhu-clsp/mmBERT-small",
 ]
 
 MULTIMODAL_EMBEDDINGS_TEST_MODELS = [


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Docs- and test-only companion to huggingface/optimum-intel#1968, which adds native OpenVINO export support for **ModernBERT**-family models (e.g. [`jhu-clsp/mmBERT-small`](https://huggingface.co/jhu-clsp/mmBERT-small)).

Fixes openvinotoolkit/omega#101 (tracking ticket with full validation report). The ticket specifically asked whether "encoder-only template" support was needed in OpenVINO GenAI.

## Finding: no C++ changes needed

`TextEmbeddingPipeline` is already fully architecture-agnostic — it consumes any encoder IR's `last_hidden_state` output with configurable `CLS`/`MEAN`/`LAST_TOKEN` pooling. Confirmed empirically: validated the **released** `openvino-genai==2026.3.1.0` package directly against an optimum-intel-exported `jhu-clsp/mmBERT-small` IR with `MEAN` pooling (matching mmBERT's `classifier_pooling: mean` config) and got **cosine similarity 1.000000** vs PyTorch mean-pooling on 3 test sentences (English, English, Chinese).

## Changes

- Add `ModernBertModel` entry to the embedding-models supported-models table (`site/docs/supported-models/_components/embedding-models-table/models.ts`), linking `jhu-clsp/mmBERT-small`.
- Add `jhu-clsp/mmBERT-small` to `EMBEDDINGS_TEST_MODELS` in `tests/python_tests/test_rag.py`, following the file's existing convention of testing against real small production models (alongside `BAAI/bge-small-en-v1.5` and `mixedbread-ai/mxbai-embed-xsmall-v1`). This extends the existing `cls_pooling`/`mean_pooling` parametrized test matrix (`test_embed_documents`, `test_embed_query`, etc.) to cover the new architecture via the same GenAI-vs-LangChain-reference cross-implementation consistency checks already used for the other embedding models — both branches read the same `TextEmbeddingPipeline.Config`, so the comparison is architecture-agnostic by construction.

## Validation

- Verified `models.ts` and `test_rag.py` changes are syntactically valid (TS structure matches existing entries exactly; `python -m py_compile` passes).
- Did not perform a full local C++ build of openvino.genai (out of scope for a docs/test-only change) — instead validated the underlying claim directly against the matching released package version, per above. CI will exercise the added `EMBEDDINGS_TEST_MODELS` entry against a from-source build.
- Full experiment log — per-device/per-precision accuracy, quantization results, and performance numbers — is posted on the tracking ticket: openvinotoolkit/omega#101.

## Who can review?
Anyone familiar with the RAG/embedding pipelines or supported-models docs is welcome to review. This is an experimental, AI-agent-authored PR intentionally marked draft/do-not-merge pending human sign-off.