### PR TITLE
[VLM] Add audio tag support for Qwen3-Omni

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -43,6 +43,7 @@ install(DIRECTORY
             python/speech_generation
             python/visual_language_chat
             python/automatic_speech_recognition
+            python/omni
             python/rag
         DESTINATION samples/python COMPONENT cpp_samples_genai
         USE_SOURCE_PERMISSIONS)

--- a/samples/deployment-requirements.txt
+++ b/samples/deployment-requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 openvino_genai~=2026.5.0.0.dev
 librosa==0.11.0  # For Whisper
+soundfile==0.13.1  # Audio I/O for the Omni samples
 pillow==12.3.0  # Image processing for VLMs
 json5==0.15.0  # For ReAct
 pydantic==2.13.4  # For Structured output json schema

--- a/samples/python/omni/README.md
+++ b/samples/python/omni/README.md
@@ -6,6 +6,7 @@ This example demonstrates interactive multimodal chat with Qwen3-Omni models: te
 
 The following are sample files:
  - [`qwen3_omni_chat.py`](./qwen3_omni_chat.py) demonstrates multimodal chat with optional speech synthesis.
+ - [`audio_placement.py`](./audio_placement.py) shows where an audio lands in the prompt, using `<ov_genai_audio_N>` tags.
 
 ## Download and convert the model and tokenizers
 
@@ -30,13 +31,30 @@ python qwen3_omni_chat.py <MODEL_DIR> <IMAGE_FILE_OR_DIR> [--audio AUDIO_WAV]
 **Parameters:**
 - `<MODEL_DIR>` — Path to the exported Qwen3-Omni OpenVINO model directory.
 - `<IMAGE_FILE_OR_DIR>` — Path to an input image or a directory of images for visual context.
-- `--audio AUDIO_WAV` — Optional path to an input audio file (16kHz mono WAV).
+- `--audio AUDIO_WAV` — Path to an input audio file (16kHz mono WAV). Repeat the flag to pass several; refer to them in a question as `<ov_genai_audio_0>`, `<ov_genai_audio_1>`, and so on.
 
 **Example:**
 
 ```sh
 python qwen3_omni_chat.py ./qwen3-omni-ov ./coco.jpg --audio ./audio.wav
 ```
+
+## Audio placement
+
+Every audio you pass gets an index, starting at zero. Write `<ov_genai_audio_N>` in the prompt to
+put audio N at that exact position:
+
+```sh
+python audio_placement.py ./qwen3-omni-ov ./first.wav ./second.wav
+```
+
+Omit the tags and the audio is prepended to your text instead. That default is also the layout
+Qwen3-Omni was trained on, so prefer it unless you specifically need the audio elsewhere. Placing
+audio between spans of text works, but it is off the training distribution and answers may be
+weaker.
+
+Media attaches to the turn you supply it on. On later turns pass an empty audio list and refer to
+earlier audio through the chat history rather than sending the tensors again.
 
 Images are loaded once at startup and available to all turns. Type questions and press Enter; the model responds with streaming text and, when speech output is enabled, 24kHz mono PCM samples in `OmniDecodedResults.speech_result.waveforms`. Press Ctrl+D to exit.
 

--- a/samples/python/omni/audio_placement.py
+++ b/samples/python/omni/audio_placement.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (C) 2023-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Qwen3-Omni audio placement sample.
+
+Preview: the Qwen3-Omni API (OmniPipeline and related types) is a preview feature
+and is subject to change in future releases.
+
+Shows where an audio lands in the prompt. Each audio you pass gets an index, and
+`<ov_genai_audio_N>` puts audio N at that exact spot. Leave the tags out and the audio
+is prepended instead.
+
+Usage:
+    python audio_placement.py <MODEL_DIR> <AUDIO_WAV> [<AUDIO_WAV> ...]
+"""
+
+import argparse
+
+import librosa
+import numpy as np
+import openvino_genai
+import soundfile as sf
+from openvino import Tensor
+
+
+def load_audio(audio_path: str, target_sr: int = 16000) -> Tensor:
+    """Load a WAV file as a mono float32 tensor at target_sr, the layout Qwen3-Omni expects."""
+    audio_data, sample_rate = sf.read(audio_path, dtype="float32")
+
+    if audio_data.ndim > 1:
+        audio_data = audio_data.mean(axis=1)
+
+    if sample_rate != target_sr:
+        audio_data = librosa.resample(audio_data, orig_sr=sample_rate, target_sr=target_sr)
+
+    return Tensor(audio_data.astype(np.float32))
+
+
+def run(pipe: openvino_genai.OmniPipeline, label: str, prompt: str, audios: list[Tensor]) -> None:
+    text_config = openvino_genai.GenerationConfig()
+    text_config.max_new_tokens = 60
+    text_config.do_sample = False
+
+    # Text only. Speech output has its own sample; here the point is prompt layout.
+    talker_config = openvino_genai.OmniTalkerSpeechConfig()
+    talker_config.return_audio = False
+
+    print(f"\n--- {label} ---")
+    print(f"prompt: {prompt!r}")
+    results = pipe.generate(
+        prompt,
+        audios=audios,
+        text_config=text_config,
+        talker_speech_config=talker_config,
+    )
+    print(f"tokens in prompt: {results.perf_metrics.get_num_input_tokens()}")
+    print(f"answer: {results.texts[0]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Where audio lands in a Qwen3-Omni prompt")
+    parser.add_argument("model_dir", help="Path to the OpenVINO model directory")
+    parser.add_argument("audio", nargs="+", metavar="WAV", help="One or more input audio WAV files")
+    args = parser.parse_args()
+
+    audios = [load_audio(path) for path in args.audio]
+    pipe = openvino_genai.OmniPipeline(args.model_dir, "CPU")
+
+    # No tag: audio goes in front. This is the default and the layout the model was trained on.
+    run(pipe, "no tag (prepended)", "Describe what you hear.", audios[:1])
+
+    # A tag puts the audio where you write it. Same token count as above, different position.
+    run(pipe, "tagged at the front", "<ov_genai_audio_0> Describe what you hear.", audios[:1])
+
+    # Text on both sides. Supported, but off-distribution, so answers may be weaker.
+    run(pipe, "interleaved", "Listen closely: <ov_genai_audio_0> now describe it.", audios[:1])
+
+    if len(audios) >= 2:
+        # The index picks the audio, so any order works, and repeats are fine.
+        run(
+            pipe,
+            "two audios, in order",
+            "First <ov_genai_audio_0>, then <ov_genai_audio_1>. What changed?",
+            audios[:2],
+        )
+        run(
+            pipe,
+            "two audios, order swapped",
+            "First <ov_genai_audio_1>, then <ov_genai_audio_0>. What changed?",
+            audios[:2],
+        )
+    else:
+        print("\n(pass a second WAV file to see two audios addressed by index)")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/omni/qwen3_omni_chat.py
+++ b/samples/python/omni/qwen3_omni_chat.py
@@ -61,7 +61,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Qwen3-Omni multimodal chat")
     parser.add_argument("model_dir", help="Path to the OpenVINO model directory")
     parser.add_argument("image_dir", help="Image file or directory with images")
-    parser.add_argument("--audio", help="Path to input audio WAV file (optional)")
+    parser.add_argument(
+        "--audio",
+        action="append",
+        default=[],
+        metavar="WAV",
+        help="Input audio WAV file. Repeat to pass several; refer to them in the prompt as "
+        "<ov_genai_audio_0>, <ov_genai_audio_1>, ... An untagged prompt gets them prepended.",
+    )
     args = parser.parse_args()
 
     rgbs = read_images(args.image_dir)
@@ -81,7 +88,7 @@ def main() -> None:
     # talker_config.speaker_id of the model's config.json.
 
     videos = []
-    audios = [load_audio(args.audio)] if args.audio else []
+    audios = [load_audio(path) for path in args.audio]
 
     history = openvino_genai.ChatHistory()
     prompt = input("question:\n")
@@ -107,13 +114,13 @@ def main() -> None:
             break
 
         history.append({"role": "user", "content": prompt})
-        # New images can be passed at each turn; here we rely on the info from turn 1.
-        images = []
+        # Media attaches to the turn it is supplied on, so later turns pass empty lists and refer
+        # back through the history rather than re-sending turn 1's tensors.
         decoded_results = pipe.generate(
             history,
-            images=images,
-            videos=videos,
-            audios=audios,
+            images=[],
+            videos=[],
+            audios=[],
             text_config=text_config,
             talker_speech_config=talker_speech_config,
             streamer=streamer,

--- a/site/docs/use-cases/visual-processing/_sections/_run_model/_code_example_python.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_run_model/_code_example_python.mdx
@@ -26,5 +26,9 @@ print(result.texts[0])
 
 # To input videos frames, use 'videos=', frames tensor layout = [Frame, H, W, C]
 # result = pipe.generate(prompt, videos=[frames], max_new_tokens=100)
+
+# Models with an audio tower (Qwen3-Omni) take 'audios=' as mono float32 PCM at 16 kHz.
+# Place each one with <ov_genai_audio_N>, or omit the tag to have it prepended.
+# result = pipe.generate("Describe <ov_genai_audio_0>", audios=[audio], max_new_tokens=100)
 `}
 </CodeBlock>

--- a/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
+++ b/site/docs/use-cases/visual-processing/_sections/_usage_options/index.mdx
@@ -40,7 +40,35 @@ Model's native video tag can be used to refer to a video. These tags are:
 6. gemma4: `<|video|>`
 7. Muse Glimmer: `<|video|>`
 
-If the prompt doesn't contain image or video tags, but images or videos are provided, the tags are prepended to the prompt.
+Audio follows the same scheme for models with an audio tower (Qwen3-Omni). Refer to an audio with
+the universal tag `<ov_genai_audio_i>`, or with the model's native tag
+`<|audio_start|><|audio_pad|><|audio_end|>`. Each audio expands to as many placeholder tokens as its
+duration requires, so you do not write the pad count yourself.
+
+If the prompt doesn't contain image, video or audio tags, but images, videos or audios are provided, the tags are prepended to the prompt.
+
+Tags let you place media anywhere, including between spans of text:
+
+```python
+# Audio between two pieces of text, and two audios referenced by index.
+pipe.generate("Compare <ov_genai_audio_0> against <ov_genai_audio_1> and explain", audios=[first, second])
+```
+
+Qwen3-Omni is trained with media placed before the text of a turn, so prepending — the default when
+you supply no tags — is the recommended form. Interleaving is supported but off-distribution.
+
+:::warning Audio and video in the same prompt
+
+Audio placeholders are positioned as text tokens, while image and video placeholders feed the 4D
+mRoPE position ids. Moving audio away from the front of the prompt therefore shifts where those
+text-positioned tokens sit relative to the vision tokens.
+
+Prompts with audio alone are unaffected, and so are prompts that leave the audio prepended. A
+prompt that interleaves audio with video has not been validated for output quality: the token
+accounting is correct and nothing raises, but generation quality may differ from the reference
+implementation. If you need that combination, compare against `transformers` on your own data
+before relying on it.
+:::
 
 ### Use Different Generation Parameters
 

--- a/src/cpp/include/openvino/genai/omni/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/omni/pipeline.hpp
@@ -74,9 +74,10 @@ public:
 
     /// @brief Generate text + (optionally) speech from a flat prompt.
     /// @param prompt The user prompt.
-    /// @param images Image tensors to be prepended to the prompt.
-    /// @param videos Video tensors to be prepended to the prompt.
-    /// @param audios Audio tensors to be prepended to the prompt.
+    /// @param images Image tensors. Place them with `<ov_genai_image_N>`; prepended if untagged.
+    /// @param videos Video tensors. Place them with `<ov_genai_video_N>`; prepended if untagged.
+    /// @param audios Audio tensors. Place them with `<ov_genai_audio_N>`; prepended if untagged,
+    ///        which is the recommended form since the model is trained with media before text.
     /// @param text_generation_config Thinker text-decode config.
     /// @param talker_speech_config Talker + speech-output config.
     /// @param streamer Optional streamer for text tokens.

--- a/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/visual_language/pipeline.hpp
@@ -190,7 +190,8 @@ public:
 
     /// @brief videos_metadata-aware generate. Forwards to the backing implementation; used by
     /// OmniPipeline to drive Qwen3-VL-style timestamp prompts. `audios` carries raw audio inputs
-    /// (Qwen3-Omni); conventional VLM implementations ignore it.
+    /// (Qwen3-Omni). A model with no audio tower throws instead of dropping the audio, so a
+    /// non-empty `audios` on a conventional VLM implementation is an error, not a no-op.
     virtual VLMDecodedResults generate(const std::string& prompt,
                                        const std::vector<ov::Tensor>& images,
                                        const std::vector<ov::Tensor>& videos,
@@ -418,7 +419,8 @@ public:
 
     /// @brief videos_metadata-aware generate. Forwards to the backing implementation; used by
     /// OmniPipeline to drive Qwen3-VL-style timestamp prompts. `audios` carries raw audio inputs
-    /// (Qwen3-Omni); conventional VLM implementations ignore it.
+    /// (Qwen3-Omni). A model with no audio tower throws instead of dropping the audio, so a
+    /// non-empty `audios` on a conventional VLM implementation is an error, not a no-op.
     VLMDecodedResults generate(
         const std::string& prompt,
         const std::vector<ov::Tensor>& images,

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -58,12 +58,15 @@ void ContinuousBatchingPipeline::IContinuousBatchingPipeline::finish_chat() {
     m_history_videos.clear();
     m_history_image_ids.clear();
     m_history_video_ids.clear();
+    m_history_audios.clear();
+    m_history_audio_ids.clear();
     m_history_vision_count.clear();
     if (m_inputs_embedder) {
         m_inputs_embedder->finish_chat();
     }
     m_image_id = 0;
     m_video_id = 0;
+    m_audio_id = 0;
 };
 
 std::vector<GenerationResult> ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
@@ -335,6 +338,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     std::vector<VLMPerfMetrics> vlm_perf_metrics(prompts.size());
     std::vector<EncodedImage> encoded_images = {};
     std::vector<EncodedVideo> encoded_videos = {};
+    std::vector<EncodedAudio> encoded_audios = {};
     bool recalculate_merged_embeddings = images_vector.size() > 0 || videos_vector.size() > 0;
 
     const auto& generation_config = sampling_params[0];
@@ -377,19 +381,23 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         vlm_utils::update_image_slice_counts(vlm_perf_metrics[0], encoded_images);
 
         // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
+        // encoded_audios is a local, so an empty batch yields an empty list rather than leaving a
+        // previous turn's audio live — that aliasing was the stale-audio bug.
         if (!m_pending_audios_batches.empty() && !m_pending_audios_batches[0].empty()) {
             std::lock_guard<std::mutex> lock(m_embeddings_mutex);
             const auto audio_encoding_start = std::chrono::steady_clock::now();
-            m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
+            encoded_audios = m_inputs_embedder->encode_audios(m_pending_audios_batches[0]);
             PerfMetrics::emplace_duration(vlm_perf_metrics[0].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
         }
 
-        auto [unified_prompt, image_sequence, video_sequence] =
-            m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
+        auto [unified_prompt, image_sequence, video_sequence, audio_sequence] =
+            m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, m_audio_id, encoded_images, encoded_videos, encoded_audios);
 
         m_history.push_back({{"role", "user"}, {"content", unified_prompt}});
         m_history_image_ids.insert(m_history_image_ids.end(), image_sequence.begin(), image_sequence.end());
         m_history_video_ids.insert(m_history_video_ids.end(), video_sequence.begin(), video_sequence.end());
+        m_history_audios.insert(m_history_audios.end(), encoded_audios.begin(), encoded_audios.end());
+        m_history_audio_ids.insert(m_history_audio_ids.end(), audio_sequence.begin(), audio_sequence.end());
         m_history_vision_count.emplace_back(std::make_pair(video_sequence.size(), image_sequence.size()));
 
         const auto template_start = std::chrono::steady_clock::now();
@@ -404,10 +412,13 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             templated_history,
             m_history_images,
             m_history_videos,
+            m_history_audios,
             vlm_perf_metrics[0],
             recalculate_merged_embeddings,
             m_history_image_ids,
             m_history_video_ids,
+            m_history_audio_ids,
+            0,
             m_history_vision_count
         ));
 
@@ -435,16 +446,18 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             vlm_utils::update_image_slice_counts(vlm_perf_metrics[i], encoded_images);
 
             // Encode this prompt's audios under m_embeddings_mutex right before tokenization.
-            // encode_audios overwrites the embedder's audio cache, so this must run per-prompt.
+            // Per-prompt local: each prompt in the batch gets its own encodings, so one prompt's
+            // audio cannot leak into the next.
+            std::vector<ov::genai::EncodedAudio> encoded_audios;
             if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
                 std::lock_guard<std::mutex> lock(m_embeddings_mutex);
                 const auto audio_encoding_start = std::chrono::steady_clock::now();
-                m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
+                encoded_audios = m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
                 PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
             }
 
-            auto [unified_prompt, image_sequence, video_sequence] =
-                m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
+            auto [unified_prompt, image_sequence, video_sequence, audio_sequence] =
+                m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, m_audio_id, encoded_images, encoded_videos, encoded_audios);
 
             m_inputs_embedder->set_apply_chat_template_status(sampling_params[i].apply_chat_template);
 
@@ -454,10 +467,14 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                 unified_prompt,
                 encoded_images,
                 encoded_videos,
+                encoded_audios,
                 vlm_perf_metrics[i],
                 recalculate_merged_embeddings,
                 image_sequence,
-                video_sequence
+                video_sequence,
+                audio_sequence,
+                m_audio_id,
+                {}
             ));
 
             extract_audio_prompt_ids(sampling_params[i], cache_size_before);
@@ -515,6 +532,7 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         if (encoded_results[0].m_status != ov::genai::GenerationStatus::CANCEL) {
             m_image_id += encoded_images.size();
             m_video_id += encoded_videos.size();
+            m_audio_id += encoded_audios.size();
             m_history.push_back({{"role", "assistant"}, {"content", results[0].texts[0]}});
         } else {
             m_history.pop_back();
@@ -646,23 +664,25 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
 
         auto start_get_inputs_embeds = std::chrono::steady_clock::now();
 
-        // Encode this history's audios under m_embeddings_mutex right before tokenization.
-        // encode_audios overwrites the embedder's audio cache, so this must run per-history.
-        if (i < m_pending_audios_batches.size() && !m_pending_audios_batches[i].empty()) {
-            std::lock_guard<std::mutex> lock(m_embeddings_mutex);
-            const auto audio_encoding_start = std::chrono::steady_clock::now();
-            m_inputs_embedder->encode_audios(m_pending_audios_batches[i]);
-            PerfMetrics::emplace_duration(vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
-        }
-
         VLMChatContext chat_context(histories[i], m_vision_registry, *m_inputs_embedder);
         chat_contexts.push_back(std::move(chat_context));
 
-        auto processed_chat_data = chat_contexts[i].process(images_vector[i], videos_vector[i], videos_metadata_vector[i]);
+        // Audio goes through the chat context so it is registered, content-hashed and reused
+        // across turns exactly like images and video, rather than re-encoded every turn.
+        const auto& audios_for_history =
+            i < m_pending_audios_batches.size() ? m_pending_audios_batches[i] : std::vector<ov::Tensor>{};
+        auto processed_chat_data = chat_contexts[i].process(images_vector[i],
+                                                           videos_vector[i],
+                                                           videos_metadata_vector[i],
+                                                           audios_for_history);
 
         vlm_perf_metrics[i].vlm_raw_metrics.vision_encoding_durations.emplace_back(
             processed_chat_data.vision_encoding_duration
         );
+        auto& audio_durations = vlm_perf_metrics[i].vlm_raw_metrics.audio_encoding_durations;
+        audio_durations.insert(audio_durations.end(),
+                               processed_chat_data.audio_encoding_durations.begin(),
+                               processed_chat_data.audio_encoding_durations.end());
 
         const auto template_start = std::chrono::steady_clock::now();
         std::string templated_history = m_tokenizer.apply_chat_template(
@@ -682,10 +702,13 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
             templated_history,
             processed_chat_data.encoded_images,
             processed_chat_data.encoded_videos,
+            processed_chat_data.encoded_audios,
             vlm_perf_metrics[i],
             recalculate_merged_embeddings,
             processed_chat_data.image_sequence,
             processed_chat_data.video_sequence,
+            processed_chat_data.audio_sequence,
+            0,
             processed_chat_data.vision_counts
         ));
 
@@ -805,7 +828,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::add_request(
 
         vlm_utils::update_image_slice_counts(metrics, encoded_images);
 
-        const auto [unified_prompt, image_sequence, video_sequence] =
+        // The 5-arg overload never fills audio; named to show the binding is deliberately unused.
+        const auto [unified_prompt, image_sequence, video_sequence, unused_audio_sequence] =
             m_inputs_embedder->normalize_prompt(prompt, 0, 0, encoded_images, encoded_videos);
 
         inputs = m_inputs_embedder->get_inputs_embeds(

--- a/src/cpp/src/continuous_batching/pipeline_base.cpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.cpp
@@ -339,6 +339,10 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
     std::vector<EncodedImage> encoded_images = {};
     std::vector<EncodedVideo> encoded_videos = {};
     std::vector<EncodedAudio> encoded_audios = {};
+    // Sizes before this turn appended to the audio history, so a cancelled turn can be rolled back
+    // exactly. The id count can differ from the media count when a prompt duplicates or omits tags.
+    size_t history_audios_before = 0;
+    size_t history_audio_ids_before = 0;
     bool recalculate_merged_embeddings = images_vector.size() > 0 || videos_vector.size() > 0;
 
     const auto& generation_config = sampling_params[0];
@@ -396,6 +400,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
         m_history.push_back({{"role", "user"}, {"content", unified_prompt}});
         m_history_image_ids.insert(m_history_image_ids.end(), image_sequence.begin(), image_sequence.end());
         m_history_video_ids.insert(m_history_video_ids.end(), video_sequence.begin(), video_sequence.end());
+        history_audios_before = m_history_audios.size();
+        history_audio_ids_before = m_history_audio_ids.size();
         m_history_audios.insert(m_history_audios.end(), encoded_audios.begin(), encoded_audios.end());
         m_history_audio_ids.insert(m_history_audio_ids.end(), audio_sequence.begin(), audio_sequence.end());
         m_history_vision_count.emplace_back(std::make_pair(video_sequence.size(), image_sequence.size()));
@@ -544,6 +550,8 @@ ContinuousBatchingPipeline::IContinuousBatchingPipeline::generate(
                 m_history_video_ids.pop_back();
                 m_history_videos.pop_back();
             }
+            m_history_audios.resize(history_audios_before);
+            m_history_audio_ids.resize(history_audio_ids_before);
             m_history_vision_count.pop_back();
         }
     }

--- a/src/cpp/src/continuous_batching/pipeline_base.hpp
+++ b/src/cpp/src/continuous_batching/pipeline_base.hpp
@@ -55,10 +55,13 @@ protected:
     std::vector<ov::genai::EncodedImage> m_history_images;
     std::vector<size_t> m_history_image_ids;
     std::vector<ov::genai::EncodedVideo> m_history_videos;
+    std::vector<ov::genai::EncodedAudio> m_history_audios;
+    std::vector<size_t> m_history_audio_ids;
     std::vector<size_t> m_history_video_ids;
     std::vector<std::pair<std::size_t, std::size_t>> m_history_vision_count;  // pair<video count, image count>
     size_t m_image_id = 0;
     size_t m_video_id = 0;
+    size_t m_audio_id = 0;
 
     float m_load_time_ms = 0.0f;
     // to access m_load_time_ms

--- a/src/cpp/src/speculative_decoding/continuous_batching/mtp_strategy.cpp
+++ b/src/cpp/src/speculative_decoding/continuous_batching/mtp_strategy.cpp
@@ -162,7 +162,8 @@ GenerationHandle ContinuousBatchingPipeline::MtpDecodingImpl::add_request(
         std::lock_guard<std::mutex> lock(m_embeddings_mutex);
         m_inputs_embedder->set_apply_chat_template_status(sampling_params.apply_chat_template);
         const std::vector<ov::genai::EncodedImage> no_images;
-        const auto [unified_prompt, image_sequence, video_sequence] =
+        // The 3-arg overload never fills audio; named to show the binding is deliberately unused.
+        const auto [unified_prompt, image_sequence, video_sequence, unused_audio_sequence] =
             m_inputs_embedder->normalize_prompt(prompt, 0, no_images);
         inputs_embeds = m_inputs_embedder->get_inputs_embeds(unified_prompt, no_images, metrics, true, image_sequence);
         const auto [position_ids, rope_delta] = m_inputs_embedder->get_position_ids(inputs_embeds.get_shape()[1], 0);

--- a/src/cpp/src/visual_language/chat_history_state.cpp
+++ b/src/cpp/src/visual_language/chat_history_state.cpp
@@ -63,6 +63,24 @@ std::vector<size_t> ChatHistoryInternalState::register_videos(const std::vector<
     return indices;
 }
 
+/**
+ * @brief Audio variant of `register_images()`.
+ */
+std::vector<size_t> ChatHistoryInternalState::register_audios(const std::vector<ov::Tensor>& audios) {
+    auto vision_registry = get_vision_registry();
+
+    std::vector<size_t> indices;
+    indices.reserve(audios.size());
+
+    for (const auto& audio : audios) {
+        VisionID id = vision_registry->register_audio(audio);
+        size_t global_idx = m_audio_index_to_id.size();
+        m_audio_index_to_id.push_back(id);
+        indices.push_back(global_idx);
+    }
+    return indices;
+}
+
 std::vector<EncodedImage> ChatHistoryInternalState::get_encoded_images(const std::vector<size_t>& indices) const {
     auto vision_registry = get_vision_registry();
     
@@ -87,6 +105,18 @@ std::vector<EncodedVideo> ChatHistoryInternalState::get_encoded_videos(const std
     return result;
 }
 
+std::vector<EncodedAudio> ChatHistoryInternalState::get_encoded_audios(const std::vector<size_t>& indices) const {
+    auto vision_registry = get_vision_registry();
+
+    std::vector<EncodedAudio> result;
+    result.reserve(indices.size());
+    for (size_t idx : indices) {
+        VisionID id = m_audio_index_to_id.at(idx);
+        result.push_back(vision_registry->get_encoded_audio(id));
+    }
+    return result;
+}
+
 /**
  * @brief Converts global vision indices to encoded vision data with corresponding
  * deduplicated index sequences.
@@ -101,7 +131,8 @@ std::vector<EncodedVideo> ChatHistoryInternalState::get_encoded_videos(const std
  */
 ChatHistoryInternalState::ResolvedVisions ChatHistoryInternalState::resolve_visions_with_sequence(
     std::optional<const std::vector<size_t>> image_sequence,
-    std::optional<const std::vector<size_t>> video_sequence
+    std::optional<const std::vector<size_t>> video_sequence,
+    std::optional<const std::vector<size_t>> audio_sequence
 ) const {
     auto vision_registry = get_vision_registry();
     
@@ -109,6 +140,7 @@ ChatHistoryInternalState::ResolvedVisions ChatHistoryInternalState::resolve_visi
     
     std::vector<size_t> global_image_sequence = image_sequence.value_or(build_full_image_sequence());
     std::vector<size_t> global_video_sequence = video_sequence.value_or(build_full_video_sequence());
+    std::vector<size_t> global_audio_sequence = audio_sequence.value_or(build_full_audio_sequence());
     
     std::unordered_map<VisionID, size_t> image_id_to_dedup_index;
     for (size_t global_idx : global_image_sequence) {
@@ -141,7 +173,17 @@ ChatHistoryInternalState::ResolvedVisions ChatHistoryInternalState::resolve_visi
             result.video_sequence.push_back(it->second);
         }
     }
-    
+
+    // Kept 1:1 with the sequence, unlike images/videos: the merge binds run k to
+    // audio_sequence[k], so a dedup-collapsed index would place the wrong audio.
+    result.encoded_audios.reserve(global_audio_sequence.size());
+    result.audio_sequence.reserve(global_audio_sequence.size());
+    for (size_t global_idx : global_audio_sequence) {
+        VisionID id = m_audio_index_to_id.at(global_idx);
+        result.audio_sequence.push_back(result.encoded_audios.size());
+        result.encoded_audios.push_back(vision_registry->get_encoded_audio(id));
+    }
+
     return result;
 }
 
@@ -161,6 +203,16 @@ std::vector<size_t> ChatHistoryInternalState::build_full_video_sequence() const 
         sequence.insert(sequence.end(),
                         metadata.video_sequence.begin(),
                         metadata.video_sequence.end());
+    }
+    return sequence;
+}
+
+std::vector<size_t> ChatHistoryInternalState::build_full_audio_sequence() const {
+    std::vector<size_t> sequence;
+    for (const auto& metadata : m_messages_metadata) {
+        sequence.insert(sequence.end(),
+                        metadata.audio_sequence.begin(),
+                        metadata.audio_sequence.end());
     }
     return sequence;
 }
@@ -229,28 +281,32 @@ void ChatHistoryInternalState::truncate_to(size_t size) {
 
     size_t new_image_base_index = 0;
     size_t new_video_base_index = 0;
+    size_t new_audio_base_index = 0;
     for (size_t i = 0; i < size; ++i) {
         new_image_base_index += m_messages_metadata[i].provided_image_indices.size();
         new_video_base_index += m_messages_metadata[i].provided_video_indices.size();
+        new_audio_base_index += m_messages_metadata[i].provided_audio_indices.size();
     }
 
-    release_refs_from(new_image_base_index, new_video_base_index);
+    release_refs_from(new_image_base_index, new_video_base_index, new_audio_base_index);
 
     m_image_index_to_id.resize(new_image_base_index);
     m_video_index_to_id.resize(new_video_base_index);
+    m_audio_index_to_id.resize(new_audio_base_index);
     
     m_messages_metadata.resize(size);
 }
 
 void ChatHistoryInternalState::reset() {
-    release_refs_from(0, 0);
+    release_refs_from(0, 0, 0);
     m_image_index_to_id.clear();
     m_video_index_to_id.clear();
+    m_audio_index_to_id.clear();
     m_messages_metadata.clear();
     m_chat_history_format = ChatHistoryFormat::UNKNOWN;
 }
 
-void ChatHistoryInternalState::release_refs_from(size_t image_index, size_t video_index) {
+void ChatHistoryInternalState::release_refs_from(size_t image_index, size_t video_index, size_t audio_index) {
     auto vision_registry = m_vision_registry.lock();
     if (!vision_registry)
         return;
@@ -260,6 +316,11 @@ void ChatHistoryInternalState::release_refs_from(size_t image_index, size_t vide
     }
     for (size_t i = video_index; i < m_video_index_to_id.size(); ++i) {
         vision_registry->release_ref(m_video_index_to_id[i]);
+    }
+    // Without this, audio entries outlive the conversation and a later turn sees a stale cache
+    // hit instead of re-encoding.
+    for (size_t i = audio_index; i < m_audio_index_to_id.size(); ++i) {
+        vision_registry->release_ref(m_audio_index_to_id[i]);
     }
 }
 

--- a/src/cpp/src/visual_language/chat_history_state.hpp
+++ b/src/cpp/src/visual_language/chat_history_state.hpp
@@ -43,11 +43,15 @@ struct MessageMetadata {
     // Global indices provided with corresponding message (input order)
     std::vector<size_t> provided_image_indices;
     std::vector<size_t> provided_video_indices;
+    std::vector<size_t> provided_audio_indices;
 
     // Global indices in order of appearance in normalized content
     std::vector<size_t> image_sequence;
     std::vector<size_t> video_sequence;
-    
+    std::vector<size_t> audio_sequence;
+
+    // Audio is deliberately absent: this feeds 4D mRoPE position ids, where audio pads are
+    // positioned as text tokens rather than as vision tokens.
     std::pair<size_t, size_t> get_vision_count() const {
         return {video_sequence.size(), image_sequence.size()};
     }
@@ -58,8 +62,10 @@ public:
     struct ResolvedVisions {
         std::vector<EncodedImage> encoded_images;
         std::vector<EncodedVideo> encoded_videos;
+        std::vector<EncodedAudio> encoded_audios;
         std::vector<size_t> image_sequence;  // Indices into encoded_images
         std::vector<size_t> video_sequence;  // Indices into encoded_videos
+        std::vector<size_t> audio_sequence;  // Indices into encoded_audios
     };
 
     ChatHistoryInternalState() = default;
@@ -79,23 +85,29 @@ public:
 
     std::vector<size_t> register_images(const std::vector<ov::Tensor>& images);
     std::vector<size_t> register_videos(const std::vector<ov::Tensor>& videos);
+    std::vector<size_t> register_audios(const std::vector<ov::Tensor>& audios);
 
     VisionID get_image_vision_id(size_t index) const { return m_image_index_to_id.at(index); }
     VisionID get_video_vision_id(size_t index) const { return m_video_index_to_id.at(index); }
+    VisionID get_audio_vision_id(size_t index) const { return m_audio_index_to_id.at(index); }
 
     size_t get_base_image_index() const { return m_image_index_to_id.size(); }
     size_t get_base_video_index() const { return m_video_index_to_id.size(); }
+    size_t get_base_audio_index() const { return m_audio_index_to_id.size(); }
 
     std::vector<EncodedImage> get_encoded_images(const std::vector<size_t>& indices) const;
     std::vector<EncodedVideo> get_encoded_videos(const std::vector<size_t>& indices) const;
+    std::vector<EncodedAudio> get_encoded_audios(const std::vector<size_t>& indices) const;
 
     ResolvedVisions resolve_visions_with_sequence(
         std::optional<const std::vector<size_t>> image_sequence = std::nullopt,
-        std::optional<const std::vector<size_t>> video_sequence = std::nullopt
+        std::optional<const std::vector<size_t>> video_sequence = std::nullopt,
+        std::optional<const std::vector<size_t>> audio_sequence = std::nullopt
     ) const;
 
     std::vector<size_t> build_full_image_sequence() const;
     std::vector<size_t> build_full_video_sequence() const;
+    std::vector<size_t> build_full_audio_sequence() const;
     std::vector<std::pair<size_t, size_t>> build_vision_counts() const;
 
     ChatHistory build_normalized_history(const ChatHistory& history) const;
@@ -123,6 +135,7 @@ private:
     // Global index to VisionID mapping
     std::vector<VisionID> m_image_index_to_id;
     std::vector<VisionID> m_video_index_to_id;
+    std::vector<VisionID> m_audio_index_to_id;
 
     std::vector<MessageMetadata> m_messages_metadata;
 
@@ -131,7 +144,7 @@ private:
     void set_vision_registry(const std::shared_ptr<VisionRegistry>& vision_registry);
     std::shared_ptr<VisionRegistry> get_vision_registry() const;
 
-    void release_refs_from(size_t image_index, size_t video_index);
+    void release_refs_from(size_t image_index, size_t video_index, size_t audio_index);
 
     void detect_chat_history_format(const ov::genai::ChatHistory& history);
 

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -422,7 +422,7 @@ NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(const std::string& promp
 
     // Images
     auto [unified_prompt, images_sequence] =
-        normalize(prompt, image_token, image_token, base_image_id, images.size(), VisionType::IMAGE);
+        normalize(prompt, image_token, image_token, base_image_id, images.size(), ModalityType::IMAGE);
 
     size_t search_offset = 0;
     for (size_t new_image_id : images_sequence) {
@@ -444,7 +444,7 @@ NormalizedPrompt InputsEmbedderGemma4::normalize_prompt(const std::string& promp
     // Videos
     std::vector<size_t> videos_sequence;
     std::tie(unified_prompt, videos_sequence) =
-        normalize(unified_prompt, video_token, video_token, base_video_id, videos.size(), VisionType::VIDEO);
+        normalize(unified_prompt, video_token, video_token, base_video_id, videos.size(), ModalityType::VIDEO);
 
     expand_video_tags_in_prompt(unified_prompt, videos, videos_sequence, base_video_id);
 

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -474,8 +474,32 @@ std::vector<ov::genai::EncodedVideo> InputsEmbedder::encode_videos(
     return m_impl->encode_videos(videos, videos_metadata);
 }
 
-void InputsEmbedder::encode_audios(const std::vector<ov::Tensor>& audios) {
-    m_impl->encode_audios(audios);
+std::vector<EncodedAudio> InputsEmbedder::encode_audios(const std::vector<ov::Tensor>& audios) {
+    return m_impl->encode_audios(audios);
+}
+
+ov::Tensor InputsEmbedder::IInputsEmbedder::get_inputs_embeds(
+    const std::string& prompt,
+    const std::vector<ov::genai::EncodedImage>& images,
+    const std::vector<ov::genai::EncodedVideo>& videos,
+    const std::vector<ov::genai::EncodedAudio>& audios,
+    ov::genai::VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& image_sequence,
+    const std::vector<size_t>& videos_sequence,
+    const std::vector<size_t>& audios_sequence,
+    size_t base_audio_id,
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count
+) {
+    OPENVINO_ASSERT(audios.empty(), "Audio input isn't supported by this model.");
+    return get_inputs_embeds(prompt,
+                             images,
+                             videos,
+                             metrics,
+                             recalculate_merged_embeddings,
+                             image_sequence,
+                             videos_sequence,
+                             history_vision_count);
 }
 
 std::pair<ov::Tensor, std::optional<int64_t>> InputsEmbedder::get_position_ids(const size_t inputs_embeds_size, const size_t history_size) {
@@ -552,32 +576,82 @@ NormalizedPrompt InputsEmbedder::normalize_prompt(const std::string& prompt,
     return m_impl->normalize_prompt(prompt, base_image_id, base_video_id, images, videos);
 }
 
+NormalizedPrompt InputsEmbedder::normalize_prompt(const std::string& prompt,
+    size_t base_image_id,
+    size_t base_video_id,
+    size_t base_audio_id,
+    const std::vector<EncodedImage>& images,
+    const std::vector<EncodedVideo>& videos,
+    const std::vector<EncodedAudio>& audios
+) const {
+    return m_impl->normalize_prompt(prompt, base_image_id, base_video_id, base_audio_id, images, videos, audios);
+}
+
+NormalizedPrompt InputsEmbedder::IInputsEmbedder::normalize_prompt(
+    const std::string& prompt,
+    size_t image_base_id,
+    size_t video_base_id,
+    size_t audio_base_id,
+    const std::vector<EncodedImage>& images,
+    const std::vector<EncodedVideo>& videos,
+    const std::vector<EncodedAudio>& audios
+) const {
+    OPENVINO_ASSERT(audios.empty(), "Audio input isn't supported by this model.");
+    return normalize_prompt(prompt, image_base_id, video_base_id, images, videos);
+}
+
+ov::Tensor InputsEmbedder::get_inputs_embeds(const std::string& prompt,
+                                             const std::vector<ov::genai::EncodedImage>& images,
+                                             const std::vector<ov::genai::EncodedVideo>& videos,
+                                             const std::vector<ov::genai::EncodedAudio>& audios,
+                                             ov::genai::VLMPerfMetrics& metrics,
+                                             bool recalculate_merged_embeddings,
+                                             const std::vector<size_t>& image_sequence,
+                                             const std::vector<size_t>& videos_sequence,
+                                             const std::vector<size_t>& audios_sequence,
+                                             size_t base_audio_id,
+                                             const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
+    return m_impl->get_inputs_embeds(prompt,
+                                     images,
+                                     videos,
+                                     audios,
+                                     metrics,
+                                     recalculate_merged_embeddings,
+                                     image_sequence,
+                                     videos_sequence,
+                                     audios_sequence,
+                                     base_audio_id,
+                                     history_vision_count);
+}
+
 void verify_ids(const std::vector<size_t>& vision_indices, size_t base_idx, size_t n_visions) {
     for (size_t idx : vision_indices) {
-        OPENVINO_ASSERT(base_idx <= idx, "Referring to older images/videos is not supported.");
-        OPENVINO_ASSERT(idx < base_idx + n_visions, "Missing image/video with index ", idx);
+        OPENVINO_ASSERT(base_idx <= idx, "Referring to older images/videos/audios is not supported.");
+        OPENVINO_ASSERT(idx < base_idx + n_visions,
+                        "Missing image/video/audio with index ", idx, " (", n_visions, " provided)");
     }
 }
 
-std::pair<std::string, std::vector<size_t>> InputsEmbedder::IInputsEmbedder::normalize(
+std::pair<std::string, std::vector<size_t>> normalize_media_tags(
     const std::string& prompt,
     const std::string& native_tag,
     const std::string& automatic_tag,
     size_t base_idx,
     size_t n_visions,
-    VisionType vision_type
-) const {
+    ModalityType modality_type
+) {
     size_t pos = prompt.find(native_tag);
     auto [vision_prompt, vision_sequence] = universal_to_native(
         prompt,
         [&](std::ostream& os, size_t) {
             os << automatic_tag;
         },
-        vision_type
+        modality_type
     );
     if (!vision_sequence.empty()) {
         OPENVINO_ASSERT(pos == std::string::npos,
-            "Prompt cannot mix universal tags (<ov_genai_image_i>/<ov_genai_video_i>) with native vision tags.");
+            "Prompt cannot mix universal tags (<ov_genai_image_i>/<ov_genai_video_i>/<ov_genai_audio_i>)"
+            " with native media tags.");
         verify_ids(vision_sequence, base_idx, n_visions);
         return {std::move(vision_prompt), std::move(vision_sequence)};
     }
@@ -588,7 +662,7 @@ std::pair<std::string, std::vector<size_t>> InputsEmbedder::IInputsEmbedder::nor
     }
     if (!vision_sequence.empty()) {
         OPENVINO_ASSERT(vision_sequence.size() == n_visions,
-            "The number of native vision tags must match the number of provided images/videos"
+            "The number of native media tags must match the number of provided images/videos/audios"
             " because it's ambiguous which input should be ignored.");
         return {std::move(vision_prompt), std::move(vision_sequence)};
     }
@@ -600,6 +674,17 @@ std::pair<std::string, std::vector<size_t>> InputsEmbedder::IInputsEmbedder::nor
     }
     stream << prompt;
     return {stream.str(), std::move(vision_sequence)};
+}
+
+std::pair<std::string, std::vector<size_t>> InputsEmbedder::IInputsEmbedder::normalize(
+    const std::string& prompt,
+    const std::string& native_tag,
+    const std::string& automatic_tag,
+    size_t base_idx,
+    size_t n_visions,
+    ModalityType modality_type
+) const {
+    return normalize_media_tags(prompt, native_tag, automatic_tag, base_idx, n_visions, modality_type);
 }
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -25,11 +25,13 @@ struct VLMPerfMetrics;
 
 const static std::regex UNIVERSAL_IMAGE_PATTERN{R"(<ov_genai_image_(\d+)>)"};
 const static std::regex UNIVERSAL_VIDEO_PATTERN{R"(<ov_genai_video_(\d+)>)"};
+const static std::regex UNIVERSAL_AUDIO_PATTERN{R"(<ov_genai_audio_(\d+)>)"};
 
 struct NormalizedPrompt {
     std::string unified_prompt;
     std::vector<size_t> images_sequence;
     std::vector<size_t> videos_sequence;
+    std::vector<size_t> audios_sequence;
 };
 
 class InputsEmbedder {
@@ -73,7 +75,7 @@ public:
         const std::vector<VideoMetadata>& videos_metadata = {}
     );
 
-    void encode_audios(const std::vector<ov::Tensor>& audios);
+    std::vector<EncodedAudio> encode_audios(const std::vector<ov::Tensor>& audios);
 
     // compute position ids for language model input
     std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
@@ -130,6 +132,29 @@ public:
         size_t base_video_id,
         const std::vector<EncodedImage>& images,
         const std::vector<EncodedVideo>& videos) const;
+
+    /// @brief Audio-aware normalization. Fills audios_sequence and expands each placeholder run.
+    virtual NormalizedPrompt normalize_prompt(
+        const std::string& prompt,
+        size_t base_image_id,
+        size_t base_video_id,
+        size_t base_audio_id,
+        const std::vector<EncodedImage>& images,
+        const std::vector<EncodedVideo>& videos,
+        const std::vector<EncodedAudio>& audios) const;
+
+    /// @brief Audio-aware embeds. audios_sequence holds absolute indices in prompt order.
+    ov::Tensor get_inputs_embeds(const std::string& prompt,
+                                 const std::vector<ov::genai::EncodedImage>& images,
+                                 const std::vector<ov::genai::EncodedVideo>& videos,
+                                 const std::vector<ov::genai::EncodedAudio>& audios,
+                                 ov::genai::VLMPerfMetrics& metrics,
+                                 bool recalculate_merged_embeddings,
+                                 const std::vector<size_t>& image_sequence,
+                                 const std::vector<size_t>& videos_sequence,
+                                 const std::vector<size_t>& audios_sequence,
+                                 size_t base_audio_id,
+                                 const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count);
 
 private:
     class IInputsEmbedder {
@@ -192,7 +217,38 @@ private:
             const std::vector<VideoMetadata>& videos_metadata = {}
         );
 
-        virtual void encode_audios(const std::vector<ov::Tensor>& audios) {}
+        /// @brief Encode each audio independently, holding no state. The default guards the input
+        /// vector, so a model with no audio tower fails loudly instead of discarding the audio.
+        virtual std::vector<ov::genai::EncodedAudio> encode_audios(const std::vector<ov::Tensor>& audios) {
+            OPENVINO_ASSERT(audios.empty(), "Audio input isn't supported by this model.");
+            return {};
+        }
+
+        /// @brief normalize_prompt() for audio-capable models. Fills audios_sequence with absolute
+        /// indices in prompt order and expands each run to its real placeholder count.
+        virtual NormalizedPrompt normalize_prompt(
+            const std::string& prompt,
+            size_t image_base_id,
+            size_t video_base_id,
+            size_t audio_base_id,
+            const std::vector<EncodedImage>& images,
+            const std::vector<EncodedVideo>& videos,
+            const std::vector<ov::genai::EncodedAudio>& audios) const;
+
+        /// @brief get_inputs_embeds() for audio-capable models. audios_sequence holds absolute
+        /// indices in placeholder order, which is what allows audio anywhere in the prompt.
+        virtual ov::Tensor get_inputs_embeds(
+            const std::string& prompt,
+            const std::vector<ov::genai::EncodedImage>& images,
+            const std::vector<ov::genai::EncodedVideo>& videos,
+            const std::vector<ov::genai::EncodedAudio>& audios,
+            ov::genai::VLMPerfMetrics& metrics,
+            bool recalculate_merged_embeddings,
+            const std::vector<size_t>& image_sequence,
+            const std::vector<size_t>& videos_sequence,
+            const std::vector<size_t>& audios_sequence,
+            size_t base_audio_id,
+            const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count);
 
         virtual std::pair<ov::Tensor, std::optional<int64_t>> get_position_ids(const size_t inputs_embeds_size, const size_t history_size);
         
@@ -307,7 +363,7 @@ private:
             const std::string& automatic_tag,
             size_t base_idx,
             size_t n_visions,
-            VisionType vision_type = VisionType::IMAGE
+            ModalityType modality_type = ModalityType::IMAGE
         ) const;
 
         /**
@@ -379,18 +435,31 @@ private:
     friend class InputsEmbedderMuseGlimmer;
 };
 
+/// @brief Universal-tag pattern for a modality. A switch, not a ternary on IMAGE: a ternary would
+/// route every non-IMAGE modality to the video regex.
+inline const std::regex& universal_pattern_for(ModalityType modality_type) {
+    switch (modality_type) {
+        case ModalityType::IMAGE:
+            return UNIVERSAL_IMAGE_PATTERN;
+        case ModalityType::VIDEO:
+            return UNIVERSAL_VIDEO_PATTERN;
+        case ModalityType::AUDIO:
+            return UNIVERSAL_AUDIO_PATTERN;
+        default:
+            OPENVINO_THROW("Unhandled ModalityType in universal_pattern_for().");
+    }
+}
+
 template <typename Func>
 std::pair<std::string, std::vector<size_t>> universal_to_native(
     const std::string& prompt,
     const Func& write_native,
-    VisionType vision_type = VisionType::IMAGE
+    ModalityType modality_type = ModalityType::IMAGE
 ) {
     std::stringstream stream;
     std::vector<size_t> vision_sequence;
     std::smatch match;
-    auto universal_pattern = vision_type == VisionType::IMAGE ?
-        UNIVERSAL_IMAGE_PATTERN :
-        UNIVERSAL_VIDEO_PATTERN;
+    const std::regex& universal_pattern = universal_pattern_for(modality_type);
     std::regex_search(prompt, match, universal_pattern);
     auto search_begin = prompt.begin();
     while (!match.empty()) {
@@ -405,5 +474,16 @@ std::pair<std::string, std::vector<size_t>> universal_to_native(
 }
 
 void verify_ids(const std::vector<size_t>& vision_indices, size_t base_idx, size_t n_visions);
+
+/// @brief Resolve media tags into a native-tag prompt plus absolute media indices. Same policy for
+/// every modality. Free function so it is unit-testable without a model; normalize() forwards here.
+std::pair<std::string, std::vector<size_t>> normalize_media_tags(
+    const std::string& prompt,
+    const std::string& native_tag,
+    const std::string& automatic_tag,
+    size_t base_idx,
+    size_t n_media,
+    ModalityType modality_type
+);
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/llava_next_video/classes.cpp
+++ b/src/cpp/src/visual_language/llava_next_video/classes.cpp
@@ -419,7 +419,7 @@ EncodedImage VisionEncoderLLaVANextVideo::encode(const ov::Tensor& image, const 
 
 NormalizedPrompt InputsEmbedderLLaVANextVideo::normalize_prompt(const std::string& prompt, size_t base_id, const std::vector<EncodedImage>& images) const {
     std::string image_token = m_vlm_config.im_start;
-    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_id, images.size(), VisionType::IMAGE);
+    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_id, images.size(), ModalityType::IMAGE);
     size_t searched_pos = 0;
     for (size_t new_image_id : images_sequence) {
         const EncodedImage& encoded_image = images.at(new_image_id - base_id);
@@ -622,7 +622,7 @@ NormalizedPrompt InputsEmbedderLLaVANextVideo::normalize_prompt(const std::strin
     const std::vector<EncodedVideo>& videos) const
 {
     std::string video_token = m_vlm_config.video_start;
-    auto [unified_prompt, video_sequence] = normalize(prompt, video_token, video_token, base_video_id, videos.size(), VisionType::VIDEO);
+    auto [unified_prompt, video_sequence] = normalize(prompt, video_token, video_token, base_video_id, videos.size(), ModalityType::VIDEO);
     size_t searched_pos = 0;
     for (size_t new_image_id : video_sequence) {
         const EncodedVideo& encoded_video = videos.at(new_image_id - base_video_id);

--- a/src/cpp/src/visual_language/muse_glimmer/classes.cpp
+++ b/src/cpp/src/visual_language/muse_glimmer/classes.cpp
@@ -356,7 +356,7 @@ NormalizedPrompt InputsEmbedderMuseGlimmer::normalize_prompt(const std::string& 
 
     std::vector<size_t> videos_sequence;
     std::tie(unified_prompt, videos_sequence) =
-        normalize(unified_prompt, VIDEO_SENTINEL, VIDEO_SENTINEL, base_video_id, videos.size(), VisionType::VIDEO);
+        normalize(unified_prompt, VIDEO_SENTINEL, VIDEO_SENTINEL, base_video_id, videos.size(), ModalityType::VIDEO);
     searched_pos = 0;
     const size_t temporal_patch_size = m_vision_encoder->get_video_processor_config().temporal_patch_size;
     for (const size_t new_video_id : videos_sequence) {

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -79,6 +79,7 @@ class VLMPipeline::VLMPipelineImpl : public VLMBackend{
     bool m_is_npu = false;
     size_t m_image_id = 0;
     size_t m_video_id = 0;
+    size_t m_audio_id = 0;
     ChatHistory m_history;
 
     // if True, full history will be used as prompt on each chat generation
@@ -86,6 +87,7 @@ class VLMPipeline::VLMPipelineImpl : public VLMBackend{
     // It stores encoded images, videos and vision count in case when m_use_full_chat_history is true
     std::vector<ov::genai::EncodedImage> m_encoded_images;
     std::vector<ov::genai::EncodedVideo> m_encoded_videos;
+    std::vector<ov::genai::EncodedAudio> m_encoded_audios;
     std::vector<std::pair<std::size_t, std::size_t>> m_history_vision_count;  // pair<video count, image count>
 
     std::string m_system_message;
@@ -357,9 +359,15 @@ public:
 
         const auto embeddings_start_time = std::chrono::steady_clock::now();
         
-        const auto audio_encoding_start = std::chrono::steady_clock::now();
-        m_inputs_embedder->encode_audios(audios);
-        PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.audio_encoding_durations, audio_encoding_start);
+        // Guarded so the metric holds one entry per actual encode: an unconditional emplace
+        // reports an audio encode for text-only requests too.
+        std::vector<ov::genai::EncodedAudio> encoded_audios;
+        if (!audios.empty()) {
+            const auto audio_encoding_start = std::chrono::steady_clock::now();
+            encoded_audios = m_inputs_embedder->encode_audios(audios);
+            PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.audio_encoding_durations,
+                                          audio_encoding_start);
+        }
 
         const auto vision_encoding_start = std::chrono::steady_clock::now();
         auto encoded_images = m_inputs_embedder->encode_images(images);
@@ -368,7 +376,7 @@ public:
 
         vlm_utils::update_image_slice_counts(perf_metrics, encoded_images);
 
-        auto [unified_prompt, image_sequence, video_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, encoded_images, encoded_videos);
+        auto [unified_prompt, image_sequence, video_sequence, audio_sequence] = m_inputs_embedder->normalize_prompt(prompt, m_image_id, m_video_id, m_audio_id, encoded_images, encoded_videos, encoded_audios);
 
         if (m_is_chat_conversation) {
             m_history.push_back({{"role", "user"}, {"content", unified_prompt}});
@@ -392,14 +400,17 @@ public:
                 std::iota(video_sequence.begin(), video_sequence.end(), 0);
                 encoded_videos = m_encoded_videos;
 
+                m_encoded_audios.reserve(m_encoded_audios.size() + encoded_audios.size());
+                m_encoded_audios.insert(m_encoded_audios.end(), encoded_audios.begin(), encoded_audios.end());
+                audio_sequence.resize(m_encoded_audios.size());
+                std::iota(audio_sequence.begin(), audio_sequence.end(), 0);
+                encoded_audios = m_encoded_audios;
+
                 m_inputs_embedder->start_chat(m_system_message);
             } else {
-                for (size_t idx = 0; idx < image_sequence.size(); idx++) {
-                   image_sequence[idx] -= m_image_id;
-                }
-                for (size_t idx = 0; idx < video_sequence.size(); idx++) {
-                    video_sequence[idx] -= m_video_id;
-                }
+                vlm_utils::rebase_media_sequence(image_sequence, m_image_id);
+                vlm_utils::rebase_media_sequence(video_sequence, m_video_id);
+                vlm_utils::rebase_media_sequence(audio_sequence, m_audio_id);
             }
         } else {
             m_inputs_embedder->set_apply_chat_template_status(generation_config.apply_chat_template);
@@ -409,8 +420,10 @@ public:
             unified_prompt,
             encoded_images,
             encoded_videos,
+            encoded_audios,
             image_sequence,
             video_sequence,
+            audio_sequence,
             m_history_vision_count,
             generation_config,
             perf_metrics,
@@ -451,6 +464,7 @@ public:
                 // encoded_images could be overriden when m_use_full_chat_history is true
                 m_image_id += images.size();
                 m_video_id += videos.size();
+                m_audio_id += audios.size();
                 // Tail of chat template is missing in KV cache.
                 // Find the tail to concatenate it with the next input prompt.
                 m_history.push_back({{"role", "assistant"}, {"content", decoded_results}});
@@ -463,6 +477,9 @@ public:
                     OPENVINO_ASSERT(videos.size() <= m_encoded_videos.size(), "Number of videos to remove is more than stored videos!");
                     m_encoded_videos.resize(m_encoded_videos.size() - videos.size());
 
+                    OPENVINO_ASSERT(audios.size() <= m_encoded_audios.size(), "Number of audios to remove is more than stored audios!");
+                    m_encoded_audios.resize(m_encoded_audios.size() - audios.size());
+
                     m_history_vision_count.pop_back();
                 }
             }
@@ -474,6 +491,7 @@ public:
         if (!(m_is_chat_conversation && m_use_full_chat_history)) {
             m_encoded_images.clear();
             m_encoded_videos.clear();
+            m_encoded_audios.clear();
             m_history_vision_count.clear();
         }
 
@@ -577,9 +595,13 @@ public:
         const auto embeddings_start_time = std::chrono::steady_clock::now();
         VLMChatContext chat_context(history, m_vision_registry, *m_inputs_embedder);
 
-        auto processed_chat_data = chat_context.process(images, videos, videos_metadata);
+        auto processed_chat_data = chat_context.process(images, videos, videos_metadata, audios);
 
         perf_metrics.vlm_raw_metrics.vision_encoding_durations.emplace_back(processed_chat_data.vision_encoding_duration);
+        auto& audio_durations = perf_metrics.vlm_raw_metrics.audio_encoding_durations;
+        audio_durations.insert(audio_durations.end(),
+                               processed_chat_data.audio_encoding_durations.begin(),
+                               processed_chat_data.audio_encoding_durations.end());
 
         bool use_full_history = processed_chat_data.needs_kv_cache_reset || m_use_full_chat_history;
 
@@ -610,6 +632,12 @@ public:
         const auto& video_seq = use_full_history
             ? processed_chat_data.video_sequence
             : processed_chat_data.new_video_sequence;
+        const auto& audios_embeds = use_full_history
+            ? processed_chat_data.encoded_audios
+            : processed_chat_data.new_encoded_audios;
+        const auto& audio_seq = use_full_history
+            ? processed_chat_data.audio_sequence
+            : processed_chat_data.new_audio_sequence;
         const auto& vision_counts = use_full_history
             ? processed_chat_data.vision_counts
             : std::vector<std::pair<std::size_t, std::size_t>>{ {video_seq.size(), image_seq.size()} };
@@ -620,8 +648,10 @@ public:
             templated_history,
             images_embeds,
             videos_embeds,
+            audios_embeds,
             image_seq,
             video_seq,
+            audio_seq,
             vision_counts,
             generation_config,
             perf_metrics,
@@ -719,6 +749,7 @@ public:
         m_is_chat_conversation = false;
         m_image_id = 0;
         m_video_id = 0;
+        m_audio_id = 0;
         // Resetting state may be slow.
         reset_language_state();
         m_language.get_tensor("attention_mask").set_shape({0, 0});
@@ -727,6 +758,7 @@ public:
         m_history.clear();
         m_encoded_images.clear();
         m_encoded_videos.clear();
+        m_encoded_audios.clear();
         m_history_vision_count.clear();
     }
 
@@ -808,8 +840,10 @@ private:
         const std::string& unified_prompt,
         const std::vector<ov::genai::EncodedImage>& encoded_images,
         const std::vector<ov::genai::EncodedVideo>& encoded_videos,
+        const std::vector<ov::genai::EncodedAudio>& encoded_audios,
         const std::vector<size_t>& image_sequence,
         const std::vector<size_t>& video_sequence,
+        const std::vector<size_t>& audio_sequence,
         const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count,
         GenerationConfig& generation_config,
         VLMPerfMetrics& perf_metrics,
@@ -824,10 +858,13 @@ private:
             unified_prompt,
             encoded_images,
             encoded_videos,
+            encoded_audios,
             perf_metrics,
             recalculate_merged_embeddings,
             image_sequence,
             video_sequence,
+            audio_sequence,
+            0,
             history_vision_count
         );
         PerfMetrics::emplace_duration(perf_metrics.vlm_raw_metrics.prepare_embeddings_durations, embeddings_start_time);

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -1066,7 +1066,7 @@ NormalizedPrompt InputsEmbedderQwen2VL::normalize_prompt(const std::string& prom
                                                          const std::vector<EncodedImage>& images,
                                                          const std::vector<EncodedVideo>& videos) const {
     // Images
-    auto [unified_prompt, images_sequence] = normalize(prompt, NATIVE_TAG, NATIVE_TAG, image_base_id, images.size(), VisionType::IMAGE);
+    auto [unified_prompt, images_sequence] = normalize(prompt, NATIVE_TAG, NATIVE_TAG, image_base_id, images.size(), ModalityType::IMAGE);
     std::vector<std::array<size_t, 3>> images_grid_thw;
     images_grid_thw.reserve(images.size());
 
@@ -1097,7 +1097,7 @@ NormalizedPrompt InputsEmbedderQwen2VL::normalize_prompt(const std::string& prom
     // Video
     std::vector<size_t> videos_sequence;
     std::tie(unified_prompt, videos_sequence) =
-        normalize(unified_prompt, NATIVE_VIDEO_TAG, NATIVE_VIDEO_TAG, video_base_id, videos.size(), VisionType::VIDEO);
+        normalize(unified_prompt, NATIVE_VIDEO_TAG, NATIVE_VIDEO_TAG, video_base_id, videos.size(), ModalityType::VIDEO);
     
     expand_video_tags_in_prompt(unified_prompt, videos, videos_sequence, video_base_id);
 

--- a/src/cpp/src/visual_language/qwen3_omni/classes.cpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.cpp
@@ -525,19 +525,23 @@ InputsEmbedderQwen3Omni::InputsEmbedderQwen3Omni(const VLMConfig& vlm_config,
     }
 }
 
-void InputsEmbedderQwen3Omni::encode_audios(const std::vector<ov::Tensor>& audios) {
-    if (audios.empty() || !has_audio_encoder()) {
-        m_audio_embeddings = ov::Tensor();
-        return;
+std::vector<ov::genai::EncodedAudio> InputsEmbedderQwen3Omni::encode_audios(const std::vector<ov::Tensor>& audios) {
+    if (audios.empty()) {
+        return {};
     }
+    OPENVINO_ASSERT(has_audio_encoder(),
+                    "Audio input was provided but this model has no audio encoder. Export the model with its "
+                    "audio tower (openvino_audio_encoder_model.xml) to use audio.");
 
-    std::vector<ov::Tensor> all_features;
-    size_t total_tokens = 0;
+    std::vector<ov::genai::EncodedAudio> encoded;
+    encoded.reserve(audios.size());
     size_t hidden_size = 0;
 
     for (const auto& audio : audios) {
-        // Empty audio tensors are silently skipped so callers can pass placeholders.
+        // An empty input keeps its slot as a zero-token entry: dropping it would shift every
+        // later <ov_genai_audio_N> index by one.
         if (audio.get_size() == 0) {
+            encoded.push_back({ov::Tensor(), 0});
             continue;
         }
 
@@ -551,9 +555,11 @@ void InputsEmbedderQwen3Omni::encode_audios(const std::vector<ov::Tensor>& audio
                         "Audio encoder output element type must be f32, got ",
                         features.get_element_type());
 
-        const size_t num_tokens = feature_shape[0];
         const size_t current_hidden_size = feature_shape[1];
-        if (all_features.empty()) {
+        OPENVINO_ASSERT(current_hidden_size > 0,
+                        "Audio encoder produced a zero-width feature tensor, which cannot be merged into the "
+                        "language model's embeddings. Re-export the audio encoder.");
+        if (hidden_size == 0) {
             hidden_size = current_hidden_size;
         } else {
             OPENVINO_ASSERT(current_hidden_size == hidden_size,
@@ -563,17 +569,10 @@ void InputsEmbedderQwen3Omni::encode_audios(const std::vector<ov::Tensor>& audio
                             current_hidden_size);
         }
 
-        total_tokens += num_tokens;
-        all_features.push_back(features);
+        encoded.push_back({features, feature_shape[0]});
     }
 
-    m_audio_embeddings = ov::Tensor(ov::element::f32, {total_tokens, hidden_size});
-    auto* dst = m_audio_embeddings.data<float>();
-    for (const auto& feat : all_features) {
-        auto byte_size = feat.get_byte_size();
-        std::memcpy(dst, feat.data<float>(), byte_size);
-        dst += feat.get_size();
-    }
+    return encoded;
 }
 
 ov::Tensor InputsEmbedderQwen3Omni::get_inputs_embeds(
@@ -594,36 +593,97 @@ ov::Tensor InputsEmbedderQwen3Omni::get_inputs_embeds(
                                                                  videos_sequence,
                                                                  history_vision_count);
 
-    // Capture input_ids set by parent's get_inputs_embeds() into a local variable,
-    // making the cross-class data dependency explicit rather than relying on
-    // implicit ordering of m_last_input_ids population.
+    return input_embeds;
+}
+
+ov::Tensor InputsEmbedderQwen3Omni::get_inputs_embeds(
+    const std::string& prompt,
+    const std::vector<ov::genai::EncodedImage>& images,
+    const std::vector<ov::genai::EncodedVideo>& videos,
+    const std::vector<ov::genai::EncodedAudio>& audios,
+    ov::genai::VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& image_sequence,
+    const std::vector<size_t>& videos_sequence,
+    const std::vector<size_t>& audios_sequence,
+    size_t base_audio_id,
+    const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) {
+    auto input_embeds = get_inputs_embeds(prompt,
+                                          images,
+                                          videos,
+                                          metrics,
+                                          recalculate_merged_embeddings,
+                                          image_sequence,
+                                          videos_sequence,
+                                          history_vision_count);
+
+    if (audios_sequence.empty()) {
+        return input_embeds;
+    }
+
+    // Copy locally to make the dependency on the parent's m_last_input_ids explicit.
     std::vector<int64_t> input_ids_vec(m_last_input_ids.data<int64_t>(),
                                        m_last_input_ids.data<int64_t>() + m_last_input_ids.get_size());
 
-    // If we have audio embeddings, replace audio token positions
-    if (m_audio_embeddings && m_audio_embeddings.get_size() > 0 && m_audio_token_id >= 0) {
-        merge_audio_embeddings(input_embeds, input_ids_vec);
-    }
+    merge_audio_embeddings(input_embeds, input_ids_vec, audios, audios_sequence, base_audio_id);
 
     return input_embeds;
 }
 
-void InputsEmbedderQwen3Omni::merge_audio_embeddings(ov::Tensor& input_embeds, const std::vector<int64_t>& input_ids) {
-    if (!m_audio_embeddings || m_audio_embeddings.get_size() == 0) {
+void InputsEmbedderQwen3Omni::expand_audio_tags_in_prompt(std::string& prompt,
+                                                          const std::vector<ov::genai::EncodedAudio>& audios,
+                                                          const std::vector<size_t>& audios_sequence,
+                                                          size_t base_audio_id) const {
+    const std::string native_tag = std::string(qwen3_omni::AUDIO_START_TAG) +
+                                   std::string(qwen3_omni::AUDIO_PAD_TAG) + std::string(qwen3_omni::AUDIO_END_TAG);
+
+    size_t searched_pos = 0;
+    for (size_t k = 0; k < audios_sequence.size(); k++) {
+        const size_t relative_id = audios_sequence[k] - base_audio_id;
+        OPENVINO_ASSERT(relative_id < audios.size(),
+                        "Audio index ",
+                        audios_sequence[k],
+                        " is out of range for ",
+                        audios.size(),
+                        " provided audios.");
+
+        const size_t pos = prompt.find(native_tag, searched_pos);
+        OPENVINO_ASSERT(pos != std::string::npos,
+                        "Expected ",
+                        audios_sequence.size(),
+                        " native audio tags in the prompt but found only ",
+                        k,
+                        ".");
+
+        std::string expanded;
+        const size_t pad_count = audios[relative_id].num_audio_tokens;
+        expanded.reserve(qwen3_omni::AUDIO_START_TAG.size() + qwen3_omni::AUDIO_PAD_TAG.size() * pad_count +
+                         qwen3_omni::AUDIO_END_TAG.size());
+        expanded.append(qwen3_omni::AUDIO_START_TAG);
+        for (size_t i = 0; i < pad_count; i++) {
+            expanded.append(qwen3_omni::AUDIO_PAD_TAG);
+        }
+        expanded.append(qwen3_omni::AUDIO_END_TAG);
+
+        prompt.replace(pos, native_tag.length(), expanded);
+        // Resume past what we just wrote. Restarting from 0 would re-find this same tag whenever
+        // pad_count == 1, because the expansion is then byte-identical to the tag.
+        searched_pos = pos + expanded.length();
+    }
+}
+
+void InputsEmbedderQwen3Omni::merge_audio_embeddings(ov::Tensor& input_embeds,
+                                                     const std::vector<int64_t>& input_ids,
+                                                     const std::vector<ov::genai::EncodedAudio>& audios,
+                                                     const std::vector<size_t>& audios_sequence,
+                                                     size_t base_audio_id) const {
+    if (audios_sequence.empty() || m_audio_token_id < 0) {
         return;
     }
 
     const auto& shape = input_embeds.get_shape();
     const auto seq_len = shape[1];
     const auto hidden_size = shape[2];
-
-    const auto audio_hidden_size = m_audio_embeddings.get_shape()[1];
-    OPENVINO_ASSERT(audio_hidden_size == hidden_size,
-                    "Audio embedding hidden_size (",
-                    audio_hidden_size,
-                    ") must match input embedding hidden_size (",
-                    hidden_size,
-                    "). Check that audio encoder output dimension matches the language model.");
 
     OPENVINO_ASSERT(input_ids.size() >= seq_len,
                     "input_ids size (",
@@ -633,26 +693,84 @@ void InputsEmbedderQwen3Omni::merge_audio_embeddings(ov::Tensor& input_embeds, c
                     "). Ensure input_ids are not from a stale or re-tokenized source.");
 
     auto* embed_data = input_embeds.data<float>();
-    const auto* audio_data = m_audio_embeddings.data<const float>();
-    const auto audio_total_tokens = m_audio_embeddings.get_shape()[0];
     const size_t bytes_per_token = hidden_size * sizeof(float);
-    size_t audio_idx = 0;
 
-    for (size_t i = 0; i < seq_len && audio_idx < audio_total_tokens; i++) {
-        if (input_ids[i] == m_audio_token_id) {
-            std::memcpy(embed_data + i * hidden_size, audio_data + audio_idx * hidden_size, bytes_per_token);
-            audio_idx++;
+    size_t run_index = 0;
+    for (size_t i = 0; i < seq_len;) {
+        if (input_ids[i] != m_audio_token_id) {
+            i++;
+            continue;
         }
+
+        size_t run_end = i;
+        while (run_end < seq_len && input_ids[run_end] == m_audio_token_id) {
+            run_end++;
+        }
+        const size_t run_length = run_end - i;
+
+        // A zero-token audio expands to start+end with no pads, so it contributes no run. Skip
+        // over those entries or run k stops lining up with audios_sequence[k].
+        while (run_index < audios_sequence.size() &&
+               audios[audios_sequence[run_index] - base_audio_id].num_audio_tokens == 0) {
+            run_index++;
+        }
+
+        OPENVINO_ASSERT(run_index < audios_sequence.size(),
+                        "Found more audio placeholder runs in the prompt than provided audios (",
+                        audios_sequence.size(),
+                        "). A literal audio marker in user text would do this.");
+
+        const size_t relative_id = audios_sequence[run_index] - base_audio_id;
+        OPENVINO_ASSERT(relative_id < audios.size(),
+                        "Audio index ",
+                        audios_sequence[run_index],
+                        " is out of range for ",
+                        audios.size(),
+                        " provided audios.");
+        const auto& audio = audios[relative_id];
+
+        OPENVINO_ASSERT(run_length == audio.num_audio_tokens,
+                        "Audio placeholder run ",
+                        run_index,
+                        " holds ",
+                        run_length,
+                        " tokens but audio ",
+                        audios_sequence[run_index],
+                        " encodes to ",
+                        audio.num_audio_tokens,
+                        ". The prompt expansion and the encoder disagree - this is an internal "
+                        "inconsistency, please report it with the prompt that triggered it.");
+
+        const auto audio_hidden_size = audio.audio_features.get_shape()[1];
+        OPENVINO_ASSERT(audio_hidden_size == hidden_size,
+                        "Audio embedding hidden_size (",
+                        audio_hidden_size,
+                        ") must match input embedding hidden_size (",
+                        hidden_size,
+                        "). Check that audio encoder output dimension matches the language model.");
+
+        const auto* audio_data = audio.audio_features.data<const float>();
+        for (size_t t = 0; t < run_length; t++) {
+            std::memcpy(embed_data + (i + t) * hidden_size, audio_data + t * hidden_size, bytes_per_token);
+        }
+
+        run_index++;
+        i = run_end;
     }
 
-    OPENVINO_ASSERT(audio_idx == audio_total_tokens,
-                    "Audio token count mismatch: placed ",
-                    audio_idx,
-                    " embeddings but encoder produced ",
-                    audio_total_tokens,
-                    " tokens. Ensure the prompt contains exactly ",
-                    audio_total_tokens,
-                    " audio placeholder tokens.");
+    // Trailing zero-token audios also have no run, so consume them before the final check.
+    while (run_index < audios_sequence.size() &&
+           audios[audios_sequence[run_index] - base_audio_id].num_audio_tokens == 0) {
+        run_index++;
+    }
+
+    OPENVINO_ASSERT(run_index == audios_sequence.size(),
+                    "Placed ",
+                    run_index,
+                    " of ",
+                    audios_sequence.size(),
+                    " audios: the prompt has fewer audio placeholder runs than tags resolved. This is an "
+                    "internal inconsistency, please report it with the prompt that triggered it.");
 }
 
 NormalizedPrompt InputsEmbedderQwen3Omni::normalize_prompt(const std::string& prompt,
@@ -667,27 +785,36 @@ NormalizedPrompt InputsEmbedderQwen3Omni::normalize_prompt(const std::string& pr
                                                            size_t video_base_id,
                                                            const std::vector<EncodedImage>& images,
                                                            const std::vector<EncodedVideo>& videos) const {
+    // Vision-only overload: callers with audio use the 7-argument one below, which needs the
+    // encoded audios to size each placeholder run. Nothing here consults audio state.
+    return InputsEmbedderQwen3VL::normalize_prompt(prompt, image_base_id, video_base_id, images, videos);
+}
+
+NormalizedPrompt InputsEmbedderQwen3Omni::normalize_prompt(const std::string& prompt,
+                                                           size_t image_base_id,
+                                                           size_t video_base_id,
+                                                           size_t audio_base_id,
+                                                           const std::vector<EncodedImage>& images,
+                                                           const std::vector<EncodedVideo>& videos,
+                                                           const std::vector<ov::genai::EncodedAudio>& audios) const {
     auto result = InputsEmbedderQwen3VL::normalize_prompt(prompt, image_base_id, video_base_id, images, videos);
 
-    if (m_audio_embeddings && m_audio_embeddings.get_size() > 0) {
-        const auto num_audio_tokens = m_audio_embeddings.get_shape()[0];
+    // Runs even when audios is empty: a prompt carrying <ov_genai_audio_0> with no audio supplied
+    // must be rejected by verify_ids, and returning early here would let it through silently.
+    const std::string native_tag = std::string(qwen3_omni::AUDIO_START_TAG) +
+                                   std::string(qwen3_omni::AUDIO_PAD_TAG) + std::string(qwen3_omni::AUDIO_END_TAG);
 
-        const std::string audio_start = "<|audio_start|>";
-        const std::string audio_pad = "<|audio_pad|>";
-        const std::string audio_end = "<|audio_end|>";
-
-        if (result.unified_prompt.find(audio_start) == std::string::npos) {
-            std::string audio_tag;
-            audio_tag.reserve(audio_start.size() + audio_pad.size() * num_audio_tokens + audio_end.size());
-            audio_tag.append(audio_start);
-            for (size_t i = 0; i < num_audio_tokens; ++i) {
-                audio_tag.append(audio_pad);
-            }
-            audio_tag.append(audio_end);
-            result.unified_prompt = audio_tag + result.unified_prompt;
-        }
-    }
-
+    // Same policy as images and video, so audio inherits the mixing and range checks. One pad
+    // each here; the expansion pass below grows them to the encoder-derived length.
+    auto [audio_prompt, audios_sequence] = normalize_media_tags(result.unified_prompt,
+                                                                native_tag,
+                                                                native_tag,
+                                                                audio_base_id,
+                                                                audios.size(),
+                                                                ModalityType::AUDIO);
+    result.unified_prompt = std::move(audio_prompt);
+    result.audios_sequence = std::move(audios_sequence);
+    expand_audio_tags_in_prompt(result.unified_prompt, audios, result.audios_sequence, audio_base_id);
     return result;
 }
 
@@ -842,16 +969,6 @@ ov::Tensor InputsEmbedderQwen3Omni::get_rotary_pos_emb(const std::vector<std::ar
     }
 
     return rotary_pos_emb;
-}
-
-void InputsEmbedderQwen3Omni::start_chat(const std::string& system_message) {
-    InputsEmbedderQwen3VL::start_chat(system_message);
-    m_audio_embeddings = ov::Tensor();
-}
-
-void InputsEmbedderQwen3Omni::finish_chat() {
-    InputsEmbedderQwen3VL::finish_chat();
-    m_audio_embeddings = ov::Tensor();
 }
 
 std::pair<ov::Tensor, int64_t> InputsEmbedderQwen3Omni::create_position_ids(

--- a/src/cpp/src/visual_language/qwen3_omni/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.hpp
@@ -20,6 +20,14 @@ std::shared_ptr<ov::Model> build_patch_rearrange_model_for_test();
 std::shared_ptr<ov::Model> build_patch_preprocess_model_for_test();
 }  // namespace qwen3_omni_testing
 
+namespace qwen3_omni {
+// Marker strings, hoisted out of the function body so the normalizer, the expansion pass, and the
+// tests share one definition. Token *ids* come from VLMConfig instead — see m_audio_token_id.
+inline constexpr std::string_view AUDIO_START_TAG = "<|audio_start|>";
+inline constexpr std::string_view AUDIO_PAD_TAG = "<|audio_pad|>";
+inline constexpr std::string_view AUDIO_END_TAG = "<|audio_end|>";
+}  // namespace qwen3_omni
+
 /// @brief Vision encoder for Qwen3-Omni.
 /// Does NOT load the vision_embeddings model (it's merged with the merger in the new export format).
 /// Only does image preprocessing (resize, normalize, create raw patches).
@@ -91,17 +99,28 @@ public:
         const std::vector<size_t>& videos_sequence = {},
         const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count = {}) override;
 
-    /// @brief Encode raw audio tensors and cache the embeddings.
-    /// Must be called before get_inputs_embeds() if audio is present.
-    void encode_audios(const std::vector<ov::Tensor>& audios) override;
+    /// @brief Audio-aware overload. Places each audio at its own placeholder run.
+    ov::Tensor get_inputs_embeds(
+        const std::string& prompt,
+        const std::vector<ov::genai::EncodedImage>& images,
+        const std::vector<ov::genai::EncodedVideo>& videos,
+        const std::vector<ov::genai::EncodedAudio>& audios,
+        ov::genai::VLMPerfMetrics& metrics,
+        bool recalculate_merged_embeddings,
+        const std::vector<size_t>& image_sequence,
+        const std::vector<size_t>& videos_sequence,
+        const std::vector<size_t>& audios_sequence,
+        size_t base_audio_id,
+        const std::vector<std::pair<std::size_t, std::size_t>>& history_vision_count) override;
+
+    /// @brief Encode each audio independently. Pure — the result is passed back in explicitly.
+    std::vector<ov::genai::EncodedAudio> encode_audios(const std::vector<ov::Tensor>& audios) override;
 
     /// @brief Check if audio encoder model was loaded and is ready for inference.
     bool has_audio_encoder() const {
         return m_audio_encoder != nullptr && m_audio_encoder->is_available();
     }
 
-    /// @brief Override to inject audio placeholder tokens into the prompt
-    /// when audio embeddings are available.
     NormalizedPrompt normalize_prompt(const std::string& prompt,
                                       size_t base_id,
                                       const std::vector<EncodedImage>& images) const override;
@@ -112,8 +131,14 @@ public:
                                       const std::vector<EncodedImage>& images,
                                       const std::vector<EncodedVideo>& videos) const override;
 
-    void start_chat(const std::string& system_message) override;
-    void finish_chat() override;
+    /// @brief Audio-aware normalization: resolves `<ov_genai_audio_N>` and expands each run.
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t image_base_id,
+                                      size_t video_base_id,
+                                      size_t audio_base_id,
+                                      const std::vector<EncodedImage>& images,
+                                      const std::vector<EncodedVideo>& videos,
+                                      const std::vector<ov::genai::EncodedAudio>& audios) const override;
 
 protected:
     /// @brief Check if the merged vision model was loaded and is ready for inference.
@@ -153,9 +178,8 @@ protected:
 
 private:
     std::unique_ptr<AudioEncoderQwen3Omni> m_audio_encoder;
-    // Cached audio embeddings from last encode_audios() call
-    ov::Tensor m_audio_embeddings;
-    // Audio token ID used to identify audio placeholder positions
+    // From VLMConfig, never a literal: the transformers config class publishes stale
+    // Qwen2.5-era ids that do not match the checkpoint.
     int64_t m_audio_token_id = -1;
 
     // Merged vision model (patch_embed + transformer + merger)
@@ -166,8 +190,20 @@ private:
     // "cu_seq_lens" input instead of the dense "attention_mask".
     bool m_with_cu_seqlens_input = false;
 
-    /// @brief Replace audio token positions in input_embeds with audio features.
-    void merge_audio_embeddings(ov::Tensor& input_embeds, const std::vector<int64_t>& input_ids);
+    /// @brief Grow each single-pad audio tag to its real pad count, using a running offset. A
+    /// one-pad expansion is byte-identical to the tag, so find()-from-zero would rewrite slot 0.
+    void expand_audio_tags_in_prompt(std::string& prompt,
+                                     const std::vector<ov::genai::EncodedAudio>& audios,
+                                     const std::vector<size_t>& audios_sequence,
+                                     size_t base_audio_id) const;
+
+    /// @brief Copy each audio's features into its own placeholder run. Binds run k to
+    /// audios_sequence[k], so out-of-order tags still place the right audio.
+    void merge_audio_embeddings(ov::Tensor& input_embeds,
+                                const std::vector<int64_t>& input_ids,
+                                const std::vector<ov::genai::EncodedAudio>& audios,
+                                const std::vector<size_t>& audios_sequence,
+                                size_t base_audio_id) const;
 };
 
 }  // namespace ov::genai

--- a/src/cpp/src/visual_language/qwen3_omni/classes.hpp
+++ b/src/cpp/src/visual_language/qwen3_omni/classes.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "visual_language/qwen3_omni/audio_encoder.hpp"
 #include "visual_language/qwen3_vl/classes.hpp"
 

--- a/src/cpp/src/visual_language/videochat_flash/classes.cpp
+++ b/src/cpp/src/visual_language/videochat_flash/classes.cpp
@@ -273,7 +273,7 @@ std::string normalize_prompt_impl(
     );
 
     // Convert universal video placeholders into the shared native visual tags.
-    auto [normalized_prompt, visual_sequence] = universal_to_native(prompt, write_native, VisionType::VIDEO);
+    auto [normalized_prompt, visual_sequence] = universal_to_native(prompt, write_native, ModalityType::VIDEO);
     if (!visual_sequence.empty()) {
         OPENVINO_ASSERT(
             !std::regex_search(prompt, native_pattern),

--- a/src/cpp/src/visual_language/vision_encoder.hpp
+++ b/src/cpp/src/visual_language/vision_encoder.hpp
@@ -15,9 +15,10 @@
 
 namespace ov::genai {
 
-enum class VisionType {
+enum class ModalityType {
     IMAGE,
-    VIDEO
+    VIDEO,
+    AUDIO
 };
 
 /// @brief A pair describing image size.
@@ -86,6 +87,16 @@ struct EncodedVideo {
 
     /// @brief Video metadata, used for video input processing and prompt normalization.
     VideoMetadata metadata;
+};
+
+/// @brief Encoder output for one audio. Empty inputs stay in the list as zero-token entries,
+/// otherwise every later `<ov_genai_audio_N>` index would shift.
+struct EncodedAudio {
+    /// @brief Audio encoder output. Shape [num_audio_tokens, hidden_size], element type f32.
+    ov::Tensor audio_features;
+
+    /// @brief Placeholder count this audio expands to. Equals audio_features.get_shape()[0].
+    size_t num_audio_tokens = 0;
 };
 
 /// @brief A class used to infer embeddings of an image using

--- a/src/cpp/src/visual_language/vision_registry.cpp
+++ b/src/cpp/src/visual_language/vision_registry.cpp
@@ -5,7 +5,7 @@
 
 namespace ov::genai {
 
-VisionRegistry::VisionEntry::VisionEntry(VisionType t, ov::Tensor tensor)
+VisionRegistry::VisionEntry::VisionEntry(ModalityType t, ov::Tensor tensor)
     : type(t), original(std::move(tensor)), ref_count(0) {}
 
 VisionRegistry::VisionEntry::VisionEntry(VisionEntry&& other) noexcept
@@ -13,6 +13,7 @@ VisionRegistry::VisionEntry::VisionEntry(VisionEntry&& other) noexcept
       original(std::move(other.original)),
       encoded_image(std::move(other.encoded_image)),
       encoded_video(std::move(other.encoded_video)),
+      encoded_audio(std::move(other.encoded_audio)),
       ref_count(other.ref_count.load()) {}
 
 VisionRegistry::VisionEntry& VisionRegistry::VisionEntry::operator=(VisionEntry&& other) noexcept {
@@ -21,6 +22,7 @@ VisionRegistry::VisionEntry& VisionRegistry::VisionEntry::operator=(VisionEntry&
         original = std::move(other.original);
         encoded_image = std::move(other.encoded_image);
         encoded_video = std::move(other.encoded_video);
+        encoded_audio = std::move(other.encoded_audio);
         ref_count.store(other.ref_count.load());
     }
     return *this;
@@ -71,8 +73,9 @@ VisionID VisionRegistry::compute_hash(const ov::Tensor& tensor) {
     hash ^= static_cast<uint64_t>(tensor.get_element_type().hash());
     hash *= FNV_PRIME;
     
-    // Hash tensor content
-    const uint8_t* data = tensor.data<uint8_t>();
+    // Untyped pointer because data<uint8_t>() throws for f32 audio. The element type is already
+    // in the hash, so raw bytes stay unambiguous.
+    const auto* data = static_cast<const uint8_t*>(tensor.data());
     const size_t byte_size = tensor.get_byte_size();
     const uint64_t* data64 = reinterpret_cast<const uint64_t*>(data);
     
@@ -109,7 +112,7 @@ VisionID VisionRegistry::compute_hash(const ov::Tensor& tensor) {
     return hash;
 }
 
-VisionID VisionRegistry::register_vision(const ov::Tensor& tensor, VisionType type) {
+VisionID VisionRegistry::register_vision(const ov::Tensor& tensor, ModalityType type) {
     VisionID id = compute_hash(tensor);
     
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -124,11 +127,15 @@ VisionID VisionRegistry::register_vision(const ov::Tensor& tensor, VisionType ty
 }
 
 VisionID VisionRegistry::register_image(const ov::Tensor& image) {
-    return register_vision(image, VisionType::IMAGE);
+    return register_vision(image, ModalityType::IMAGE);
 }
 
 VisionID VisionRegistry::register_video(const ov::Tensor& video) {
-    return register_vision(video, VisionType::VIDEO);
+    return register_vision(video, ModalityType::VIDEO);
+}
+
+VisionID VisionRegistry::register_audio(const ov::Tensor& audio) {
+    return register_vision(audio, ModalityType::AUDIO);
 }
 
 std::vector<VisionID> VisionRegistry::register_images(const std::vector<ov::Tensor>& images) {
@@ -145,6 +152,15 @@ std::vector<VisionID> VisionRegistry::register_videos(const std::vector<ov::Tens
     ids.reserve(videos.size());
     for (const auto& vid : videos) {
         ids.push_back(register_video(vid));
+    }
+    return ids;
+}
+
+std::vector<VisionID> VisionRegistry::register_audios(const std::vector<ov::Tensor>& audios) {
+    std::vector<VisionID> ids;
+    ids.reserve(audios.size());
+    for (const auto& audio : audios) {
+        ids.push_back(register_audio(audio));
     }
     return ids;
 }
@@ -175,7 +191,7 @@ bool VisionRegistry::contains(const VisionID& id) const {
     return m_entries.find(id) != m_entries.end();
 }
 
-VisionType VisionRegistry::get_type(const VisionID& id) const {
+ModalityType VisionRegistry::get_type(const VisionID& id) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     return m_entries.at(id).type;
 }
@@ -188,7 +204,7 @@ const ov::Tensor& VisionRegistry::get_original(const VisionID& id) const {
 void VisionRegistry::set_encoded_image(const VisionID& id, EncodedImage encoded) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto& entry = m_entries.at(id);
-    OPENVINO_ASSERT(entry.type == VisionType::IMAGE, 
+    OPENVINO_ASSERT(entry.type == ModalityType::IMAGE, 
                     "Cannot set encoded image for video entry");
     entry.encoded_image = std::move(encoded);
 }
@@ -202,7 +218,7 @@ bool VisionRegistry::has_encoded_image(const VisionID& id) const {
 const EncodedImage& VisionRegistry::get_encoded_image(const VisionID& id) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     const auto& entry = m_entries.at(id);
-    OPENVINO_ASSERT(entry.type == VisionType::IMAGE,
+    OPENVINO_ASSERT(entry.type == ModalityType::IMAGE,
                     "Cannot get encoded image for video entry");
     OPENVINO_ASSERT(entry.encoded_image.has_value(),
                     "Encoded image not available for id: ", id);
@@ -212,7 +228,7 @@ const EncodedImage& VisionRegistry::get_encoded_image(const VisionID& id) const 
 void VisionRegistry::set_encoded_video(const VisionID& id, EncodedVideo encoded) {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto& entry = m_entries.at(id);
-    OPENVINO_ASSERT(entry.type == VisionType::VIDEO,
+    OPENVINO_ASSERT(entry.type == ModalityType::VIDEO,
                     "Cannot set encoded video for image entry");
     entry.encoded_video = std::move(encoded);
 }
@@ -226,11 +242,32 @@ bool VisionRegistry::has_encoded_video(const VisionID& id) const {
 const EncodedVideo& VisionRegistry::get_encoded_video(const VisionID& id) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     const auto& entry = m_entries.at(id);
-    OPENVINO_ASSERT(entry.type == VisionType::VIDEO,
+    OPENVINO_ASSERT(entry.type == ModalityType::VIDEO,
                     "Cannot get encoded video for image entry");
     OPENVINO_ASSERT(entry.encoded_video.has_value(),
                     "Encoded video not available for id: ", id);
     return *entry.encoded_video;
+}
+
+void VisionRegistry::set_encoded_audio(const VisionID& id, EncodedAudio encoded) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto& entry = m_entries.at(id);
+    OPENVINO_ASSERT(entry.type == ModalityType::AUDIO, "Cannot set encoded audio for a non-audio entry");
+    entry.encoded_audio = std::move(encoded);
+}
+
+bool VisionRegistry::has_encoded_audio(const VisionID& id) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_entries.find(id);
+    return it != m_entries.end() && it->second.encoded_audio.has_value();
+}
+
+const EncodedAudio& VisionRegistry::get_encoded_audio(const VisionID& id) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto& entry = m_entries.at(id);
+    OPENVINO_ASSERT(entry.type == ModalityType::AUDIO, "Cannot get encoded audio for a non-audio entry");
+    OPENVINO_ASSERT(entry.encoded_audio.has_value(), "Encoded audio not available for id: ", id);
+    return *entry.encoded_audio;
 }
 
 } // namespace ov::genai

--- a/src/cpp/src/visual_language/vision_registry.hpp
+++ b/src/cpp/src/visual_language/vision_registry.hpp
@@ -23,16 +23,18 @@ public:
 
     VisionID register_image(const ov::Tensor& image);
     VisionID register_video(const ov::Tensor& video);
+    VisionID register_audio(const ov::Tensor& audio);
 
     std::vector<VisionID> register_images(const std::vector<ov::Tensor>& images);
     std::vector<VisionID> register_videos(const std::vector<ov::Tensor>& videos);
+    std::vector<VisionID> register_audios(const std::vector<ov::Tensor>& audios);
 
     void add_ref(const VisionID& id);
     void release_ref(const VisionID& id);
 
     size_t size() const;
     bool contains(const VisionID& id) const;
-    VisionType get_type(const VisionID& id) const;
+    ModalityType get_type(const VisionID& id) const;
 
     const ov::Tensor& get_original(const VisionID& id) const;
 
@@ -44,15 +46,20 @@ public:
     bool has_encoded_video(const VisionID& id) const;
     const EncodedVideo& get_encoded_video(const VisionID& id) const;
 
+    void set_encoded_audio(const VisionID& id, EncodedAudio encoded);
+    bool has_encoded_audio(const VisionID& id) const;
+    const EncodedAudio& get_encoded_audio(const VisionID& id) const;
+
 private:
     struct VisionEntry {
-        VisionType type;
+        ModalityType type;
         ov::Tensor original;
         std::optional<EncodedImage> encoded_image;
         std::optional<EncodedVideo> encoded_video;
+        std::optional<EncodedAudio> encoded_audio;
         std::atomic<size_t> ref_count{0};
         
-        VisionEntry(VisionType t, ov::Tensor tensor);
+        VisionEntry(ModalityType t, ov::Tensor tensor);
         VisionEntry(VisionEntry&& other) noexcept;
         VisionEntry& operator=(VisionEntry&& other) noexcept;
         
@@ -66,7 +73,7 @@ private:
 
     mutable std::mutex m_mutex;
 
-    VisionID register_vision(const ov::Tensor& tensor, VisionType type);
+    VisionID register_vision(const ov::Tensor& tensor, ModalityType type);
 
     static VisionID compute_hash(const ov::Tensor& tensor);
 };

--- a/src/cpp/src/visual_language/vlm_chat_context.cpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.cpp
@@ -20,12 +20,14 @@ VLMChatContext::VLMChatContext(
     m_initial_messages_metadata_count = m_history_state->get_messages_metadata().size();
     m_initial_base_image_index = m_history_state->get_base_image_index();
     m_initial_base_video_index = m_history_state->get_base_video_index();
+    m_initial_base_audio_index = m_history_state->get_base_audio_index();
 }
 
 VLMChatContext::ProcessedChatData VLMChatContext::process(
     const std::vector<ov::Tensor>& new_images,
     const std::vector<ov::Tensor>& new_videos,
-    const std::vector<VideoMetadata>& new_videos_metadata
+    const std::vector<VideoMetadata>& new_videos_metadata,
+    const std::vector<ov::Tensor>& new_audios
 ) {
     ProcessedChatData result;
     
@@ -36,17 +38,20 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
         m_history_state->truncate_to(matching_history_length);
         m_initial_base_image_index = m_history_state->get_base_image_index();
         m_initial_base_video_index = m_history_state->get_base_video_index();
+        m_initial_base_audio_index = m_history_state->get_base_audio_index();
     }
     
     std::vector<size_t> new_image_indices = m_history_state->register_images(new_images);
     std::vector<size_t> new_video_indices = m_history_state->register_videos(new_videos);
+    std::vector<size_t> new_audio_indices = m_history_state->register_audios(new_audios);
     
     ManualTimer vision_encoding_timer("Vision Encoding");
     vision_encoding_timer.start();
-    encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata);
+    result.audio_encoding_durations =
+        encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata, new_audio_indices);
     vision_encoding_timer.end();
     
-    fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices);
+    fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices, new_audio_indices);
     
     result.normalized_history = m_history_state->build_normalized_history(m_history);
     
@@ -54,8 +59,10 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
 
     result.encoded_images = std::move(resolved_visions.encoded_images);
     result.encoded_videos = std::move(resolved_visions.encoded_videos);
+    result.encoded_audios = std::move(resolved_visions.encoded_audios);
     result.image_sequence = std::move(resolved_visions.image_sequence);
     result.video_sequence = std::move(resolved_visions.video_sequence);
+    result.audio_sequence = std::move(resolved_visions.audio_sequence);
 
     const auto& last_user_message_metadata = m_history_state->get_messages_metadata().at(
         m_history_state->get_last_user_message_index()
@@ -63,13 +70,16 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
 
     auto resolved_new_visions = m_history_state->resolve_visions_with_sequence(
         last_user_message_metadata.image_sequence,
-        last_user_message_metadata.video_sequence
+        last_user_message_metadata.video_sequence,
+        last_user_message_metadata.audio_sequence
     );
 
     result.new_encoded_images = std::move(resolved_new_visions.encoded_images);
     result.new_encoded_videos = std::move(resolved_new_visions.encoded_videos);
+    result.new_encoded_audios = std::move(resolved_new_visions.encoded_audios);
     result.new_image_sequence = std::move(resolved_new_visions.image_sequence);
     result.new_video_sequence = std::move(resolved_new_visions.video_sequence);
+    result.new_audio_sequence = std::move(resolved_new_visions.audio_sequence);
     
     result.vision_counts = m_history_state->build_vision_counts();
     
@@ -84,13 +94,16 @@ void VLMChatContext::rollback() {
      m_history_state->truncate_to(m_initial_messages_metadata_count);
      m_initial_base_image_index = m_history_state->get_base_image_index();
      m_initial_base_video_index = m_history_state->get_base_video_index();
+     m_initial_base_audio_index = m_history_state->get_base_audio_index();
 }
 
-void VLMChatContext::encode_visions_if_needed(
+std::vector<MicroSeconds> VLMChatContext::encode_visions_if_needed(
     const std::vector<size_t>& image_indices,
     const std::vector<size_t>& video_indices,
-    const std::vector<VideoMetadata>& videos_metadata
+    const std::vector<VideoMetadata>& videos_metadata,
+    const std::vector<size_t>& audio_indices
 ) {
+    std::vector<MicroSeconds> audio_encoding_durations;
     for (size_t idx : image_indices) {
         VisionID id = m_history_state->get_image_vision_id(idx);
         if (!m_vision_registry->has_encoded_image(id)) {
@@ -118,15 +131,32 @@ void VLMChatContext::encode_visions_if_needed(
             m_vision_registry->set_encoded_video(id, std::move(encoded[0]));
         }
     }
+
+    // Content-hash cache hit means an identical tensor re-sent on a later turn is not re-encoded,
+    // which is the whole point of routing audio through the registry.
+    for (size_t idx : audio_indices) {
+        VisionID id = m_history_state->get_audio_vision_id(idx);
+        if (!m_vision_registry->has_encoded_audio(id)) {
+            const ov::Tensor& original = m_vision_registry->get_original(id);
+            const auto audio_encoding_start = std::chrono::steady_clock::now();
+            auto encoded = m_inputs_embedder.encode_audios({original});
+            PerfMetrics::emplace_duration(audio_encoding_durations, audio_encoding_start);
+            m_vision_registry->set_encoded_audio(id, std::move(encoded[0]));
+        }
+    }
+
+    return audio_encoding_durations;
 }
 
 void VLMChatContext::fill_messages_metadata(
     size_t start_index,
     const std::vector<size_t>& new_image_indices,
-    const std::vector<size_t>& new_video_indices
+    const std::vector<size_t>& new_video_indices,
+    const std::vector<size_t>& new_audio_indices
 ) {
     size_t base_image_index = m_initial_base_image_index;
     size_t base_video_index = m_initial_base_video_index;
+    size_t base_audio_index = m_initial_base_audio_index;
 
     for (size_t i = start_index; i < m_history.size(); ++i) {
         const auto& message = m_history[i];
@@ -146,26 +176,36 @@ void VLMChatContext::fill_messages_metadata(
         if (i == m_history_state->get_last_user_message_index()) {
             metadata.provided_image_indices = new_image_indices;
             metadata.provided_video_indices = new_video_indices;
+            metadata.provided_audio_indices = new_audio_indices;
         }
         
         std::vector<EncodedImage> encoded_images = m_history_state->get_encoded_images(metadata.provided_image_indices);
         std::vector<EncodedVideo> encoded_videos = m_history_state->get_encoded_videos(metadata.provided_video_indices);
+        std::vector<EncodedAudio> encoded_audios = m_history_state->get_encoded_audios(metadata.provided_audio_indices);
 
         std::string prompt_to_normalize;
         if (m_history_state->get_chat_history_format() == ChatHistoryFormat::STRING_CONTENT) {
             prompt_to_normalize = message["content"].get_string();
         }
         if (m_history_state->get_chat_history_format() == ChatHistoryFormat::MULTIPART_CONTENT) {
-            prompt_to_normalize = multipart_message_to_string(message, base_image_index, base_video_index);
+            prompt_to_normalize =
+                multipart_message_to_string(message, base_image_index, base_video_index, base_audio_index);
         }
 
-        auto normalized = m_inputs_embedder.normalize_prompt(
-            prompt_to_normalize, base_image_index, base_video_index, encoded_images, encoded_videos
-        );
+        // Per-message audio: each message normalizes with only its own audio, so a block can no
+        // longer be prepended to every user message the way the embedder-member version did.
+        auto normalized = m_inputs_embedder.normalize_prompt(prompt_to_normalize,
+                                                             base_image_index,
+                                                             base_video_index,
+                                                             base_audio_index,
+                                                             encoded_images,
+                                                             encoded_videos,
+                                                             encoded_audios);
         metadata.normalized_content = normalized.unified_prompt;
         
         metadata.image_sequence = normalized.images_sequence;
         metadata.video_sequence = normalized.videos_sequence;
+        metadata.audio_sequence = normalized.audios_sequence;
 
         // image_sequence can be empty after prompt normalization (phi3_vision and phi4mm).
         // It is processed later in corresponding inputs_embedder `get_inputs_embeds()`.
@@ -179,6 +219,7 @@ void VLMChatContext::fill_messages_metadata(
         
         base_image_index += metadata.provided_image_indices.size();
         base_video_index += metadata.provided_video_indices.size();
+        base_audio_index += metadata.provided_audio_indices.size();
         
         m_history_state->add_message_metadata(std::move(metadata));
     }
@@ -190,11 +231,13 @@ void VLMChatContext::fill_messages_metadata(
 std::string VLMChatContext::multipart_message_to_string(
     const JsonContainer& message,
     size_t base_image_index,
-    size_t base_video_index
+    size_t base_video_index,
+    size_t base_audio_index
 ) const {
     std::string result = "";
     size_t image_index = base_image_index;
     size_t video_index = base_video_index;
+    size_t audio_index = base_audio_index;
     for (size_t i = 0; i < message["content"].size(); ++i) {
         const auto& item = message["content"][i];
         if (item.is_object() && item.contains("type")) {
@@ -207,6 +250,9 @@ std::string VLMChatContext::multipart_message_to_string(
             } else if (type == "video") {
                 result += "<ov_genai_video_" + std::to_string(video_index) + ">";
                 video_index++;
+            } else if (type == "audio") {
+                result += "<ov_genai_audio_" + std::to_string(audio_index) + ">";
+                audio_index++;
             } else {
                 OPENVINO_THROW("Unsupported content type in multipart message: ", type);
             }            

--- a/src/cpp/src/visual_language/vlm_chat_context.cpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.cpp
@@ -47,9 +47,12 @@ VLMChatContext::ProcessedChatData VLMChatContext::process(
     
     ManualTimer vision_encoding_timer("Vision Encoding");
     vision_encoding_timer.start();
-    result.audio_encoding_durations =
-        encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata, new_audio_indices);
+    encode_visions_if_needed(new_image_indices, new_video_indices, new_videos_metadata);
     vision_encoding_timer.end();
+
+    // Timed separately: folding audio into vision_encoding_duration would both mis-attribute it
+    // and count it twice, since encode_audios_if_needed() already reports its own durations.
+    result.audio_encoding_durations = encode_audios_if_needed(new_audio_indices);
     
     fill_messages_metadata(matching_history_length, new_image_indices, new_video_indices, new_audio_indices);
     
@@ -97,13 +100,11 @@ void VLMChatContext::rollback() {
      m_initial_base_audio_index = m_history_state->get_base_audio_index();
 }
 
-std::vector<MicroSeconds> VLMChatContext::encode_visions_if_needed(
+void VLMChatContext::encode_visions_if_needed(
     const std::vector<size_t>& image_indices,
     const std::vector<size_t>& video_indices,
-    const std::vector<VideoMetadata>& videos_metadata,
-    const std::vector<size_t>& audio_indices
+    const std::vector<VideoMetadata>& videos_metadata
 ) {
-    std::vector<MicroSeconds> audio_encoding_durations;
     for (size_t idx : image_indices) {
         VisionID id = m_history_state->get_image_vision_id(idx);
         if (!m_vision_registry->has_encoded_image(id)) {
@@ -131,9 +132,12 @@ std::vector<MicroSeconds> VLMChatContext::encode_visions_if_needed(
             m_vision_registry->set_encoded_video(id, std::move(encoded[0]));
         }
     }
+}
 
-    // Content-hash cache hit means an identical tensor re-sent on a later turn is not re-encoded,
-    // which is the whole point of routing audio through the registry.
+// Content-hash cache hit means an identical tensor re-sent on a later turn is not re-encoded,
+// which is the whole point of routing audio through the registry.
+std::vector<MicroSeconds> VLMChatContext::encode_audios_if_needed(const std::vector<size_t>& audio_indices) {
+    std::vector<MicroSeconds> audio_encoding_durations;
     for (size_t idx : audio_indices) {
         VisionID id = m_history_state->get_audio_vision_id(idx);
         if (!m_vision_registry->has_encoded_audio(id)) {

--- a/src/cpp/src/visual_language/vlm_chat_context.hpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.hpp
@@ -25,19 +25,27 @@ public:
         
         std::vector<EncodedImage> encoded_images;
         std::vector<EncodedVideo> encoded_videos;
+        std::vector<EncodedAudio> encoded_audios;
         std::vector<size_t> image_sequence;
         std::vector<size_t> video_sequence;
+        std::vector<size_t> audio_sequence;
         
         std::vector<EncodedImage> new_encoded_images;
         std::vector<EncodedVideo> new_encoded_videos;
+        std::vector<EncodedAudio> new_encoded_audios;
         std::vector<size_t> new_image_sequence;
         std::vector<size_t> new_video_sequence;
+        std::vector<size_t> new_audio_sequence;
         
         std::vector<std::pair<size_t, size_t>> vision_counts;
 
         bool needs_kv_cache_reset = false;
 
         float vision_encoding_duration = 0.0f;
+
+        // One entry per audio actually encoded, so a registry cache hit is distinguishable from a
+        // miss. An aggregate scalar could not express "nothing was re-encoded this turn".
+        std::vector<MicroSeconds> audio_encoding_durations;
     };
 
     VLMChatContext(
@@ -49,7 +57,8 @@ public:
     ProcessedChatData process(
         const std::vector<ov::Tensor>& new_images,
         const std::vector<ov::Tensor>& new_videos = {},
-        const std::vector<VideoMetadata>& new_videos_metadata = {}
+        const std::vector<VideoMetadata>& new_videos_metadata = {},
+        const std::vector<ov::Tensor>& new_audios = {}
     );
 
     void rollback();
@@ -65,23 +74,28 @@ private:
     size_t m_initial_messages_metadata_count = 0;
     size_t m_initial_base_image_index = 0;
     size_t m_initial_base_video_index = 0;
+    size_t m_initial_base_audio_index = 0;
 
-    void encode_visions_if_needed(
+    /// @return Per-encode audio durations, one entry per cache miss.
+    std::vector<MicroSeconds> encode_visions_if_needed(
         const std::vector<size_t>& image_indices,
         const std::vector<size_t>& video_indices,
-        const std::vector<VideoMetadata>& videos_metadata = {}
+        const std::vector<VideoMetadata>& videos_metadata = {},
+        const std::vector<size_t>& audio_indices = {}
     );
                 
     void fill_messages_metadata(
         size_t start_index,
         const std::vector<size_t>& new_image_indices,
-        const std::vector<size_t>& new_video_indices
+        const std::vector<size_t>& new_video_indices,
+        const std::vector<size_t>& new_audio_indices = {}
     );
 
     std::string multipart_message_to_string(
         const JsonContainer& message,
         size_t base_image_index,
-        size_t base_video_index
+        size_t base_video_index,
+        size_t base_audio_index
     ) const;
 };
 

--- a/src/cpp/src/visual_language/vlm_chat_context.hpp
+++ b/src/cpp/src/visual_language/vlm_chat_context.hpp
@@ -76,13 +76,14 @@ private:
     size_t m_initial_base_video_index = 0;
     size_t m_initial_base_audio_index = 0;
 
-    /// @return Per-encode audio durations, one entry per cache miss.
-    std::vector<MicroSeconds> encode_visions_if_needed(
+    void encode_visions_if_needed(
         const std::vector<size_t>& image_indices,
         const std::vector<size_t>& video_indices,
-        const std::vector<VideoMetadata>& videos_metadata = {},
-        const std::vector<size_t>& audio_indices = {}
+        const std::vector<VideoMetadata>& videos_metadata = {}
     );
+
+    /// @return Per-encode audio durations, one entry per cache miss.
+    std::vector<MicroSeconds> encode_audios_if_needed(const std::vector<size_t>& audio_indices);
                 
     void fill_messages_metadata(
         size_t start_index,

--- a/src/cpp/src/visual_language/vlm_utils.hpp
+++ b/src/cpp/src/visual_language/vlm_utils.hpp
@@ -34,6 +34,20 @@ inline void update_image_slice_counts(VLMPerfMetrics& metrics, const std::vector
     }
 }
 
+/// @brief Rebase conversation-absolute media indices onto one turn's encoded list. Asserts rather
+/// than wrapping: a size_t underflow here would index far out of bounds instead of failing.
+inline void rebase_media_sequence(std::vector<size_t>& sequence, size_t base_id) {
+    for (auto& index : sequence) {
+        OPENVINO_ASSERT(index >= base_id,
+                        "Media index ",
+                        index,
+                        " is below this turn's base index ",
+                        base_id,
+                        ". Referring to media from an earlier turn is not supported.");
+        index -= base_id;
+    }
+}
+
 std::vector<std::variant<ov::Tensor, size_t>> split_tokenize(const std::string& text,
                                                              ov::genai::Tokenizer& tokenizer,
                                                              const std::regex& native_pattern);

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2907,16 +2907,17 @@ class OmniPipeline:
             :param prompt: Input prompt
             :type prompt: str
         
-            :param images: image tensors to be prepended to the prompt
+            :param images: image tensors. Place with `<ov_genai_image_N>`; prepended if untagged
             :type images: list[ov.Tensor]
         
-            :param videos: video tensors to be prepended to the prompt
+            :param videos: video tensors. Place with `<ov_genai_video_N>`; prepended if untagged
             :type videos: list[ov.Tensor]
         
             :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
             :type videos_metadata: list[VideoMetadata]
         
-            :param audios: audio tensors to be prepended to the prompt
+            :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt, where N
+                indexes this list; untagged audio is prepended, which is the recommended form
             :type audios: list[ov.Tensor]
         
             :param text_config: thinker text-decode config. None = use the VLM's default
@@ -5644,7 +5645,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5684,7 +5686,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5724,7 +5727,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5764,7 +5768,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5804,7 +5809,7 @@ class VLMPipeline(VLMPipelineBase):
             image: ov.Tensor - input image,
             images: list[ov.Tensor] - input images,
             videos: list[ov.Tensor] - input videos,
-            audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
+            audios: list[ov.Tensor] - audio tensors, placed with `<ov_genai_audio_N>` or prepended if untagged,
             videos_metadata: list[VideoMetadata] - metadata for each video,
             generation_config: GenerationConfig,
             streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,
@@ -5830,7 +5835,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5870,7 +5876,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5910,7 +5917,8 @@ class VLMPipeline(VLMPipelineBase):
             :param videos: list of frames
             :type videos: list[ov.Tensor]
         
-            :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+            :param audios: audio tensors, for multimodal models supporting audio input. Place with
+                `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
             :type audios: list[ov.Tensor]
         
             :param generation_config: generation_config
@@ -5950,7 +5958,7 @@ class VLMPipeline(VLMPipelineBase):
             image: ov.Tensor - input image,
             images: list[ov.Tensor] - input images,
             videos: list[ov.Tensor] - input videos,
-            audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
+            audios: list[ov.Tensor] - audio tensors, placed with `<ov_genai_audio_N>` or prepended if untagged,
             videos_metadata: list[VideoMetadata] - metadata for each video,
             generation_config: GenerationConfig,
             streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,

--- a/src/python/openvino_genai/py_openvino_genai.pyi
+++ b/src/python/openvino_genai/py_openvino_genai.pyi
@@ -2916,8 +2916,10 @@ class OmniPipeline:
             :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
             :type videos_metadata: list[VideoMetadata]
         
-            :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt, where N
-                indexes this list; untagged audio is prepended, which is the recommended form
+            :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt; untagged
+                audio is prepended, which is the recommended form. Outside a chat, N indexes this list. In a
+                chat, N is conversation-absolute: a second turn that adds one audio uses the next global
+                index, so `<ov_genai_audio_1>` rather than `<ov_genai_audio_0>`.
             :type audios: list[ov.Tensor]
         
             :param text_config: thinker text-decode config. None = use the VLM's default

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -112,16 +112,17 @@ auto omni_generate_prompt_docstring = R"(
     :param prompt: Input prompt
     :type prompt: str
 
-    :param images: image tensors to be prepended to the prompt
+    :param images: image tensors. Place with `<ov_genai_image_N>`; prepended if untagged
     :type images: list[ov.Tensor]
 
-    :param videos: video tensors to be prepended to the prompt
+    :param videos: video tensors. Place with `<ov_genai_video_N>`; prepended if untagged
     :type videos: list[ov.Tensor]
 
     :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
     :type videos_metadata: list[VideoMetadata]
 
-    :param audios: audio tensors to be prepended to the prompt
+    :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt, where N
+        indexes this list; untagged audio is prepended, which is the recommended form
     :type audios: list[ov.Tensor]
 
     :param text_config: thinker text-decode config. None = use the VLM's default

--- a/src/python/py_omni_pipeline.cpp
+++ b/src/python/py_omni_pipeline.cpp
@@ -121,8 +121,10 @@ auto omni_generate_prompt_docstring = R"(
     :param videos_metadata: metadata for each video (fps, frames_indices). Must be empty or have the same length as videos.
     :type videos_metadata: list[VideoMetadata]
 
-    :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt, where N
-        indexes this list; untagged audio is prepended, which is the recommended form
+    :param audios: audio tensors. Place with `<ov_genai_audio_N>` anywhere in the prompt; untagged
+        audio is prepended, which is the recommended form. Outside a chat, N indexes this list. In a
+        chat, N is conversation-absolute: a second turn that adds one audio uses the next global
+        index, so `<ov_genai_audio_1>` rather than `<ov_genai_audio_0>`.
     :type audios: list[ov.Tensor]
 
     :param text_config: thinker text-decode config. None = use the VLM's default

--- a/src/python/py_vlm_pipeline.cpp
+++ b/src/python/py_vlm_pipeline.cpp
@@ -46,7 +46,8 @@ auto vlm_generate_common_params = R"(
     :param videos: list of frames
     :type videos: list[ov.Tensor]
 
-    :param audios: audio tensors to be prepended to the prompt (for multimodal models supporting audio input)
+    :param audios: audio tensors, for multimodal models supporting audio input. Place with
+        `<ov_genai_audio_N>` anywhere in the prompt; untagged audio is prepended
     :type audios: list[ov.Tensor]
 
     :param generation_config: generation_config
@@ -78,7 +79,7 @@ auto vlm_generate_kwargs_param = R"(
     image: ov.Tensor - input image,
     images: list[ov.Tensor] - input images,
     videos: list[ov.Tensor] - input videos,
-    audios: list[ov.Tensor] - audio tensors to be prepended to the prompt (for multimodal models supporting audio input),
+    audios: list[ov.Tensor] - audio tensors, placed with `<ov_genai_audio_N>` or prepended if untagged,
     videos_metadata: list[VideoMetadata] - metadata for each video,
     generation_config: GenerationConfig,
     streamer: Callable[[str], bool], ov.genai.StreamerBase - streamer either as a lambda with a boolean returning flag whether generation should be stopped,

--- a/tests/cpp/test_media_tag_normalization.cpp
+++ b/tests/cpp/test_media_tag_normalization.cpp
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "visual_language/inputs_embedder.hpp"
+#include "visual_language/vlm_utils.hpp"
+
+using ov::genai::ModalityType;
+using ov::genai::normalize_media_tags;
+using ov::genai::vlm_utils::rebase_media_sequence;
+
+namespace {
+
+// Qwen3-Omni's audio marker. Single pad here; the per-audio expansion happens later.
+const std::string AUDIO_TAG = "<|audio_start|><|audio_pad|><|audio_end|>";
+
+std::pair<std::string, std::vector<size_t>> normalize_audio(const std::string& prompt,
+                                                            size_t base_idx,
+                                                            size_t n_audios) {
+    return normalize_media_tags(prompt, AUDIO_TAG, AUDIO_TAG, base_idx, n_audios, ModalityType::AUDIO);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------- no tags: prepend
+
+TEST(MediaTagNormalization, NoTagPrependsInInputOrder) {
+    const auto [prompt, sequence] = normalize_audio("Describe", 0, 2);
+    EXPECT_EQ(prompt, AUDIO_TAG + AUDIO_TAG + "Describe");
+    EXPECT_EQ(sequence, (std::vector<size_t>{0, 1}));
+}
+
+TEST(MediaTagNormalization, NoTagNoMediaLeavesPromptAlone) {
+    const auto [prompt, sequence] = normalize_audio("Describe", 0, 0);
+    EXPECT_EQ(prompt, "Describe");
+    EXPECT_TRUE(sequence.empty());
+}
+
+// ------------------------------------------------------- universal tags keep position
+
+TEST(MediaTagNormalization, UniversalTagAtFrontMatchesPrependDefault) {
+    const auto tagged = normalize_audio("<ov_genai_audio_0>Describe", 0, 1);
+    const auto defaulted = normalize_audio("Describe", 0, 1);
+    EXPECT_EQ(tagged.first, defaulted.first) << "an explicit leading tag must equal the prepend default";
+    EXPECT_EQ(tagged.second, defaulted.second);
+}
+
+TEST(MediaTagNormalization, UniversalTagAppended) {
+    const auto [prompt, sequence] = normalize_audio("Describe this: <ov_genai_audio_0>", 0, 1);
+    EXPECT_EQ(prompt, "Describe this: " + AUDIO_TAG);
+    EXPECT_EQ(sequence, (std::vector<size_t>{0}));
+}
+
+// The case no modality covered before this branch: a tag with text on BOTH sides.
+TEST(MediaTagNormalization, UniversalTagInterleaved) {
+    const auto [prompt, sequence] = normalize_audio("text <ov_genai_audio_0> more text", 0, 1);
+    EXPECT_EQ(prompt, "text " + AUDIO_TAG + " more text");
+    EXPECT_EQ(sequence, (std::vector<size_t>{0}));
+}
+
+TEST(MediaTagNormalization, TwoUniversalTagsKeepTheirOwnPositions) {
+    const auto [prompt, sequence] = normalize_audio("A <ov_genai_audio_0> B <ov_genai_audio_1> C", 0, 2);
+    EXPECT_EQ(prompt, "A " + AUDIO_TAG + " B " + AUDIO_TAG + " C");
+    EXPECT_EQ(sequence, (std::vector<size_t>{0, 1}));
+}
+
+// Reversed indices must produce a reversed *sequence* while the tag positions stay put — that is
+// what makes per-item binding observable at all.
+TEST(MediaTagNormalization, ReversedIndicesReverseTheSequenceNotThePositions) {
+    const auto forward = normalize_audio("A <ov_genai_audio_0> B <ov_genai_audio_1>", 0, 2);
+    const auto reversed = normalize_audio("A <ov_genai_audio_1> B <ov_genai_audio_0>", 0, 2);
+    EXPECT_EQ(forward.first, reversed.first) << "same skeleton, so the rendered prompt is identical";
+    EXPECT_EQ(forward.second, (std::vector<size_t>{0, 1}));
+    EXPECT_EQ(reversed.second, (std::vector<size_t>{1, 0}));
+}
+
+TEST(MediaTagNormalization, DuplicateIndexRendersTwice) {
+    const auto [prompt, sequence] = normalize_audio("<ov_genai_audio_0> and <ov_genai_audio_0>", 0, 1);
+    EXPECT_EQ(prompt, AUDIO_TAG + " and " + AUDIO_TAG);
+    EXPECT_EQ(sequence, (std::vector<size_t>{0, 0}));
+}
+
+// ----------------------------------------------------------------- base index offset
+
+TEST(MediaTagNormalization, BaseIndexOffsetsTheSequence) {
+    const auto [prompt, sequence] = normalize_audio("<ov_genai_audio_3>x", 3, 1);
+    EXPECT_EQ(prompt, AUDIO_TAG + "x");
+    EXPECT_EQ(sequence, (std::vector<size_t>{3}));
+}
+
+TEST(MediaTagNormalization, NoTagPrependStartsAtBaseIndex) {
+    const auto [prompt, sequence] = normalize_audio("x", 5, 2);
+    EXPECT_EQ(sequence, (std::vector<size_t>{5, 6}));
+}
+
+// ------------------------------------------------------------------------ error paths
+
+TEST(MediaTagNormalization, IndexBelowBaseIsRejected) {
+    EXPECT_THROW(normalize_audio("<ov_genai_audio_0>x", 1, 1), ov::Exception);
+}
+
+TEST(MediaTagNormalization, IndexAtOrAboveRangeIsRejected) {
+    EXPECT_THROW(normalize_audio("<ov_genai_audio_5>x", 0, 1), ov::Exception);
+}
+
+TEST(MediaTagNormalization, TagWithNoMediaIsRejected) {
+    EXPECT_THROW(normalize_audio("<ov_genai_audio_0>x", 0, 0), ov::Exception);
+}
+
+TEST(MediaTagNormalization, MixingUniversalAndNativeIsRejected) {
+    EXPECT_THROW(normalize_audio(AUDIO_TAG + "<ov_genai_audio_0>", 0, 1), ov::Exception);
+}
+
+TEST(MediaTagNormalization, NativeTagCountMustMatchMediaCount) {
+    EXPECT_THROW(normalize_audio(AUDIO_TAG + AUDIO_TAG, 0, 1), ov::Exception);
+    EXPECT_THROW(normalize_audio(AUDIO_TAG, 0, 2), ov::Exception);
+}
+
+// Error messages are load-bearing: the Python suite pins these substrings, and a reworded message
+// sends users to the wrong modality (plan risk R2).
+TEST(MediaTagNormalization, ErrorMessagesNameAllThreeModalities) {
+    try {
+        normalize_audio("<ov_genai_audio_0>x", 1, 1);
+        FAIL() << "expected a throw";
+    } catch (const ov::Exception& e) {
+        EXPECT_NE(std::string(e.what()).find("images/videos/audios"), std::string::npos) << e.what();
+    }
+    try {
+        normalize_audio("<ov_genai_audio_5>x", 0, 1);
+        FAIL() << "expected a throw";
+    } catch (const ov::Exception& e) {
+        EXPECT_NE(std::string(e.what()).find("Missing image/video/audio with index"), std::string::npos) << e.what();
+    }
+    try {
+        normalize_audio(AUDIO_TAG + AUDIO_TAG, 0, 1);
+        FAIL() << "expected a throw";
+    } catch (const ov::Exception& e) {
+        EXPECT_NE(std::string(e.what()).find("native media tags"), std::string::npos) << e.what();
+    }
+}
+
+// ------------------------------------------------- audio must not share the video regex
+
+// Guards the ternary that adding AUDIO exposed: `modality == IMAGE ? IMAGE : VIDEO` routed audio
+// through the video regex.
+TEST(MediaTagNormalization, AudioModalityIgnoresImageAndVideoTags) {
+    const auto [prompt, sequence] = normalize_audio("<ov_genai_video_0><ov_genai_image_0>x", 0, 1);
+    EXPECT_EQ(prompt, AUDIO_TAG + "<ov_genai_video_0><ov_genai_image_0>x")
+        << "video/image tags are inert under AUDIO, so the audio falls back to prepend";
+    EXPECT_EQ(sequence, (std::vector<size_t>{0}));
+}
+
+// ------------------------------------------- rebasing absolute indices onto one turn
+
+// The SDPA prompt path shipped audio without this rebase, so turn 2 asked for index 1 of a
+// one-element list. Gated here because the end-to-end SDPA path cannot run.
+TEST(MediaTagNormalization, RebaseShiftsIndicesOntoThisTurn) {
+    std::vector<size_t> sequence{3, 4, 5};
+    rebase_media_sequence(sequence, 3);
+    EXPECT_EQ(sequence, (std::vector<size_t>{0, 1, 2}));
+}
+
+TEST(MediaTagNormalization, RebaseWithZeroBaseIsIdentity) {
+    std::vector<size_t> sequence{0, 1, 2};
+    rebase_media_sequence(sequence, 0);
+    EXPECT_EQ(sequence, (std::vector<size_t>{0, 1, 2}));
+}
+
+TEST(MediaTagNormalization, RebaseHandlesEmptyAndOutOfOrderSequences) {
+    std::vector<size_t> empty;
+    rebase_media_sequence(empty, 7);
+    EXPECT_TRUE(empty.empty());
+
+    // Out-of-order indices must keep their order; only the offset changes.
+    std::vector<size_t> reversed{5, 4};
+    rebase_media_sequence(reversed, 4);
+    EXPECT_EQ(reversed, (std::vector<size_t>{1, 0}));
+}
+
+// An index below the base would underflow size_t and index far out of bounds, so it must throw
+// rather than wrap.
+TEST(MediaTagNormalization, RebaseRejectsIndexBelowBase) {
+    std::vector<size_t> sequence{2};
+    EXPECT_THROW(rebase_media_sequence(sequence, 3), ov::Exception);
+}
+
+// The full chain a second turn goes through: absolute indices out of normalize, then rebased.
+TEST(MediaTagNormalization, SecondTurnAbsoluteIndicesRebaseToLocalSlots) {
+    // Turn 2 supplies one audio; its absolute index is 1 because turn 1 consumed index 0.
+    auto [prompt, sequence] = normalize_audio("Second <ov_genai_audio_1>", 1, 1);
+    EXPECT_EQ(sequence, (std::vector<size_t>{1})) << "normalize returns absolute indices";
+
+    rebase_media_sequence(sequence, 1);
+    EXPECT_EQ(sequence, (std::vector<size_t>{0})) << "rebased onto this turn's single-element list";
+}
+
+// ------------------------------------------------- known gap, pinned rather than fixed
+
+// Under-tagging drops the unreferenced item silently, because verify_ids only checks the indices
+// present. Shared by every modality, so pinned rather than fixed — tightening it needs its own ticket.
+TEST(MediaTagNormalization, UnderTaggingSilentlyDropsMediaForEveryModality) {
+    // Two audios supplied, only index 0 referenced (twice). Audio 1 is dropped without error.
+    const auto audio = normalize_audio("<ov_genai_audio_0> and <ov_genai_audio_0>", 0, 2);
+    EXPECT_EQ(audio.second, (std::vector<size_t>{0, 0})) << "audio 1 is silently absent";
+
+    // Identical for images, which is the point: audio did not introduce this.
+    const std::string img = "<img>";
+    const auto image = normalize_media_tags("<ov_genai_image_0> and <ov_genai_image_0>", img, img, 0, 2,
+                                            ModalityType::IMAGE);
+    EXPECT_EQ(image.second, (std::vector<size_t>{0, 0})) << "image 1 is silently absent";
+
+    // A native tag in the same position DOES enforce the count, so the two schemes differ.
+    EXPECT_THROW(normalize_audio(AUDIO_TAG, 0, 2), ov::Exception);
+}
+
+TEST(MediaTagNormalization, EachModalityResolvesOnlyItsOwnTag) {
+    const std::string img = "<img>";
+    const std::string vid = "<vid>";
+    const auto as_image = normalize_media_tags("<ov_genai_image_0>x", img, img, 0, 1, ModalityType::IMAGE);
+    EXPECT_EQ(as_image.first, img + "x");
+
+    const auto as_video = normalize_media_tags("<ov_genai_video_0>x", vid, vid, 0, 1, ModalityType::VIDEO);
+    EXPECT_EQ(as_video.first, vid + "x");
+
+    // An image tag under VIDEO is inert, so the video prepends instead of substituting.
+    const auto crossed = normalize_media_tags("<ov_genai_image_0>x", vid, vid, 0, 1, ModalityType::VIDEO);
+    EXPECT_EQ(crossed.first, vid + "<ov_genai_image_0>x");
+}

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -32,6 +32,7 @@ import utils.patch_pyav_for_servercore as patch_pyav_for_servercore
 patch_pyav_for_servercore.install_av_stub_module_for_windows()
 
 import inspect
+import json
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
@@ -59,6 +60,7 @@ from openvino_genai import (
     GenerationFinishReason,
     ChatHistory,
     VideoMetadata,
+    VLMDecodedResults,
     draft_model,
 )
 
@@ -78,9 +80,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class VisionType(Enum):
+class ModalityType(Enum):
+    # Values stay UPPERCASE: `.value` is interpolated into parametrize ids, so lowercasing would
+    # rewrite every existing test id and break CI filters and xfail selectors.
     IMAGE = "IMAGE"
     VIDEO = "VIDEO"
+    AUDIO = "AUDIO"
 
 
 @dataclass(frozen=True)
@@ -93,8 +98,12 @@ class VlmModelInfo:
     pipeline: VLMPipeline
     prompt_lookup: bool
 
-    def get_vision_tag(self, vision_type: VisionType) -> Callable[[int], str]:
-        return self.image_tag if vision_type == VisionType.IMAGE else self.video_tag
+    def get_media_tag(self, modality_type: ModalityType) -> Callable[[int], str]:
+        # AUDIO is unreachable here: parametrize_model_with_modality never yields it, and the
+        # audio suites use their own fixture.
+        if modality_type == ModalityType.AUDIO:
+            raise ValueError("VlmModelInfo carries no audio tag; audio suites do not use ov_pipe_model")
+        return self.image_tag if modality_type == ModalityType.IMAGE else self.video_tag
 
 
 def _is_videochat_flash_qwen_model(model_id: str) -> bool:
@@ -796,8 +805,128 @@ def synthetic_video_32x32_tensor(synthetic_video_32x32):
 
 
 @pytest.fixture(scope="module")
+def inverted_video_32x32_tensor(synthetic_video_32x32):
+    """A video that differs from `synthetic_video_32x32_tensor` in every pixel of every frame.
+
+    Ordering tests need two media items whose embeddings cannot coincide; inverting is independent
+    of however a model samples frames, unlike reordering the same frames.
+    """
+    return openvino.Tensor(255 - np.asarray(synthetic_video_32x32))
+
+
+@pytest.fixture(scope="module")
 def handwritten_tensor(pytestconfig: pytest.Config) -> openvino.Tensor:
     return openvino.Tensor(from_cache_or_download(pytestconfig, TEST_IMAGE_URLS['handwritten'], "handwritten.png"))
+
+
+# The tiny CI model's tokenizer lacks the audio tokens, so audio dies in the merge assert; audio
+# tests use a real export instead. `expected_audio_pads` is upstream's formula, not this repo's.
+AUDIO_SAMPLE_RATE = 16000
+AUDIO_TONE_HZ = 440
+
+
+def make_audio(seconds: float) -> openvino.Tensor:
+    """Mono float32 PCM sine tone at 16 kHz — the layout Qwen3-Omni's feature extractor expects."""
+    samples = np.arange(int(AUDIO_SAMPLE_RATE * seconds))
+    return openvino.Tensor(np.sin(2 * np.pi * AUDIO_TONE_HZ * samples / AUDIO_SAMPLE_RATE).astype(np.float32))
+
+
+def expected_audio_pads(num_frames: int, n_window: int = 50, pads_per_chunk: int = 13) -> int:
+    """Upstream processor's audio pad count, in mel frames (100 frames per second at 16 kHz)."""
+    chunk_len = n_window * 2
+    leave = num_frames % chunk_len
+    feat = (leave - 1) // 2 + 1
+    return ((feat - 1) // 2 + 1 - 1) // 2 + 1 + (num_frames // chunk_len) * pads_per_chunk
+
+
+@pytest.fixture(scope="session")
+def audio_05s_tensor() -> openvino.Tensor:
+    return make_audio(0.5)
+
+
+@pytest.fixture(scope="session")
+def audio_1s_tensor() -> openvino.Tensor:
+    return make_audio(1.0)
+
+
+@pytest.fixture(scope="session")
+def audio_2s_tensor() -> openvino.Tensor:
+    return make_audio(2.0)
+
+
+def test_expected_audio_pads_formula():
+    """Pin the transcribed upstream formula against its published pad counts, with no model loaded."""
+    assert expected_audio_pads(50) == 7
+    assert expected_audio_pads(100) == 13
+    assert expected_audio_pads(200) == 26
+    assert expected_audio_pads(500) == 65
+    assert expected_audio_pads(3000) == 390
+
+
+def genai_audio_pads(num_frames: int, n_window_infer: int) -> int:
+    """Audio pad count this repository actually produces, which is NOT the upstream count.
+
+    audio_encoder.cpp:103-140 chunks the mel spectrogram into windows of ``n_window_infer * 2``
+    frames that advance by only ``n_window_infer``, so interior frames are encoded twice. Each
+    chunk then passes three stride-2 convolutions (audio_encoder.hpp:64-71).
+
+    Diverges from ``expected_audio_pads`` once the audio spans more than one chunk — see the
+    spike note above. Tests assert against this, never against the upstream formula.
+    """
+
+    def conv3(length: int) -> int:
+        for _ in range(3):
+            length = (length + 1) // 2
+        return length
+
+    num_chunks = -(-num_frames // n_window_infer)  # ceil
+    return sum(conv3(min((c + 2) * n_window_infer, num_frames) - c * n_window_infer) for c in range(num_chunks))
+
+
+def audio_frames(seconds: float) -> int:
+    """Mel frames for a duration: Whisper hop_length=160 at 16 kHz gives 100 frames/second."""
+    return int(AUDIO_SAMPLE_RATE * seconds) // 160
+
+
+def test_genai_audio_pads_matches_measured_counts():
+    """Pin the repo's real pad formula against counts measured on a real Qwen3-Omni export.
+
+    Measured on _qwen3omni_dense_ov_cli (n_window_infer=200) against unmodified master. Model-free:
+    this pins the arithmetic, so a regression in the formula is caught without loading anything.
+    """
+    measured = {0.08: 1, 0.16: 2, 0.5: 7, 1.0: 13, 2.0: 25, 4.0: 75}
+    for seconds, pads in measured.items():
+        assert genai_audio_pads(audio_frames(seconds), n_window_infer=200) == pads, (
+            f"formula disagrees with the measured pad count for {seconds}s audio"
+        )
+    # Agrees with upstream only while the audio fits in a single chunk.
+    assert genai_audio_pads(audio_frames(1.0), 200) == expected_audio_pads(audio_frames(1.0))
+    assert genai_audio_pads(audio_frames(4.0), 200) != expected_audio_pads(audio_frames(4.0))
+
+
+# Marked real_models because the CI tiny model cannot run audio at all: its tokenizer has none of
+# the audio tokens, so audio fails on unmodified master. pytest.ini excludes these by default.
+QWEN3_OMNI_OV_MODEL_ENV = "QWEN3_OMNI_OV_MODEL"
+QWEN3_OMNI_OV_MODEL_DEFAULT = "/home/sgonorov/optimum-intel/var/_qwen3omni_dense_ov_cli"
+
+
+@pytest.fixture(scope="session")
+def qwen3_omni_ov_model() -> str:
+    """Path to a real Qwen3-Omni OV export, overridable via $QWEN3_OMNI_OV_MODEL."""
+    path = Path(os.environ.get(QWEN3_OMNI_OV_MODEL_ENV, QWEN3_OMNI_OV_MODEL_DEFAULT))
+    if not (path / "openvino_audio_encoder_model.xml").exists():
+        pytest.skip(f"No Qwen3-Omni export with an audio encoder at {path}; set ${QWEN3_OMNI_OV_MODEL_ENV}")
+    return str(path)
+
+
+@pytest.fixture(scope="session")
+def qwen3_omni_n_window_infer(qwen3_omni_ov_model: str) -> int:
+    """audio_config.n_window_infer of the model under test — drives the expected pad count."""
+    config = json.loads((Path(qwen3_omni_ov_model) / "config.json").read_text())
+    thinker = config.get("thinker_config", config)
+    n_window_infer = thinker.get("audio_config", {}).get("n_window_infer")
+    assert n_window_infer, "audio_config.n_window_infer missing; cannot predict pad counts"
+    return int(n_window_infer)
 
 
 @pytest.fixture(scope="function", params=[
@@ -1841,14 +1970,16 @@ def retry(func, exception_type=AssertionError):
 
 
 def generate(
-    vlm: VLMPipeline, requests: list[tuple[str, list[openvino.Tensor]]], vision_type: VisionType = VisionType.IMAGE
+    vlm: VLMPipeline,
+    requests: list[tuple[str, list[openvino.Tensor]]],
+    modality_type: ModalityType = ModalityType.IMAGE,
 ):
     generation_config = _setup_generation_config(vlm, set_eos_token=False)
     vlm.set_generation_config(generation_config)
     vlm.start_chat()
     answers = [
-        vlm.generate(prompt, **get_vision_inputs_kwargs(visions, vision_type), do_sample=False)
-        for (prompt, visions) in requests
+        vlm.generate(prompt, **get_media_inputs_kwargs(media, modality_type), do_sample=False)
+        for (prompt, media) in requests
     ]
     vlm.finish_chat()
     return answers
@@ -1917,49 +2048,53 @@ else:
     ]
 
 
-def get_vision_inputs_kwargs(visions: list[openvino.Tensor], vision_type: VisionType) -> dict:
-    if vision_type == VisionType.IMAGE:
-        return {"images": visions}
+def get_media_inputs_kwargs(media: list[openvino.Tensor], modality_type: ModalityType) -> dict:
+    if modality_type == ModalityType.IMAGE:
+        return {"images": media}
+    elif modality_type == ModalityType.VIDEO:
+        return {"videos": media}
     else:
-        return {"videos": visions}
+        return {"audios": media}
 
 
-def get_universal_tag(vision_type: VisionType, index: int) -> str:
-    if vision_type == VisionType.IMAGE:
+def get_universal_tag(modality_type: ModalityType, index: int) -> str:
+    if modality_type == ModalityType.IMAGE:
         return f"<ov_genai_image_{index}>"
-    else:
+    elif modality_type == ModalityType.VIDEO:
         return f"<ov_genai_video_{index}>"
+    else:
+        return f"<ov_genai_audio_{index}>"
 
 
-def parametrize_model_with_vision_type(
+def parametrize_model_with_modality(
     items: list[tuple[str, str]] | None = None,
-    xfail: dict[tuple[str, str, VisionType], str] | None = None,  # (model, attn_backend, VisionType) -> reason,
+    xfail: dict[tuple[str, str, ModalityType], str] | None = None,  # (model, attn_backend, ModalityType) -> reason,
 ) -> Callable[[Callable], Generator]:
     if items is None:
         items = MODELS_TO_TAG
 
     xfail = xfail or {}
 
-    # params: items (model and backend) + vision_type
-    params: list[tuple[tuple[str, str], VisionType]] = []
+    # params: items (model and backend) + modality_type
+    params: list[tuple[tuple[str, str], ModalityType]] = []
     ids = []
     for item in items:
 
-        def append_param(item, vision_type):
+        def append_param(item, modality_type):
             model_id, attn_backend = item[0], item[1]
-            ids.append(f"{model_id}/{attn_backend}/{vision_type.value}")
-            reason = xfail.get((model_id, attn_backend, vision_type))
+            ids.append(f"{model_id}/{attn_backend}/{modality_type.value}")
+            reason = xfail.get((model_id, attn_backend, modality_type))
             if reason:
-                params.append(pytest.param(item, vision_type, marks=pytest.mark.xfail(reason=reason)))
+                params.append(pytest.param(item, modality_type, marks=pytest.mark.xfail(reason=reason)))
             else:
-                params.append((item, vision_type))
+                params.append((item, modality_type))
 
-        append_param(item, VisionType.IMAGE)
+        append_param(item, ModalityType.IMAGE)
         if item[0] in VIDEO_MODEL_IDS:
-            append_param(item, VisionType.VIDEO)
+            append_param(item, ModalityType.VIDEO)
 
     return pytest.mark.parametrize(
-        "ov_pipe_model,vision_type",
+        "ov_pipe_model,modality_type",
         params,
         indirect=["ov_pipe_model"],
         ids=ids,
@@ -1967,13 +2102,13 @@ def parametrize_model_with_vision_type(
 
 
 @pytest.mark.transformers_dependent(reason="CSV-186059")
-@parametrize_model_with_vision_type(
+@parametrize_model_with_modality(
     TAG_INSERTED_BY_TEMPLATE,
-    xfail={("optimum-intel-internal-testing/tiny-random-llava", "PA", VisionType.IMAGE): "CVS-179090"},
+    xfail={("optimum-intel-internal-testing/tiny-random-llava", "PA", ModalityType.IMAGE): "CVS-179090"},
 )
 def test_model_tags_representation(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
@@ -1987,7 +2122,7 @@ def test_model_tags_representation(
     model_cached = snapshot_download(model_id)  # required to avoid HF rate limits
     if model_id == "qnguyen3/nanoLLaVA":
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
-        messages = [{"role": "user", "content": f"{ov_pipe_model.get_vision_tag(vision_type)(0)}{prompt}"}]
+        messages = [{"role": "user", "content": f"{ov_pipe_model.get_media_tag(modality_type)(0)}{prompt}"}]
         templated_prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
     else:
         processor = retry_request(
@@ -2001,7 +2136,7 @@ def test_model_tags_representation(
             {
                 "role": "user",
                 "content": [
-                    {"type": "image" if vision_type == VisionType.IMAGE else "video"},
+                    {"type": "image" if modality_type == ModalityType.IMAGE else "video"},
                     {"type": "text", "text": prompt},
                 ],
             }
@@ -2009,15 +2144,15 @@ def test_model_tags_representation(
         templated_prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
 
     input_tensor: openvino.Tensor = request.getfixturevalue(
-        "cat_tensor" if vision_type == VisionType.IMAGE else "synthetic_video_32x32_tensor"
+        "cat_tensor" if modality_type == ModalityType.IMAGE else "synthetic_video_32x32_tensor"
     )
-    vision_inputs_kwargs = get_vision_inputs_kwargs([input_tensor], vision_type)
+    media_inputs_kwargs = get_media_inputs_kwargs([input_tensor], modality_type)
 
     def workaround_inconsistent_inference():
         __tracebackhide__ = True
-        automatic_tags = ov_pipe.generate(prompt, **vision_inputs_kwargs, do_sample=False)
+        automatic_tags = ov_pipe.generate(prompt, **media_inputs_kwargs, do_sample=False)
         reference_tags = ov_pipe.generate(
-            templated_prompt, **vision_inputs_kwargs, apply_chat_template=False, do_sample=False
+            templated_prompt, **media_inputs_kwargs, apply_chat_template=False, do_sample=False
         )
         assert automatic_tags.texts == reference_tags.texts
         assert automatic_tags.scores == reference_tags.scores
@@ -2028,34 +2163,34 @@ def test_model_tags_representation(
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava - CVS-186059"
 )
-@parametrize_model_with_vision_type()
+@parametrize_model_with_modality()
 def test_model_tags_prepend_native(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
-    vision_tag = ov_pipe_model.get_vision_tag(vision_type)
+    media_tag = ov_pipe_model.get_media_tag(modality_type)
 
     conversation_requests = request.getfixturevalue(
-        "conversation_requests" if vision_type == VisionType.IMAGE else "conversation_video_requests"
+        "conversation_requests" if modality_type == ModalityType.IMAGE else "conversation_video_requests"
     )
 
     def workaround_inconsistent_inference():
         __tracebackhide__ = True
-        answers = generate(ov_pipe, conversation_requests, vision_type)
+        answers = generate(ov_pipe, conversation_requests, modality_type)
 
         ov_pipe.start_chat()
         native_tag0 = ov_pipe.generate(
-            vision_tag(0) + conversation_requests[0][0],
-            **get_vision_inputs_kwargs(conversation_requests[0][1], vision_type),
+            media_tag(0) + conversation_requests[0][0],
+            **get_media_inputs_kwargs(conversation_requests[0][1], modality_type),
             do_sample=False,
         )
         assert native_tag0.texts == answers[0].texts
         assert native_tag0.scores == answers[0].scores
         native_tags1 = ov_pipe.generate(
-            vision_tag(1) + vision_tag(2) + conversation_requests[1][0],
-            **get_vision_inputs_kwargs(conversation_requests[1][1], vision_type),
+            media_tag(1) + media_tag(2) + conversation_requests[1][0],
+            **get_media_inputs_kwargs(conversation_requests[1][1], modality_type),
             do_sample=False,
         )
         assert native_tags1.texts == answers[1].texts
@@ -2068,33 +2203,33 @@ def test_model_tags_prepend_native(
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava - CVS-186059"
 )
-@parametrize_model_with_vision_type()
+@parametrize_model_with_modality()
 def test_model_tags_prepend_universal(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
 
     conversation_requests = request.getfixturevalue(
-        "conversation_requests" if vision_type == VisionType.IMAGE else "conversation_video_requests"
+        "conversation_requests" if modality_type == ModalityType.IMAGE else "conversation_video_requests"
     )
 
     def workaround_inconsistent_inference():
         __tracebackhide__ = True
-        answers = generate(ov_pipe, conversation_requests, vision_type)
+        answers = generate(ov_pipe, conversation_requests, modality_type)
 
         ov_pipe.start_chat()
         universal_tag0 = ov_pipe.generate(
-            get_universal_tag(vision_type, 0) + conversation_requests[0][0],
-            **get_vision_inputs_kwargs(conversation_requests[0][1], vision_type),
+            get_universal_tag(modality_type, 0) + conversation_requests[0][0],
+            **get_media_inputs_kwargs(conversation_requests[0][1], modality_type),
             do_sample=False,
         )
         assert universal_tag0.texts == answers[0].texts
         assert universal_tag0.scores == answers[0].scores
         universal_tags1 = ov_pipe.generate(
-            get_universal_tag(vision_type, 1) + get_universal_tag(vision_type, 2) + conversation_requests[1][0],
-            **get_vision_inputs_kwargs(conversation_requests[1][1], vision_type),
+            get_universal_tag(modality_type, 1) + get_universal_tag(modality_type, 2) + conversation_requests[1][0],
+            **get_media_inputs_kwargs(conversation_requests[1][1], modality_type),
             do_sample=False
         )
         assert universal_tags1.texts == answers[1].texts
@@ -2107,17 +2242,17 @@ def test_model_tags_prepend_universal(
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava - CVS-186059"
 )
-@parametrize_model_with_vision_type()
+@parametrize_model_with_modality()
 def test_model_tags_append(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
-    vision_tag = ov_pipe_model.get_vision_tag(vision_type)
+    media_tag = ov_pipe_model.get_media_tag(modality_type)
 
     conversation_requests = request.getfixturevalue(
-        "conversation_requests" if vision_type == VisionType.IMAGE else "conversation_video_requests"
+        "conversation_requests" if modality_type == ModalityType.IMAGE else "conversation_video_requests"
     )
 
     generation_config = _setup_generation_config(ov_pipe, set_eos_token=False)
@@ -2127,28 +2262,28 @@ def test_model_tags_append(
         __tracebackhide__ = True
         ov_pipe.start_chat()
         native_tag0 = ov_pipe.generate(
-            conversation_requests[0][0] + vision_tag(0),
-            **get_vision_inputs_kwargs(conversation_requests[0][1], vision_type),
+            conversation_requests[0][0] + media_tag(0),
+            **get_media_inputs_kwargs(conversation_requests[0][1], modality_type),
             do_sample=False,
         )
         native_tags1 = ov_pipe.generate(
-            conversation_requests[1][0] + vision_tag(1) + vision_tag(2),
-            **get_vision_inputs_kwargs(conversation_requests[1][1], vision_type),
+            conversation_requests[1][0] + media_tag(1) + media_tag(2),
+            **get_media_inputs_kwargs(conversation_requests[1][1], modality_type),
             do_sample=False,
         )
         ov_pipe.finish_chat()
 
         ov_pipe.start_chat()
         universal_tag0 = ov_pipe.generate(
-            conversation_requests[0][0] + get_universal_tag(vision_type, 0),
-            **get_vision_inputs_kwargs(conversation_requests[0][1], vision_type),
+            conversation_requests[0][0] + get_universal_tag(modality_type, 0),
+            **get_media_inputs_kwargs(conversation_requests[0][1], modality_type),
             do_sample=False,
         )
         assert universal_tag0.texts == native_tag0.texts
         assert universal_tag0.scores == native_tag0.scores
         universal_tags1 = ov_pipe.generate(
-            conversation_requests[1][0] + get_universal_tag(vision_type, 1) + get_universal_tag(vision_type, 2),
-            **get_vision_inputs_kwargs(conversation_requests[1][1], vision_type),
+            conversation_requests[1][0] + get_universal_tag(modality_type, 1) + get_universal_tag(modality_type, 2),
+            **get_media_inputs_kwargs(conversation_requests[1][1], modality_type),
             do_sample=False
         )
         assert universal_tags1.texts == native_tags1.texts
@@ -2161,10 +2296,10 @@ def test_model_tags_append(
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
 )
-@parametrize_model_with_vision_type(IMAGE_ID_IGNORANT_MODELS_TO_TAG)
+@parametrize_model_with_modality(IMAGE_ID_IGNORANT_MODELS_TO_TAG)
 def test_model_tags_same_reference(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
@@ -2173,19 +2308,19 @@ def test_model_tags_same_reference(
     ov_pipe.set_generation_config(generation_config)
 
     input_tensor: openvino.Tensor = request.getfixturevalue(
-        "cat_tensor" if vision_type == VisionType.IMAGE else "synthetic_video_32x32_tensor"
+        "cat_tensor" if modality_type == ModalityType.IMAGE else "synthetic_video_32x32_tensor"
     )
 
     def workaround_inconsistent_inference():
         __tracebackhide__ = True
         one_input = ov_pipe.generate(
-            get_universal_tag(vision_type, 0) * 2,
-            **get_vision_inputs_kwargs([input_tensor], vision_type),
+            get_universal_tag(modality_type, 0) * 2,
+            **get_media_inputs_kwargs([input_tensor], modality_type),
             do_sample=False,
         )
         two_inputs = ov_pipe.generate(
-            get_universal_tag(vision_type, 0) + get_universal_tag(vision_type, 1),
-            **get_vision_inputs_kwargs([input_tensor] * 2, vision_type),
+            get_universal_tag(modality_type, 0) + get_universal_tag(modality_type, 1),
+            **get_media_inputs_kwargs([input_tensor] * 2, modality_type),
             do_sample=False,
         )
         assert one_input.texts == two_inputs.texts
@@ -2197,48 +2332,178 @@ def test_model_tags_same_reference(
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
 )
-@parametrize_model_with_vision_type()
+@parametrize_model_with_modality()
 def test_model_tags_older(
     ov_pipe_model: VlmModelInfo,
-    vision_type: VisionType,
+    modality_type: ModalityType,
     request: pytest.FixtureRequest,
 ):
     ov_pipe = ov_pipe_model.pipeline
 
     input_tensor: openvino.Tensor = request.getfixturevalue(
-        "car_tensor" if vision_type == VisionType.IMAGE else "synthetic_video_32x32_tensor"
+        "car_tensor" if modality_type == ModalityType.IMAGE else "synthetic_video_32x32_tensor"
     )
 
     generation_config = _setup_generation_config(ov_pipe, set_eos_token=False)
     ov_pipe.set_generation_config(generation_config)
     ov_pipe.start_chat()
-    ov_pipe.generate("", **get_vision_inputs_kwargs([input_tensor], vision_type))
+    ov_pipe.generate("", **get_media_inputs_kwargs([input_tensor], modality_type))
     with pytest.raises(RuntimeError):
-        ov_pipe.generate(get_universal_tag(vision_type, 0), **get_vision_inputs_kwargs([input_tensor], vision_type))
+        ov_pipe.generate(get_universal_tag(modality_type, 0), **get_media_inputs_kwargs([input_tensor], modality_type))
     ov_pipe.finish_chat()
 
 
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
 )
-@parametrize_model_with_vision_type()
-def test_model_tags_missing_universal(ov_pipe_model: VlmModelInfo, vision_type: VisionType):
+@parametrize_model_with_modality()
+def test_model_tags_missing_universal(ov_pipe_model: VlmModelInfo, modality_type: ModalityType):
     ov_pipe = ov_pipe_model.pipeline
 
     with pytest.raises(RuntimeError):
-        ov_pipe.generate(get_universal_tag(vision_type, 0))
+        ov_pipe.generate(get_universal_tag(modality_type, 0))
 
 
 @pytest.mark.transformers_dependent(
     "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
 )
-@parametrize_model_with_vision_type()
-def test_model_tags_missing_native(ov_pipe_model: VlmModelInfo, vision_type: VisionType):
+@parametrize_model_with_modality()
+def test_model_tags_missing_native(ov_pipe_model: VlmModelInfo, modality_type: ModalityType):
     ov_pipe = ov_pipe_model.pipeline
-    vision_tag = ov_pipe_model.get_vision_tag(vision_type)
+    media_tag = ov_pipe_model.get_media_tag(modality_type)
 
     with pytest.raises(RuntimeError):
-        ov_pipe.generate(vision_tag(0))
+        ov_pipe.generate(media_tag(0))
+
+
+# A tag with text on both sides is where per-model expansion-offset bugs surface: LLaVA keeps a
+# running position, Qwen2-VL restarts `find` from zero (qwen2vl/classes.cpp:1092).
+INTERLEAVED_MAX_NEW_TOKENS = 20
+
+
+def _interleaved_media_pair(modality_type: ModalityType, request: pytest.FixtureRequest) -> list[openvino.Tensor]:
+    """Two media items of `modality_type` that are guaranteed to differ from each other."""
+    if modality_type == ModalityType.IMAGE:
+        names = ("cat_tensor", "car_tensor")
+    else:
+        names = ("synthetic_video_32x32_tensor", "inverted_video_32x32_tensor")
+    return [request.getfixturevalue(name) for name in names]
+
+
+def _setup_interleaved_config(ov_pipe: VLMPipeline) -> None:
+    generation_config = _setup_generation_config(
+        ov_pipe,
+        max_new_tokens=INTERLEAVED_MAX_NEW_TOKENS,
+        ignore_eos=True,
+        set_eos_token=False,
+        do_sample=False,
+    )
+    ov_pipe.set_generation_config(generation_config)
+
+
+@pytest.mark.transformers_dependent(
+    "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
+)
+@parametrize_model_with_modality()
+def test_tags_interleaved_universal(
+    ov_pipe_model: VlmModelInfo,
+    modality_type: ModalityType,
+    request: pytest.FixtureRequest,
+):
+    """A universal tag between two text segments must resolve exactly like the native tag there."""
+    ov_pipe = ov_pipe_model.pipeline
+    media_tag = ov_pipe_model.get_media_tag(modality_type)
+    _setup_interleaved_config(ov_pipe)
+
+    input_tensor = _interleaved_media_pair(modality_type, request)[0]
+    media_kwargs = get_media_inputs_kwargs([input_tensor], modality_type)
+
+    def workaround_inconsistent_inference():
+        __tracebackhide__ = True
+        universal = ov_pipe.generate(
+            "Look at this " + get_universal_tag(modality_type, 0) + " and describe it",
+            **media_kwargs,
+            do_sample=False,
+        )
+        native = ov_pipe.generate(
+            "Look at this " + media_tag(0) + " and describe it",
+            **media_kwargs,
+            do_sample=False,
+        )
+        assert universal.texts[0] == native.texts[0]
+
+    retry(workaround_inconsistent_inference)
+
+
+@pytest.mark.transformers_dependent(
+    "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
+)
+@parametrize_model_with_modality()
+def test_tags_interleaved_two_universal(
+    ov_pipe_model: VlmModelInfo,
+    modality_type: ModalityType,
+    request: pytest.FixtureRequest,
+):
+    """Two universal tags, each surrounded by text, must resolve exactly like the native tags."""
+    ov_pipe = ov_pipe_model.pipeline
+    media_tag = ov_pipe_model.get_media_tag(modality_type)
+    _setup_interleaved_config(ov_pipe)
+
+    media_kwargs = get_media_inputs_kwargs(_interleaved_media_pair(modality_type, request), modality_type)
+
+    def workaround_inconsistent_inference():
+        __tracebackhide__ = True
+        universal = ov_pipe.generate(
+            "First " + get_universal_tag(modality_type, 0) + " then " + get_universal_tag(modality_type, 1) + " done",
+            **media_kwargs,
+            do_sample=False,
+        )
+        native = ov_pipe.generate(
+            "First " + media_tag(0) + " then " + media_tag(1) + " done",
+            **media_kwargs,
+            do_sample=False,
+        )
+        assert universal.texts[0] == native.texts[0]
+
+    retry(workaround_inconsistent_inference)
+
+
+@pytest.mark.transformers_dependent(
+    "minicpmv, internvl_chat is not supported by transformers>=v5; gemma3, llava-next, llava, qwen3_vl - CVS-186059"
+)
+@parametrize_model_with_modality()
+def test_tags_interleaved_reversed_order(
+    ov_pipe_model: VlmModelInfo,
+    modality_type: ModalityType,
+    request: pytest.FixtureRequest,
+):
+    """Swapping the two universal indices must swap where the media land, not be normalized away.
+
+    The two media items differ, so a pipeline that binds by tag position instead of by tag index
+    produces the forward-order output for the reversed-order prompt.
+    """
+    ov_pipe = ov_pipe_model.pipeline
+    _setup_interleaved_config(ov_pipe)
+
+    media_kwargs = get_media_inputs_kwargs(_interleaved_media_pair(modality_type, request), modality_type)
+
+    forward_prompt = (
+        "First " + get_universal_tag(modality_type, 0) + " then " + get_universal_tag(modality_type, 1) + " done"
+    )
+    reversed_prompt = (
+        "First " + get_universal_tag(modality_type, 1) + " then " + get_universal_tag(modality_type, 0) + " done"
+    )
+
+    # Check reproducibility first: a flaky run would satisfy the inequality below for reasons
+    # unrelated to tag order, and the test would pass while proving nothing.
+    forward = ov_pipe.generate(forward_prompt, **media_kwargs, do_sample=False)
+    forward_again = ov_pipe.generate(forward_prompt, **media_kwargs, do_sample=False)
+    if forward.texts[0] != forward_again.texts[0]:
+        pytest.skip("model output is not reproducible run-to-run; the inequality below would be meaningless")
+
+    reversed_order = ov_pipe.generate(reversed_prompt, **media_kwargs, do_sample=False)
+
+    assert reversed_order.texts[0] != forward.texts[0]
 
 
 def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):
@@ -3420,3 +3685,809 @@ def test_qwen3_omni_vision_preprocess_modes_equivalence(cat_tensor):
         f"CPP:          '{results['CPP']}'\n"
         f"OV_REARRANGE: '{results['OV_REARRANGE']}'"
     )
+
+
+# ----------------------------------------------------------------------------------------------
+# T-C: audio placement on the prompt path. Token assertions are same-skeleton differentials: two
+# runs, byte-identical prompt, only the tensor differs. Deleting a tag is not a valid baseline.
+#
+# Token counts are blind to where an expansion landed, so each placement test is paired with a
+# native-tag equivalence test. Pad counts come from genai_audio_pads, never the upstream formula.
+AUDIO_MAX_NEW_TOKENS = 20
+
+# Index-independent by design: every audio uses the same triple, ordering is positional. This is
+# the real export's tag; the tiny CI model has none of these tokens.
+NATIVE_AUDIO_TAG = "<|audio_start|><|audio_pad|><|audio_end|>"
+
+# The minimum-contribution control: short enough that the encoder emits exactly one pad, so
+# `<|audio_start|><|audio_pad|><|audio_end|>` expands to a string identical to the native tag.
+# That is the input a `find`-from-zero expansion loop mis-handles (plan R8).
+ONE_PAD_AUDIO_SECONDS = 0.08
+
+
+def audio_generation_config() -> GenerationConfig:
+    """Greedy, fixed length — deterministic O1 so two formulations can be compared textually."""
+    return GenerationConfig(max_new_tokens=AUDIO_MAX_NEW_TOKENS, do_sample=False, ignore_eos=True)
+
+
+def audio_tag(index: int) -> str:
+    return get_universal_tag(ModalityType.AUDIO, index)
+
+
+def pads(seconds: float, n_window_infer: int) -> int:
+    return genai_audio_pads(audio_frames(seconds), n_window_infer)
+
+
+@pytest.fixture(scope="session")
+def audio_8s_tensor() -> openvino.Tensor:
+    return make_audio(8.0)
+
+
+@pytest.fixture(scope="session")
+def audio_1pad_tensor() -> openvino.Tensor:
+    return make_audio(ONE_PAD_AUDIO_SECONDS)
+
+
+@pytest.fixture(scope="session")
+def audio_empty_tensor() -> openvino.Tensor:
+    return openvino.Tensor(np.zeros(0, dtype=np.float32))
+
+
+@pytest.fixture(scope="session")
+def qwen3_omni_pipe_pa(qwen3_omni_ov_model: str) -> VLMPipeline:
+    return VLMPipeline(qwen3_omni_ov_model, "CPU", ATTENTION_BACKEND="PA")
+
+
+# Qwen3-Omni derives its embedder from Qwen3VL and inherits the qwen3-vl SDPA embedding-count
+# defect: SDPA fails on a text-only prompt with no audio involved. The qwen3-vl gate above does
+# not string-match qwen3-omni. Non-strict so a real audio regression cannot hide behind the xfail.
+#
+# Measured, not assumed: the SDPA prompt path fails, but its ChatHistory path works for video
+# (see the ungated video-only control). An XPASS here means the audio drop was the real cause.
+QWEN3_OMNI_SDPA_XFAIL_REASON = (
+    "qwen3-omni inherits the qwen3-vl SDPA embedding-count defect; the SDPA prompt path fails on "
+    "unmodified master with no audio involved. Flips to XPASS if audio wiring was the real cause"
+)
+qwen3_omni_sdpa_xfail = pytest.mark.xfail(reason=QWEN3_OMNI_SDPA_XFAIL_REASON, strict=False)
+
+
+@pytest.fixture(scope="session")
+def qwen3_omni_pipe_sdpa(qwen3_omni_ov_model: str) -> VLMPipeline:
+    return VLMPipeline(qwen3_omni_ov_model, "CPU", ATTENTION_BACKEND="SDPA")
+
+
+def audio_run(pipe: VLMPipeline, prompt: str, audios: list[openvino.Tensor]) -> VLMDecodedResults:
+    return pipe.generate(prompt, audios=audios, generation_config=audio_generation_config())
+
+
+def num_input_tokens(results: VLMDecodedResults) -> int:
+    # A method, not a property: `perf_metrics.num_input_tokens` raises AttributeError.
+    return results.perf_metrics.get_num_input_tokens()
+
+
+def audio_encodings(results: VLMDecodedResults) -> int:
+    return len(results.perf_metrics.vlm_raw_metrics.audio_encoding_durations)
+
+
+def assert_pad_delta(hi: VLMDecodedResults, lo: VLMDecodedResults, expected_delta: int, what: str) -> None:
+    __tracebackhide__ = True
+    actual = num_input_tokens(hi) - num_input_tokens(lo)
+    assert actual == expected_delta, (
+        f"{what}: expected the token count to grow by {expected_delta} when only the audio tensor "
+        f"changes under a byte-identical prompt, got {actual} "
+        f"(hi={num_input_tokens(hi)}, lo={num_input_tokens(lo)})"
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_prepend_equals_explicit_tag_at_front(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """The no-tag default must be exactly the same prompt as an explicit tag at the front.
+
+    This is the in-repo form of the prepend-compatibility gate: it needs no committed golden and
+    no absolute token count, because the two formulations must normalize to the same prompt.
+    """
+    implicit = audio_run(qwen3_omni_pipe_pa, "Describe", [audio_1s_tensor])
+    explicit = audio_run(qwen3_omni_pipe_pa, audio_tag(0) + "Describe", [audio_1s_tensor])
+
+    assert implicit.texts == explicit.texts
+    assert num_input_tokens(implicit) == num_input_tokens(explicit)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_universal_append(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """A trailing tag must consume its own audio: the pad budget tracks the tensor's duration."""
+    prompt = "Describe this: " + audio_tag(0)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_2s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "appended audio tag",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_universal_append_matches_native_tag(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """A trailing universal tag must resolve to the native tag in the same position.
+
+    The paired placement half of `test_audio_universal_append`: token counts alone cannot see
+    which span an audio landed in, but two spellings of the same skeleton can only agree if the
+    universal tag was consumed at its own position instead of being left as literal text.
+    """
+    universal = audio_run(qwen3_omni_pipe_pa, "Describe this: " + audio_tag(0), [audio_1s_tensor])
+    native = audio_run(qwen3_omni_pipe_pa, "Describe this: " + NATIVE_AUDIO_TAG, [audio_1s_tensor])
+
+    assert universal.texts == native.texts
+    assert num_input_tokens(universal) == num_input_tokens(native)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_universal_interleaved(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """A tag surrounded by text on both sides must consume its audio there."""
+    prompt = "text " + audio_tag(0) + " more text"
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_2s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "interleaved audio tag",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_universal_interleaved_matches_native_tag(
+    qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor
+):
+    """An interleaved universal tag must resolve to the native tag in the same position."""
+    universal = audio_run(qwen3_omni_pipe_pa, "text " + audio_tag(0) + " more text", [audio_1s_tensor])
+    native = audio_run(qwen3_omni_pipe_pa, "text " + NATIVE_AUDIO_TAG + " more text", [audio_1s_tensor])
+
+    assert universal.texts == native.texts
+    assert num_input_tokens(universal) == num_input_tokens(native)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_two_distinct_indices(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """The second tag's span is sized by the second tensor, not by a shared aggregate."""
+    prompt = "A " + audio_tag(0) + " B " + audio_tag(1)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor, audio_2s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor, audio_1s_tensor])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "second of two audio tags",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_two_universal_tags_match_native_tags(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Two universal tags must resolve to two native tags in the same two positions.
+
+    The placement half of `test_audio_two_distinct_indices`: pad totals are conserved when an
+    expansion lands in the wrong span, so only comparing two spellings of the same skeleton can
+    show that each tag was consumed where it stands.
+    """
+    audios = [audio_1s_tensor, audio_2s_tensor]
+    universal = audio_run(qwen3_omni_pipe_pa, "A " + audio_tag(0) + " B " + audio_tag(1), audios)
+    native = audio_run(qwen3_omni_pipe_pa, "A " + NATIVE_AUDIO_TAG + " B " + NATIVE_AUDIO_TAG, audios)
+
+    assert universal.texts == native.texts
+    assert num_input_tokens(universal) == num_input_tokens(native)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_two_indices_order_matters(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Swapping the two indices must swap which audio lands in which run.
+
+    Both orders must run without raising, and the totals must match. Completing at all is the
+    load-bearing part: the runs are 13 and 25 pads long, so a merge that bound in document order
+    instead of by index would try to copy the 13-token audio into the 25-token run and trip the
+    run-length assert in merge_audio_embeddings(). Deterministic proof that the sequence itself
+    reverses lives in MediaTagNormalization.ReversedIndicesReverseTheSequenceNotThePositions.
+
+    Deliberately does NOT assert the generated text differs: both fixtures are 440 Hz sine tones,
+    which carry nothing the model can tell apart, so it emits the same greedy continuation for
+    either order. That assertion would be unprovable here rather than merely strict.
+    """
+    audios = [audio_1s_tensor, audio_2s_tensor]
+    forward = audio_run(qwen3_omni_pipe_pa, "A " + audio_tag(0) + " B " + audio_tag(1), audios)
+    swapped = audio_run(qwen3_omni_pipe_pa, "A " + audio_tag(1) + " B " + audio_tag(0), audios)
+
+    assert num_input_tokens(forward) == num_input_tokens(swapped)
+
+    # Same-skeleton differential: byte-identical prompt, only the second tensor's duration changes,
+    # so the token delta must be exactly that audio's pad-count delta.
+    shorter = audio_run(
+        qwen3_omni_pipe_pa, "A " + audio_tag(0) + " B " + audio_tag(1), [audio_1s_tensor, audio_1s_tensor]
+    )
+    delta = pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer)
+    assert_pad_delta(forward, shorter, delta, "second audio's own run grows with its duration")
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_duplicate_index_renders_twice(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Referring to the same audio twice expands both occurrences — the delta doubles."""
+    prompt = audio_tag(0) + " and " + audio_tag(0)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_2s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor])
+
+    expected = 2 * (pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer))
+    assert_pad_delta(hi, lo, expected, "duplicated audio index")
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_sub_second(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_05s_tensor: openvino.Tensor,
+    audio_1s_tensor: openvino.Tensor,
+):
+    """Audio shorter than one encoder chunk still expands to its own pad count."""
+    prompt = "Describe " + audio_tag(0)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_05s_tensor])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(1.0, qwen3_omni_n_window_infer) - pads(0.5, qwen3_omni_n_window_infer),
+        "sub-second audio",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_one_pad_audio_still_expands(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1pad_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """An audio worth exactly one pad must not swallow the following tag's expansion.
+
+    A one-pad expansion leaves the native tag byte-identical to its unexpanded form, so an
+    expansion loop that restarts its search from position zero writes the second audio's pads into
+    the first tag's slot. O2 only sees that the second audio expanded at all; which span it landed
+    in is pinned by the C++ `ExpandAudioTags` cases.
+    """
+    assert pads(ONE_PAD_AUDIO_SECONDS, qwen3_omni_n_window_infer) == 1, (
+        "the one-pad control no longer yields a single pad on this model"
+    )
+    prompt = "A " + audio_tag(0) + " B " + audio_tag(1)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1pad_tensor, audio_2s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1pad_tensor, audio_1pad_tensor])
+
+    assert_pad_delta(hi, lo, pads(2.0, qwen3_omni_n_window_infer) - 1, "one-pad audio")
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_empty_list_adds_no_pads(qwen3_omni_pipe_pa: VLMPipeline):
+    """An empty `audios` list with no tag must be indistinguishable from passing no audio at all."""
+    with_empty_list = audio_run(qwen3_omni_pipe_pa, "Describe", [])
+    without_argument = qwen3_omni_pipe_pa.generate("Describe", generation_config=audio_generation_config())
+
+    assert num_input_tokens(with_empty_list) == num_input_tokens(without_argument)
+    assert audio_encodings(with_empty_list) == 0
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_empty_tensor_keeps_its_index(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_empty_tensor: openvino.Tensor,
+):
+    """An empty audio contributes zero pads while still occupying its own index.
+
+    If the empty entry were dropped from the list instead, the second tag would bind to the first
+    tensor and the delta would collapse to zero.
+    """
+    prompt = "A " + audio_tag(0) + " B " + audio_tag(1)
+    hi = audio_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor, audio_1s_tensor])
+    lo = audio_run(qwen3_omni_pipe_pa, prompt, [audio_empty_tensor, audio_1s_tensor])
+
+    assert_pad_delta(hi, lo, pads(1.0, qwen3_omni_n_window_infer), "empty audio tensor")
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_tag_without_any_audio_rejected(qwen3_omni_pipe_pa: VLMPipeline):
+    with pytest.raises(RuntimeError, match="Missing image/video/audio with index 0"):
+        audio_run(qwen3_omni_pipe_pa, audio_tag(0), [])
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_index_out_of_range_rejected(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    with pytest.raises(RuntimeError, match="Missing image/video/audio with index 5"):
+        audio_run(qwen3_omni_pipe_pa, audio_tag(5), [audio_1s_tensor])
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_mixed_universal_and_native_rejected(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    with pytest.raises(RuntimeError, match="Prompt cannot mix universal tags"):
+        audio_run(qwen3_omni_pipe_pa, NATIVE_AUDIO_TAG + audio_tag(0), [audio_1s_tensor])
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_native_tag_count_mismatch_rejected(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    with pytest.raises(RuntimeError, match="The number of native media tags must match"):
+        audio_run(qwen3_omni_pipe_pa, NATIVE_AUDIO_TAG * 2, [audio_1s_tensor])
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_rejected_by_non_audio_model(audio_1s_tensor: openvino.Tensor):
+    """A model without an audio tower must say so instead of failing deep in the encoder."""
+    # This export is not covered by _maybe_skip_unsupported_model_export, so a version mismatch
+    # arrives as a ValueError. An unavailable control model says nothing about the guard.
+    try:
+        models_path = _get_ov_model("optimum-intel-internal-testing/tiny-random-qwen3-vl")
+    except ValueError as export_error:
+        pytest.skip(f"tiny-random-qwen3-vl cannot be exported here: {export_error}")
+    pipe = VLMPipeline(models_path, "CPU", ATTENTION_BACKEND="PA")
+
+    with pytest.raises(RuntimeError, match="Audio input isn't supported by this model"):
+        audio_run(pipe, "Describe", [audio_1s_tensor])
+
+
+# ----------------------------------------------------------------------------------------------
+# T-D: audio across chat turns, multipart messages, and the encoder cache. Where turn 1 differs
+# between runs, its generated reply enters turn 2 and cannot be predicted exactly.
+STALE_TURN_MAX_NEW_TOKENS = 1
+
+
+def audio_conversation(
+    pipe: VLMPipeline,
+    turns: list[tuple[str, list[openvino.Tensor]]],
+    max_new_tokens: int = AUDIO_MAX_NEW_TOKENS,
+) -> list:
+    """Run a multi-turn chat, always leaving chat mode even if a turn raises."""
+    config = GenerationConfig(max_new_tokens=max_new_tokens, do_sample=False, ignore_eos=True)
+    pipe.start_chat()
+    try:
+        return [pipe.generate(prompt, audios=audios, generation_config=config) for prompt, audios in turns]
+    finally:
+        pipe.finish_chat()
+
+
+def audio_history_run(pipe: VLMPipeline, messages: list[dict], audios: list[openvino.Tensor]):
+    """One `generate` call over an explicit history — no generated reply to confound the counts."""
+    history = ChatHistory()
+    for message in messages:
+        history.append(message)
+    return pipe.generate(history, audios=audios, generation_config=audio_generation_config())
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_stale_across_turns(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_8s_tensor: openvino.Tensor,
+):
+    """Turn 1's audio must be counted once, not re-attached to turn 2.
+
+    Both conversations use byte-identical prompts on both turns; only turn 1's tensor differs. Turn
+    2 therefore differs by turn 1's pad count exactly once. If turn 1's audio leaks into turn 2 the
+    difference doubles — two orders of magnitude outside the tolerance below.
+
+    The +-2 band absorbs the single generated token that turn 1 contributes to turn 2's history,
+    which differs between the two conversations because their audio differs.
+    """
+    short_pads = pads(1.0, qwen3_omni_n_window_infer)
+    long_pads = pads(8.0, qwen3_omni_n_window_infer)
+
+    def turns(audio: openvino.Tensor) -> list[tuple[str, list[openvino.Tensor]]]:
+        return [("Describe " + audio_tag(0), [audio]), ("And now?", [])]
+
+    with_short = audio_conversation(
+        qwen3_omni_pipe_pa, turns(audio_1s_tensor), max_new_tokens=STALE_TURN_MAX_NEW_TOKENS
+    )
+    with_long = audio_conversation(qwen3_omni_pipe_pa, turns(audio_8s_tensor), max_new_tokens=STALE_TURN_MAX_NEW_TOKENS)
+
+    measured = num_input_tokens(with_short[1]) - num_input_tokens(with_long[1])
+    expected = short_pads - long_pads
+    assert abs(measured - expected) <= 2, (
+        f"turn 2 differs by {measured} tokens, expected {expected} +-2. A difference near "
+        f"{2 * expected} means turn 1's audio was counted again on turn 2."
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_binds_only_to_its_message(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """An audio tagged in one user message must expand in that message only, not in every one.
+
+    The pre-fix code held audio on the embedder and prepended a block to each user message it
+    normalized, so a history with two user messages got the audio twice. The delta below is one
+    audio's worth; two would be double.
+
+    The tag sits in the LAST user message because that is where call-time media attaches, for
+    every modality — `fill_messages_metadata` assigns `provided_*_indices` to
+    `get_last_user_message_index()`. Tagging an earlier message in a single call refers to media
+    that was never registered for it, and `verify_ids` rejects it. Earlier messages carry their own
+    media only when the history was built up across turns, which
+    `test_audio_stale_across_turns` covers.
+
+    Assistant turns are supplied rather than generated, so no reply text can confound the counts.
+    """
+    messages = [
+        {"role": "user", "content": "First"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Second " + audio_tag(0)},
+    ]
+    hi = audio_history_run(qwen3_omni_pipe_pa, messages, [audio_2s_tensor])
+    lo = audio_history_run(qwen3_omni_pipe_pa, messages, [audio_1s_tensor])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "one audio across a two-user-message history, not one per user message",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_multipart_matches_string_history(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """An `{"type": "audio"}` part must be the same prompt as a universal tag in the same place."""
+    multipart = audio_history_run(
+        qwen3_omni_pipe_pa,
+        [{"role": "user", "content": [{"type": "text", "text": "Describe "}, {"type": "audio"}]}],
+        [audio_1s_tensor],
+    )
+    string_form = audio_history_run(
+        qwen3_omni_pipe_pa,
+        [{"role": "user", "content": "Describe " + audio_tag(0)}],
+        [audio_1s_tensor],
+    )
+
+    assert multipart.texts == string_form.texts
+    assert num_input_tokens(multipart) == num_input_tokens(string_form)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_multipart_audio_first(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """An audio part before the text part must keep that order."""
+    multipart = audio_history_run(
+        qwen3_omni_pipe_pa,
+        [{"role": "user", "content": [{"type": "audio"}, {"type": "text", "text": "Describe"}]}],
+        [audio_1s_tensor],
+    )
+    string_form = audio_history_run(
+        qwen3_omni_pipe_pa,
+        [{"role": "user", "content": audio_tag(0) + "Describe"}],
+        [audio_1s_tensor],
+    )
+
+    assert multipart.texts == string_form.texts
+    assert num_input_tokens(multipart) == num_input_tokens(string_form)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_multipart_unsupported_type_still_throws(
+    qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor
+):
+    """Adding an audio branch to the multipart parser must not swallow the unknown-type fallthrough."""
+    with pytest.raises(RuntimeError, match="Unsupported content type in multipart message: hologram"):
+        audio_history_run(
+            qwen3_omni_pipe_pa,
+            [{"role": "user", "content": [{"type": "text", "text": "Describe "}, {"type": "hologram"}]}],
+            [audio_1s_tensor],
+        )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_identical_tensor_not_reencoded(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """Re-sending the same tensor on a later turn must hit the content-hash cache, not re-encode.
+
+    Uses the ChatHistory overload on one persistent ChatHistory object, because that is where the
+    cache lives: `VLMChatContext` registers media in the `VisionRegistry` and skips encoding on a
+    hash hit. The `start_chat()` + prompt path accumulates `m_history_*` and re-encodes each turn
+    instead — for images and video too, not just audio — and a fresh ChatHistory per call would
+    release the registry refs and drop the entry.
+    """
+    history = ChatHistory()
+    history.append({"role": "user", "content": "Describe " + audio_tag(0)})
+    first = qwen3_omni_pipe_pa.generate(history, audios=[audio_1s_tensor], generation_config=audio_generation_config())
+
+    history.append({"role": "assistant", "content": first.texts[0]})
+    history.append({"role": "user", "content": "And this? " + audio_tag(1)})
+    second = qwen3_omni_pipe_pa.generate(history, audios=[audio_1s_tensor], generation_config=audio_generation_config())
+
+    assert audio_encodings(first) == 1
+    assert audio_encodings(second) == 0, "an identical tensor must be served from the registry cache"
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_different_tensor_is_reencoded(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """The control for the cache-hit test: a new tensor must actually be encoded."""
+    turns = audio_conversation(
+        qwen3_omni_pipe_pa,
+        [
+            ("Describe " + audio_tag(0), [audio_1s_tensor]),
+            ("And this? " + audio_tag(1), [audio_2s_tensor]),
+        ],
+    )
+
+    assert audio_encodings(turns[0]) == 1
+    assert audio_encodings(turns[1]) == 1
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_index_absolute_across_turns(
+    qwen3_omni_pipe_pa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Indices are absolute across turns: turn 2's audio is `<ov_genai_audio_1>`.
+
+    Turn 1 is identical in both conversations — same string, same tensor — so its reply and its
+    pads cancel exactly and no tolerance is needed.
+    """
+
+    def conversation(turn2_audio: openvino.Tensor):
+        return audio_conversation(
+            qwen3_omni_pipe_pa,
+            [
+                ("Describe " + audio_tag(0), [audio_1s_tensor]),
+                ("And now? " + audio_tag(1), [turn2_audio]),
+            ],
+            max_new_tokens=STALE_TURN_MAX_NEW_TOKENS,
+        )
+
+    hi = conversation(audio_2s_tensor)
+    lo = conversation(audio_1s_tensor)
+
+    assert_pad_delta(
+        hi[1],
+        lo[1],
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "audio attached on turn 2 under an absolute index",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+def test_audio_older_turn_reference_rejected(qwen3_omni_pipe_pa: VLMPipeline, audio_1s_tensor: openvino.Tensor):
+    """Referring back to a previous turn's audio is an inherited non-goal, and must say so."""
+    with pytest.raises(RuntimeError, match="Referring to older images/videos/audios is not supported"):
+        audio_conversation(
+            qwen3_omni_pipe_pa,
+            [
+                ("Describe " + audio_tag(0), [audio_1s_tensor]),
+                ("Again " + audio_tag(0), [audio_1s_tensor]),
+            ],
+            max_new_tokens=STALE_TURN_MAX_NEW_TOKENS,
+        )
+
+
+# ----------------------------------------------------------------------------------------------
+# T-E: the SDPA `VLMPipeline` ChatHistory path. Its overload puts `audios` before
+# `videos_metadata`, the opposite of `OmniPipeline`; both are vectors, so a swap compiles silently.
+#
+# Cross-backend checks assert on `texts` only: `num_input_tokens` counts different things on the
+# two backends, so comparing it across them would fail for reasons unrelated to audio.
+
+
+def audio_sdpa_history_run(
+    pipe: VLMPipeline,
+    prompt: str,
+    audios: list[openvino.Tensor],
+    videos: list[openvino.Tensor] | None = None,
+):
+    history = ChatHistory()
+    history.append({"role": "user", "content": prompt})
+    kwargs: dict[str, Any] = {"audios": audios, "generation_config": audio_generation_config()}
+    if videos is not None:
+        kwargs["videos"] = videos
+        kwargs["videos_metadata"] = [VideoMetadata() for _ in videos]
+    return pipe.generate(history, **kwargs)
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+@qwen3_omni_sdpa_xfail
+def test_vlm_chat_history_audio_is_encoded_sdpa(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """The SDPA ChatHistory path must encode audio instead of silently dropping it."""
+    prompt = "Describe " + audio_tag(0)
+    hi = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_2s_tensor])
+    lo = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_1s_tensor])
+
+    assert audio_encodings(hi) == 1
+    assert audio_encodings(lo) == 1
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "audio on the SDPA ChatHistory path",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+@qwen3_omni_sdpa_xfail
+def test_vlm_chat_history_audio_matches_pa_backend(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    qwen3_omni_pipe_pa: VLMPipeline,
+    audio_1s_tensor: openvino.Tensor,
+):
+    """Both backends decode greedily from the same weights, so the same history must yield the
+    same text. A divergence means the two backends built different prompts."""
+    prompt = "Describe " + audio_tag(0)
+    sdpa = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_1s_tensor])
+    pa = audio_sdpa_history_run(qwen3_omni_pipe_pa, prompt, [audio_1s_tensor])
+
+    assert sdpa.texts == pa.texts
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+@qwen3_omni_sdpa_xfail
+def test_vlm_chat_history_audio_only_no_video(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Audio with explicitly empty video arguments must still reach the audio encoder.
+
+    Half of the argument-swap check: routing `audios` into the video slot would send a 1-D waveform
+    through the vision tower and raise a shape error.
+    """
+    prompt = "Describe " + audio_tag(0)
+    hi = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_2s_tensor], videos=[])
+    lo = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_1s_tensor], videos=[])
+
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "audio with explicitly empty videos",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+# Deliberately not xfailed: this passes on SDPA today. It is the control showing video works on
+# that path, so an audio failure there is attributable rather than inherited.
+def test_vlm_chat_history_video_only_no_audio(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    synthetic_video_32x32_tensor: openvino.Tensor,
+):
+    """Video with an empty `audios` list must behave exactly as if `audios` were never passed.
+
+    The other half of the argument-swap check, and the guard that adding audio plumbing to this
+    overload does not perturb the video path.
+    """
+    prompt = "Describe " + get_universal_tag(ModalityType.VIDEO, 0)
+    with_empty_audios = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [], videos=[synthetic_video_32x32_tensor])
+
+    history = ChatHistory()
+    history.append({"role": "user", "content": prompt})
+    without_audios = qwen3_omni_pipe_sdpa.generate(
+        history,
+        videos=[synthetic_video_32x32_tensor],
+        videos_metadata=[VideoMetadata()],
+        generation_config=audio_generation_config(),
+    )
+
+    assert with_empty_audios.texts == without_audios.texts
+    assert audio_encodings(with_empty_audios) == 0
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+@qwen3_omni_sdpa_xfail
+def test_vlm_chat_history_audio_and_video_together(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    qwen3_omni_n_window_infer: int,
+    synthetic_video_32x32_tensor: openvino.Tensor,
+    audio_1s_tensor: openvino.Tensor,
+    audio_2s_tensor: openvino.Tensor,
+):
+    """Audio and video in one message must not mis-count each other.
+
+    The video is identical in both runs, so its pads cancel and only the audio contributes to the
+    delta. Generation *quality* for this combination is a documented limitation (audio pads are
+    positioned as text tokens relative to vision tokens); this test only pins that it runs and
+    counts correctly.
+    """
+    prompt = "Watch " + get_universal_tag(ModalityType.VIDEO, 0) + " and hear " + audio_tag(0)
+    hi = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_2s_tensor], videos=[synthetic_video_32x32_tensor])
+    lo = audio_sdpa_history_run(qwen3_omni_pipe_sdpa, prompt, [audio_1s_tensor], videos=[synthetic_video_32x32_tensor])
+
+    assert audio_encodings(hi) == 1
+    assert audio_encodings(lo) == 1
+    assert_pad_delta(
+        hi,
+        lo,
+        pads(2.0, qwen3_omni_n_window_infer) - pads(1.0, qwen3_omni_n_window_infer),
+        "audio alongside a video",
+    )
+
+
+@pytest.mark.real_models
+@pytest.mark.vlm
+@qwen3_omni_sdpa_xfail
+def test_vlm_prompt_path_audio_unchanged_sdpa(
+    qwen3_omni_pipe_sdpa: VLMPipeline,
+    qwen3_omni_pipe_pa: VLMPipeline,
+    audio_1s_tensor: openvino.Tensor,
+):
+    """Wiring audio into the ChatHistory overload must not regress the prompt overload."""
+    sdpa = audio_run(qwen3_omni_pipe_sdpa, "Describe", [audio_1s_tensor])
+    pa = audio_run(qwen3_omni_pipe_pa, "Describe", [audio_1s_tensor])
+
+    assert sdpa.texts == pa.texts

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -2479,31 +2479,32 @@ def test_tags_interleaved_reversed_order(
 ):
     """Swapping the two universal indices must swap where the media land, not be normalized away.
 
-    The two media items differ, so a pipeline that binds by tag position instead of by tag index
-    produces the forward-order output for the reversed-order prompt.
+    Reversing the tag indices over media [first, second] has to mean the same thing as keeping the
+    tags in order and reversing the media list. A pipeline that binds by tag position instead of by
+    tag index leaves the media where they were, so only the second form swaps them and the two
+    outputs diverge.
     """
     ov_pipe = ov_pipe_model.pipeline
     _setup_interleaved_config(ov_pipe)
 
-    media_kwargs = get_media_inputs_kwargs(_interleaved_media_pair(modality_type, request), modality_type)
+    first, second = _interleaved_media_pair(modality_type, request)
 
-    forward_prompt = (
-        "First " + get_universal_tag(modality_type, 0) + " then " + get_universal_tag(modality_type, 1) + " done"
-    )
-    reversed_prompt = (
-        "First " + get_universal_tag(modality_type, 1) + " then " + get_universal_tag(modality_type, 0) + " done"
-    )
+    def workaround_inconsistent_inference():
+        __tracebackhide__ = True
+        reversed_tags = ov_pipe.generate(
+            "First " + get_universal_tag(modality_type, 1) + " then " + get_universal_tag(modality_type, 0) + " done",
+            **get_media_inputs_kwargs([first, second], modality_type),
+            do_sample=False,
+        )
+        reversed_media = ov_pipe.generate(
+            "First " + get_universal_tag(modality_type, 0) + " then " + get_universal_tag(modality_type, 1) + " done",
+            **get_media_inputs_kwargs([second, first], modality_type),
+            do_sample=False,
+        )
+        assert reversed_tags.texts == reversed_media.texts
+        assert reversed_tags.scores == reversed_media.scores
 
-    # Check reproducibility first: a flaky run would satisfy the inequality below for reasons
-    # unrelated to tag order, and the test would pass while proving nothing.
-    forward = ov_pipe.generate(forward_prompt, **media_kwargs, do_sample=False)
-    forward_again = ov_pipe.generate(forward_prompt, **media_kwargs, do_sample=False)
-    if forward.texts[0] != forward_again.texts[0]:
-        pytest.skip("model output is not reproducible run-to-run; the inequality below would be meaningless")
-
-    reversed_order = ov_pipe.generate(reversed_prompt, **media_kwargs, do_sample=False)
-
-    assert reversed_order.texts[0] != forward.texts[0]
+    retry(workaround_inconsistent_inference)
 
 
 def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):


### PR DESCRIPTION
## Description

`OmniPipeline::generate` accepted audio, but the prompt had no way to say where that audio belonged. Audio could only sit at the start of a conversation. Multi-turn audio chat was impossible.

Audio now works like images and video. `<ov_genai_audio_N>` places audio N anywhere in the prompt. Untagged audio is still prepended. No public API signature changed. One behaviour change: a model with no audio tower now throws on a non-empty `audios` instead of silently dropping it. The feature rides in the prompt string.

- Added `<ov_genai_audio_N>` and routed audio through the shared `normalize_media_tags()`, which brings mixing detection, range checks and the prepend fallback with it. `VisionType` is now `ModalityType` with an `AUDIO` member.
- `encode_audios` is pure and returns one `EncodedAudio` per input. Deleting the `m_audio_embeddings` member fixes two silent bugs: turn 1's audio replaying on turn 2, and one audio binding to every user message in a history.
- The merge binds placeholder run k to `audios_sequence[k]`. Out-of-order tags then place the right audio.
- Audio is registered in `VisionRegistry` / `VLMChatContext`, which keeps an identical tensor on a later ChatHistory turn from being re-encoded. Multipart `{"type": "audio"}` no longer throws.
- Wired through the CB prompt, batch and ChatHistory paths, and both `VLMPipeline` paths. The SDPA ChatHistory path used to drop audio without a word.

Two caveats. The 5 xfails are a pre-existing qwen3-vl/SDPA defect, not audio: SDPA fails there on a text-only prompt. And interleaving audio with video is unvalidated for quality, since audio placeholders sit as text tokens while vision feeds 4D mRoPE; the site docs note this.

CVS-191736

Also closes CVS-193125 and CVS-194080.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing).
- [x] Tests have been updated or added to cover the new code. 33 Python tests in `tests/python_tests/test_vlm_pipeline.py` (27 pass, 1 skip, 5 xfail), 24 model-free C++ tests in `tests/cpp/test_media_tag_normalization.cpp`, and 48 interleaved image/video tests for a case no modality covered before.
- [x] This PR fully addresses the ticket.
- [x] I have made corresponding changes to the documentation. Site docs, the public header, both binding docstrings, and a new `samples/python/omni/audio_placement.py`.
