### PR TITLE
[Dependabot] Add transformers ignore version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,7 +97,7 @@ updates:
       # update transformers version is dependent on optimum-intel for now and required more precise changes in repo
       - dependency-name: "transformers"
         versions:
-          - ">=5.0"
+          - ">=5.6"
       # update required more precise changes in repo and made upon request
       - dependency-name: "optimum-intel"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,8 @@ updates:
       - dependency-name: "huggingface-hub"
       # update transformers version is dependent on optimum-intel for now and required more precise changes in repo
       - dependency-name: "transformers"
+        versions:
+          - ">=5.0"
       # update required more precise changes in repo and made upon request
       - dependency-name: "optimum-intel"
     groups:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

Dependabot is opening PRs on security updates of transformers, despite transformers being in ignore list (we resolve them manually, as it is usually involves dependencies like optimum-intel and might be not trivial). Example of PR: https://github.com/openvinotoolkit/openvino.genai/pull/4433/.

The theory of why it is happening, though I can be wrong:

1. The repository rule has no versions field in .github/dependabot.yml. Security updates use this field to check ignore lists.

2. Dependabot then returns versions as [] for security alerts: https://github.com/dependabot/dependabot-core/blob/091038ad8f69ac6b2b60db5cf3aeede6cab2d9ba/common/lib/dependabot/config/ignore_condition.rb#L42. If it won't be the security update, it'd proceed to the next line and get his ">=0" string, which will block PR creation. 

3. It checks then if the upgraded version is in ignored versions, which it isn't. And checks then if it is == ALL_VERSIONS, which is a literal string ">=0", not comparison? I know it's weird, but I even run it locally to make sure:
```ruby
[].any?(">= 0")
# => false
```
(https://github.com/dependabot/dependabot-core/blob/091038ad8f69ac6b2b60db5cf3aeede6cab2d9ba/updater/lib/dependabot/job.rb#L554-L557),
(https://github.com/dependabot/dependabot-core/blob/091038ad8f69ac6b2b60db5cf3aeede6cab2d9ba/common/lib/dependabot/config/ignore_condition.rb#L16).

4. As it is not ignored, it then return allow_update true: https://github.com/dependabot/dependabot-core/blob/091038ad8f69ac6b2b60db5cf3aeede6cab2d9ba/updater/lib/dependabot/job.rb#L338-L370.

I'm adding the version then, it should block the automatic PRs creation, so we can continue upgrading transformers manually when we are ready for it. Tried to run dependabot gems locally and it seems like it helped.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->