### PR TITLE
[CI] [GHA] Do not use tmp directories for building wheels so that `(s)ccache` work

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -363,18 +363,19 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
-          # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
-          export PATH="$(dirname "$python_exec_path"):$PATH"
+          # Build in a per-version venv so the pip-installed cmake (>=3.26) and pybind11-stubgen are first on PATH with --no-build-isolation.
+          python${{ matrix.python-version }} -m venv ${{ env.OV_INSTALL_DIR }}/.venv-build
+          venv_python=${{ env.OV_INSTALL_DIR }}/.venv-build/bin/python
+          export PATH="${{ env.OV_INSTALL_DIR }}/.venv-build/bin:$PATH"
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $python_exec_path -m pip install \
+          $venv_python -m pip install \
               "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               "openvino~=2026.5.0.0.dev"
 
-          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+          $venv_python -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -365,10 +365,13 @@ jobs:
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
 
-          # Prototype: keep pip build isolation but pin find_package(OpenVINO) to the stable downloaded package so the random build-isolation overlay path never reaches the compile line and sccache stays warm
-          $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
+          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps sccache warm.
+          mapfile -t build_reqs < <(python3.11 -c "import sys, tomllib; print('\n'.join(tomllib.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
+          $python_exec_path -m pip install "${build_reqs[@]}" ${{ needs.openvino_download.outputs.ov_wheel_source }}
+
+          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
-              --config-settings=cmake.args="-DOpenVINO_DIR=${{ env.OV_INSTALL_DIR }}/runtime/cmake -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
+              --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               ${{ env.SRC_DIR }}
         working-directory: ${{ env.OV_INSTALL_DIR }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -362,7 +362,15 @@ jobs:
       - name: Build GenAI Wheel
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
-          $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
+
+          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
+          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
+          $python_exec_path -m pip install \
+              "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
+              ${{ needs.openvino_download.outputs.ov_wheel_source }} \
+              "openvino~=2026.5.0.0.dev"
+
+          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -332,6 +332,8 @@ jobs:
       WHEELS_DIR: ${{ github.workspace }}/install/wheels
       SRC_DIR: ${{ github.workspace }}/src
       OpenVINODeveloperPackage_DIR: ${{ github.workspace }}/ov/developer_package/cmake
+      # Per-Python-version cache prefix so each matrix leg keeps its own sccache entries.
+      SCCACHE_AZURE_KEY_PREFIX: genai/ubuntu/22_04/x64/py${{ matrix.python-version }}
     steps:
       - name: Clone openvino.genai
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -362,6 +364,8 @@ jobs:
       - name: Build GenAI Wheel
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
+          # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
+          export PATH="$(dirname "$python_exec_path"):$PATH"
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -365,12 +365,9 @@ jobs:
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
 
-          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
-          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $python_exec_path -m pip install \
-              "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
-              ${{ needs.openvino_download.outputs.ov_wheel_source }} \
-              "openvino~=2026.5.0.0.dev"
+          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps sccache warm.
+          mapfile -t build_reqs < <(python3.11 -c "import sys, tomllib; print('\n'.join(tomllib.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
+          $python_exec_path -m pip install "${build_reqs[@]}" ${{ needs.openvino_download.outputs.ov_wheel_source }}
 
           $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -363,19 +363,16 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          # Build in a per-version venv so the pip-installed cmake (>=3.26) and pybind11-stubgen are first on PATH with --no-build-isolation.
-          python${{ matrix.python-version }} -m venv ${{ env.OV_INSTALL_DIR }}/.venv-build
-          venv_python=${{ env.OV_INSTALL_DIR }}/.venv-build/bin/python
-          export PATH="${{ env.OV_INSTALL_DIR }}/.venv-build/bin:$PATH"
+          python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $venv_python -m pip install \
+          $python_exec_path -m pip install \
               "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               "openvino~=2026.5.0.0.dev"
 
-          $venv_python -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -365,13 +365,10 @@ jobs:
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
 
-          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps sccache warm.
-          mapfile -t build_reqs < <(python3.11 -c "import sys, tomllib; print('\n'.join(tomllib.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
-          $python_exec_path -m pip install "${build_reqs[@]}" ${{ needs.openvino_download.outputs.ov_wheel_source }}
-
-          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+          # Prototype: keep pip build isolation but pin find_package(OpenVINO) to the stable downloaded package so the random build-isolation overlay path never reaches the compile line and sccache stays warm.
+          $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
-              --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
+              --config-settings=cmake.args="-DOpenVINO_DIR=${{ env.OV_INSTALL_DIR }}/runtime/cmake -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               ${{ env.SRC_DIR }}
         working-directory: ${{ env.OV_INSTALL_DIR }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -365,7 +365,7 @@ jobs:
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
 
-          # Prototype: keep pip build isolation but pin find_package(OpenVINO) to the stable downloaded package so the random build-isolation overlay path never reaches the compile line and sccache stays warm.
+          # Prototype: keep pip build isolation but pin find_package(OpenVINO) to the stable downloaded package so the random build-isolation overlay path never reaches the compile line and sccache stays warm
           $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=override=cross.arch="manylinux_2_31_x86_64" \
               --config-settings=cmake.args="-DOpenVINO_DIR=${{ env.OV_INSTALL_DIR }}/runtime/cmake -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -226,6 +226,10 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CMAKE_C_COMPILER_LAUNCHER: ccache
+      # Normalize workspace paths and volatile time macros so ccache hits across runs.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: 'true'
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
       OV_INSTALL_DIR: ${{ github.workspace }}/ov
       INSTALL_DIR: ${{ github.workspace }}/install
       WHEELS_DIR: ${{ github.workspace }}/install/wheels
@@ -286,7 +290,12 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          python -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
+          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps ccache warm.
+          build_reqs=()
+          while IFS= read -r req; do build_reqs+=("$req"); done < <(python -c "import sys, tomllib; print('\n'.join(tomllib.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
+          python -m pip install "${build_reqs[@]}" ${{ needs.openvino_download.outputs.ov_wheel_source }}
+
+          python -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache" \
               --config-settings=override=cmake.generator="Ninja" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -343,13 +343,28 @@ jobs:
           build_type: Release
           save_to: ${{ github.workspace }}
 
+      - name: Clean sccache stats
+        run: ${SCCACHE_PATH} --zero-stats
+
       - name: Build GenAI Wheel
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
-          $python_exec_path -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} \
+
+          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
+          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
+          $python_exec_path -m pip install \
+              "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
+              ${{ needs.openvino_download.outputs.ov_wheel_source }} \
+              "openvino~=2026.5.0.0.dev"
+
+          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+              --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               ${{ env.SRC_DIR }}
         working-directory: ${{ env.OV_INSTALL_DIR }}
+
+      - name: Show sccache stats
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Upload GenAI Wheel
         if: ${{ always() }}

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -354,12 +354,9 @@ jobs:
           # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
           export PATH="$(dirname "$python_exec_path"):$PATH"
 
-          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
-          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $python_exec_path -m pip install \
-              "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
-              ${{ needs.openvino_download.outputs.ov_wheel_source }} \
-              "openvino~=2026.5.0.0.dev"
+          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps sccache warm.
+          mapfile -t build_reqs < <(python3.11 -c "import sys, tomllib; print('\n'.join(tomllib.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
+          $python_exec_path -m pip install "${build_reqs[@]}" ${{ needs.openvino_download.outputs.ov_wheel_source }}
 
           $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -318,6 +318,8 @@ jobs:
       WHEELS_DIR: ${{ github.workspace }}/install/wheels
       SRC_DIR: ${{ github.workspace }}/src
       OpenVINODeveloperPackage_DIR: ${{ github.workspace }}/ov/developer_package/cmake
+      # Per-Python-version cache prefix so each matrix leg keeps its own sccache entries.
+      SCCACHE_AZURE_KEY_PREFIX: genai/manylinux_2_28/py${{ matrix.python-version }}
 
     steps:
       - name: Clone openvino.genai
@@ -349,6 +351,8 @@ jobs:
       - name: Build GenAI Wheel
         run: |
           python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
+          # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
+          export PATH="$(dirname "$python_exec_path"):$PATH"
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -350,18 +350,19 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
-          # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
-          export PATH="$(dirname "$python_exec_path"):$PATH"
+          # Build in a per-version venv so the pip-installed cmake (>=3.26) and pybind11-stubgen are first on PATH with --no-build-isolation.
+          python${{ matrix.python-version }} -m venv ${{ env.OV_INSTALL_DIR }}/.venv-build
+          venv_python=${{ env.OV_INSTALL_DIR }}/.venv-build/bin/python
+          export PATH="${{ env.OV_INSTALL_DIR }}/.venv-build/bin:$PATH"
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $python_exec_path -m pip install \
+          $venv_python -m pip install \
               "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               "openvino~=2026.5.0.0.dev"
 
-          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+          $venv_python -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               ${{ env.SRC_DIR }}

--- a/.github/workflows/manylinux_2_28.yml
+++ b/.github/workflows/manylinux_2_28.yml
@@ -350,19 +350,18 @@ jobs:
 
       - name: Build GenAI Wheel
         run: |
-          # Build in a per-version venv so the pip-installed cmake (>=3.26) and pybind11-stubgen are first on PATH with --no-build-isolation.
-          python${{ matrix.python-version }} -m venv ${{ env.OV_INSTALL_DIR }}/.venv-build
-          venv_python=${{ env.OV_INSTALL_DIR }}/.venv-build/bin/python
-          export PATH="${{ env.OV_INSTALL_DIR }}/.venv-build/bin:$PATH"
+          python_exec_path=$(python${{ matrix.python-version }} -c "import sys; print(sys.executable)")
+          # Put the interpreter's console-scripts dir on PATH so CMake's find_program locates pybind11-stubgen with --no-build-isolation.
+          export PATH="$(dirname "$python_exec_path"):$PATH"
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps sccache hashes stable across runs.
           # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
-          $venv_python -m pip install \
+          $python_exec_path -m pip install \
               "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               "openvino~=2026.5.0.0.dev"
 
-          $venv_python -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
+          $python_exec_path -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} \
               --config-settings=cmake.args="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache" \
               ${{ needs.openvino_download.outputs.ov_wheel_source }} \
               ${{ env.SRC_DIR }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -480,10 +480,11 @@ jobs:
           $pythonExecutablePath = & cmd /c $pythonCommand
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps ccache hashes stable across runs.
+          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
           & $pythonExecutablePath -m pip install `
             "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" `
             ${{ needs.openvino_download.outputs.ov_wheel_source }} `
-            openvino
+            "openvino~=2026.5.0.0.dev"
 
           & $pythonExecutablePath -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} `
             --config-settings=override=cmake.generator='Ninja' `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -403,11 +403,7 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}\genai
       WHEELS_DIR: ${{ github.workspace }}\genai\wheels
       CCACHE_DIR: ${{ github.workspace }}\ccache
-      CCACHE_MAXSIZE: 1.5Gi
-      # TODO: CCACHE_DEBUG is temporary to diagnose cache misses; remove with the debug-log upload step afterwards.
-      CCACHE_DEBUG: '1'
-      CCACHE_DEBUGDIR: ${{ github.workspace }}\ccache_debug
-      # pip build isolation compiles from a fresh temp source dir each run; these make ccache hashing path-independent so caches hit across runs.
+      # Normalize workspace paths and volatile time macros so ccache hits across runs.
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: 'true'
       CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
@@ -451,9 +447,9 @@ jobs:
         id: ccache-restore
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test
+            ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}
           path: ${{ env.CCACHE_DIR }}
 
       - name: Set CI environment
@@ -498,22 +494,11 @@ jobs:
         run: ccache --show-stats
 
       - name: Save ccache
-        # TODO: always-save is temporary for cache testing; restore the push/cache-hit guard afterwards.
-        # TODO: if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
-        if: always()
+        if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
-
-      - name: Upload ccache debug log
-        # TODO: temporary diagnostic; remove together with CCACHE_DEBUG env
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ccache_debug_genai_wheel_python_${{ matrix.python-version }}
-          path: ${{ env.CCACHE_DEBUGDIR }}
-          if-no-files-found: 'warn'
 
       - name: Upload GenAI wheel
         if: ${{ always() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -479,7 +479,13 @@ jobs:
           $pythonCommand = "py -${{ matrix.python-version }} -c `"import sys; print(f'{sys.executable}')`""
           $pythonExecutablePath = & cmd /c $pythonCommand
 
-          & $pythonExecutablePath -m pip wheel -v --no-deps --wheel-dir ${{ env.WHEELS_DIR }} `
+          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps ccache hashes stable across runs.
+          & $pythonExecutablePath -m pip install `
+            "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" `
+            ${{ needs.openvino_download.outputs.ov_wheel_source }} `
+            openvino
+
+          & $pythonExecutablePath -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} `
             --config-settings=override=cmake.generator='Ninja' `
             --config-settings=override=cmake.build_path='${{ env.BUILD_DIR }}/genai' `
             --config-settings='override=wheel.build_tag="${{ github.run_number }}"' `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -403,6 +403,7 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}\genai
       WHEELS_DIR: ${{ github.workspace }}\genai\wheels
       CCACHE_DIR: ${{ github.workspace }}\ccache
+      CCACHE_MAXSIZE: 1.5Gi
       # pip build isolation compiles from a fresh temp source dir each run; these make ccache hashing path-independent so caches hit across runs.
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: 'true'
@@ -447,9 +448,9 @@ jobs:
         id: ccache-restore
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}
+            ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test
           path: ${{ env.CCACHE_DIR }}
 
       - name: Set CI environment
@@ -487,10 +488,11 @@ jobs:
         run: ccache --show-stats
 
       - name: Save ccache
-        if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
+        # TODO: always-save is temporary for cache testing; restore the push/cache-hit guard afterwards.
+        if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
 
       - name: Upload GenAI wheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -404,6 +404,9 @@ jobs:
       WHEELS_DIR: ${{ github.workspace }}\genai\wheels
       CCACHE_DIR: ${{ github.workspace }}\ccache
       CCACHE_MAXSIZE: 1.5Gi
+      # TODO: CCACHE_DEBUG is temporary to diagnose cache misses; remove with the debug-log upload step afterwards.
+      CCACHE_DEBUG: '1'
+      CCACHE_DEBUGDIR: ${{ github.workspace }}\ccache_debug
       # pip build isolation compiles from a fresh temp source dir each run; these make ccache hashing path-independent so caches hit across runs.
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_NOHASHDIR: 'true'
@@ -495,6 +498,15 @@ jobs:
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-test-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
+
+      - name: Upload ccache debug log
+        # TODO: temporary diagnostic; remove together with CCACHE_DEBUG env.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccache_debug_genai_wheel_python_${{ matrix.python-version }}
+          path: ${{ env.CCACHE_DEBUGDIR }}
+          if-no-files-found: 'warn'
 
       - name: Upload GenAI wheel
         if: ${{ always() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -500,7 +500,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
 
       - name: Upload ccache debug log
-        # TODO: temporary diagnostic; remove together with CCACHE_DEBUG env.
+        # TODO: temporary diagnostic; remove together with CCACHE_DEBUG env
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Setup ccache
         id: ccache-restore
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-${{ matrix.build-type }}-cpack-${{ github.sha }}
           restore-keys: |
@@ -249,7 +249,7 @@ jobs:
         if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-${{ matrix.build-type }}-cpack-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
 
       - name: Upload cpack package
@@ -337,7 +337,7 @@ jobs:
 
       - name: Setup ccache
         id: ccache-restore
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-wheels-${{ github.sha }}
           restore-keys: |
@@ -372,7 +372,7 @@ jobs:
         if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-wheels-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
 
       - name: Upload wheels
@@ -403,6 +403,10 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}\genai
       WHEELS_DIR: ${{ github.workspace }}\genai\wheels
       CCACHE_DIR: ${{ github.workspace }}\ccache
+      # pip build isolation compiles from a fresh temp source dir each run; these make ccache hashing path-independent so caches hit across runs.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: 'true'
+      CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
       OpenVINODeveloperPackage_DIR: ${{ github.workspace }}\install\ov\developer_package\cmake
 
     steps:
@@ -441,7 +445,7 @@ jobs:
 
       - name: Setup ccache
         id: ccache-restore
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
           restore-keys: |
@@ -486,7 +490,7 @@ jobs:
         if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ env.TARGET_BRANCH }}-Release-genai-wheel-${{ matrix.python-version }}-${{ github.sha }}
           path: ${{ env.CCACHE_DIR }}
 
       - name: Upload GenAI wheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -489,6 +489,7 @@ jobs:
 
       - name: Save ccache
         # TODO: always-save is temporary for cache testing; restore the push/cache-hit guard afterwards.
+        # if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -480,7 +480,7 @@ jobs:
           $pythonExecutablePath = & cmd /c $pythonCommand
 
           # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps ccache hashes stable across runs.
-          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release.
+          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release
           & $pythonExecutablePath -m pip install `
             "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" `
             ${{ needs.openvino_download.outputs.ov_wheel_source }} `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -489,7 +489,7 @@ jobs:
 
       - name: Save ccache
         # TODO: always-save is temporary for cache testing; restore the push/cache-hit guard afterwards.
-        # if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
+        # TODO: if: always() && steps.ccache-restore.outputs.cache-hit != 'true' && github.event_name == 'push'
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -475,12 +475,10 @@ jobs:
           $pythonCommand = "py -${{ matrix.python-version }} -c `"import sys; print(f'{sys.executable}')`""
           $pythonExecutablePath = & cmd /c $pythonCommand
 
-          # Pre-install build requirements so OpenVINO resolves to a stable site-packages path instead of pip's random build-isolation dir, which keeps ccache hashes stable across runs.
-          # The openvino spec must match pyproject [build-system].requires so pip picks the dev build from ov_wheel_source, not the stable PyPI release
-          & $pythonExecutablePath -m pip install `
-            "py-build-cmake==0.5.0" "pybind11-stubgen==2.5.5" "cmake~=3.26.0" `
-            ${{ needs.openvino_download.outputs.ov_wheel_source }} `
-            "openvino~=2026.5.0.0.dev"
+          # Install build requirements read from pyproject so the list isn't duplicated here; --no-build-isolation skips pip's auto build-deps and a stable OpenVINO path keeps ccache warm.
+          & $pythonExecutablePath -m pip install tomli
+          $buildReqs = @(& $pythonExecutablePath -c "import sys, tomli; print('\n'.join(tomli.load(open(sys.argv[1], 'rb'))['build-system']['requires']))" "${{ env.SRC_DIR }}/pyproject.toml")
+          & $pythonExecutablePath -m pip install @buildReqs ${{ needs.openvino_download.outputs.ov_wheel_source }}
 
           & $pythonExecutablePath -m pip wheel -v --no-deps --no-build-isolation --wheel-dir ${{ env.WHEELS_DIR }} `
             --config-settings=override=cmake.generator='Ninja' `


### PR DESCRIPTION

## Description

The `pip wheel` mechanism of building the wheels is creating and using temporary directories each time the wheels are built. Because of this, ccache/sccache does not work due to paths being different each build. This PR sets `--no-build-isolation` so that the directory is not isolated. Unfortunately, it requires `pip install` of all the dependencies used in the build. 
Additionally, there was no cache used for building wheels on manylinux; this PR addresses it.

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-194303


## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
