### PR TITLE
[docs] add z-image, z-image-turbo to the list of supported models

### DIFF
--- a/site/docs/supported-models/_components/image-generation-models-table/models.ts
+++ b/site/docs/supported-models/_components/image-generation-models-table/models.ts
@@ -130,4 +130,15 @@ export const IMAGE_GENERATION_MODELS: ImageGenerationModelType[] = [
       'https://huggingface.co/Qwen/Qwen-Image',
     ],
   },
+  {
+    architecture: 'Z-Image',
+    textToImage: true,
+    imageToImage: true,
+    inpainting: true,
+    loraSupport: true,
+    links: [
+      'https://huggingface.co/Tongyi-MAI/Z-Image',
+      'https://huggingface.co/Tongyi-MAI/Z-Image-Turbo',
+    ],
+  },
 ];

--- a/site/docs/supported-models/_components/image-generation-models-table/models.ts
+++ b/site/docs/supported-models/_components/image-generation-models-table/models.ts
@@ -134,7 +134,7 @@ export const IMAGE_GENERATION_MODELS: ImageGenerationModelType[] = [
     architecture: 'Z-Image',
     textToImage: true,
     imageToImage: true,
-    inpainting: true,
+    inpainting: false,
     loraSupport: true,
     links: [
       'https://huggingface.co/Tongyi-MAI/Z-Image',


### PR DESCRIPTION
## Description
Add ZImage, ZImageTurbo to the list of supported models after https://github.com/openvinotoolkit/openvino.genai/pull/4305 is merged

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-178686 

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] <!-- (or N/A) --> Tests have been updated or added to cover the new code. Tests were added in the enabling PR.
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. 
- [x] <!-- (or N/A) --> I have made corresponding changes to the documentation. 