### PR TITLE
[OpenVINO] Support Unlimited-OCR with task image-text-to-text

### DIFF
--- a/site/docs/supported-models/_components/vlm-models-table/models.ts
+++ b/site/docs/supported-models/_components/vlm-models-table/models.ts
@@ -238,6 +238,16 @@ export const VLM_MODELS: VLMModelType[] = [
     ],
   },
   {
+    architecture: 'UnlimitedOCRForCausalLM',
+    models: [
+      {
+        name: 'Unlimited-OCR',
+        links: ['https://huggingface.co/baidu/Unlimited-OCR'],
+        notesLink: '#unlimited-ocr-notes',
+      },
+    ],
+  },
+  {
     architecture: 'Gemma3ForConditionalGeneration',
     models: [
       {

--- a/site/docs/supported-models/index.mdx
+++ b/site/docs/supported-models/index.mdx
@@ -92,6 +92,13 @@ Apply https://huggingface.co/microsoft/Phi-4-multimodal-instruct/discussions/78/
 2. The model has no built-in chat template. A template is only applied if one is explicitly set on the tokenizer via `pipe.get_tokenizer().set_chat_template(...)`.
 3. The model requires `transformers==5.11.0` for the export with `optimum-cli`.
 
+#### Unlimited-OCR {#unlimited-ocr-notes}
+
+1. Accepts exactly one image per request; multi-image input is not supported.
+2. The model has no built-in chat template. A template is only applied if one is explicitly set on the tokenizer via `pipe.get_tokenizer().set_chat_template(...)`.
+3. The model's `trust_remote_code` implementation requires `transformers<5.0` (the 4.5x line) for loading and export with `optimum-cli`.
+4. Only the default SDPA/stateful attention backend is supported. The PagedAttention backend is not available because the DeepSeek-V2 MoE language model export does not contain a ScaledDotProductAttention operation.
+
 #### Gemma 4 {#gemma4-notes}
 
 Gemma 4 implementation supports text, image and video inputs.

--- a/src/cpp/src/visual_language/inputs_embedder.cpp
+++ b/src/cpp/src/visual_language/inputs_embedder.cpp
@@ -25,6 +25,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/deepseek_ocr2/classes.hpp"
+#include "visual_language/unlimited_ocr/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
 
@@ -372,7 +373,7 @@ InputsEmbedder::InputsEmbedder(const std::filesystem::path& model_dir,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, model_dir, tokenizer, device, device_config);
-    } else if (vlm_config.model_type == VLMModelType::DEEPSEEK_OCR2) {
+    } else if (vlm_config.model_type == VLMModelType::DEEPSEEK_OCR2 || vlm_config.model_type == VLMModelType::UNLIMITED_OCR) {
         m_impl = std::make_shared<InputsEmbedderDeepseekOCR2>(vlm_config, model_dir, tokenizer, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, model_dir, tokenizer, device, device_config);
@@ -424,7 +425,7 @@ InputsEmbedder::InputsEmbedder(const ModelsMap& models_map,
         m_impl = std::make_shared<InputsEmbedderGemma4>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::VIDEOCHAT_FLASH_QWEN) {
         m_impl = std::make_shared<InputsEmbedderVideoChatFlashQwen>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
-    } else if (vlm_config.model_type == VLMModelType::DEEPSEEK_OCR2) {
+    } else if (vlm_config.model_type == VLMModelType::DEEPSEEK_OCR2 || vlm_config.model_type == VLMModelType::UNLIMITED_OCR) {
         m_impl = std::make_shared<InputsEmbedderDeepseekOCR2>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);
     } else if (vlm_config.model_type == VLMModelType::MUSE_GLIMMER) {
         m_impl = std::make_shared<InputsEmbedderMuseGlimmer>(vlm_config, models_map, tokenizer, config_dir_path, device, device_config);

--- a/src/cpp/src/visual_language/unlimited_ocr/classes.cpp
+++ b/src/cpp/src/visual_language/unlimited_ocr/classes.cpp
@@ -1,0 +1,359 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "visual_language/unlimited_ocr/classes.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "openvino/core/type/float16.hpp"
+#include "utils.hpp"
+#include "visual_language/clip.hpp"
+
+namespace ov::genai {
+
+namespace {
+
+// Constants mirror baidu/Unlimited-OCR remote code (modeling_unlimitedocr.py):
+//   patch_size = 16, downsample_ratio = 4, base_size = 1024, image_size = 640.
+constexpr int BASE_SIZE = 1024;   // global view resolution
+constexpr int TILE_SIZE = 640;    // crop tile resolution
+constexpr int DYN_MIN_NUM = 2;    // dynamic_preprocess(min_num=2, ...)
+constexpr int DYN_MAX_NUM = 32;   // dynamic_preprocess(..., max_num=32)
+// BasicImageTransform(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)).
+constexpr std::array<float, 3> IMAGE_MEAN{0.5f, 0.5f, 0.5f};
+constexpr std::array<float, 3> IMAGE_STD{0.5f, 0.5f, 0.5f};
+// ImageOps.pad fill color = int(0.5 * 255) = 127 per channel.
+constexpr std::array<uint8_t, 3> PAD_VALUES{127, 127, 127};
+
+std::pair<int, int> find_closest_aspect_ratio(float aspect_ratio,
+                                              const std::vector<std::pair<int, int>>& target_ratios,
+                                              int width,
+                                              int height,
+                                              int image_size) {
+    float best_ratio_diff = std::numeric_limits<float>::infinity();
+    std::pair<int, int> best_ratio = {1, 1};
+    const int area = width * height;
+
+    for (const auto& ratio : target_ratios) {
+        const float target_aspect_ratio = static_cast<float>(ratio.first) / static_cast<float>(ratio.second);
+        const float ratio_diff = std::abs(aspect_ratio - target_aspect_ratio);
+        if (ratio_diff < best_ratio_diff) {
+            best_ratio_diff = ratio_diff;
+            best_ratio = ratio;
+        } else if (ratio_diff == best_ratio_diff) {
+            if (area > 0.5f * image_size * image_size * ratio.first * ratio.second) {
+                best_ratio = ratio;
+            }
+        }
+    }
+    return best_ratio;
+}
+
+// Reproduces dynamic_preprocess(image, min_num=2, max_num=32, image_size=640).
+// Returns the crop tiles (row-major) and the {width_crop_num, height_crop_num} ratio.
+std::pair<std::vector<clip_image_u8>, std::pair<int, int>> dynamic_preprocess(const clip_image_u8& image,
+                                                                              int image_size,
+                                                                              int min_num,
+                                                                              int max_num) {
+    const int orig_width = image.nx;
+    const int orig_height = image.ny;
+    const float aspect_ratio = static_cast<float>(orig_width) / static_cast<float>(orig_height);
+
+    std::vector<std::pair<int, int>> target_ratios;
+    for (int n = min_num; n <= max_num; ++n) {
+        for (int i = 1; i <= n; ++i) {
+            for (int j = 1; j <= n; ++j) {
+                const int prod = i * j;
+                if (prod <= max_num && prod >= min_num) {
+                    target_ratios.emplace_back(i, j);
+                }
+            }
+        }
+    }
+    std::sort(target_ratios.begin(), target_ratios.end());
+    target_ratios.erase(std::unique(target_ratios.begin(), target_ratios.end()), target_ratios.end());
+    std::sort(target_ratios.begin(), target_ratios.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.first * lhs.second < rhs.first * rhs.second;
+    });
+
+    const auto target_aspect_ratio =
+        find_closest_aspect_ratio(aspect_ratio, target_ratios, orig_width, orig_height, image_size);
+
+    const int target_width = image_size * target_aspect_ratio.first;
+    const int target_height = image_size * target_aspect_ratio.second;
+    const int blocks = target_aspect_ratio.first * target_aspect_ratio.second;
+
+    clip_image_u8 resized_img;
+    bicubic_resize(image, resized_img, target_width, target_height);
+
+    std::vector<clip_image_u8> processed_images;
+    processed_images.reserve(blocks);
+    const int cols = target_width / image_size;
+    for (int i = 0; i < blocks; ++i) {
+        const int x = (i % cols) * image_size;
+        const int y = (i / cols) * image_size;
+
+        clip_image_u8 tile_img;
+        tile_img.nx = image_size;
+        tile_img.ny = image_size;
+        tile_img.buf.resize(3 * image_size * image_size);
+        for (int dy = 0; dy < image_size; ++dy) {
+            for (int dx = 0; dx < image_size; ++dx) {
+                for (int c = 0; c < 3; ++c) {
+                    const int src_idx = ((y + dy) * target_width + (x + dx)) * 3 + c;
+                    const int dst_idx = (dy * image_size + dx) * 3 + c;
+                    tile_img.buf[dst_idx] = resized_img.buf[src_idx];
+                }
+            }
+        }
+        processed_images.emplace_back(std::move(tile_img));
+    }
+    return {std::move(processed_images), target_aspect_ratio};
+}
+
+// Reproduces PIL ImageOps.pad(img, (target, target), color): scale keeping aspect
+// ratio (contain), then center-pad with the given color.
+clip_image_u8 pad_to_square(const clip_image_u8& image, int target, const std::array<uint8_t, 3>& pad_values) {
+    const float scale = std::min(static_cast<float>(target) / static_cast<float>(image.nx),
+                                 static_cast<float>(target) / static_cast<float>(image.ny));
+    const int new_width = std::max(1, static_cast<int>(std::lround(static_cast<float>(image.nx) * scale)));
+    const int new_height = std::max(1, static_cast<int>(std::lround(static_cast<float>(image.ny) * scale)));
+
+    clip_image_u8 resized;
+    bicubic_resize(image, resized, new_width, new_height);
+
+    clip_image_u8 padded;
+    padded.nx = target;
+    padded.ny = target;
+    padded.buf.resize(3 * target * target);
+    for (int i = 0; i < target * target; ++i) {
+        padded.buf[3 * i + 0] = pad_values[0];
+        padded.buf[3 * i + 1] = pad_values[1];
+        padded.buf[3 * i + 2] = pad_values[2];
+    }
+
+    const int pad_x = (target - new_width) / 2;
+    const int pad_y = (target - new_height) / 2;
+    for (int y = 0; y < new_height; ++y) {
+        for (int x = 0; x < new_width; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                const int dst_index = 3 * ((y + pad_y) * target + (x + pad_x)) + c;
+                const int src_index = 3 * (y * new_width + x) + c;
+                padded.buf[dst_index] = resized.buf[src_index];
+            }
+        }
+    }
+    return padded;
+}
+
+// Normalizes a batch of equally sized RGB images into an (N, 3, H, W) f32 tensor:
+// value = pixel / 255; out = (value - mean) / std.
+ov::Tensor to_batch_tensor(const std::vector<clip_image_u8>& images,
+                           const std::array<float, 3>& mean,
+                           const std::array<float, 3>& std) {
+    OPENVINO_ASSERT(!images.empty(), "Cannot create a batch tensor from an empty image list");
+    const size_t channels = 3;
+    const size_t height = static_cast<size_t>(images.front().ny);
+    const size_t width = static_cast<size_t>(images.front().nx);
+
+    ov::Tensor batch_tensor(ov::element::f32, {images.size(), channels, height, width});
+    float* batch_data = batch_tensor.data<float>();
+
+    for (size_t idx = 0; idx < images.size(); ++idx) {
+        const clip_image_u8& img = images[idx];
+        OPENVINO_ASSERT(static_cast<size_t>(img.nx) == width && static_cast<size_t>(img.ny) == height,
+                        "Inconsistent tile tensor shape during Unlimited-OCR preprocessing");
+        float* dst = batch_data + idx * channels * height * width;
+        for (size_t y = 0; y < height; ++y) {
+            for (size_t x = 0; x < width; ++x) {
+                for (size_t c = 0; c < channels; ++c) {
+                    const uint8_t pixel = img.buf[3 * (y * width + x) + c];
+                    const float value = static_cast<float>(pixel) / 255.0f;
+                    dst[c * height * width + y * width + x] = (value - mean[c]) / std[c];
+                }
+            }
+        }
+    }
+    return batch_tensor;
+}
+
+ov::Tensor infer_and_copy(CircularBufferQueue<ov::InferRequest>* queue, const ov::Tensor& pixel_values) {
+    CircularBufferQueueElementGuard<ov::InferRequest> infer_request_guard(queue);
+    ov::InferRequest& infer_request = infer_request_guard.get();
+    infer_request.set_tensor("pixel_values", pixel_values);
+    infer_request.infer();
+    const ov::Tensor& output = infer_request.get_output_tensor();
+    ov::Tensor copy(output.get_element_type(), output.get_shape());
+    output.copy_to(copy);
+    return copy;
+}
+
+void copy_rows_to_f32(const ov::Tensor& src, size_t src_row, float* dst, size_t rows, size_t hidden) {
+    const size_t values = rows * hidden;
+    if (src.get_element_type() == ov::element::f32) {
+        std::copy_n(src.data<const float>() + src_row * hidden, values, dst);
+        return;
+    }
+    OPENVINO_ASSERT(src.get_element_type() == ov::element::f16,
+                    "Unlimited-OCR vision features are expected to be fp16/fp32 but got ",
+                    src.get_element_type().to_string());
+    const ov::float16* src_data = src.data<const ov::float16>() + src_row * hidden;
+    for (size_t i = 0; i < values; ++i) {
+        dst[i] = static_cast<float>(src_data[i]);
+    }
+}
+
+// Assembles the global view: a (grid x grid) feature map, terminating every grid row
+// with the learnable ``image_newline`` vector. Returns grid * (grid + 1) rows.
+// Mirrors UnlimitedOCRModel: view(h, w, dim) -> cat newline -> view(-1, dim).
+void append_global_with_newlines(const ov::Tensor& global_features,
+                                 const std::vector<float>& image_newline,
+                                 std::vector<float>& out,
+                                 size_t hidden) {
+    const ov::Shape& shape = global_features.get_shape();  // (1, grid*grid, hidden)
+    OPENVINO_ASSERT(shape.size() == 3 && shape.at(0) == 1, "Unexpected Unlimited-OCR global feature shape");
+    const size_t hw = shape.at(1);
+    const auto grid = static_cast<size_t>(std::lround(std::sqrt(static_cast<double>(hw))));
+    OPENVINO_ASSERT(grid * grid == hw, "Unlimited-OCR global feature grid must be square, got ", hw);
+    OPENVINO_ASSERT(image_newline.size() == hidden, "Unlimited-OCR image_newline size does not match hidden size");
+
+    for (size_t row = 0; row < grid; ++row) {
+        const size_t base = out.size();
+        out.resize(base + grid * hidden);
+        copy_rows_to_f32(global_features, row * grid, out.data() + base, grid, hidden);
+        out.insert(out.end(), image_newline.begin(), image_newline.end());
+    }
+}
+
+// Assembles the local tiles feature map. The (P) tiles of (tgrid x tgrid) tokens are
+// rearranged into a (height_crop_num*tgrid) x (width_crop_num*tgrid) grid, then every
+// grid row is terminated with the learnable ``image_newline`` vector. Mirrors
+// UnlimitedOCRModel: local.view(hcn, wcn, h2, w2, dim).permute(0,2,1,3,4)
+//                    .reshape(hcn*h2, wcn*w2, dim) -> cat newline -> view(-1, dim).
+void append_local_with_newlines(const ov::Tensor& tile_features,
+                                int width_crop_num,
+                                int height_crop_num,
+                                const std::vector<float>& image_newline,
+                                std::vector<float>& out,
+                                size_t hidden) {
+    const ov::Shape& shape = tile_features.get_shape();  // (P, tgrid*tgrid, hidden)
+    OPENVINO_ASSERT(shape.size() == 3, "Unexpected Unlimited-OCR tile feature shape");
+    const size_t num_tiles = shape.at(0);
+    const size_t hw2 = shape.at(1);
+    OPENVINO_ASSERT(shape.at(2) == hidden, "Unlimited-OCR tile feature hidden size mismatch");
+    const auto tgrid = static_cast<size_t>(std::lround(std::sqrt(static_cast<double>(hw2))));
+    OPENVINO_ASSERT(tgrid * tgrid == hw2, "Unlimited-OCR tile feature grid must be square, got ", hw2);
+    OPENVINO_ASSERT(num_tiles == static_cast<size_t>(width_crop_num) * static_cast<size_t>(height_crop_num),
+                    "Unlimited-OCR tile count does not match crop ratio");
+
+    const size_t grid_h = static_cast<size_t>(height_crop_num) * tgrid;
+    const size_t grid_w = static_cast<size_t>(width_crop_num) * tgrid;
+
+    // Cache all tile rows as f32 for random access.
+    std::vector<float> tiles(num_tiles * hw2 * hidden);
+    copy_rows_to_f32(tile_features, 0, tiles.data(), num_tiles * hw2, hidden);
+
+    for (size_t gy = 0; gy < grid_h; ++gy) {
+        const size_t tile_row = gy / tgrid;   // crop row index (0..height_crop_num-1)
+        const size_t in_row = gy % tgrid;     // token row inside the tile
+        for (size_t gx = 0; gx < grid_w; ++gx) {
+            const size_t tile_col = gx / tgrid;  // crop col index (0..width_crop_num-1)
+            const size_t in_col = gx % tgrid;    // token col inside the tile
+            const size_t tile_idx = tile_row * static_cast<size_t>(width_crop_num) + tile_col;
+            const size_t token_idx = in_row * tgrid + in_col;
+            const float* src = tiles.data() + (tile_idx * hw2 + token_idx) * hidden;
+            out.insert(out.end(), src, src + hidden);
+        }
+        out.insert(out.end(), image_newline.begin(), image_newline.end());
+    }
+}
+
+}  // namespace
+
+VisionEncoderUnlimitedOCR::VisionEncoderUnlimitedOCR(const std::filesystem::path& model_dir,
+                                                     const std::string& device,
+                                                     const ov::AnyMap properties)
+    : VisionEncoder(model_dir, device, properties) {
+    auto compiled_tiles = utils::singleton_core().compile_model(
+        model_dir / "openvino_vision_embeddings_tiles_model.xml",
+        device,
+        utils::get_model_properties(properties, "vision_embeddings_tiles", device));
+    m_ireq_queue_vision_encoder_tiles = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_tiles.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_tiles]() -> ov::InferRequest {
+            return compiled_tiles.create_infer_request();
+        });
+    m_vlm_config = utils::from_config_json_if_exists<VLMConfig>(model_dir, "config.json");
+}
+
+VisionEncoderUnlimitedOCR::VisionEncoderUnlimitedOCR(const ModelsMap& models_map,
+                                                     const std::filesystem::path& config_dir_path,
+                                                     const std::string& device,
+                                                     const ov::AnyMap properties)
+    : VisionEncoder(models_map, config_dir_path, device, properties) {
+    const auto& [tiles_model, tiles_weights] = utils::get_model_weights_pair(models_map, "vision_embeddings_tiles");
+    auto compiled_tiles = utils::singleton_core().compile_model(
+        tiles_model,
+        tiles_weights,
+        device,
+        utils::get_model_properties(properties, "vision_embeddings_tiles", device));
+    m_ireq_queue_vision_encoder_tiles = std::make_unique<CircularBufferQueue<ov::InferRequest>>(
+        compiled_tiles.get_property(ov::optimal_number_of_infer_requests),
+        [&compiled_tiles]() -> ov::InferRequest {
+            return compiled_tiles.create_infer_request();
+        });
+    m_vlm_config = utils::from_config_json_if_exists<VLMConfig>(config_dir_path, "config.json");
+}
+
+EncodedImage VisionEncoderUnlimitedOCR::encode(const ov::Tensor& image, const ov::AnyMap& config_map) {
+    const clip_image_u8 input_image = tensor_to_clip_image_u8(image);
+    const size_t hidden = m_vlm_config.image_newline.size();
+    OPENVINO_ASSERT(hidden > 0, "Unlimited-OCR requires a non-empty image_newline in config.json");
+    OPENVINO_ASSERT(m_vlm_config.view_separator.size() == hidden,
+                    "Unlimited-OCR view_separator size does not match image_newline size");
+
+    // Crop mode is enabled when the image exceeds the tile resolution in any dimension.
+    std::vector<clip_image_u8> tile_images;
+    std::pair<int, int> crop_ratio{1, 1};
+    if (input_image.nx > TILE_SIZE || input_image.ny > TILE_SIZE) {
+        auto [tiles, ratio] = dynamic_preprocess(input_image, TILE_SIZE, DYN_MIN_NUM, DYN_MAX_NUM);
+        crop_ratio = ratio;
+        if (ratio.first > 1 || ratio.second > 1) {
+            tile_images = std::move(tiles);
+        }
+    }
+    const bool crop_mode = !tile_images.empty();
+
+    // Global view is always processed at BASE_SIZE (1024x1024).
+    const clip_image_u8 global_view = pad_to_square(input_image, BASE_SIZE, PAD_VALUES);
+    const ov::Tensor global_tensor = to_batch_tensor({global_view}, IMAGE_MEAN, IMAGE_STD);
+    const ov::Tensor global_features = infer_and_copy(m_ireq_queue_vision_encoder.get(), global_tensor);
+
+    std::vector<float> feature_values;
+    if (crop_mode) {
+        // Layout: cat([local_tiles, global, view_separator]).
+        const ov::Tensor tile_tensor = to_batch_tensor(tile_images, IMAGE_MEAN, IMAGE_STD);
+        const ov::Tensor tile_features = infer_and_copy(m_ireq_queue_vision_encoder_tiles.get(), tile_tensor);
+        append_local_with_newlines(tile_features, crop_ratio.first, crop_ratio.second,
+                                   m_vlm_config.image_newline, feature_values, hidden);
+    }
+    append_global_with_newlines(global_features, m_vlm_config.image_newline, feature_values, hidden);
+    feature_values.insert(feature_values.end(), m_vlm_config.view_separator.begin(), m_vlm_config.view_separator.end());
+
+    OPENVINO_ASSERT(feature_values.size() % hidden == 0, "Unlimited-OCR assembled feature size is not hidden-aligned");
+    const size_t total_tokens = feature_values.size() / hidden;
+    ov::Tensor merged_features(ov::element::f32, {1, total_tokens, hidden});
+    std::copy_n(feature_values.data(), feature_values.size(), merged_features.data<float>());
+
+    EncodedImage encoded_image;
+    encoded_image.resized_source = std::move(merged_features);
+    encoded_image.num_image_tokens = total_tokens;
+    encoded_image.resized_source_size = ImageSize{static_cast<size_t>(BASE_SIZE), static_cast<size_t>(BASE_SIZE)};
+    encoded_image.original_image_size = ImageSize{static_cast<size_t>(input_image.ny), static_cast<size_t>(input_image.nx)};
+    return encoded_image;
+}
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/unlimited_ocr/classes.hpp
+++ b/src/cpp/src/visual_language/unlimited_ocr/classes.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <filesystem>
+
+#include "visual_language/vision_encoder.hpp"
+
+namespace ov::genai {
+
+// baidu/Unlimited-OCR (model_type == "unlimited-ocr"): a DeepEncoder vision branch
+// (SAM ViT-B fused into CLIP-L followed by a linear projector) coupled with a
+// DeepSeek-V2 MoE language model.
+//
+// The vision branch is exported as two static-shape submodels that already include
+// the multimodal projector, so their output lives in the text-embedding space:
+//   * openvino_vision_embeddings_model        -> global view  (1024x1024 -> 256 tokens)
+//   * openvino_vision_embeddings_tiles_model  -> crop tiles   (640x640   -> 100 tokens)
+//
+// The per-image visual feature reproduces UnlimitedOCRModel.forward: every feature
+// grid row is terminated by a learnable ``image_newline`` vector and each image is
+// closed by a learnable ``view_separator`` vector. In crop mode the layout is
+// ``cat([local_tiles, global, view_separator])`` and in the non-crop mode it is
+// ``cat([global, view_separator])``. Every placeholder position uses the
+// ``<image>`` token id (128815), so the text side reuses InputsEmbedderDeepseekOCR2.
+class VisionEncoderUnlimitedOCR : public VisionEncoder {
+public:
+    VisionEncoderUnlimitedOCR(
+        const std::filesystem::path& model_dir,
+        const std::string& device,
+        const ov::AnyMap properties);
+
+    VisionEncoderUnlimitedOCR(
+        const ModelsMap& models_map,
+        const std::filesystem::path& config_dir_path,
+        const std::string& device,
+        const ov::AnyMap properties);
+
+    EncodedImage encode(const ov::Tensor& image, const ov::AnyMap& config_map) override;
+
+private:
+    std::unique_ptr<CircularBufferQueue<ov::InferRequest>> m_ireq_queue_vision_encoder_tiles;
+    VLMConfig m_vlm_config;
+};
+
+}  // namespace ov::genai

--- a/src/cpp/src/visual_language/vision_encoder.cpp
+++ b/src/cpp/src/visual_language/vision_encoder.cpp
@@ -25,6 +25,7 @@
 #include "visual_language/gemma3n/classes.hpp"
 #include "visual_language/gemma4/classes.hpp"
 #include "visual_language/deepseek_ocr2/classes.hpp"
+#include "visual_language/unlimited_ocr/classes.hpp"
 #include "visual_language/videochat_flash/classes.hpp"
 #include "visual_language/muse_glimmer/classes.hpp"
 
@@ -150,6 +151,8 @@ VisionEncoder::Ptr VisionEncoder::create(const std::filesystem::path& model_dir,
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(model_dir, device, properties);
     } else if (model_type == VLMModelType::DEEPSEEK_OCR2) {
         return std::make_shared<VisionEncoderDeepseekOCR2>(model_dir, device, properties);
+    } else if (model_type == VLMModelType::UNLIMITED_OCR) {
+        return std::make_shared<VisionEncoderUnlimitedOCR>(model_dir, device, properties);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(model_dir, device, properties);
     } else {
@@ -201,6 +204,8 @@ VisionEncoder::Ptr VisionEncoder::create(
         return std::make_shared<VisionEncoderVideoChatFlashQwen>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::DEEPSEEK_OCR2) {
         return std::make_shared<VisionEncoderDeepseekOCR2>(models_map, config_dir_path, device, device_config);
+    } else if (model_type == VLMModelType::UNLIMITED_OCR) {
+        return std::make_shared<VisionEncoderUnlimitedOCR>(models_map, config_dir_path, device, device_config);
     } else if (model_type == VLMModelType::MUSE_GLIMMER) {
         return std::make_shared<VisionEncoderMuseGlimmer>(models_map, config_dir_path, device, device_config);
     } else {

--- a/src/cpp/src/visual_language/vlm_config.cpp
+++ b/src/cpp/src/visual_language/vlm_config.cpp
@@ -35,6 +35,7 @@ VLMModelType to_vlm_model_type(const std::string& value) {
         {"qwen3_omni", VLMModelType::QWEN3_OMNI},
         {"qwen3_omni_moe", VLMModelType::QWEN3_OMNI},
         {"deepseek_ocr2", VLMModelType::DEEPSEEK_OCR2},
+        {"unlimited-ocr", VLMModelType::UNLIMITED_OCR},
         {"muse_glimmer", VLMModelType::MUSE_GLIMMER},
     };
 

--- a/src/cpp/src/visual_language/vlm_config.hpp
+++ b/src/cpp/src/visual_language/vlm_config.hpp
@@ -33,6 +33,7 @@ enum class VLMModelType {
     VIDEOCHAT_FLASH_QWEN,
     QWEN3_OMNI,
     DEEPSEEK_OCR2,
+    UNLIMITED_OCR,
     MUSE_GLIMMER,
 };
 

--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -169,6 +169,7 @@ MODEL_GEMMA = "optimum-intel-internal-testing/tiny-random-gemma3"
 MODEL_GEMMA3N = "optimum-intel-internal-testing/tiny-random-gemma3n"
 MODEL_QWEN3_OMNI = "optimum-intel-internal-testing/tiny-random-qwen3-omni"
 MODEL_DEEPSEEK_OCR2 = "optimum-intel-internal-testing/tiny-random-deepseek-ocr-2"
+MODEL_UNLIMITED_OCR = "optimum-intel-internal-testing/tiny-random-unlimited-ocr"
 
 MODEL_IDS: list[str] = []
 if is_transformers_version("<", "5.0"):
@@ -183,6 +184,7 @@ if is_transformers_version("<", "5.0"):
         "optimum-intel-internal-testing/tiny-random-gemma3",
         MODEL_GEMMA3N,
         "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+        MODEL_UNLIMITED_OCR,
         *VIDEO_MODEL_IDS,
     ]
 else:
@@ -212,6 +214,7 @@ IMAGE_TAG_GENERATOR_BY_MODEL: dict[str, Callable[[int], str]] = {
     MODEL_GEMMA3N: lambda idx: "<image_soft_token>",
     "optimum-intel-internal-testing/tiny-random-internvl2": lambda idx: "<image>\n",
     MODEL_DEEPSEEK_OCR2: lambda idx: "<image>",
+    MODEL_UNLIMITED_OCR: lambda idx: "<image>",
     "optimum-intel-internal-testing/tiny-random-minicpmv-2_6": lambda idx: "<image>./</image>\n",
     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6": lambda idx: "<image>./</image>\n",
     "optimum-intel-internal-testing/tiny-random-phi3-vision": lambda idx: f"<|image_{idx + 1}|>\n",
@@ -288,10 +291,12 @@ NPU_UNSUPPORTED_MODELS = {
     "optimum-intel-internal-testing/tiny-random-gemma4-unified-it",
     "optimum-intel-internal-testing/tiny-random-gemma4-31B",
     MODEL_DEEPSEEK_OCR2,
+    MODEL_UNLIMITED_OCR,
 }
 
 MODELS_WITHOUT_CHAT_TEMPLATE = {
     MODEL_DEEPSEEK_OCR2,
+    MODEL_UNLIMITED_OCR,
 }
 
 DEFAULT_NPUW_PROPERTIES = {
@@ -453,10 +458,13 @@ def _get_ov_model(model_id: str) -> str:
                     "qnguyen3/nanoLLaVA",
                     "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
                     VIDEOCHAT_FLASH_QWEN_MODEL_ID,
+                    MODEL_UNLIMITED_OCR,
                 },
             )
         )
-        if model.config.model_type == "llava-qwen2" or _is_videochat_flash_qwen_model(model_id):
+        if model.config.model_type == "llava-qwen2" or _is_videochat_flash_qwen_model(model_id) or model_id == MODEL_UNLIMITED_OCR:
+            # For Unlimited-OCR the AutoProcessor resolves to a bare tokenizer
+            # (LlamaTokenizerFast); preprocessing is done by GenAI's C++ vision encoder.
             tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
         # For tiny-random-internvl2 processor is actually tokenizer
         elif isinstance(processor, transformers.Qwen2TokenizerFast):
@@ -532,6 +540,14 @@ def ov_pipe_model(request: pytest.FixtureRequest) -> VlmModelInfo:
 
     if "qwen3-vl" in ov_model and ov_backend == "SDPA":
         pytest.xfail(QWEN3_VL_SDPA_XFAIL_REASON)
+
+    if ov_model == MODEL_UNLIMITED_OCR and ov_backend == "PA":
+        pytest.skip(
+            "Unlimited-OCR uses a DeepSeek-V2 MoE language model whose OpenVINO export does not "
+            "contain a ScaledDotProductAttention op, so the SDPAToPagedAttention transformation "
+            "cannot run. The PagedAttention backend is therefore unsupported for this model; the "
+            "default SDPA/stateful backend is validated instead."
+        )
 
     models_path = _get_ov_model(ov_model)
 
@@ -811,6 +827,7 @@ def test_images(request: pytest.FixtureRequest):
 
 SINGLE_IMAGE_ONLY_MODELS = {
     MODEL_DEEPSEEK_OCR2,
+    MODEL_UNLIMITED_OCR,
 }
 
 
@@ -2319,7 +2336,9 @@ def run_compare_genai_optimum(ov_pipe_model: VlmModelInfo, image, video):
             processor.tokenizer.add_bos_token = False
         if optimum_model.config.model_type == "muse_glimmer":
             processor.tokenizer.add_bos_token = False
-        if optimum_model.config.model_type in ["internvl_chat", "minicpmv"]:
+        if optimum_model.config.model_type in ["internvl_chat", "minicpmv", "unlimited-ocr"]:
+            # Unlimited-OCR's AutoProcessor resolves to a bare tokenizer, so optimum-intel
+            # preprocessing requires an explicit tokenizer (it text-encodes with it directly).
             tokenizer = transformers.AutoTokenizer.from_pretrained(model_cached, trust_remote_code=True)
         if optimum_model.config.model_type == "minicpmv":
             # optimum 1.27.0 will manually apply chat template if processor.chat_template isn't set.
@@ -2440,6 +2459,8 @@ OPTIMUM_VS_GENAI_MODEL_EXPECTED_FAIL_CASES = {
     "*tiny-videochat-flash-qwen/PA/CPP/text-only": "CVS-183813",
     # deepseek-ocr-2 text-only cases
     "*tiny-random-deepseek-ocr-2/*/text-only": "DeepSeek OCR-2 model requires image input.",
+    # unlimited-ocr text-only cases
+    "*tiny-random-unlimited-ocr/*/text-only": "Unlimited-OCR model requires image input.",
 }
 
 # For these models, we will add both CPP and GRAPH pre-processing tests.

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/__init__.py
@@ -9,10 +9,12 @@ from .qwen3 import Qwen3VLInputsPreprocessor, Qwen3_5VLInputsPreprocessor, Qwen3
 from .gemma3 import Gemma3InputsPreprocessor
 from .gemma4 import Gemma4InputsPreprocessor, Gemma4UnifiedInputsPreprocessor, Gemma3nInputsPreprocessor
 from .muse_glimmer import MuseGlimmerInputsPreprocessor
+from .unlimitedocr import UnlimitedOCRInputsPreprocessor
 from .vlm_inputs_preprocessor import VLMInputsPreprocessor
 
 MODEL_TYPE_TO_CLS_MAPPING = {
     "muse_glimmer": MuseGlimmerInputsPreprocessor,
+    "unlimited-ocr": UnlimitedOCRInputsPreprocessor,
     "qwen3_vl": Qwen3VLInputsPreprocessor,
     "qwen3_5_moe": Qwen3_5VLInputsPreprocessor,
     "qwen3_5": Qwen3_5VLInputsPreprocessor,

--- a/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/unlimitedocr.py
+++ b/tools/who_what_benchmark/whowhatbench/inputs_preprocessors/unlimitedocr.py
@@ -1,0 +1,184 @@
+import importlib
+import math
+
+import numpy as np
+import torch
+from transformers import (
+    AutoImageProcessor,
+    PretrainedConfig,
+    PreTrainedTokenizer,
+)
+from typing import TYPE_CHECKING, Optional, Union, Any
+
+from .vlm_inputs_preprocessor import VLMInputsPreprocessor
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
+    from transformers.image_utils import VideoInput
+
+
+# Constants defined by the UnlimitedOCR / DeepSeek-OCR remote-code `infer` method.
+IMAGE_TOKEN = "<image>"
+IMAGE_TOKEN_ID = 128815
+BOS_ID = 0
+PATCH_SIZE = 16
+DOWNSAMPLE_RATIO = 4
+DEFAULT_BASE_SIZE = 1024
+DEFAULT_IMAGE_SIZE = 640
+
+
+class UnlimitedOCRInputsPreprocessor(VLMInputsPreprocessor):
+    """Inputs preprocessor for baidu/Unlimited-OCR (model_type == "unlimited-ocr").
+
+    The model ships a custom remote-code ``UnlimitedOCRForCausalLM`` (SAM ViT-B +
+    CLIP-L -> linear projector -> DeepSeek-V2 MoE). Generation does not go through
+    a HF processor: the reference ``infer`` method builds ``input_ids`` interleaved
+    with image placeholder tokens plus ``images``, ``images_seq_mask`` and
+    ``images_spatial_crop`` tensors that the custom ``forward`` consumes.
+
+    This class reproduces that preprocessing (crop mode) generically, reusing the
+    model's own remote-code helpers (image transform, dynamic crop, text encode)
+    resolved from the live config module, so no dependency on a Hub id is needed.
+    """
+
+    def __init__(self, chat_mode: bool = False, model: Optional[Any] = None):
+        super().__init__(chat_mode)
+        self.def_image_token_id = IMAGE_TOKEN_ID
+
+    def update_chat_history_with_answer(self, answer):
+        self.chat_history.append({"role": "<|Assistant|>", "content": answer})
+
+    def _resolve_remote_helpers(self, config: PretrainedConfig):
+        # The custom config class is defined in the model's remote-code module,
+        # which also exposes BasicImageTransform / dynamic_preprocess / text_encode.
+        module = importlib.import_module(type(config).__module__)
+        return (
+            module.BasicImageTransform,
+            module.dynamic_preprocess,
+            module.text_encode,
+        )
+
+    def preprocess_inputs(
+        self,
+        text: str,
+        image: Optional[Union["Image", list["Image"]]] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional[Union["VideoInput", list["VideoInput"]]] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required for unlimited-ocr preprocessing.")
+        if config is None:
+            raise ValueError("Model config is required for unlimited-ocr preprocessing.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        from PIL import ImageOps
+
+        BasicImageTransform, dynamic_preprocess, text_encode = self._resolve_remote_helpers(config)
+
+        base_size = DEFAULT_BASE_SIZE
+        image_size = DEFAULT_IMAGE_SIZE
+
+        images = []
+        if image is not None:
+            if not isinstance(image, list):
+                image = [image]
+            images = [im.convert("RGB") for im in image if im is not None]
+        self.update_images(images if images else None)
+
+        # Interleave one <image> placeholder per image if the prompt has none.
+        if images and IMAGE_TOKEN not in text:
+            prompt = (IMAGE_TOKEN + "\n") * len(images) + text
+        else:
+            prompt = text
+
+        image_transform = BasicImageTransform(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5), normalize=True)
+        # Model is loaded in float32 by WWB (no torch_dtype override); keep inputs float32.
+        target_dtype = torch.float32
+
+        text_splits = prompt.split(IMAGE_TOKEN)
+
+        images_list, images_crop_list = [], []
+        tokenized_str, images_seq_mask, images_spatial_crop = [], [], []
+
+        num_queries = math.ceil((image_size // PATCH_SIZE) / DOWNSAMPLE_RATIO)
+        num_queries_base = math.ceil((base_size // PATCH_SIZE) / DOWNSAMPLE_RATIO)
+
+        for text_sep, img in zip(text_splits, images):
+            tokenized_sep = text_encode(tokenizer, text_sep, bos=False, eos=False)
+            tokenized_str += tokenized_sep
+            images_seq_mask += [False] * len(tokenized_sep)
+
+            # crop mode (matches infer default crop_mode=True)
+            if img.size[0] <= 640 and img.size[1] <= 640:
+                images_crop_raw, crop_ratio = [], [1, 1]
+            else:
+                images_crop_raw, crop_ratio = dynamic_preprocess(img)
+
+            global_view = ImageOps.pad(
+                img,
+                (base_size, base_size),
+                color=tuple(int(x * 255) for x in image_transform.mean),
+            )
+            images_list.append(image_transform(global_view).to(target_dtype))
+
+            width_crop_num, height_crop_num = crop_ratio
+            images_spatial_crop.append([width_crop_num, height_crop_num])
+
+            if width_crop_num > 1 or height_crop_num > 1:
+                for crop in images_crop_raw:
+                    images_crop_list.append(image_transform(crop).to(target_dtype))
+
+            tokenized_image = ([IMAGE_TOKEN_ID] * num_queries_base + [IMAGE_TOKEN_ID]) * num_queries_base
+            tokenized_image += [IMAGE_TOKEN_ID]
+            if width_crop_num > 1 or height_crop_num > 1:
+                tokenized_image += ([IMAGE_TOKEN_ID] * (num_queries * width_crop_num) + [IMAGE_TOKEN_ID]) * (
+                    num_queries * height_crop_num
+                )
+            tokenized_str += tokenized_image
+            images_seq_mask += [True] * len(tokenized_image)
+
+        # trailing text after the last <image> placeholder
+        tokenized_sep = text_encode(tokenizer, text_splits[-1], bos=False, eos=False)
+        tokenized_str += tokenized_sep
+        images_seq_mask += [False] * len(tokenized_sep)
+
+        # prepend bos
+        tokenized_str = [BOS_ID] + tokenized_str
+        images_seq_mask = [False] + images_seq_mask
+
+        input_ids = torch.LongTensor(tokenized_str).unsqueeze(0)
+        images_seq_mask = torch.tensor(images_seq_mask, dtype=torch.bool).unsqueeze(0)
+        attention_mask = torch.ones_like(input_ids)
+
+        if len(images_list) == 0:
+            images_ori = torch.zeros((1, 3, image_size, image_size), dtype=target_dtype)
+            images_spatial_crop = torch.zeros((1, 2), dtype=torch.long)
+            images_crop = torch.zeros((1, 3, base_size, base_size), dtype=target_dtype)
+        else:
+            images_ori = torch.stack(images_list, dim=0)
+            images_spatial_crop = torch.tensor(images_spatial_crop, dtype=torch.long)
+            if images_crop_list:
+                images_crop = torch.stack(images_crop_list, dim=0)
+            else:
+                images_crop = torch.zeros((1, 3, base_size, base_size), dtype=target_dtype)
+
+        # The DeepSeek-V2 backbone uses a ring-buffer sliding-window KV cache during
+        # decode; the reference `infer` disables `config.sliding_window` before
+        # generate so DynamicCache does not truncate the (long) image prefill.
+        # Mirror that here on the live config object.
+        if getattr(config, "sliding_window", None) is not None:
+            config.sliding_window = None
+
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "images": [(images_crop, images_ori)],
+            "images_seq_mask": images_seq_mask,
+            "images_spatial_crop": images_spatial_crop,
+        }

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -30,6 +30,7 @@ from .utils import (
     mock_torch_cuda_is_available,
     mock_AwqQuantizer_validate_environment,
     disable_diffusers_model_progress_bar,
+    enable_cpu_fallback_for_cuda_hardcoded_models,
     get_json_config,
     normalize_lora_adapters_and_alphas,
 )
@@ -512,6 +513,11 @@ def load_visual_text_model(
 ):
     if use_hf:
         logger.info("Using HF Transformers API")
+
+        # Some remote-code VLMs hardcode `.cuda()` in their forward; on a CPU-only
+        # torch build such calls can only raise. Enable a safe CPU fallback so HF
+        # baseline/ground-truth generation can run on CPU (no-op on CUDA setups).
+        enable_cpu_fallback_for_cuda_hardcoded_models(device)
 
         trust_remote_code = False
         try:

--- a/tools/who_what_benchmark/whowhatbench/utils.py
+++ b/tools/who_what_benchmark/whowhatbench/utils.py
@@ -182,6 +182,40 @@ def get_ignore_parameters_flag():
     return {}
 
 
+def enable_cpu_fallback_for_cuda_hardcoded_models(device):
+    """Make hardcoded ``Tensor.cuda()`` calls fall back to CPU when appropriate.
+
+    Some remote-code models (e.g. OCR/VLM families) hardcode ``.cuda()`` inside
+    their ``forward``/embedding-merge code. When WWB runs such a model on CPU with
+    a CUDA-less torch build, those calls can *only* raise
+    ``AssertionError("Torch not compiled with CUDA enabled")`` - there is no CUDA
+    device they could ever target. Redirecting them to the tensor's current
+    (CPU) device is therefore a safe, generic compatibility shim:
+
+      * It is applied only when the target device is CPU and ``torch.cuda`` is
+        unavailable, so it cannot mask or alter a genuinely working CUDA path.
+      * It is generic (keyed on device/availability, not on any model name/id).
+      * It does not modify cached Hub remote-code sources.
+
+    This is a no-op on GPU/CUDA setups.
+    """
+    import torch
+
+    if str(device).upper() != "CPU":
+        return
+    if torch.cuda.is_available():
+        return
+    if getattr(torch.Tensor, "_wwb_cuda_cpu_fallback", False):
+        return
+
+    def _cuda_to_cpu(self, *args, **kwargs):
+        # Tensor is already on CPU in this configuration; keep it there.
+        return self
+
+    torch.Tensor.cuda = _cuda_to_cpu
+    torch.Tensor._wwb_cuda_cpu_fallback = True
+
+
 def get_json_config(config):
     if config is None or (isinstance(config, str) and config.strip() == ""):
         raise ValueError("Config must be a non-empty string or path to a JSON file.")

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -530,9 +530,61 @@ def check_args(args):
         args.dataset_field = "text"
 
 
+def _load_local_csv_prompts(path):
+    """Load a local CSV dataset for (visual-)text tasks.
+
+    The CSV is treated as *input data only*: WWB still generates the ground
+    truth. Recognized columns:
+      - "prompts" (required): text prompt per row.
+      - "images"  (optional): path to an image file, resolved relative to the
+        CSV location when not absolute. Empty values become None.
+      - "videos"  (optional): path to a video, resolved the same way.
+
+    Returns a dict with "prompts" and, when present, "images"/"videos" so it can
+    be passed straight through WWB's dataset interface (test_data).
+    """
+    import pandas as pd
+    from PIL import Image
+
+    csv_dir = os.path.dirname(os.path.abspath(path))
+    df = pd.read_csv(path)
+    if "prompts" not in df.columns:
+        raise ValueError(
+            f"Local dataset CSV '{path}' must contain a 'prompts' column, got columns: {list(df.columns)}"
+        )
+
+    def _resolve(rel_path):
+        if rel_path is None:
+            return None
+        if isinstance(rel_path, float) and pd.isna(rel_path):
+            return None
+        rel_path = str(rel_path).strip()
+        if rel_path == "" or rel_path.lower() == "nan":
+            return None
+        return rel_path if os.path.isabs(rel_path) else os.path.join(csv_dir, rel_path)
+
+    res = {"prompts": list(df["prompts"])}
+
+    if "images" in df.columns:
+        images = []
+        for value in df["images"]:
+            resolved = _resolve(value)
+            images.append(Image.open(resolved).convert("RGB") if resolved is not None else None)
+        res["images"] = images
+
+    if "videos" in df.columns:
+        res["videos"] = [_resolve(value) for value in df["videos"]]
+
+    return res
+
+
 def load_prompts(args):
     if args.dataset is None:
         return None
+    # Support a deterministic local CSV dataset (prompts/images/videos columns),
+    # e.g. when the default remote dataset is unavailable or too slow.
+    if "," not in args.dataset and os.path.isfile(args.dataset) and args.dataset.lower().endswith(".csv"):
+        return _load_local_csv_prompts(args.dataset)
     split = "validation"
     if args.split is not None:
         split = args.split


### PR DESCRIPTION
## Reproduce generation

```python
from PIL import Image
import openvino_genai

pipe = openvino_genai.VLMPipeline("output_dir", "CPU")
image = Image.new("RGB", (64, 64), "white")
result = pipe.generate("Describe this image.", image=image, max_new_tokens=10)
print(result.texts[0])
```

## Validation

**Machine Info:**

- **CPU Model:** Intel(R) Core(TM) i9-14900
- **GPU:** Intel Corporation Device a780 (rev 04)
- **RAM:** 125.54 GiB

**WWB Accuracy:**

- **fp16 CPU (Paged Attention):** 1.0

- **int8 CPU:** Not run

- **int4 CPU:** Not run

- **fp16 GPU (Paged Attention):** 0.698662

- **int8 GPU:** Not run

- **int4 GPU:** Not run

**OpenVINO GenAI Validation Backend:**

- **fp16 CPU GenAI:** Paged Attention
- **fp16 GPU GenAI:** Paged Attention

**LLM Bench Performance:**

- **fp16 CPU - GenAI:**
  - Not run

- **int8 CPU - GenAI:**
  - Not run

- **int4 CPU - GenAI:**
  - Not run

- **fp16 GPU - GenAI:**
  - Not run

- **int8 GPU - GenAI:**
  - Not run

- **int4 GPU - GenAI:**
  - Not run

**Validation Warnings:**

- GPU GenAI FP16 fails: device=GPU, precision=FP16, Paged Attention HF-relative=0.698662, SDPA fallback HF-relative=0.698662 (both RC=0, config accepted, byte-identical output), both < 0.95 threshold. SDPA did not recover the failure, so it is not an accepted fallback here.
- INT8/INT4 WWB and all llm_bench performance measurements were intentionally not run because the terminal FP16 GPU GenAI failure already forces status=bad and those measurements cannot change the decision.
- Environment integrity preserved: primary venv_new_model transformers=5.5.4 unchanged; export/WWB run through compat overlay compat_envs/tf4571 (transformers 4.57.1, openvino 2026.5.0-23005-9b1d5c9494e, nncf 3.3.0).
- optimum_intel did not resolve final validation after its single repair attempt.

## Related model-support PRs

- Optimum Intel: https://github.com/huggingface/optimum-intel/pull/1987

## Checklist

- [x] This PR follows the GenAI contributing guidelines.
- [x] Tests have been updated or added to cover the new code.
- [x] This PR fully addresses the model-support work.
- [x] Documentation was updated, or its absence is explained in the validation handoff.
