### PR TITLE
[EXPERIMENT][WIP] Add support for LFM2-VL (LiquidAI/LFM2.5-VL-3B)

### DIFF
--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -27,6 +27,7 @@
 #include "visual_language/deepseek_ocr2/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
+#include "visual_language/lfm2_vl/classes.hpp"
 
 #include "continuous_batching/timer.hpp"
 #include "utils.hpp"
@@ -401,6 +402,8 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderDeepseekOCR2>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, model_dir, tokenizer, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::LFM2_VL) {
+        m_impl = std::make_shared<InputsEmbedderLfm2Vl>(vlm_config, model_dir, tokenizer, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }
@@ -453,6 +456,8 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderDeepseekOCR2>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
+    } else if (vlm_config.model_type == VLMModelType::LFM2_VL) {
+        m_impl = std::make_shared<InputsEmbedderLfm2Vl>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM InputsEmbedder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/inputs_embedder.hpp
+++ b/src/cpp/src/visual_language/inputs_embedder.hpp
@@ -405,6 +405,7 @@ private:
     friend class InputsEmbedderDeepseekOCR2;
     friend class InputsEmbedderVideoChatFlashQwen;
     friend class InputsEmbedderMuseGlimmer;
+    friend class InputsEmbedderLfm2Vl;
 };
 
 template <typename Func>

--- a/src/cpp/src/visual_language/lfm2_vl/classes.cpp
+++ b/src/cpp/src/visual_language/lfm2_vl/classes.cpp
@@ -120,8 +120,10 @@ EncodedImage VisionEncoderLfm2Vl::encode(const ov::Tensor& image, const ov::AnyM
     const auto [target_height, target_width] =
         smart_resize(static_cast<size_t>(input_image.ny), static_cast<size_t>(input_image.nx), config);
 
+    // Lfm2VlImageProcessor's saved preprocessor_config.json specifies resample=3 (PILImageResampling.BICUBIC),
+    // overriding the class's BILINEAR default, so the exported checkpoint's actual preprocessing is bicubic.
     clip_image_u8 resized_image;
-    bilinear_resize(input_image, resized_image, static_cast<int>(target_width), static_cast<int>(target_height));
+    bicubic_resize(input_image, resized_image, static_cast<int>(target_width), static_cast<int>(target_height));
 
     const size_t num_patches_height = target_height / config.encoder_patch_size;
     const size_t num_patches_width = target_width / config.encoder_patch_size;

--- a/src/cpp/src/visual_language/lfm2_vl/classes.cpp
+++ b/src/cpp/src/visual_language/lfm2_vl/classes.cpp
@@ -1,0 +1,232 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/lfm2_vl/classes.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "utils.hpp"
+#include "visual_language/clip.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+constexpr size_t NUM_CHANNELS = 3;
+
+size_t round_by_factor(double value, size_t factor) {
+    return static_cast<size_t>(std::llround(value / static_cast<double>(factor))) * factor;
+}
+
+// Mirrors Lfm2VlImageProcessor._is_image_too_large: an image whose smart-resized single-tile patch
+// grid would exceed max_image_tokens (with max_pixels_tolerance headroom) requires multi-tile
+// grid splitting, which VisionEncoderLfm2Vl does not implement yet.
+bool exceeds_single_tile_budget(size_t height, size_t width, const ProcessorConfig& config) {
+    const size_t total_factor = config.encoder_patch_size * config.downsample_factor;
+    const size_t h_bar =
+        std::max(config.encoder_patch_size, round_by_factor(static_cast<double>(height), total_factor));
+    const size_t w_bar = std::max(config.encoder_patch_size, round_by_factor(static_cast<double>(width), total_factor));
+    const double max_pixels = static_cast<double>(config.max_image_tokens) *
+                              static_cast<double>(config.encoder_patch_size * config.encoder_patch_size) *
+                              static_cast<double>(config.downsample_factor * config.downsample_factor) *
+                              static_cast<double>(config.max_pixels_tolerance);
+    return static_cast<double>(h_bar * w_bar) > max_pixels;
+}
+
+// Mirrors Lfm2VlImageProcessor.smart_resize: rescales height/width so both dimensions are divisible
+// by encoder_patch_size * downsample_factor (no padding needed before downsampling) and the resulting
+// patch count falls within [min_image_tokens, max_image_tokens] after downsampling.
+std::pair<size_t, size_t> smart_resize(size_t height, size_t width, const ProcessorConfig& config) {
+    const size_t total_factor = config.encoder_patch_size * config.downsample_factor;
+    const size_t patch_area =
+        config.encoder_patch_size * config.encoder_patch_size * config.downsample_factor * config.downsample_factor;
+    const size_t min_pixels = config.min_image_tokens * patch_area;
+    const size_t max_pixels = config.max_image_tokens * patch_area;
+
+    size_t h_bar = std::max(total_factor, round_by_factor(static_cast<double>(height), total_factor));
+    size_t w_bar = std::max(total_factor, round_by_factor(static_cast<double>(width), total_factor));
+
+    if (h_bar * w_bar > max_pixels) {
+        const double beta = std::sqrt(static_cast<double>(height * width) / static_cast<double>(max_pixels));
+        h_bar =
+            std::max(total_factor,
+                     static_cast<size_t>(std::floor(static_cast<double>(height) / beta / total_factor)) * total_factor);
+        w_bar =
+            std::max(total_factor,
+                     static_cast<size_t>(std::floor(static_cast<double>(width) / beta / total_factor)) * total_factor);
+    } else if (h_bar * w_bar < min_pixels) {
+        const double beta = std::sqrt(static_cast<double>(min_pixels) / static_cast<double>(height * width));
+        h_bar = static_cast<size_t>(std::ceil(static_cast<double>(height) * beta / total_factor)) * total_factor;
+        w_bar = static_cast<size_t>(std::ceil(static_cast<double>(width) * beta / total_factor)) * total_factor;
+    }
+    return {h_bar, w_bar};
+}
+
+// Mirrors Lfm2VlImageProcessor.convert_image_to_patches: flattens a resized, normalized image into a
+// NaFlex-style patch sequence with a channel-last patch layout, patches ordered row-major over the
+// patch grid. resized is expected to already be sized to whole patch_size multiples.
+ov::Tensor image_to_patches(const clip_image_u8& resized,
+                            size_t patch_size,
+                            const std::array<float, 3>& mean,
+                            const std::array<float, 3>& std_dev) {
+    const size_t num_patches_height = static_cast<size_t>(resized.ny) / patch_size;
+    const size_t num_patches_width = static_cast<size_t>(resized.nx) / patch_size;
+    const size_t num_patches = num_patches_height * num_patches_width;
+    const size_t patch_dim = patch_size * patch_size * NUM_CHANNELS;
+    const size_t image_width = static_cast<size_t>(resized.nx);
+
+    ov::Tensor pixel_values{ov::element::f32, {1, num_patches, patch_dim}};
+    float* pixel_values_data = pixel_values.data<float>();
+
+    for (size_t patch_row = 0; patch_row < num_patches_height; ++patch_row) {
+        for (size_t patch_col = 0; patch_col < num_patches_width; ++patch_col) {
+            float* patch_data = pixel_values_data + (patch_row * num_patches_width + patch_col) * patch_dim;
+            for (size_t py = 0; py < patch_size; ++py) {
+                const size_t src_y = patch_row * patch_size + py;
+                for (size_t px = 0; px < patch_size; ++px) {
+                    const size_t src_x = patch_col * patch_size + px;
+                    const uint8_t* src_pixel = &resized.buf[(src_y * image_width + src_x) * NUM_CHANNELS];
+                    float* dst_pixel = patch_data + (py * patch_size + px) * NUM_CHANNELS;
+                    for (size_t c = 0; c < NUM_CHANNELS; ++c) {
+                        dst_pixel[c] = (static_cast<float>(src_pixel[c]) / 255.0f - mean[c]) / std_dev[c];
+                    }
+                }
+            }
+        }
+    }
+    return pixel_values;
+}
+
+}  // namespace
+
+EncodedImage VisionEncoderLfm2Vl::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    ProcessorConfig config = ProcessorConfig::from_any_map(config_map, m_processor_config);
+    clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+
+    OPENVINO_ASSERT(
+        !exceeds_single_tile_budget(static_cast<size_t>(input_image.ny), static_cast<size_t>(input_image.nx), config),
+        "LFM2-VL multi-tile image splitting isn't implemented: the input image (",
+        input_image.nx,
+        "x",
+        input_image.ny,
+        ") exceeds the single-tile pixel budget (max_image_tokens=",
+        config.max_image_tokens,
+        ", tile_size=",
+        config.tile_size,
+        "). Resize the image below the single-tile threshold before passing it to VLMPipeline.");
+
+    const auto [target_height, target_width] =
+        smart_resize(static_cast<size_t>(input_image.ny), static_cast<size_t>(input_image.nx), config);
+
+    clip_image_u8 resized_image;
+    bilinear_resize(input_image, resized_image, static_cast<int>(target_width), static_cast<int>(target_height));
+
+    const size_t num_patches_height = target_height / config.encoder_patch_size;
+    const size_t num_patches_width = target_width / config.encoder_patch_size;
+    const size_t num_patches = num_patches_height * num_patches_width;
+
+    ov::Tensor pixel_values =
+        image_to_patches(resized_image, config.encoder_patch_size, config.image_mean, config.image_std);
+
+    ov::Tensor spatial_shapes{ov::element::i64, {1, 2}};
+    int64_t* spatial_shapes_data = spatial_shapes.data<int64_t>();
+    spatial_shapes_data[0] = static_cast<int64_t>(num_patches_height);
+    spatial_shapes_data[1] = static_cast<int64_t>(num_patches_width);
+
+    ov::Tensor pixel_attention_mask{ov::element::boolean, {1, num_patches}};
+    std::fill_n(pixel_attention_mask.data<bool>(), num_patches, true);
+
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(this->m_ireq_queue_vision_encoder.get());
+    ov::InferRequest& encoder = infer_request_guard.get();
+    encoder.set_tensor("pixel_values", pixel_values);
+    encoder.set_tensor("spatial_shapes", spatial_shapes);
+    encoder.set_tensor("pixel_attention_mask", pixel_attention_mask);
+    encoder.infer();
+
+    // The exported openvino_vision_embeddings_model already fuses the SigLIP2-NaFlex vision tower and
+    // Lfm2VlMultiModalProjector (including the pixel-unshuffle downsampling), so its output token count
+    // reflects downsample_factor already applied; it isn't re-derived here.
+    const ov::Tensor& infer_output = encoder.get_output_tensor();
+    const size_t num_image_tokens = infer_output.get_shape().at(0);
+    const size_t hidden_size = infer_output.get_shape().at(1);
+    ov::Tensor image_features{ov::element::f32, {1, num_image_tokens, hidden_size}};
+    std::memcpy(image_features.data(), infer_output.data(), infer_output.get_byte_size());
+
+    EncodedImage encoded_image;
+    encoded_image.resized_source = std::move(image_features);
+    encoded_image.resized_source_size =
+        ImageSize{num_patches_height / config.downsample_factor, num_patches_width / config.downsample_factor};
+    encoded_image.original_image_size =
+        ImageSize{static_cast<size_t>(input_image.ny), static_cast<size_t>(input_image.nx)};
+    encoded_image.num_image_tokens = num_image_tokens;
+    return encoded_image;
+}
+
+InputsEmbedderLfm2Vl::InputsEmbedderLfm2Vl(const VLMConfig& vlm_config,
+                                           const std::filesystem::path& model_dir,
+                                           const Tokenizer& tokenizer,
+                                           const std::string& device,
+                                           const ov::AnyMap device_config)
+    : IInputsEmbedder(vlm_config, model_dir, tokenizer, device, device_config) {}
+
+InputsEmbedderLfm2Vl::InputsEmbedderLfm2Vl(const VLMConfig& vlm_config,
+                                           const ModelsMap& models_map,
+                                           const Tokenizer& tokenizer,
+                                           const std::filesystem::path& config_dir_path,
+                                           const std::string& device,
+                                           const ov::AnyMap device_config)
+    : IInputsEmbedder(vlm_config, models_map, tokenizer, config_dir_path, device, device_config) {}
+
+NormalizedPrompt InputsEmbedderLfm2Vl::normalize_prompt(const std::string& prompt,
+                                                        size_t base_id,
+                                                        const std::vector<EncodedImage>& images) const {
+    const std::string& image_token = m_vlm_config.im_start;
+    auto [unified_prompt, images_sequence] = normalize(prompt, image_token, image_token, base_id, images.size());
+
+    size_t searched_pos = 0;
+    for (size_t new_image_id : images_sequence) {
+        const EncodedImage& image = images.at(new_image_id - base_id);
+        std::string expanded_tag = m_vlm_config.lfm2_vl_image_start_token;
+        for (size_t idx = 0; idx < image.num_image_tokens; ++idx) {
+            expanded_tag += image_token;
+        }
+        expanded_tag += m_vlm_config.lfm2_vl_image_end_token;
+        OPENVINO_ASSERT(searched_pos < unified_prompt.length());
+        searched_pos = unified_prompt.find(image_token, searched_pos);
+        OPENVINO_ASSERT(searched_pos != std::string::npos);
+        unified_prompt.replace(searched_pos, image_token.length(), expanded_tag);
+        searched_pos += expanded_tag.length();
+    }
+    return {std::move(unified_prompt), std::move(images_sequence), {}};
+}
+
+ov::Tensor InputsEmbedderLfm2Vl::get_inputs_embeds(const std::string& unified_prompt,
+                                                   const std::vector<ov::genai::EncodedImage>& images,
+                                                   ov::genai::VLMPerfMetrics& metrics,
+                                                   bool recalculate_merged_embeddings,
+                                                   const std::vector<size_t>& images_sequence) {
+    std::vector<ov::Tensor> image_embeds;
+    image_embeds.reserve(images_sequence.size());
+    for (size_t new_image_id : images_sequence) {
+        image_embeds.push_back(images.at(new_image_id).resized_source);
+    }
+
+    ov::Tensor input_ids = get_encoded_input_ids(unified_prompt, metrics);
+    CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());
+    EmbeddingsRequest& req = embeddings_request_guard.get();
+    ov::Tensor text_embeds = get_text_embedding(req, input_ids, metrics);
+
+    if (images.empty()) {
+        ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
+        std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
+        return inputs_embeds;
+    }
+    return utils::merge_text_and_image_embeddings_llava(input_ids,
+                                                        text_embeds,
+                                                        image_embeds,
+                                                        m_vlm_config.image_token_id);
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/lfm2_vl/classes.hpp
+++ b/src/cpp/src/visual_language/lfm2_vl/classes.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/inputs_embedder.hpp"
+#include "visual_language/vision_encoder.hpp"
+#include "visual_language/vlm_config.hpp"
+
+namespace ov::genai {
+
+// SigLIP2-NaFlex vision tower with a fused projector, single-tile only. LFM2-VL's image processor
+// (`do_image_splitting=True`, `min_tiles=2`) additionally supports multi-tile grid splitting with a
+// thumbnail tile for images that don't fit the single-tile pixel budget; that path isn't implemented
+// here yet, see `encode()`.
+class VisionEncoderLfm2Vl : public VisionEncoder {
+public:
+    using VisionEncoder::VisionEncoder;
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+};
+
+class InputsEmbedderLfm2Vl : public InputsEmbedder::IInputsEmbedder {
+public:
+    InputsEmbedderLfm2Vl(const VLMConfig& vlm_config,
+                         const std::filesystem::path& model_dir,
+                         const Tokenizer& tokenizer,
+                         const std::string& device,
+                         const ov::AnyMap device_config);
+
+    InputsEmbedderLfm2Vl(const VLMConfig& vlm_config,
+                         const ModelsMap& models_map,
+                         const Tokenizer& tokenizer,
+                         const std::filesystem::path& config_dir_path,
+                         const std::string& device,
+                         const ov::AnyMap device_config);
+
+    ov::Tensor get_inputs_embeds(const std::string& prompt,
+                                 const std::vector<ov::genai::EncodedImage>& images,
+                                 ov::genai::VLMPerfMetrics& metrics,
+                                 bool recalculate_merged_embeddings = true,
+                                 const std::vector<size_t>& image_sequence = {}) override;
+
+    NormalizedPrompt normalize_prompt(const std::string& prompt,
+                                      size_t base_id,
+                                      const std::vector<EncodedImage>& images) const override;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/processor_config.cpp
+++ b/src/cpp/src/visual_language/processor_config.cpp
@@ -61,6 +61,12 @@ ov::genai::ProcessorConfig::ProcessorConfig(const nlohmann::json& parsed) {
     // Setting gemma4 config params
     read_json_param(parsed, "pooling_kernel_size", pooling_kernel_size);
     read_json_param(parsed, "max_soft_tokens", max_soft_tokens);
+
+    // Setting LFM2-VL config params
+    read_json_param(parsed, "encoder_patch_size", encoder_patch_size);
+    read_json_param(parsed, "downsample_factor", downsample_factor);
+    read_json_param(parsed, "min_image_tokens", min_image_tokens);
+    read_json_param(parsed, "max_pixels_tolerance", max_pixels_tolerance);
 }
 
 ov::genai::ProcessorConfig::ProcessorConfig(const std::filesystem::path& json_path)

--- a/src/cpp/src/visual_language/processor_config.hpp
+++ b/src/cpp/src/visual_language/processor_config.hpp
@@ -75,6 +75,12 @@ public:
     size_t max_patches = 6;
     std::array<uint8_t, 3> background_color{127, 127, 127};
 
+    // LFM2-VL specific params
+    size_t encoder_patch_size = 16;
+    size_t downsample_factor = 2;
+    size_t min_image_tokens = 64;
+    float max_pixels_tolerance = 2.0f;
+
     /// @brief Default constructor
     ProcessorConfig() = default;
 

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -27,6 +27,7 @@
 #include "visual_language/deepseek_ocr2/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
+#include "visual_language/lfm2_vl/classes.hpp"
 
 namespace ov::genai {
 
@@ -152,6 +153,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderDeepseekOCR2>(model_dir, device, properties);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::LFM2_VL) {
+        return std::make_shared<VisionEncoderLfm2Vl>(model_dir, device, properties);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }
@@ -203,6 +206,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderDeepseekOCR2>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::LFM2_VL) {
+        return std::make_shared<VisionEncoderLfm2Vl>(models_map, config_dir_path, device, device_config);
     } else {
         OPENVINO_THROW("Unsupported model type in VLM VisionEncoder class. Please, create feature request on new model support");
     }

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -36,6 +36,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
         {"deepseek_ocr2", VLMModelType::DEEPSEEK_OCR2},
         {"muse_glimmer", VLMModelType::MUSE_GLIMMER},
+        {"lfm2_vl", VLMModelType::LFM2_VL},
     };
 
     auto it = model_types_map.find(value);

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -34,6 +34,7 @@ enum class VLMModelType {
     QWEN3_OMNI,
     DEEPSEEK_OCR2,
     MUSE_GLIMMER,
+    LFM2_VL,
 };
 
 /// @brief A Configuration class passed to VLMPipeline and used to
@@ -128,6 +129,11 @@ public:
 
     /// @brief A string token denoting start of video embeddings
     std::string video_start = "<video>";
+
+    /// @brief A string token denoting start of image embeddings for LFM2-VL model.
+    std::string lfm2_vl_image_start_token = "<|image_start|>";
+    /// @brief A string token denoting end of image embeddings for LFM2-VL model.
+    std::string lfm2_vl_image_end_token = "<|image_end|>";
 
     // Qwen3-VL specific config
     /// @brief Number of position embeddings in vision encoder for Qwen3-VL model.

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -169,6 +169,7 @@ MODEL_GEMMA = "optimum-intel-internal-testing/tiny-random-gemma3"
 MODEL_GEMMA3N = "optimum-intel-internal-testing/tiny-random-gemma3n"
 MODEL_QWEN3_OMNI = "optimum-intel-internal-testing/tiny-random-qwen3-omni"
 MODEL_DEEPSEEK_OCR2 = "optimum-intel-internal-testing/tiny-random-deepseek-ocr-2"
+MODEL_LFM2_VL = "optimum-intel-internal-testing/tiny-random-lfm2-vl"
 
 MODEL_IDS: list[str] = []
 if is_transformers_version("<", "5.0"):
@@ -191,6 +192,7 @@ else:
         "optimum-intel-internal-testing/tiny-random-phi-4-multimodal",
         "qnguyen3/nanoLLaVA",
         MODEL_DEEPSEEK_OCR2,
+        MODEL_LFM2_VL,
         *VIDEO_MODEL_IDS,
     ]
 
@@ -212,6 +214,7 @@ IMAGE_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
     MODEL_GEMMA3N: lambda idx: "<image_soft_token>",
     "optimum-intel-internal-testing/tiny-random-internvl2": lambda idx: "<image>\n",
     MODEL_DEEPSEEK_OCR2: lambda idx: "<image>",
+    MODEL_LFM2_VL: lambda idx: "<image>",
     "optimum-intel-internal-testing/tiny-random-minicpmv-2_6": lambda idx: "<image>./</image>\n",
     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6": lambda idx: "<image>./</image>\n",
     "optimum-intel-internal-testing/tiny-random-phi3-vision": lambda idx: f"<|image_{idx + 1}|>\n",
@@ -288,6 +291,7 @@ NPU_UNSUPPORTED_MODELS = {
     "optimum-intel-internal-testing/tiny-random-gemma4-unified-it",
     "optimum-intel-internal-testing/tiny-random-gemma4-31B",
     MODEL_DEEPSEEK_OCR2,
+    MODEL_LFM2_VL,
 }
 
 MODELS_WITHOUT_CHAT_TEMPLATE = {
@@ -356,6 +360,11 @@ def _maybe_skip_unsupported_model_export(model_id: str) -> None:
     if model_id == MODEL_DEEPSEEK_OCR2 and is_transformers_version("<", "5.11.0"):
         pytest.skip(
             "ValueError: The current version of Transformers does not allow for the export of DeepSeek-OCR-2. Minimum required is 5.11.0."
+        )
+    if model_id == MODEL_LFM2_VL:
+        pytest.skip(
+            "The tiny-random-lfm2-vl checkpoint hasn't been uploaded to the HF Hub yet "
+            "(huggingface/optimum-intel#1979). Unskip once it's available."
         )
     if _is_videochat_flash_qwen_model(model_id) and not is_optimum_intel_version_for_videochat_flash_qwen():
         pytest.skip("ValueError: The current version of optimum-intel does not support videochat_flash_qwen")


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

---

## Summary

Adds `openvino_genai.VLMPipeline` support for **LiquidAI/LFM2.5-VL-3B**
(architecture `lfm2_vl`), a SigLIP2-NaFlex vision encoder + LFM2 hybrid
conv-cache/PagedAttention text decoder VLM.

- Registers a new `VLMModelType::LFM2_VL` at all four required dispatch
  points (`vlm_config.hpp`/`.cpp` enum + string map, `VisionEncoder::create()`
  both overloads, `InputsEmbedder` constructor both overloads).
- `VisionEncoderLfm2Vl` (`src/cpp/src/visual_language/lfm2_vl/classes.{hpp,cpp}`):
  SigLIP2-NaFlex `smart_resize` + single-tile patch extraction mirroring HF's
  `image_processing_lfm2_vl.py`. Reads the actual post-projector token count
  from the exported vision-embeddings submodel output at runtime rather than
  re-deriving the downsample-factor formula.
- `InputsEmbedderLfm2Vl`: expands each image occurrence to
  `<|image_start|><image>×N<|image_end|>` and reuses the existing generic
  `utils::merge_text_and_image_embeddings_llava` helper — no new merge logic.
- New generic `ProcessorConfig` fields (`encoder_patch_size`,
  `downsample_factor`, `min_image_tokens`, `max_pixels_tolerance`) read from
  `preprocessor_config.json`.
- No changes needed in the text-decoder core: LFM2's existing hybrid
  conv-cache + PagedAttention `LLMPipeline` is reused as-is.

Two commits:
1. `f5b203c4` — initial `VLMPipeline` implementation.
2. `be1ed16a` — accuracy fix: the vision-encoder resize step hardcoded
   bilinear resize, but this checkpoint's `preprocessor_config.json`
   specifies `resample=3` (bicubic), which caused a real image-conditioning
   mismatch. See "Accuracy" section below.

## Scope / limitations

- **Single-tile images only.** This mirrors HF's own bypass path for images
  under the model's tiling pixel budget. Multi-tile grid-splitting +
  thumbnail support (for images that exceed the single-tile budget) is
  **not implemented** in this PR — oversized images now fail fast with a
  clear `OPENVINO_ASSERT` (`exceeds_single_tile_budget`) instead of being
  silently mis-processed. Recommended as a separate follow-up PR/ticket.
- **Tiny-checkpoint test self-skips.** `tests/python_tests/test_vlm_pipeline.py`
  is fully wired for `lfm2_vl` (`MODEL_LFM2_VL` constant + registry entries),
  but the required tiny checkpoint
  (`optimum-intel-internal-testing/tiny-random-lfm2-vl`) is not yet uploaded
  to the HF Hub (tracked in huggingface/optimum-intel#1979). The test
  currently self-skips with an explicit `pytest.skip(...)` documenting this;
  it will activate automatically once the checkpoint exists and the skip
  line is removed.
- **NPU not validated.** No NPU device was visible at the OpenVINO plugin
  level on the validation host, so NPU was not exercised. Proactively added
  to `NPU_UNSUPPORTED_MODELS` in the test registry pending future validation
  on NPU-capable hardware.

## Accuracy — please weigh in (open question for reviewers)

WWB accuracy benchmark (32 VQAv2 samples, similarity metric, threshold 0.9),
**after** the `be1ed16a` bicubic-resize fix:

| Device | Score |
|---|---|
| CPU | 0.8904 |
| GPU.1 (discrete) | 0.8913 |
| GPU.0 (integrated) | 0.8876 |

This is a **borderline band, not a clean pass** against the 0.9 threshold.
Two real bugs were found and fixed during the investigation leading here:

1. The bicubic-vs-bilinear resize-filter bug fixed in this PR's second
   commit (`be1ed16a`).
2. A separate, earlier optimum-intel export bug, reported and fixed
   independently upstream: huggingface/optimum-intel#1979.

After both fixes, the residual gap to 0.9 is concentrated in 2 of the 32
samples, and in both cases the model's answer is **verbose but factually
correct**, while WWB's ground truth is a **terse single word** — this looks
like a known limitation of the WWB text-similarity metric for
instruction-tuned chat VLMs (which tend to answer in full sentences rather
than a bare label), rather than an identified technical defect in this PR's
code. See `agent-results/optimum-genai-orchestrator/accuracy_diagnosis.md`
in the OMEGA pipeline run for full per-sample evidence.

**We are stating this plainly rather than claiming either "fully resolved"
or "unresolved/broken"** — reviewers should weigh in on whether to:
- (a) accept as-is for a first-time enablement (the answers are factually
  correct; only the *style* diverges from the terse ground truth on the 2
  affected samples), or
- (b) request further generation-style tuning as a separate follow-up.

## Known, separate, out-of-scope issue (not fixed here)

`OVModelForVisualCausalLM.generate()` (optimum-intel's Python inference
path) crashes on **padded** `pixel_values` batches for `lfm2_vl` — a CPU
plugin eltwise shape-mismatch in the vision-tower positional-embedding
`Add` node, triggered when `do_pad=True` (the HF processor's default).
This does **not** affect this PR's C++ GenAI pipeline, which never pads
(`pixel_values` is always sized exactly to `spatial_shapes`), so it is not
a blocker here. Flagging as a suggested follow-up ticket against
optimum-intel.

## Validation performed

- `openvino_genai.VLMPipeline` loads without the previous "Unsupported
  lfm2_vl VLM model type" error.
- Text-only generation and image+text generation validated on **CPU,
  GPU.0 (integrated), and GPU.1 (discrete Intel Arc Pro B60)**.
- Qualitative comparison against real HF PyTorch
  `transformers.AutoModelForImageTextToText.generate()` on identical
  image/prompt: semantically matching output.
- Multi-tile guard: an oversized image correctly raises a clear
  `RuntimeError` instead of silently mis-processing.
- Multi-turn chat (`start_chat()` / image turn / text-only follow-up /
  `finish_chat()`) produces coherent, context-aware answers — confirms the
  LFM2 hybrid conv-cache PagedAttention decoder works unchanged through the
  new VLM pipeline.
- WWB 32-sample VQAv2 accuracy run on CPU/GPU.1/GPU.0 — see Accuracy section
  above.

---

*This PR was generated by the OMEGA automated model-enablement pipeline
for tracking issue openvinotoolkit/omega#104.*
