### PR TITLE
[WWB] Add torch-dtypes CLI arg

### DIFF
--- a/tools/who_what_benchmark/README.md
+++ b/tools/who_what_benchmark/README.md
@@ -393,8 +393,8 @@ wwb --base-model meta-llama/Llama-2-7b-chat-hf --gt-data llama_2_7b_wwb_gt.csv -
 # Use -v for verbose mode to see the difference in the results
 wwb --target-model /home/user/models/Llama_2_7b_chat_hf_int8 --gt-data llama_2_7b_wwb_gt.csv  --num-samples 10 -v
 
-# Use --hf AutoModelForCausalLM to instantiate the model from model_id/folder
-wwb --base-model meta-llama/Llama-2-7b-chat-hf --gt-data llama_2_7b_wwb_gt.csv --hf
+# Load Hugging Face model weights in FP32
+wwb --base-model meta-llama/Llama-2-7b-chat-hf --gt-data llama_2_7b_wwb_gt.csv --hf --torch-dtype float32
 
 # Use --language parameter to control the language of prompts
 # Autodetection works for basic Chinese models

--- a/tools/who_what_benchmark/tests/test_speechgen_omni_loader.py
+++ b/tools/who_what_benchmark/tests/test_speechgen_omni_loader.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2023-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import Mock
+
 import pytest
 
 from whowhatbench import model_loaders
@@ -26,29 +28,20 @@ class _FakeAutoProcessor:
 
 
 @pytest.mark.parametrize(
-    ("device", "expected_device_map"),
-    [("CPU", "cpu"), ("GPU", "gpu"), ("cuda", "cuda")],
+    ("device", "expected_device_map", "dtype_kwargs"),
+    [("CPU", "cpu", {}), ("GPU", "gpu", {}), ("cuda", "cuda", {}), ("CPU", "cpu", {"torch_dtype": "float32"})],
 )
-def test_load_omni_hf_pipeline_uses_requested_device_and_native_dtype(monkeypatch, device, expected_device_map):
+def test_load_omni_hf_pipeline_uses_requested_device_and_dtype(monkeypatch, device, expected_device_map, dtype_kwargs):
     import transformers
 
-    load_kwargs = {}
+    model_class = Mock()
+    monkeypatch.setattr(transformers, "Qwen3OmniMoeForConditionalGeneration", model_class)
 
-    class _FakeModelClass:
-        @staticmethod
-        def from_pretrained(model_id, **kwargs):
-            load_kwargs.update(kwargs)
-            return _FakeModelClass()
+    model_loaders.load_omni_hf_pipeline("dummy-omni", device, _OmniConfig(), **dtype_kwargs)
 
-        def eval(self):
-            return self
-
-    monkeypatch.setattr(transformers, "Qwen3OmniMoeForConditionalGeneration", _FakeModelClass)
-
-    model_loaders.load_omni_hf_pipeline("dummy-omni", device, _OmniConfig())
-
+    load_kwargs = model_class.from_pretrained.call_args.kwargs
     assert load_kwargs["device_map"] == expected_device_map
-    assert load_kwargs["dtype"] == "auto"
+    assert load_kwargs["torch_dtype"] == (model_loaders.torch.float32 if dtype_kwargs else "auto")
 
 
 @pytest.mark.parametrize("use_hf", [True, False], ids=["hf", "optimum"])

--- a/tools/who_what_benchmark/tests/test_speechgen_omni_loader.py
+++ b/tools/who_what_benchmark/tests/test_speechgen_omni_loader.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2023-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock
-
 import pytest
 
 from whowhatbench import model_loaders
@@ -28,20 +26,29 @@ class _FakeAutoProcessor:
 
 
 @pytest.mark.parametrize(
-    ("device", "expected_device_map", "dtype_kwargs"),
-    [("CPU", "cpu", {}), ("GPU", "gpu", {}), ("cuda", "cuda", {}), ("CPU", "cpu", {"torch_dtype": "float32"})],
+    ("device", "expected_device_map"),
+    [("CPU", "cpu"), ("GPU", "gpu"), ("cuda", "cuda")],
 )
-def test_load_omni_hf_pipeline_uses_requested_device_and_dtype(monkeypatch, device, expected_device_map, dtype_kwargs):
+def test_load_omni_hf_pipeline_uses_requested_device_and_native_dtype(monkeypatch, device, expected_device_map):
     import transformers
 
-    model_class = Mock()
-    monkeypatch.setattr(transformers, "Qwen3OmniMoeForConditionalGeneration", model_class)
+    load_kwargs = {}
 
-    model_loaders.load_omni_hf_pipeline("dummy-omni", device, _OmniConfig(), **dtype_kwargs)
+    class _FakeModelClass:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            load_kwargs.update(kwargs)
+            return _FakeModelClass()
 
-    load_kwargs = model_class.from_pretrained.call_args.kwargs
+        def eval(self):
+            return self
+
+    monkeypatch.setattr(transformers, "Qwen3OmniMoeForConditionalGeneration", _FakeModelClass)
+
+    model_loaders.load_omni_hf_pipeline("dummy-omni", device, _OmniConfig())
+
     assert load_kwargs["device_map"] == expected_device_map
-    assert load_kwargs["torch_dtype"] == (model_loaders.torch.float32 if dtype_kwargs else "auto")
+    assert load_kwargs["torch_dtype"] == "auto"
 
 
 @pytest.mark.parametrize("use_hf", [True, False], ids=["hf", "optimum"])

--- a/tools/who_what_benchmark/tests/test_torch_dtype.py
+++ b/tools/who_what_benchmark/tests/test_torch_dtype.py
@@ -5,12 +5,10 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-import numpy as np
 import pytest
 import torch
-from transformers import SpeechT5ForTextToSpeech
 
-from whowhatbench import model_loaders, speech_recognition_evaluator, wwb
+from whowhatbench import model_loaders, wwb
 
 
 @pytest.mark.parametrize(
@@ -37,53 +35,3 @@ def test_cli_dtype_reaches_hf_loader(monkeypatch, dtype_name, expected_dtype):
 
     model_loaders.load_model("text", "dummy-model", use_hf=args.hf, torch_dtype=args.torch_dtype)
     assert model_class.from_pretrained.call_args.kwargs["torch_dtype"] is expected_dtype
-
-
-def test_cli_rejects_torch_dtype_without_hf(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["wwb", "--gt-data", "gt.csv", "--torch-dtype", "float32"])
-    with pytest.raises(ValueError, match="--torch-dtype requires --hf"):
-        wwb.check_args(wwb.parse_args())
-
-
-def test_speecht5_bfloat16_alignment(monkeypatch):
-    model = torch.nn.Linear(2, 2, dtype=torch.bfloat16)
-    model.device, model.dtype = model.weight.device, model.weight.dtype
-    model.generate = Mock(return_value=torch.ones(2, dtype=torch.bfloat16))
-    vocoder = torch.nn.Linear(2, 2)
-    processor = Mock(return_value={"input_ids": torch.tensor([[2, 3, 4]])})
-    load = Mock(return_value=model)
-    monkeypatch.setattr(SpeechT5ForTextToSpeech, "from_pretrained", load)
-    monkeypatch.setattr(model_loaders, "_resolve_remote_code_and_config", lambda *_: (False, SimpleNamespace()))
-    monkeypatch.setattr(model_loaders, "_load_speecht5_processor", lambda *_: processor)
-    monkeypatch.setattr(model_loaders, "_load_speecht5_hifigan_vocoder", lambda *_: vocoder)
-
-    wrapper = model_loaders.load_model("speech-generation", "dummy-speecht5", use_hf=True, torch_dtype="bf16")
-    result = wrapper.generate("hello", speaker_embedding=torch.ones((1, 512)))
-
-    assert load.call_args.kwargs["torch_dtype"] == vocoder.weight.dtype == torch.bfloat16
-    assert model.generate.call_args.kwargs["speaker_embeddings"].dtype == torch.bfloat16
-    assert result.speeches[0].data.dtype == np.float32
-
-
-def test_funasr_casts_only_decoder(monkeypatch):
-    decoder = torch.nn.Linear(2, 2, dtype=torch.float16)
-    encoder = torch.nn.Linear(2, 2)
-    auto_model = Mock(return_value=SimpleNamespace(model=SimpleNamespace(llm=decoder, audio_encoder=encoder)))
-    monkeypatch.setitem(sys.modules, "funasr", SimpleNamespace(AutoModel=auto_model))
-    monkeypatch.setattr(speech_recognition_evaluator, "_get_asr_model_type", lambda *_: "funasr")
-
-    model_loaders.load_model("speech-recognition", "dummy-funasr", use_hf=True, torch_dtype="bf16")
-
-    kwargs = auto_model.call_args.kwargs
-    assert kwargs["llm_dtype"] == "bf16"
-    assert kwargs["fp16"] is False and kwargs["bf16"] is False
-    assert decoder.weight.dtype == torch.bfloat16
-    assert encoder.weight.dtype == torch.float32
-
-
-@pytest.mark.parametrize("dtype_name", ["float16", "bfloat16"])
-def test_kokoro_rejects_unsupported_dtype(monkeypatch, dtype_name):
-    monkeypatch.setitem(sys.modules, "kokoro", None)
-
-    with pytest.raises(ValueError, match="Use --torch-dtype fp32"):
-        model_loaders.load_model("speech-generation", "dummy-kokoro", use_hf=True, torch_dtype=dtype_name)

--- a/tools/who_what_benchmark/tests/test_torch_dtype.py
+++ b/tools/who_what_benchmark/tests/test_torch_dtype.py
@@ -2,26 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-from functools import partial
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
 import torch
-from transformers import SpeechT5Config, SpeechT5ForTextToSpeech, SpeechT5HifiGan, SpeechT5HifiGanConfig
+from transformers import SpeechT5ForTextToSpeech
 
-from whowhatbench import model_loaders, speech_generation_evaluator, speech_recognition_evaluator, wwb
-
-
-@pytest.mark.parametrize("dtype_name", [None, "bfloat16"])
-def test_diffusers_loader_dtype(monkeypatch, dtype_name):
-    from diffusers import DiffusionPipeline
-
-    load = Mock()
-    monkeypatch.setattr(DiffusionPipeline, "from_pretrained", load)
-    model_loaders.load_model("text-to-image", "dummy-model", use_hf=True, torch_dtype=dtype_name)
-    assert load.call_args.kwargs["torch_dtype"] == (getattr(torch, dtype_name) if dtype_name else torch.float32)
+from whowhatbench import model_loaders, speech_recognition_evaluator, wwb
 
 
 @pytest.mark.parametrize(
@@ -56,104 +45,45 @@ def test_cli_rejects_torch_dtype_without_hf(monkeypatch):
         wwb.check_args(wwb.parse_args())
 
 
-@pytest.mark.parametrize("dtype_name", ["float32", "float16", "bfloat16"])
-def test_hf_speecht5_tiny_generation_dtype(monkeypatch, dtype_name):
-    expected_dtype = getattr(torch, dtype_name)
-    config = SpeechT5Config(
-        hidden_size=16,
-        encoder_layers=1,
-        decoder_layers=1,
-        encoder_attention_heads=2,
-        decoder_attention_heads=2,
-        encoder_ffn_dim=32,
-        decoder_ffn_dim=32,
-        speech_decoder_prenet_units=16,
-        speech_decoder_postnet_units=16,
-    )
-    vocoder = SpeechT5HifiGan(
-        SpeechT5HifiGanConfig(
-            upsample_initial_channel=16,
-            upsample_rates=[2],
-            upsample_kernel_sizes=[4],
-            resblock_kernel_sizes=[3],
-            resblock_dilation_sizes=[[1, 3, 5]],
-        )
-    ).eval()
-
-    def from_pretrained(model_id, **kwargs):
-        model = SpeechT5ForTextToSpeech(config).eval().to(dtype=kwargs["torch_dtype"])
-        model.generate = partial(model.generate, maxlenratio=1.0)
-        return model
-
-    def processor(**kwargs):
-        return {"input_ids": torch.tensor([[2, 3, 4]])}
-
-    monkeypatch.setattr(SpeechT5ForTextToSpeech, "from_pretrained", from_pretrained)
-    monkeypatch.setattr(model_loaders, "_resolve_remote_code_and_config", lambda *_: (False, config))
+def test_speecht5_bfloat16_alignment(monkeypatch):
+    model = torch.nn.Linear(2, 2, dtype=torch.bfloat16)
+    model.device, model.dtype = model.weight.device, model.weight.dtype
+    model.generate = Mock(return_value=torch.ones(2, dtype=torch.bfloat16))
+    vocoder = torch.nn.Linear(2, 2)
+    processor = Mock(return_value={"input_ids": torch.tensor([[2, 3, 4]])})
+    load = Mock(return_value=model)
+    monkeypatch.setattr(SpeechT5ForTextToSpeech, "from_pretrained", load)
+    monkeypatch.setattr(model_loaders, "_resolve_remote_code_and_config", lambda *_: (False, SimpleNamespace()))
     monkeypatch.setattr(model_loaders, "_load_speecht5_processor", lambda *_: processor)
     monkeypatch.setattr(model_loaders, "_load_speecht5_hifigan_vocoder", lambda *_: vocoder)
 
-    wrapper = model_loaders.load_model("speech-generation", "tiny-speecht5", use_hf=True, torch_dtype=dtype_name)
+    wrapper = model_loaders.load_model("speech-generation", "dummy-speecht5", use_hf=True, torch_dtype="bf16")
     result = wrapper.generate("hello", speaker_embedding=torch.ones((1, 512)))
-    audio = result.speeches[0].data
 
-    assert wrapper.model.dtype == expected_dtype
-    assert vocoder.dtype == expected_dtype
-    assert audio.size > 0
-    assert np.isfinite(audio).all()
-    assert audio.dtype == np.float32
+    assert load.call_args.kwargs["torch_dtype"] == vocoder.weight.dtype == torch.bfloat16
+    assert model.generate.call_args.kwargs["speaker_embeddings"].dtype == torch.bfloat16
+    assert result.speeches[0].data.dtype == np.float32
 
 
-def test_speecht5_optimum_inputs_remain_native():
-    generate = Mock(return_value=torch.zeros(2))
-    wrapper = speech_generation_evaluator.SpeechT5Wrapper(
-        SimpleNamespace(device="CPU", dtype="f32", generate=generate),
-        lambda **kwargs: {"input_ids": torch.tensor([[2, 3, 4]])},
-        None,
-    )
-    wrapper.generate("hello", speaker_embedding=torch.ones((1, 512)))
-    assert generate.call_args.args[0].dtype == torch.int64
-    assert generate.call_args.kwargs["speaker_embeddings"].dtype == torch.float32
-
-
-def test_funasr_float32_weights(monkeypatch):
-    model = torch.nn.Linear(2, 2, dtype=torch.float16)
-    auto_model = Mock(return_value=SimpleNamespace(model=model))
+def test_funasr_casts_only_decoder(monkeypatch):
+    decoder = torch.nn.Linear(2, 2, dtype=torch.float16)
+    encoder = torch.nn.Linear(2, 2)
+    auto_model = Mock(return_value=SimpleNamespace(model=SimpleNamespace(llm=decoder, audio_encoder=encoder)))
     monkeypatch.setitem(sys.modules, "funasr", SimpleNamespace(AutoModel=auto_model))
     monkeypatch.setattr(speech_recognition_evaluator, "_get_asr_model_type", lambda *_: "funasr")
 
-    model_loaders.load_model("speech-recognition", "dummy-funasr", use_hf=True, torch_dtype="float32")
+    model_loaders.load_model("speech-recognition", "dummy-funasr", use_hf=True, torch_dtype="bf16")
 
-    assert model.weight.dtype == torch.float32
-    precision = {
-        key: value for key, value in auto_model.call_args.kwargs.items() if key in ("fp16", "bf16", "llm_dtype")
-    }
-    assert precision == {"fp16": False, "bf16": False, "llm_dtype": "fp32"}
-
-
-def test_kokoro_float32_weights(monkeypatch):
-    model = torch.nn.Linear(2, 2, dtype=torch.float16)
-    monkeypatch.setitem(sys.modules, "kokoro", SimpleNamespace(KPipeline=Mock()))
-    monkeypatch.setitem(sys.modules, "kokoro.model", SimpleNamespace(KModel=lambda **kwargs: model))
-
-    model_loaders.load_model("speech-generation", "dummy-kokoro", use_hf=True, torch_dtype="float32")
-
-    assert model.weight.dtype == torch.float32
+    kwargs = auto_model.call_args.kwargs
+    assert kwargs["llm_dtype"] == "bf16"
+    assert kwargs["fp16"] is False and kwargs["bf16"] is False
+    assert decoder.weight.dtype == torch.bfloat16
+    assert encoder.weight.dtype == torch.float32
 
 
-@pytest.mark.parametrize(
-    ("model_type", "model_id", "module_name"),
-    [
-        ("speech-recognition", "dummy-funasr", "funasr"),
-        ("speech-generation", "dummy-kokoro", "kokoro"),
-    ],
-)
 @pytest.mark.parametrize("dtype_name", ["float16", "bfloat16"])
-def test_source_speech_rejects_unsupported_dtype_before_import(
-    monkeypatch, model_type, model_id, module_name, dtype_name
-):
-    monkeypatch.setitem(sys.modules, module_name, None)
-    monkeypatch.setattr(speech_recognition_evaluator, "_get_asr_model_type", lambda *_: "funasr")
+def test_kokoro_rejects_unsupported_dtype(monkeypatch, dtype_name):
+    monkeypatch.setitem(sys.modules, "kokoro", None)
 
-    with pytest.raises(ValueError, match="support only float32 for --torch-dtype"):
-        model_loaders.load_model(model_type, model_id, use_hf=True, torch_dtype=dtype_name)
+    with pytest.raises(ValueError, match="Use --torch-dtype fp32"):
+        model_loaders.load_model("speech-generation", "dummy-kokoro", use_hf=True, torch_dtype=dtype_name)

--- a/tools/who_what_benchmark/tests/test_torch_dtype.py
+++ b/tools/who_what_benchmark/tests/test_torch_dtype.py
@@ -1,0 +1,159 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+from transformers import SpeechT5Config, SpeechT5ForTextToSpeech, SpeechT5HifiGan, SpeechT5HifiGanConfig
+
+from whowhatbench import model_loaders, speech_generation_evaluator, speech_recognition_evaluator, wwb
+
+
+@pytest.mark.parametrize("dtype_name", [None, "bfloat16"])
+def test_diffusers_loader_dtype(monkeypatch, dtype_name):
+    from diffusers import DiffusionPipeline
+
+    load = Mock()
+    monkeypatch.setattr(DiffusionPipeline, "from_pretrained", load)
+    model_loaders.load_model("text-to-image", "dummy-model", use_hf=True, torch_dtype=dtype_name)
+    assert load.call_args.kwargs["torch_dtype"] == (getattr(torch, dtype_name) if dtype_name else torch.float32)
+
+
+@pytest.mark.parametrize(
+    ("dtype_name", "expected_dtype"),
+    [
+        ("float32", torch.float32),
+        ("fp32", torch.float32),
+        ("float16", torch.float16),
+        ("fp16", torch.float16),
+        ("bfloat16", torch.bfloat16),
+        ("bf16", torch.bfloat16),
+    ],
+)
+def test_cli_dtype_reaches_hf_loader(monkeypatch, dtype_name, expected_dtype):
+    monkeypatch.setattr(sys, "argv", ["wwb", "--gt-data", "gt.csv", "--hf", "--torch-dtype", dtype_name])
+    args = wwb.parse_args()
+    wwb.check_args(args)
+    model_class = Mock()
+    monkeypatch.setattr(
+        model_loaders.AutoConfig, "from_pretrained", lambda *_: SimpleNamespace(quantization_config=None)
+    )
+    monkeypatch.setattr(model_loaders, "AutoModelForCausalLM", model_class)
+    monkeypatch.setattr(model_loaders.torch.cuda, "is_available", lambda: False)
+
+    model_loaders.load_model("text", "dummy-model", use_hf=args.hf, torch_dtype=args.torch_dtype)
+    assert model_class.from_pretrained.call_args.kwargs["torch_dtype"] is expected_dtype
+
+
+def test_cli_rejects_torch_dtype_without_hf(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["wwb", "--gt-data", "gt.csv", "--torch-dtype", "float32"])
+    with pytest.raises(ValueError, match="--torch-dtype requires --hf"):
+        wwb.check_args(wwb.parse_args())
+
+
+@pytest.mark.parametrize("dtype_name", ["float32", "float16", "bfloat16"])
+def test_hf_speecht5_tiny_generation_dtype(monkeypatch, dtype_name):
+    expected_dtype = getattr(torch, dtype_name)
+    config = SpeechT5Config(
+        hidden_size=16,
+        encoder_layers=1,
+        decoder_layers=1,
+        encoder_attention_heads=2,
+        decoder_attention_heads=2,
+        encoder_ffn_dim=32,
+        decoder_ffn_dim=32,
+        speech_decoder_prenet_units=16,
+        speech_decoder_postnet_units=16,
+    )
+    vocoder = SpeechT5HifiGan(
+        SpeechT5HifiGanConfig(
+            upsample_initial_channel=16,
+            upsample_rates=[2],
+            upsample_kernel_sizes=[4],
+            resblock_kernel_sizes=[3],
+            resblock_dilation_sizes=[[1, 3, 5]],
+        )
+    ).eval()
+
+    def from_pretrained(model_id, **kwargs):
+        model = SpeechT5ForTextToSpeech(config).eval().to(dtype=kwargs["torch_dtype"])
+        model.generate = partial(model.generate, maxlenratio=1.0)
+        return model
+
+    def processor(**kwargs):
+        return {"input_ids": torch.tensor([[2, 3, 4]])}
+
+    monkeypatch.setattr(SpeechT5ForTextToSpeech, "from_pretrained", from_pretrained)
+    monkeypatch.setattr(model_loaders, "_resolve_remote_code_and_config", lambda *_: (False, config))
+    monkeypatch.setattr(model_loaders, "_load_speecht5_processor", lambda *_: processor)
+    monkeypatch.setattr(model_loaders, "_load_speecht5_hifigan_vocoder", lambda *_: vocoder)
+
+    wrapper = model_loaders.load_model("speech-generation", "tiny-speecht5", use_hf=True, torch_dtype=dtype_name)
+    result = wrapper.generate("hello", speaker_embedding=torch.ones((1, 512)))
+    audio = result.speeches[0].data
+
+    assert wrapper.model.dtype == expected_dtype
+    assert vocoder.dtype == expected_dtype
+    assert audio.size > 0
+    assert np.isfinite(audio).all()
+    assert audio.dtype == np.float32
+
+
+def test_speecht5_optimum_inputs_remain_native():
+    generate = Mock(return_value=torch.zeros(2))
+    wrapper = speech_generation_evaluator.SpeechT5Wrapper(
+        SimpleNamespace(device="CPU", dtype="f32", generate=generate),
+        lambda **kwargs: {"input_ids": torch.tensor([[2, 3, 4]])},
+        None,
+    )
+    wrapper.generate("hello", speaker_embedding=torch.ones((1, 512)))
+    assert generate.call_args.args[0].dtype == torch.int64
+    assert generate.call_args.kwargs["speaker_embeddings"].dtype == torch.float32
+
+
+def test_funasr_float32_weights(monkeypatch):
+    model = torch.nn.Linear(2, 2, dtype=torch.float16)
+    auto_model = Mock(return_value=SimpleNamespace(model=model))
+    monkeypatch.setitem(sys.modules, "funasr", SimpleNamespace(AutoModel=auto_model))
+    monkeypatch.setattr(speech_recognition_evaluator, "_get_asr_model_type", lambda *_: "funasr")
+
+    model_loaders.load_model("speech-recognition", "dummy-funasr", use_hf=True, torch_dtype="float32")
+
+    assert model.weight.dtype == torch.float32
+    precision = {
+        key: value for key, value in auto_model.call_args.kwargs.items() if key in ("fp16", "bf16", "llm_dtype")
+    }
+    assert precision == {"fp16": False, "bf16": False, "llm_dtype": "fp32"}
+
+
+def test_kokoro_float32_weights(monkeypatch):
+    model = torch.nn.Linear(2, 2, dtype=torch.float16)
+    monkeypatch.setitem(sys.modules, "kokoro", SimpleNamespace(KPipeline=Mock()))
+    monkeypatch.setitem(sys.modules, "kokoro.model", SimpleNamespace(KModel=lambda **kwargs: model))
+
+    model_loaders.load_model("speech-generation", "dummy-kokoro", use_hf=True, torch_dtype="float32")
+
+    assert model.weight.dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    ("model_type", "model_id", "module_name"),
+    [
+        ("speech-recognition", "dummy-funasr", "funasr"),
+        ("speech-generation", "dummy-kokoro", "kokoro"),
+    ],
+)
+@pytest.mark.parametrize("dtype_name", ["float16", "bfloat16"])
+def test_source_speech_rejects_unsupported_dtype_before_import(
+    monkeypatch, model_type, model_id, module_name, dtype_name
+):
+    monkeypatch.setitem(sys.modules, module_name, None)
+    monkeypatch.setattr(speech_recognition_evaluator, "_get_asr_model_type", lambda *_: "funasr")
+
+    with pytest.raises(ValueError, match="support only float32 for --torch-dtype"):
+        model_loaders.load_model(model_type, model_id, use_hf=True, torch_dtype=dtype_name)

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -443,11 +443,11 @@ def load_text2image_model(
         from diffusers import DiffusionPipeline
 
         logger.info("Using HF Transformers API")
-        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
+        torch_dtype = _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32
         try:
-            model = DiffusionPipeline.from_pretrained(model_id, **model_kwargs)
+            model = DiffusionPipeline.from_pretrained(model_id, torch_dtype=torch_dtype)
         except Exception:
-            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
+            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch_dtype)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -944,11 +944,11 @@ def load_text2video_model(model_id, device="CPU", ov_config=None, use_hf=False, 
         from diffusers import LTXPipeline
 
         logger.info("Using HF Transformers API")
-        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
+        torch_dtype = _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32
         try:
-            model = LTXPipeline.from_pretrained(model_id, **model_kwargs)
+            model = LTXPipeline.from_pretrained(model_id, torch_dtype=torch_dtype)
         except ValueError:
-            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
+            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch_dtype)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -1000,11 +1000,11 @@ def load_image2video_model(model_id, device="CPU", ov_config=None, use_hf=False,
         from diffusers import LTXImageToVideoPipeline
 
         logger.info("Using HF Transformers API")
-        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
+        torch_dtype = _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32
         try:
-            model = LTXImageToVideoPipeline.from_pretrained(model_id, **model_kwargs)
+            model = LTXImageToVideoPipeline.from_pretrained(model_id, torch_dtype=torch_dtype)
         except ValueError:
-            model = LTXImageToVideoPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
+            model = LTXImageToVideoPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch_dtype)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)

--- a/tools/who_what_benchmark/whowhatbench/model_loaders.py
+++ b/tools/who_what_benchmark/whowhatbench/model_loaders.py
@@ -44,6 +44,26 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+# HF INT8/INT4 loading requires quantization configuration or a quantized checkpoint, not torch_dtype.
+TORCH_DTYPES = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+
+def _resolve_torch_dtype(dtype):
+    if dtype is None or dtype == "auto" or isinstance(dtype, torch.dtype):
+        return dtype
+    try:
+        return TORCH_DTYPES[dtype]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported PyTorch dtype '{dtype}'. Supported values: {', '.join(TORCH_DTYPES)}.") from exc
+
+
 def _sanitize_load_kwargs(model_type, use_hf, use_genai, use_llamacpp, kwargs):
     sanitized_kwargs = dict(kwargs)
     n_ctx = sanitized_kwargs.get("llamacpp_n_ctx")
@@ -265,7 +285,7 @@ def load_omni_hf_pipeline(model_id, device, config, trust_remote_code=False, **k
         model_id,
         trust_remote_code=trust_remote_code,
         device_map=device.lower(),
-        dtype="auto",
+        torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype", "auto")),
     )
 
     if kwargs.get("adapters") is not None:
@@ -276,7 +296,7 @@ def load_omni_hf_pipeline(model_id, device, config, trust_remote_code=False, **k
 
 
 def load_text_hf_pipeline(model_id, device, **kwargs):
-    model_kwargs = {}
+    model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype"))}
     trust_remote_code = False
     config = None
     if kwargs.get('gguf_file'):
@@ -423,10 +443,11 @@ def load_text2image_model(
         from diffusers import DiffusionPipeline
 
         logger.info("Using HF Transformers API")
+        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
         try:
-            model = DiffusionPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
+            model = DiffusionPipeline.from_pretrained(model_id, **model_kwargs)
         except Exception:
-            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
+            model = DiffusionPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -529,7 +550,10 @@ def load_visual_text_model(
         if getattr(config, "model_type", None) in OMNI_MODEL_TYPES:
             return load_omni_hf_pipeline(model_id, device, config, trust_remote_code, **kwargs)
 
-        model_kwargs = {"trust_remote_code": trust_remote_code}
+        model_kwargs = {
+            "trust_remote_code": trust_remote_code,
+            "torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")),
+        }
         try:
             model_cls = None
 
@@ -544,7 +568,7 @@ def load_visual_text_model(
                 model_cls = AutoModelForMultimodalLM
             elif config.model_type == "gemma3n":
                 model_cls = AutoModelForCausalLM
-                model_kwargs.update({"torch_dtype": torch.float32})
+                model_kwargs["torch_dtype"] = model_kwargs["torch_dtype"] or torch.float32
             elif transformers_version < Version("5.0.0"):
                 from transformers import AutoModelForVision2Seq
 
@@ -671,7 +695,11 @@ def load_imagetext2image_model(
         from diffusers import AutoPipelineForImage2Image
 
         logger.info("Using HF Transformers API")
-        model = AutoPipelineForImage2Image.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
+        model = AutoPipelineForImage2Image.from_pretrained(
+            model_id,
+            trust_remote_code=True,
+            torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32,
+        )
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         model = load_image2image_genai_pipeline(model_id, device, ov_config)
@@ -718,7 +746,11 @@ def load_inpainting_model(
         from diffusers import AutoPipelineForInpainting
 
         logger.info("Using HF Transformers API")
-        model = AutoPipelineForInpainting.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
+        model = AutoPipelineForInpainting.from_pretrained(
+            model_id,
+            trust_remote_code=True,
+            torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32,
+        )
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         model = load_inpainting_genai_pipeline(model_id, device, ov_config)
@@ -791,7 +823,9 @@ def load_embedding_model(model_id, device="CPU", ov_config=None, use_hf=False, u
         from transformers import AutoModel
 
         logger.info("Using HF Transformers API")
-        model = AutoModel.from_pretrained(model_id, trust_remote_code=True)
+        model = AutoModel.from_pretrained(
+            model_id, trust_remote_code=True, torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype"))
+        )
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         model = load_embedding_genai_pipeline(model_id, device, ov_config, **kwargs)
@@ -837,7 +871,7 @@ def load_reranking_genai_pipeline(model_dir, device="CPU", ov_config=None, is_qw
     )
 
 
-def load_reranking_model(model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False):
+def load_reranking_model(model_id, device="CPU", ov_config=None, use_hf=False, use_genai=False, **kwargs):
     try:
         config = AutoConfig.from_pretrained(model_id, trust_remote_code=False)
     except Exception:
@@ -848,11 +882,15 @@ def load_reranking_model(model_id, device="CPU", ov_config=None, use_hf=False, u
         if is_qwen3_causallm(config):
             from transformers import AutoModelForCausalLM
 
-            model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=True)
+            model = AutoModelForCausalLM.from_pretrained(
+                model_id, trust_remote_code=True, torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype"))
+            )
         else:
             from transformers import AutoModelForSequenceClassification
 
-            model = AutoModelForSequenceClassification.from_pretrained(model_id, trust_remote_code=True)
+            model = AutoModelForSequenceClassification.from_pretrained(
+                model_id, trust_remote_code=True, torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype"))
+            )
     elif use_genai:
         logger.info("Using OpenVINO GenAI API")
         is_qwen3_model = is_qwen3(config)
@@ -906,10 +944,11 @@ def load_text2video_model(model_id, device="CPU", ov_config=None, use_hf=False, 
         from diffusers import LTXPipeline
 
         logger.info("Using HF Transformers API")
+        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
         try:
-            model = LTXPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
+            model = LTXPipeline.from_pretrained(model_id, **model_kwargs)
         except ValueError:
-            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
+            model = LTXPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -961,10 +1000,11 @@ def load_image2video_model(model_id, device="CPU", ov_config=None, use_hf=False,
         from diffusers import LTXImageToVideoPipeline
 
         logger.info("Using HF Transformers API")
+        model_kwargs = {"torch_dtype": _resolve_torch_dtype(kwargs.get("torch_dtype")) or torch.float32}
         try:
-            model = LTXImageToVideoPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
+            model = LTXImageToVideoPipeline.from_pretrained(model_id, **model_kwargs)
         except ValueError:
-            model = LTXImageToVideoPipeline.from_pretrained(model_id, trust_remote_code=True, torch_dtype=torch.float32)
+            model = LTXImageToVideoPipeline.from_pretrained(model_id, trust_remote_code=True, **model_kwargs)
         if kwargs.get("adapters") is not None:
             adapters = kwargs["adapters"]
             alphas = kwargs.get("alphas", None)
@@ -1074,7 +1114,10 @@ def load_speech_generation_model(model_id, device="CPU", ov_config=None, use_hf=
     if use_hf:
         if _is_kokoro_model_id(model_id):
             logger.info("Using Kokoro HF API")
-            return KokoroModelWrapper(model_id)
+            return KokoroModelWrapper(
+                model_id,
+                torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype")),
+            )
 
         remote_code, model_config = _resolve_remote_code_and_config(model_id)
         logger.info("Using HF Transformers API")
@@ -1084,12 +1127,15 @@ def load_speech_generation_model(model_id, device="CPU", ov_config=None, use_hf=
 
         from transformers import SpeechT5ForTextToSpeech
 
-        model = SpeechT5ForTextToSpeech.from_pretrained(model_id, trust_remote_code=remote_code)
+        model = SpeechT5ForTextToSpeech.from_pretrained(
+            model_id,
+            trust_remote_code=remote_code,
+            torch_dtype=_resolve_torch_dtype(kwargs.get("torch_dtype")),
+        )
         processor = _load_speecht5_processor(model_id, remote_code)
 
-        # for HF, we need to explicitly load the vocoder.
-        # Assume it's microsoft/speecht5_hifigan for now.
         vocoder = _load_speecht5_hifigan_vocoder(vocoder_path)
+        vocoder.to(device=model.device, dtype=model.dtype)
         return SpeechT5Wrapper(model, processor, vocoder)
 
     if use_genai:
@@ -1151,6 +1197,7 @@ def load_speech_recognition_model(model_id, device="CPU", ov_config=None, use_hf
     from .speech_recognition_evaluator import ASRGenAITranscriber, ASRHFTranscriber, ASROptimumTranscriber
 
     if use_hf:
+        kwargs["torch_dtype"] = _resolve_torch_dtype(kwargs.get("torch_dtype"))
         return ASRHFTranscriber.create(model_id, device, ov_config, language, **kwargs)
     if use_genai:
         return ASRGenAITranscriber.create(model_id, device, ov_config, language, **kwargs)
@@ -1185,7 +1232,7 @@ def load_model(
     elif model_type in ("text-embedding", "image-embedding", "video-embedding"):
         return load_embedding_model(model_id, device, ov_options, use_hf, use_genai, **sanitized_kwargs)
     elif model_type == "text-reranking":
-        return load_reranking_model(model_id, device, ov_options, use_hf, use_genai)
+        return load_reranking_model(model_id, device, ov_options, use_hf, use_genai, **sanitized_kwargs)
     elif model_type == "text-to-video":
         return load_text2video_model(model_id, device, ov_options, use_hf, use_genai, **sanitized_kwargs)
     elif model_type == "image-to-video":

--- a/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
@@ -234,7 +234,9 @@ class KokoroModelWrapper:
         import torch
 
         if torch_dtype not in (None, torch.float32):
-            raise ValueError("Kokoro source models support only float32 for --torch-dtype.")
+            raise ValueError(
+                "Kokoro creates FP32 intermediate tensors that conflict with FP16/BF16 weights. Use --torch-dtype fp32."
+            )
         if ov_model is not None and torch_dtype is not None:
             raise ValueError("--torch-dtype is not supported when ov_model is provided.")
 

--- a/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_generation_evaluator.py
@@ -204,6 +204,11 @@ class SpeechT5Wrapper:
         if emb.ndim == 1:
             emb = emb.unsqueeze(0)
 
+        # Align HF inputs with the model; keep FP32 inputs for the Optimum OpenVINO backend.
+        if isinstance(self.model, torch.nn.Module):
+            input_tokens = input_tokens.to(device=self.model.device)
+            emb = emb.to(device=self.model.device, dtype=self.model.dtype)
+
         generation_kwargs = {"speaker_embeddings": emb}
         if self.vocoder is not None:
             generation_kwargs["vocoder"] = self.vocoder
@@ -212,10 +217,8 @@ class SpeechT5Wrapper:
             output = self.model.generate(input_tokens, **generation_kwargs)
             if isinstance(output, tuple):
                 output = output[0]
-            if isinstance(output, torch.Tensor):
-                speech = output.detach().cpu().reshape(-1).numpy()
-            else:
-                speech = torch.as_tensor(output).cpu().reshape(-1).numpy()
+            # Convert audio to FP32 because PyTorch cannot export BF16 tensors to NumPy.
+            speech = torch.as_tensor(output).detach().float().cpu().reshape(-1).numpy()
 
         return _SpeechResult(speech, 16000)
 
@@ -227,7 +230,14 @@ class KokoroModelWrapper:
     Optimum path uses OVModelForTextToSpeechSeq2Seq preprocess_input() + generate().
     """
 
-    def __init__(self, model_id, ov_model=None):
+    def __init__(self, model_id, ov_model=None, torch_dtype=None):
+        import torch
+
+        if torch_dtype not in (None, torch.float32):
+            raise ValueError("Kokoro source models support only float32 for --torch-dtype.")
+        if ov_model is not None and torch_dtype is not None:
+            raise ValueError("--torch-dtype is not supported when ov_model is provided.")
+
         from kokoro import KPipeline
         from kokoro.model import KModel
 
@@ -249,6 +259,9 @@ class KokoroModelWrapper:
             else:
                 # if model_id is not a local directory, KModel will fetch config using repo_id.
                 self._kmodel = KModel(repo_id=self._model_id)
+
+            if torch_dtype is not None:
+                self._kmodel.to(dtype=torch_dtype)
 
             self._pipeline = KPipeline(lang_code=self._lang_code, model=self._kmodel)
 

--- a/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
@@ -108,7 +108,12 @@ class GenAIMultimodalTranscriber:
 
 
 class FunASRSourceTranscriber:
-    def __init__(self, model_id: str, language: str = "") -> None:
+    def __init__(self, model_id: str, language: str = "", torch_dtype=None) -> None:
+        import torch
+
+        if torch_dtype not in (None, torch.float32):
+            raise ValueError("FunASR source models support only float32 for --torch-dtype.")
+
         try:
             from funasr import AutoModel
         except ImportError as error:
@@ -118,6 +123,14 @@ class FunASRSourceTranscriber:
             ) from error
 
         self.language = language or None
+        precision_kwargs = {}
+        if torch_dtype is not None:
+            precision_kwargs = {
+                "fp16": False,
+                "bf16": False,
+                "llm_dtype": "fp32",
+            }
+
         with _silenced_output():
             self.model = AutoModel(
                 model=str(model_id),
@@ -125,7 +138,11 @@ class FunASRSourceTranscriber:
                 device="cpu",
                 disable_update=True,
                 trust_remote_code=True,
+                **precision_kwargs,
             )
+
+        if torch_dtype is not None:
+            self.model.model.to(dtype=torch_dtype)
 
     def transcribe(self, audio, max_new_tokens: int) -> str:
         import torch
@@ -192,7 +209,11 @@ class ASRHFTranscriber:
     def create(model_id, device="CPU", ov_config=None, language="", **kwargs):
         if _get_asr_model_type(model_id) in ASR_MODEL_TYPES:
             logger.info("Using FunASR API")
-            return FunASRSourceTranscriber(model_id, language or "en")
+            return FunASRSourceTranscriber(
+                model_id,
+                language or "en",
+                torch_dtype=kwargs.get("torch_dtype"),
+            )
 
         model = _load_multimodal_model(model_id, device, ov_config, True, False, **kwargs)
         return MultimodalTranscriber(model, model_id, language or "English")

--- a/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
@@ -122,11 +122,10 @@ class FunASRSourceTranscriber:
         self.language = language or None
         precision_kwargs = {}
         if torch_dtype is not None:
-            llm_dtype = {torch.float32: "fp32", torch.float16: "fp16", torch.bfloat16: "bf16"}[torch_dtype]
             precision_kwargs = {
                 "fp16": False,
                 "bf16": False,
-                "llm_dtype": llm_dtype,
+                "llm_dtype": {torch.float32: "fp32", torch.float16: "fp16", torch.bfloat16: "bf16"}[torch_dtype],
             }
 
         with _silenced_output():

--- a/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
+++ b/tools/who_what_benchmark/whowhatbench/speech_recognition_evaluator.py
@@ -111,9 +111,6 @@ class FunASRSourceTranscriber:
     def __init__(self, model_id: str, language: str = "", torch_dtype=None) -> None:
         import torch
 
-        if torch_dtype not in (None, torch.float32):
-            raise ValueError("FunASR source models support only float32 for --torch-dtype.")
-
         try:
             from funasr import AutoModel
         except ImportError as error:
@@ -125,10 +122,11 @@ class FunASRSourceTranscriber:
         self.language = language or None
         precision_kwargs = {}
         if torch_dtype is not None:
+            llm_dtype = {torch.float32: "fp32", torch.float16: "fp16", torch.bfloat16: "bf16"}[torch_dtype]
             precision_kwargs = {
                 "fp16": False,
                 "bf16": False,
-                "llm_dtype": "fp32",
+                "llm_dtype": llm_dtype,
             }
 
         with _silenced_output():
@@ -142,7 +140,8 @@ class FunASRSourceTranscriber:
             )
 
         if torch_dtype is not None:
-            self.model.model.to(dtype=torch_dtype)
+            # Cast only the decoder: casting the audio encoder breaks inference with its FP32 inputs.
+            self.model.model.llm.to(dtype=torch_dtype)
 
     def transcribe(self, audio, max_new_tokens: int) -> str:
         import torch

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -245,9 +245,7 @@ def parse_args():
     )
     parser.add_argument(
         "--torch-dtype",
-        type=str,
         choices=TORCH_DTYPES,
-        default=None,
         help="PyTorch weight dtype with --hf. If omitted, the model-specific default is used.",
     )
     parser.add_argument(

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -248,7 +248,7 @@ def parse_args():
         type=str,
         choices=TORCH_DTYPES,
         default=None,
-        help="Data type used to load PyTorch model weights with --hf. If omitted, the model-specific default is used.",
+        help="PyTorch weight dtype with --hf. If omitted, the model-specific default is used.",
     )
     parser.add_argument(
         "--genai",

--- a/tools/who_what_benchmark/whowhatbench/wwb.py
+++ b/tools/who_what_benchmark/whowhatbench/wwb.py
@@ -17,7 +17,7 @@ from PIL import Image
 from datasets import load_dataset
 from typing import Any, Optional
 
-from whowhatbench.model_loaders import load_model
+from whowhatbench.model_loaders import TORCH_DTYPES, load_model
 from whowhatbench import EVALUATOR_REGISTRY
 from whowhatbench.utils import fix_phi3_v_eos_token_id
 from whowhatbench.chat_visualtext_evaluator import VisualTextChatInput
@@ -242,6 +242,13 @@ def parse_args():
         "--hf",
         action="store_true",
         help="Use AutoModelForCausalLM from transformers library to instantiate the model.",
+    )
+    parser.add_argument(
+        "--torch-dtype",
+        type=str,
+        choices=TORCH_DTYPES,
+        default=None,
+        help="Data type used to load PyTorch model weights with --hf. If omitted, the model-specific default is used.",
     )
     parser.add_argument(
         "--genai",
@@ -516,6 +523,8 @@ def check_args(args):
         )
     if args.hf and args.empty_adapters:
         raise ValueError("'empty_adapters' mode is not supported for HF Transformers.")
+    if args.torch_dtype is not None and not args.hf:
+        raise ValueError("--torch-dtype requires --hf")
     if args.speaker_embeddings is not None and not os.path.exists(args.speaker_embeddings):
         raise ValueError(f"Speaker embedding file does not exist: {args.speaker_embeddings}")
     if args.gt_data is not None and os.path.isdir(args.gt_data):
@@ -1523,6 +1532,8 @@ def main():
         kwargs["from_onnx"] = args.from_onnx
     if args.gguf_file:
         kwargs["gguf_file"] = args.gguf_file
+    if args.torch_dtype is not None:
+        kwargs["torch_dtype"] = args.torch_dtype
     if args.adapters is not None:
         kwargs["adapters"] = args.adapters
         if args.alphas is not None:


### PR DESCRIPTION
<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
[CVS-194706)](https://jira.devtools.intel.com/browse/CVS-194706)

Add CLI arg to manage dtypes for HF models. Named `torch-dtype` for now, as it's how it's named in HF.
Added aliases (both 'fp32' and 'float32' will cast to 'torch.float32') just for user convenience, as first variant is what optimum-intel users might be used to, second - transformers.
Small caveat: I've got errors on tensors type mismatch trying to cast Kokoro and FunASR audio parts to something other then fp32, so I'm raising and casting llm part only for them.

## Checklist:
- [x] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [x] <!-- (or N/A) --> Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [x] <!-- (or N/A) --> This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [x] <!-- (or N/A) --> I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
